### PR TITLE
Add a `sources_directory` to `countries.json`

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -57,6 +57,7 @@ task 'countries.json' do
     {
       country: name,
       code: meta['iso_code'] || name_to_iso_code(name),
+      sources_directory: "data/#{name}/sources",
       popolo: json_file,
       lastmod: lastmod,
       sha: sha

--- a/countries.json
+++ b/countries.json
@@ -2,6 +2,7 @@
   {
     "country": "Andorra",
     "code": "AD",
+    "sources_directory": "data/Andorra/sources",
     "popolo": "data/Andorra/final.json",
     "lastmod": "1431638645",
     "sha": "ff3dff8"
@@ -9,6 +10,7 @@
   {
     "country": "Angola",
     "code": "AO",
+    "sources_directory": "data/Angola/sources",
     "popolo": "data/Angola/final.json",
     "lastmod": "1432501853",
     "sha": "a3495fc"
@@ -16,6 +18,7 @@
   {
     "country": "Australia",
     "code": "AU",
+    "sources_directory": "data/Australia/sources",
     "popolo": "data/Australia/final.json",
     "lastmod": "1433346497",
     "sha": "f56cec7"
@@ -23,6 +26,7 @@
   {
     "country": "Bangladesh",
     "code": "BD",
+    "sources_directory": "data/Bangladesh/sources",
     "popolo": "data/Bangladesh/final.json",
     "lastmod": "1431284116",
     "sha": "06b76da"
@@ -30,6 +34,7 @@
   {
     "country": "Belarus",
     "code": "BY",
+    "sources_directory": "data/Belarus/sources",
     "popolo": "data/Belarus/final.json",
     "lastmod": "1431518622",
     "sha": "6d00ce3"
@@ -37,6 +42,7 @@
   {
     "country": "Bermuda",
     "code": "BM",
+    "sources_directory": "data/Bermuda/sources",
     "popolo": "data/Bermuda/final.json",
     "lastmod": "1433144995",
     "sha": "b53e1e0"
@@ -44,6 +50,7 @@
   {
     "country": "Bhutan",
     "code": "BT",
+    "sources_directory": "data/Bhutan/sources",
     "popolo": "data/Bhutan/final.json",
     "lastmod": "1432559592",
     "sha": "0a873b7"
@@ -51,6 +58,7 @@
   {
     "country": "Botswana",
     "code": "BW",
+    "sources_directory": "data/Botswana/sources",
     "popolo": "data/Botswana/final.json",
     "lastmod": "1431635523",
     "sha": "e44c1af"
@@ -58,6 +66,7 @@
   {
     "country": "Brazil",
     "code": "BR",
+    "sources_directory": "data/Brazil/sources",
     "popolo": "data/Brazil/final.json",
     "lastmod": "1431502561",
     "sha": "2a6c588"
@@ -65,6 +74,7 @@
   {
     "country": "Burundi",
     "code": "BI",
+    "sources_directory": "data/Burundi/sources",
     "popolo": "data/Burundi/final.json",
     "lastmod": "1432017051",
     "sha": "78fcdf8"
@@ -72,6 +82,7 @@
   {
     "country": "Canada",
     "code": "CA",
+    "sources_directory": "data/Canada/sources",
     "popolo": "data/Canada/final.json",
     "lastmod": "1431785828",
     "sha": "998e9c5"
@@ -79,6 +90,7 @@
   {
     "country": "Chile",
     "code": "CL",
+    "sources_directory": "data/Chile/sources",
     "popolo": "data/Chile/final.json",
     "lastmod": "1431785828",
     "sha": "998e9c5"
@@ -86,6 +98,7 @@
   {
     "country": "Congo-Brazzaville",
     "code": "CG",
+    "sources_directory": "data/Congo-Brazzaville/sources",
     "popolo": "data/Congo-Brazzaville/final.json",
     "lastmod": "1432661024",
     "sha": "7f9eb69"
@@ -93,6 +106,7 @@
   {
     "country": "Denmark",
     "code": "DK",
+    "sources_directory": "data/Denmark/sources",
     "popolo": "data/Denmark/final.json",
     "lastmod": "1431267337",
     "sha": "c397806"
@@ -100,6 +114,7 @@
   {
     "country": "Estonia",
     "code": "EE",
+    "sources_directory": "data/Estonia/sources",
     "popolo": "data/Estonia/final.json",
     "lastmod": "1431267337",
     "sha": "c397806"
@@ -107,6 +122,7 @@
   {
     "country": "Finland",
     "code": "FI",
+    "sources_directory": "data/Finland/sources",
     "popolo": "data/Finland/final.json",
     "lastmod": "1432548937",
     "sha": "c9d6e1a"
@@ -114,6 +130,7 @@
   {
     "country": "Germany",
     "code": "DE",
+    "sources_directory": "data/Germany/sources",
     "popolo": "data/Germany/final.json",
     "lastmod": "1433323425",
     "sha": "7c428b9"
@@ -121,6 +138,7 @@
   {
     "country": "Ghana",
     "code": "GH",
+    "sources_directory": "data/Ghana/sources",
     "popolo": "data/Ghana/final.json",
     "lastmod": "1432670426",
     "sha": "3ef4d40"
@@ -128,6 +146,7 @@
   {
     "country": "Greenland",
     "code": "GL",
+    "sources_directory": "data/Greenland/sources",
     "popolo": "data/Greenland/final.json",
     "lastmod": "1431267337",
     "sha": "c397806"
@@ -135,6 +154,7 @@
   {
     "country": "Iceland",
     "code": "IS",
+    "sources_directory": "data/Iceland/sources",
     "popolo": "data/Iceland/final.json",
     "lastmod": "1431284116",
     "sha": "06b76da"
@@ -142,6 +162,7 @@
   {
     "country": "Iran",
     "code": "IR",
+    "sources_directory": "data/Iran/sources",
     "popolo": "data/Iran/final.json",
     "lastmod": "1431267337",
     "sha": "c397806"
@@ -149,6 +170,7 @@
   {
     "country": "Italy",
     "code": "IT",
+    "sources_directory": "data/Italy/sources",
     "popolo": "data/Italy/final.json",
     "lastmod": "1431267337",
     "sha": "c397806"
@@ -156,6 +178,7 @@
   {
     "country": "Kazakhstan",
     "code": "KZ",
+    "sources_directory": "data/Kazakhstan/sources",
     "popolo": "data/Kazakhstan/final.json",
     "lastmod": "1431284116",
     "sha": "06b76da"
@@ -163,6 +186,7 @@
   {
     "country": "Kosovo",
     "code": "XK",
+    "sources_directory": "data/Kosovo/sources",
     "popolo": "data/Kosovo/final.json",
     "lastmod": "1433345196",
     "sha": "4cbf144"
@@ -170,6 +194,7 @@
   {
     "country": "Liberia",
     "code": "LR",
+    "sources_directory": "data/Liberia/sources",
     "popolo": "data/Liberia/final.json",
     "lastmod": "1433047961",
     "sha": "d3c2544"
@@ -177,6 +202,7 @@
   {
     "country": "Malawi",
     "code": "MW",
+    "sources_directory": "data/Malawi/sources",
     "popolo": "data/Malawi/final.json",
     "lastmod": "1432999685",
     "sha": "0ba514a"
@@ -184,6 +210,7 @@
   {
     "country": "Moldova",
     "code": "MD",
+    "sources_directory": "data/Moldova/sources",
     "popolo": "data/Moldova/final.json",
     "lastmod": "1433410395",
     "sha": "4607583"
@@ -191,6 +218,7 @@
   {
     "country": "Mongolia",
     "code": "MN",
+    "sources_directory": "data/Mongolia/sources",
     "popolo": "data/Mongolia/final.json",
     "lastmod": "1431284116",
     "sha": "06b76da"
@@ -198,6 +226,7 @@
   {
     "country": "Montenegro",
     "code": "ME",
+    "sources_directory": "data/Montenegro/sources",
     "popolo": "data/Montenegro/final.json",
     "lastmod": "1433322021",
     "sha": "0b9d706"
@@ -205,6 +234,7 @@
   {
     "country": "New Zealand",
     "code": "NZ",
+    "sources_directory": "data/New Zealand/sources",
     "popolo": "data/New_Zealand/final.json",
     "lastmod": "1431792979",
     "sha": "393cb01"
@@ -212,6 +242,7 @@
   {
     "country": "Niger",
     "code": "NE",
+    "sources_directory": "data/Niger/sources",
     "popolo": "data/Niger/final.json",
     "lastmod": "1431861016",
     "sha": "9c5a81e"
@@ -219,6 +250,7 @@
   {
     "country": "Northern Ireland",
     "code": "GB-NIR",
+    "sources_directory": "data/Northern Ireland/sources",
     "popolo": "data/Northern_Ireland/final.json",
     "lastmod": "1431804638",
     "sha": "3e503c7"
@@ -226,6 +258,7 @@
   {
     "country": "Paraguay",
     "code": "PY",
+    "sources_directory": "data/Paraguay/sources",
     "popolo": "data/Paraguay/final.json",
     "lastmod": "1432871772",
     "sha": "91285fe"
@@ -233,6 +266,7 @@
   {
     "country": "Portugal",
     "code": "PT",
+    "sources_directory": "data/Portugal/sources",
     "popolo": "data/Portugal/final.json",
     "lastmod": "1433410985",
     "sha": "0fed72a"
@@ -240,6 +274,7 @@
   {
     "country": "Rwanda",
     "code": "RW",
+    "sources_directory": "data/Rwanda/sources",
     "popolo": "data/Rwanda/final.json",
     "lastmod": "1432867467",
     "sha": "e2020e9"
@@ -247,6 +282,7 @@
   {
     "country": "Scotland",
     "code": "GB-SCT",
+    "sources_directory": "data/Scotland/sources",
     "popolo": "data/Scotland/final.json",
     "lastmod": "1432215238",
     "sha": "0b7af5f"
@@ -254,6 +290,7 @@
   {
     "country": "Seychelles",
     "code": "SC",
+    "sources_directory": "data/Seychelles/sources",
     "popolo": "data/Seychelles/final.json",
     "lastmod": "1433148693",
     "sha": "f736cdc"
@@ -261,6 +298,7 @@
   {
     "country": "Suriname",
     "code": "SR",
+    "sources_directory": "data/Suriname/sources",
     "popolo": "data/Suriname/final.json",
     "lastmod": "1432499945",
     "sha": "29b6dee"
@@ -268,6 +306,7 @@
   {
     "country": "Tanzania",
     "code": "TZ",
+    "sources_directory": "data/Tanzania/sources",
     "popolo": "data/Tanzania/final.json",
     "lastmod": "1431866370",
     "sha": "764bcf1"
@@ -275,6 +314,7 @@
   {
     "country": "Turkey",
     "code": "TR",
+    "sources_directory": "data/Turkey/sources",
     "popolo": "data/Turkey/final.json",
     "lastmod": "1431284116",
     "sha": "06b76da"
@@ -282,6 +322,7 @@
   {
     "country": "UK",
     "code": "GB",
+    "sources_directory": "data/UK/sources",
     "popolo": "data/UK/final.json",
     "lastmod": "1433346322",
     "sha": "8231275"
@@ -289,6 +330,7 @@
   {
     "country": "Wales",
     "code": "GB-WLS",
+    "sources_directory": "data/Wales/sources",
     "popolo": "data/Wales/final.json",
     "lastmod": "1431599670",
     "sha": "07690d6"
@@ -296,6 +338,7 @@
   {
     "country": "Zambia",
     "code": "ZM",
+    "sources_directory": "data/Zambia/sources",
     "popolo": "data/Zambia/final.json",
     "lastmod": "1431780112",
     "sha": "e40698b"
@@ -303,6 +346,7 @@
   {
     "country": "Zimbabwe",
     "code": "ZW",
+    "sources_directory": "data/Zimbabwe/sources",
     "popolo": "data/Zimbabwe/final.json",
     "lastmod": "1433437248",
     "sha": "9933279"


### PR DESCRIPTION
If apps want to make automated commits of new data, they shouldn’t rely
on a shared convention of where those should go, as then we can never
change our structures without ensuring that all those apps are changed.
Instead they should look up the `sources_directory` for a country and
use that.