### PR TITLE
Add instructions.json for Parldata countries

### DIFF
--- a/data/Albania/Assembly/Rakefile.rb
+++ b/data/Albania/Assembly/Rakefile.rb
@@ -1,11 +1,1 @@
 require_relative '../../../rakefile_parldata.rb'
-
-@PARLDATA = 'al/kuvendi'
-
-@FACTION_CLASSIFICATION = 'parliamentary_group'
-
-namespace :whittle do
-  task :standardise_terminology do
-    # binding.pry
-  end
-end

--- a/data/Albania/Assembly/sources/parldata/instructions.json
+++ b/data/Albania/Assembly/sources/parldata/instructions.json
@@ -1,0 +1,4 @@
+{
+  "source": "al/kuvendi",
+  "faction_classification": "parliamentary_group"
+}

--- a/data/Czech_Republic/Deputies/Rakefile.rb
+++ b/data/Czech_Republic/Deputies/Rakefile.rb
@@ -1,7 +1,3 @@
 require_relative '../../../rakefile_parldata.rb'
 
-@PARLDATA = 'cz/psp'
-@FACTION_CLASSIFICATION = 'political group'
-@MEMBERSHIP_GROUPING = 'faction'
-
 

--- a/data/Czech_Republic/Deputies/sources/parldata/instructions.json
+++ b/data/Czech_Republic/Deputies/sources/parldata/instructions.json
@@ -1,0 +1,5 @@
+{
+  "source": "cz/psp",
+  "faction_classification": "political group",
+  "membership_grouping": "faction"
+}

--- a/data/Czech_Republic/Senate/Rakefile.rb
+++ b/data/Czech_Republic/Senate/Rakefile.rb
@@ -1,7 +1,3 @@
 require_relative '../../../rakefile_parldata.rb'
 
-@PARLDATA = 'cz/senat' 
-@FACTION_CLASSIFICATION = 'political group'
-@MEMBERSHIP_GROUPING = 'faction'
-
 

--- a/data/Czech_Republic/Senate/sources/parldata/instructions.json
+++ b/data/Czech_Republic/Senate/sources/parldata/instructions.json
@@ -1,0 +1,5 @@
+{
+  "source": "cz/senat",
+  "faction_classification": "political group",
+  "membership_grouping": "faction"
+}

--- a/data/Hungary/Assembly/Rakefile.rb
+++ b/data/Hungary/Assembly/Rakefile.rb
@@ -1,3 +1,1 @@
 require_relative '../../../rakefile_parldata.rb'
-
-@PARLDATA = 'hu/orszaggyules'

--- a/data/Hungary/Assembly/sources/parldata/instructions.json
+++ b/data/Hungary/Assembly/sources/parldata/instructions.json
@@ -1,0 +1,3 @@
+{
+  "source": "hu/orszaggyules"
+}

--- a/data/Kosovo/Assembly/Rakefile.rb
+++ b/data/Kosovo/Assembly/Rakefile.rb
@@ -1,8 +1,5 @@
 require_relative '../../../rakefile_parldata.rb'
 
-@PARLDATA = 'kv/kuvendi'
-@MEMBERSHIP_GROUPING = 'parliamentary_group'
-
 namespace :transform do
   task :write => :rename_terms 
   task :rename_terms => :ensure_term do

--- a/data/Kosovo/Assembly/sources/parldata/instructions.json
+++ b/data/Kosovo/Assembly/sources/parldata/instructions.json
@@ -1,0 +1,4 @@
+{
+  "source": "kv/kuvendi",
+  "membership_grouping": "parliamentary_group"
+}

--- a/data/Montenegro/Assembly/Rakefile.rb
+++ b/data/Montenegro/Assembly/Rakefile.rb
@@ -1,3 +1,1 @@
 require_relative '../../../rakefile_parldata.rb'
-
-@PARLDATA = 'me/skupstina'

--- a/data/Montenegro/Assembly/sources/parldata/instructions.json
+++ b/data/Montenegro/Assembly/sources/parldata/instructions.json
@@ -1,0 +1,3 @@
+{
+  "source": "me/skupstina"
+}

--- a/data/Poland/Sejm/Rakefile.rb
+++ b/data/Poland/Sejm/Rakefile.rb
@@ -1,3 +1,1 @@
 require_relative '../../../rakefile_parldata.rb'
-
-@PARLDATA = 'pl/sejm'

--- a/data/Poland/Sejm/sources/parldata/instructions.json
+++ b/data/Poland/Sejm/sources/parldata/instructions.json
@@ -1,0 +1,3 @@
+{
+  "source": "pl/sejm"
+}

--- a/data/Poland/Senat/Rakefile.rb
+++ b/data/Poland/Senat/Rakefile.rb
@@ -1,4 +1,1 @@
 require_relative '../../../rakefile_parldata.rb'
-
-@PARLDATA = 'pl/senat' 
-

--- a/data/Poland/Senat/sources/parldata/instructions.json
+++ b/data/Poland/Senat/sources/parldata/instructions.json
@@ -1,0 +1,3 @@
+{
+  "source": "pl/senat"
+}

--- a/data/Serbia/Assembly/Rakefile.rb
+++ b/data/Serbia/Assembly/Rakefile.rb
@@ -1,9 +1,1 @@
-
 require_relative '../../../rakefile_parldata.rb'
-
-@PARLDATA = 'rs/skupstina'
-@FACTION_CLASSIFICATION = 'parliamentary_group'
-@MEMBERSHIP_GROUPING = 'faction'
-
-
-

--- a/data/Serbia/Assembly/sources/parldata/instructions.json
+++ b/data/Serbia/Assembly/sources/parldata/instructions.json
@@ -1,0 +1,5 @@
+{
+  "source": "rs/skupstina",
+  "faction_classification": "parliamentary_group",
+  "membership_grouping": "faction"
+}

--- a/data/Slovakia/National_Council/Rakefile.rb
+++ b/data/Slovakia/National_Council/Rakefile.rb
@@ -1,9 +1,1 @@
-
 require_relative '../../../rakefile_parldata.rb'
-
-@PARLDATA = 'sk/nrsr'
-@FACTION_CLASSIFICATION = 'parliamentary group'
-@MEMBERSHIP_GROUPING = 'faction'
-
-
-

--- a/data/Slovakia/National_Council/sources/parldata/instructions.json
+++ b/data/Slovakia/National_Council/sources/parldata/instructions.json
@@ -1,0 +1,5 @@
+{
+  "source": "sk/nrsr",
+  "faction_classification": "parliamentary group",
+  "membership_grouping": "faction"
+}

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -296,3 +296,13 @@ namespace :term_csvs do
 
 end
 
+desc "Make the Parldata instructions.json file"
+task :generate_instructions_file do
+  data = { 
+    source: @PARLDATA,
+    faction_classification: @FACTION_CLASSIFICATION,
+  }.reject { |_,v| v.empty? }
+  require 'fileutils'
+  FileUtils.mkpath 'sources/parldata'
+  File.write('sources/parldata/instructions.json', JSON.pretty_generate(data))
+end

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -302,7 +302,7 @@ task :generate_instructions_file do
     source: @PARLDATA,
     faction_classification: @FACTION_CLASSIFICATION,
     membership_grouping: @MEMBERSHIP_GROUPING,
-  }.reject { |_,v| v.empty? }
+  }.reject { |_,v| v.to_s.empty? }
   require 'fileutils'
   FileUtils.mkpath 'sources/parldata'
   File.write('sources/parldata/instructions.json', JSON.pretty_generate(data))

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -301,6 +301,7 @@ task :generate_instructions_file do
   data = { 
     source: @PARLDATA,
     faction_classification: @FACTION_CLASSIFICATION,
+    membership_grouping: @MEMBERSHIP_GROUPING,
   }.reject { |_,v| v.empty? }
   require 'fileutils'
   FileUtils.mkpath 'sources/parldata'

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -20,6 +20,11 @@ def deep_sort(element)
   end
 end
 
+def json_load(file)
+  return unless File.exist? file
+  JSON.parse(File.read(file), symbolize_names: true)
+end
+
 def json_write(file, json)
   # TODO remove the need for the .to_s here, by ensuring all People and Orgs have names
   json[:persons].sort_by!       { |p| [ p[:name].to_s, p[:id] ] }

--- a/rakefile_morph.rb
+++ b/rakefile_morph.rb
@@ -8,12 +8,6 @@ require 'json'
 require 'pry'
 require 'rake/clean'
 
-def json_load(file)
-  return unless File.exist? file
-  JSON.parse(File.read(file), symbolize_names: true)
-end
-
-
 @SOURCE_DIR = 'sources/morph'
 CLOBBER.include(FileList.new('sources/morph/*.csv'))
 

--- a/rakefile_parldata.rb
+++ b/rakefile_parldata.rb
@@ -91,7 +91,7 @@ namespace :transform do
     terms = @json[:events].find_all { |e| e[:classification] == 'legislative period' } or raise "No terms!"
 
     # Which type of memberships do care about?
-    want_type = @MEMBERSHIP_GROUPING || 'party'
+    want_type = instructions[:membership_grouping] || 'party'
     groups    = @json[:organizations].find_all { |h| h[:classification] == want_type }
     groupids  = groups.map { |p| p[:id] }.to_set
 


### PR DESCRIPTION
Make the Rakefiles as minimal as possible for Parldata countries, by moving the data on how to build them in `instructions.json` files.