### PR TITLE
Add instructions.json for Popit countries

### DIFF
--- a/data/Denmark/Folketing/Rakefile.rb
+++ b/data/Denmark/Folketing/Rakefile.rb
@@ -1,7 +1,5 @@
 require_relative '../../../rakefile_popit.rb'
 
-@POPIT = 'denmark'
-
 namespace :whittle do
 
   task :no_orphaned_memberships => :dk_remove_not_current

--- a/data/Denmark/Folketing/sources/popit/instructions.json
+++ b/data/Denmark/Folketing/sources/popit/instructions.json
@@ -1,0 +1,3 @@
+{
+  "source": "denmark"
+}

--- a/data/Estonia/Riigikogu/Rakefile.rb
+++ b/data/Estonia/Riigikogu/Rakefile.rb
@@ -1,3 +1,1 @@
 require_relative '../../../rakefile_popit.rb'
-
-@POPIT = 'riigikogu2015'

--- a/data/Estonia/Riigikogu/sources/popit/instructions.json
+++ b/data/Estonia/Riigikogu/sources/popit/instructions.json
@@ -1,0 +1,3 @@
+{
+  "source": "riigikogu2015"
+}

--- a/data/Greenland/Inatsisartut/Rakefile.rb
+++ b/data/Greenland/Inatsisartut/Rakefile.rb
@@ -1,3 +1,1 @@
 require_relative '../../../rakefile_popit.rb'
-
-@POPIT = 'inatsisartut'

--- a/data/Greenland/Inatsisartut/sources/popit/instructions.json
+++ b/data/Greenland/Inatsisartut/sources/popit/instructions.json
@@ -1,0 +1,3 @@
+{
+  "source": "inatsisartut"
+}

--- a/data/Iran/Assembly/Rakefile.rb
+++ b/data/Iran/Assembly/Rakefile.rb
@@ -1,3 +1,1 @@
 require_relative '../../../rakefile_popit.rb'
-
-@POPIT = 'iran-test'

--- a/data/Iran/Assembly/sources/popit/instructions.json
+++ b/data/Iran/Assembly/sources/popit/instructions.json
@@ -1,0 +1,3 @@
+{
+  "source": "iran-test"
+}

--- a/data/South_Africa/Assembly/Rakefile.rb
+++ b/data/South_Africa/Assembly/Rakefile.rb
@@ -1,8 +1,5 @@
 require_relative '../../../rakefile_popit.rb'
 
-@POPIT = 'za-peoples-assembly'
-
-
 @KEEP_ORG_TYPES = %w(executive parliament party)
 
 namespace :whittle do

--- a/data/South_Africa/Assembly/sources/popit/instructions.json
+++ b/data/South_Africa/Assembly/sources/popit/instructions.json
@@ -1,0 +1,3 @@
+{
+  "source": "za-peoples-assembly"
+}

--- a/data/Zimbabwe/Assembly/Rakefile.rb
+++ b/data/Zimbabwe/Assembly/Rakefile.rb
@@ -1,3 +1,1 @@
 require_relative '../../../rakefile_popit.rb'
-
-@POPIT = 'zimbabwe-test'

--- a/data/Zimbabwe/Assembly/sources/popit/instructions.json
+++ b/data/Zimbabwe/Assembly/sources/popit/instructions.json
@@ -1,0 +1,3 @@
+{
+  "source": "zimbabwe-test"
+}

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -295,13 +295,3 @@ namespace :term_csvs do
   end
 
 end
-
-desc "Make the Popit instructions.json file"
-task :generate_instructions_file do
-  data = { 
-    source: @POPIT,
-  }.reject { |_,v| v.to_s.empty? }
-  require 'fileutils'
-  FileUtils.mkpath 'sources/popit'
-  File.write('sources/popit/instructions.json', JSON.pretty_generate(data))
-end

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -296,14 +296,12 @@ namespace :term_csvs do
 
 end
 
-desc "Make the Parldata instructions.json file"
+desc "Make the Popit instructions.json file"
 task :generate_instructions_file do
   data = { 
-    source: @PARLDATA,
-    faction_classification: @FACTION_CLASSIFICATION,
-    membership_grouping: @MEMBERSHIP_GROUPING,
+    source: @POPIT,
   }.reject { |_,v| v.to_s.empty? }
   require 'fileutils'
-  FileUtils.mkpath 'sources/parldata'
-  File.write('sources/parldata/instructions.json', JSON.pretty_generate(data))
+  FileUtils.mkpath 'sources/popit'
+  File.write('sources/popit/instructions.json', JSON.pretty_generate(data))
 end

--- a/rakefile_popit.rb
+++ b/rakefile_popit.rb
@@ -4,13 +4,15 @@ require_relative 'rakefile_common.rb'
 desc "Reload the source data"
 task :raw => 'popit.json'
 
+
+@POPIT_RAW_FILE = 'sources/popit/raw.json'
+CLOBBER.include(@POPIT_RAW_FILE)
+
 def popit_source 
   @POPIT_URL || "https://#{@POPIT || @DEST}.popit.mysociety.org/api/v0.1/export.json"
 end
 
 namespace :raw do
-
-  @POPIT_RAW_FILE = 'sources/popit/raw.json'
 
   file @POPIT_RAW_FILE do
     File.write(@POPIT_RAW_FILE, open(popit_source).read) 

--- a/rakefile_popit.rb
+++ b/rakefile_popit.rb
@@ -5,23 +5,28 @@ desc "Reload the source data"
 task :raw => 'popit.json'
 
 
-@POPIT_RAW_FILE = 'sources/popit/raw.json'
+@SOURCE_DIR        = 'sources/popit'
+@POPIT_RAW_FILE    = @SOURCE_DIR + '/raw.json'
+@INSTRUCTIONS_FILE = @SOURCE_DIR + '/instructions.json'
+
 CLOBBER.include(@POPIT_RAW_FILE)
 
+if File.exist? @INSTRUCTIONS_FILE
+  @instructions = json_load(@INSTRUCTIONS_FILE)
+  raise "No `source` in instructions.json" unless @instructions.key? :source
+end
+
 def popit_source 
-  @POPIT_URL || "https://#{@POPIT || @DEST}.popit.mysociety.org/api/v0.1/export.json"
+  "https://%s.popit.mysociety.org/api/v0.1/export.json" % @instructions[:source]
 end
 
 namespace :raw do
-
   file @POPIT_RAW_FILE do
     File.write(@POPIT_RAW_FILE, open(popit_source).read) 
   end
-
 end
 
 namespace :whittle do
-
   @POPIT_CLEAN_FILE = 'clean.json'
 
   task :load => @POPIT_RAW_FILE do
@@ -34,6 +39,5 @@ namespace :whittle do
       end
     }, { symbolize_names: true })
   end
-
 end
 


### PR DESCRIPTION
Make the Rakefiles as minimal as possible for Popit-source countries, by moving the data on how to build them into `instructions.json` files.
