### PR TITLE
Remove trailing blank lines from Rakefiles

### DIFF
--- a/data/Benin/National_Assembly/Rakefile.rb
+++ b/data/Benin/National_Assembly/Rakefile.rb
@@ -1,2 +1,1 @@
 require_relative '../../../rakefile_morph.rb'
-

--- a/data/Bermuda/Assembly/Rakefile.rb
+++ b/data/Bermuda/Assembly/Rakefile.rb
@@ -1,3 +1,1 @@
 require_relative '../../../rakefile_morph.rb'
-
-

--- a/data/Burkina_Faso/Assembly/Rakefile.rb
+++ b/data/Burkina_Faso/Assembly/Rakefile.rb
@@ -1,2 +1,1 @@
 require_relative '../../../rakefile_morph.rb'
-

--- a/data/Cameroon/Assembly/Rakefile.rb
+++ b/data/Cameroon/Assembly/Rakefile.rb
@@ -1,2 +1,1 @@
 require_relative '../../../rakefile_morph.rb'
-

--- a/data/Czech_Republic/Deputies/Rakefile.rb
+++ b/data/Czech_Republic/Deputies/Rakefile.rb
@@ -1,3 +1,1 @@
 require_relative '../../../rakefile_parldata.rb'
-
-

--- a/data/Czech_Republic/Senate/Rakefile.rb
+++ b/data/Czech_Republic/Senate/Rakefile.rb
@@ -1,3 +1,1 @@
 require_relative '../../../rakefile_parldata.rb'
-
-

--- a/data/Dominican_Republic/Diputados/Rakefile.rb
+++ b/data/Dominican_Republic/Diputados/Rakefile.rb
@@ -1,2 +1,1 @@
 require_relative '../../../rakefile_morph.rb'
-

--- a/data/Gabon/Assembly/Rakefile.rb
+++ b/data/Gabon/Assembly/Rakefile.rb
@@ -1,2 +1,1 @@
 require_relative '../../../rakefile_morph.rb'
-

--- a/data/Moldova/Parlamentul/Rakefile.rb
+++ b/data/Moldova/Parlamentul/Rakefile.rb
@@ -1,2 +1,1 @@
 require_relative '../../../rakefile_morph.rb'
-


### PR DESCRIPTION
It’s easier to keep track of which Rakefiles still contain logic (#106) if we strip all the single-line ones of their trailing newlines.