### PR TITLE
Don't rebuild the Fuzzer for every match

### DIFF
--- a/rakefile_merged.rb
+++ b/rakefile_merged.rb
@@ -105,9 +105,8 @@ class CSVPatch
 
     # Approximate match?
     elsif opts.key? :amatch_threshold
-      # TODO: don't rebuild this this every time around
-      fuzzer = FuzzyMatch.new(@_csv, read: existing_field)
-      match = fuzzer.find_with_score(new_row[incoming_field])
+      (@fuzzer ||= {})[existing_field] ||= FuzzyMatch.new(@_csv, read: existing_field)
+      match = @fuzzer[existing_field].find_with_score(new_row[incoming_field])
       confidence = match[1].to_f * 100
 
       if confidence < opts[:amatch_threshold].to_f


### PR DESCRIPTION
When doing approximate matches, cache the Fuzzer, rather than rebuilding it on every match.