### PR TITLE
Remove the instructions-builder code

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -44,63 +44,6 @@ def name_from(json)
   orgs.first[:name]
 end
 
-desc 'Make a new set of instructions'
-task 'sources/instructions.json' do |t|
-  basedir = Rake.original_dir
-  root = File.expand_path("#{basedir}/../..")
-  raise "Need to be in Legislature directory" unless Pathname.new(root).basename.to_s == 'data'
-  puts "OK"
-
-  Dir.chdir basedir
-  FileUtils.mkpath 'sources'
-
-  meta_file = Rake.original_dir + "/meta.json"
-  meta = json_from meta_file
-  morph_long  = meta.delete(:morph) or abort "no `morph` entry in meta.json" 
-  morph_short = morph_long.split('/').last(2).join("/")
-
-  sources = {
-    sources: [
-      {
-        file: 'morph/data.csv',
-        create: {
-          type: 'morph',
-          scraper: morph_short,
-          query: 'SELECT * FROM data'
-        },
-        source: morph_long,
-        type: 'membership'
-      }
-    ]
-  }
-
-  if terms = meta.delete(:terms)
-    sources[:sources] << {
-      file: 'morph/terms.csv',
-      create: {
-        type: 'morph',
-        scraper: morph_short,
-        query: 'SELECT * FROM terms'
-      },
-      type: 'term',
-    }
-  else
-    warn "Now write a termfile"
-  end
-
-  puts "Writing #{t.name}"
-  json_write(t.name, sources)
-
-  puts "Writing sources/Rakefile.rb"
-  File.write('sources/Rakefile.rb', "require_relative '../../../../rakefile_merged.rb'")
-
-  puts "Writing Rakefile.rb"
-  File.write('Rakefile.rb', "require_relative '../../../rakefile_local.rb'")
-
-  puts "Writing #{meta_file}"
-  json_write(meta_file, meta)
-end
-
 desc 'Install country-list locally'
 task 'countries.json' do
   countries = @HOUSES.group_by { |h| h.split('/')[1] }


### PR DESCRIPTION
We no longer have such a complex process, and so don’t need this.
Perhaps later we’ll write another version of it.