### PR TITLE
Somalia: Add wikidata reference

### DIFF
--- a/data/Somalia/Lower/ep-popolo-v1.0.json
+++ b/data/Somalia/Lower/ep-popolo-v1.0.json
@@ -1866,6 +1866,12 @@
     {
       "classification": "legislature",
       "id": "legislature",
+      "identifiers": [
+        {
+          "identifier": "Q21078126",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "House of the People",
       "seats": 275
     }

--- a/data/Somalia/Lower/meta.json
+++ b/data/Somalia/Lower/meta.json
@@ -1,4 +1,5 @@
 {
   "name": "House of the People",
+  "wikidata": "Q21078126",
   "seats": 275
 }


### PR DESCRIPTION
Add last remaining missing Wikidata reference for a legislature. Closes https://github.com/everypolitician/everypolitician-data/issues/398