### PR TITLE
Check that ruby version is at least 2.0.0 in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
-ruby "2.0.0"
+
+abort 'Ruby should be >= 2.0.0' unless RUBY_VERSION.to_f >= 2.0
+
 gem 'json'
 gem 'nokogiri'
 gem 'pry'


### PR DESCRIPTION
Instead of requiring an exact ruby version this just checks that the
user has at least ruby 2.0.0.

Fixes https://github.com/everypolitician/everypolitician/issues/181