### PR TITLE
Cleaner git-log options

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -64,7 +64,7 @@ task 'countries.json' do
         json_file = h + '/ep-popolo-v1.0.json'
         popolo = json_from(json_file)
 
-        cmd = "git log -p --format='%h|%at' --no-notes -s -1 #{h}"
+        cmd = "git --no-pager log --format='%h|%at' -1 #{h}"
         (sha, lastmod) = `#{cmd}`.chomp.split('|')
         lname = name_from(popolo)
         lslug = h.split('/').last.tr('_', '-')


### PR DESCRIPTION
There's no real need to supply the -p, -s, and --no-notes to git-log if we're supplying our own --format