### PR TITLE
Show 100% matches in reconciliation interface

### DIFF
--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -1,9 +1,9 @@
 jQuery(function($) {
   var table = $('table');
   $.each(matches, function(i, match) {
-    // Skip 100 confidence for now
+    // Skip exact matches for now
     // TODO: This will get removed when we display everyone we know about
-    if (match[4] == 100) {
+    if (match[1].toLowerCase() == match[3].toLowerCase()) {
       return;
     }
     var row = $('<tr>');


### PR DESCRIPTION
We want to show 100% matches because they're not the same as exact
matches. e.g. you could have 'Joe Bloggs' and 'Joe A Bloggs' and they're
100% matches because the latter contains 100% of the former, but they're
not exact matches.