### PR TITLE
Feed all person data into the reconciliation template

### DIFF
--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -31,7 +31,7 @@ class Fuzzer
           next
         end
         matched_uuid = match.first.key?(:uuid)? match.first[:uuid] : nil
-        data = [ incoming_row[:id], incoming_row[@_incoming_field], matched_uuid, match.first[@_existing_field], match[1].to_f * 100 ]
+        data = [incoming_row[:id], matched_uuid, match[1].to_f * 100]
         warn "Fuzzed #{data.to_s}"
         data
       end
@@ -247,8 +247,8 @@ namespace :merge_sources do
         if rec_file = merger[:reconciliation_file]
           rec_filename = File.join "sources", rec_file
 
-          incoming_fieldname = "incoming_" + merger[:incoming_field]
-          existing_fieldname = "existing_" + merger[:existing_field]
+          incoming_field = merger[:incoming_field]
+          existing_field = merger[:existing_field]
 
           if File.exist? rec_filename
             reconciled = CSV.table(rec_filename)
@@ -257,8 +257,7 @@ namespace :merge_sources do
             fuzzer = Fuzzer.new(merged_rows, incoming_data, merger)
             matched = fuzzer.find_all.sort_by { |m| m.last }.reverse
             FileUtils.mkpath File.dirname rec_filename
-            headers = ['id', incoming_fieldname, 'uuid', existing_fieldname, 'confidence']
-            unique_merged_rows = merged_rows.uniq { |row| row[:uuid] }.sort_by { |row| row[:name] }
+            existing_people = merged_rows.uniq { |row| row[:uuid] }.sort_by { |row| row[:name] }
             templates_dir = File.expand_path('../../templates', __FILE__)
             reconciliation_js = File.read(File.join(templates_dir, 'reconciliation.js'))
             html = ERB.new(File.read(File.join(templates_dir, 'reconciliation.html.erb')))

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -12,8 +12,11 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/4.1.2/papaparse.min.js"></script>
     <script>
-window.headers = <%= Yajl::Encoder.encode(headers, html_safe: true) %>;
+window.existingField = <%= Yajl::Encoder.encode(existing_field, html_safe: true) %>
+window.incomingField = <%= Yajl::Encoder.encode(incoming_field, html_safe: true) %>
 window.matches = <%= Yajl::Encoder.encode(matched, html_safe: true) %>;
+window.existingPeople = <%= Yajl::Encoder.encode(existing_people, html_safe: true) %>;
+window.incomingPeople = <%= Yajl::Encoder.encode(incoming_data, html_safe: true) %>;
     </script>
     <script>
 <%= reconciliation_js %>
@@ -34,7 +37,7 @@ window.matches = <%= Yajl::Encoder.encode(matched, html_safe: true) %>;
           </table>
           <select class="js-merged-rows" style="display: none;">
             <option value="">Select an existing person to match with</option>
-            <% unique_merged_rows.each do |row| %>
+            <% existing_people.each do |row| %>
               <option value="<%= row[:uuid] %>"><%= row[:name] %></option>
             <% end %>
           </select>

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -1,13 +1,20 @@
 jQuery(function($) {
   var table = $('table');
   $.each(matches, function(i, match) {
+    var incomingPerson = incomingPeople.find(function(person) {
+      return person.id === match[0];
+    });
+    var existingPerson = existingPeople.find(function(person) {
+      return person.uuid === match[1];
+    });
+
     // Skip exact matches for now
     // TODO: This will get removed when we display everyone we know about
-    if (match[1].toLowerCase() == match[3].toLowerCase()) {
+    if (incomingPerson[incomingField].toLowerCase() == existingPerson[existingField].toLowerCase()) {
       return;
     }
     var row = $('<tr>');
-    var existing = $('<td>').addClass('existing').text(match[3]).data({uuid: match[2], text: match[3]});
+    var existing = $('<td>').addClass('existing').text(existingPerson.name).data('uuid', existingPerson.uuid);
     existing.droppable({
       activate: function(e, ui) {
         // Add some styles or whatever to indicate where draggable should be dropped
@@ -31,7 +38,7 @@ jQuery(function($) {
       }
     });
     row.append(existing);
-    var incoming = $('<td>').addClass('incoming').text(match[1]).data({id: match[0], text: match[1]});
+    var incoming = $('<td>').addClass('incoming').text(incomingPerson.name).data('id', incomingPerson.id);
     incoming.draggable({revert: 'invalid'});
     row.append(incoming);
     table.append(row);
@@ -55,29 +62,21 @@ jQuery(function($) {
   $('#generate-csv').click(function(e) {
     e.preventDefault();
     var csv = [];
-    csv.push(headers);
+    csv.push(['id', 'uuid']);
     $('table tr').each(function(i, row) {
       // Skip header rows
       if ($('th', row).length > 0) {
         return;
       }
       var id = $('.incoming', row).data('id');
-      var incoming = $('.incoming', row).data('text');
       var $existing = $('.existing', row);
       var uuid;
-      var existing;
       if ($('select', $existing).length >= 1) {
         uuid = $('select', $existing).val();
-        if (uuid) {
-          existing = $('select option:selected', $existing).text();
-        } else {
-          existing = '';
-        }
       } else {
         uuid = $existing.data('uuid');
-        existing = $existing.data('text');
       }
-      csv.push([id, incoming, uuid, existing, null]);
+      csv.push([id, uuid]);
     });
     $('#csv-output').val(Papa.unparse(csv));
   });


### PR DESCRIPTION
Rather than just feeding the fields specified in instructions.json into
the template we instead give it the whole existing and incoming objects
so that any information can be displayed on that page.

This also changes the reconciliation csv format so there are now just
two columns, 'id' and 'uuid'.

Related to https://github.com/everypolitician/everypolitician/issues/195