### PR TITLE
Use incoming and existing fields in reconciliation UI

### DIFF
--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -64,7 +64,7 @@
       {% } else if(person.id){ %}
         <div class="person" data-id="{{ person.id }}">
       {% } %}
-            <h1>{{ person.name }}</h1>
+            <h1>{{ person[field] || person.name }}</h1>
             <dl>
               {% if(person.gender){ %}
                 <dt>Gender:</dt>

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -101,12 +101,12 @@ jQuery(function($) {
 
     var existingPersonHTML = _.map(match[1], function(uuid) {
       var person = _.findWhere(existingPeople, { uuid: uuid });
-      return renderTemplate('person', { person: person });
+      return renderTemplate('person', { person: person, field: existingField });
     });
 
     var html = renderTemplate('pairing', {
       existingPersonHTML: existingPersonHTML.join("\n"),
-      incomingPersonHTML: renderTemplate('person', { person: incomingPerson })
+      incomingPersonHTML: renderTemplate('person', { person: incomingPerson, field: incomingField })
     });
     $('.pairings').append(html);
   });


### PR DESCRIPTION
Don't assume that the person's 'name' is always the field that we want to show. Sometimes the `incoming_field` might be set to `name__en`, in which case we should use that instead.