### PR TITLE
Persist CSV data between reconciliation runs

### DIFF
--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -261,7 +261,7 @@ namespace :merge_sources do
           end
           reconciler = Reconciler.new(merged_rows, merger, reconciled)
           need_reconciling = incoming_data.find_all do |d|
-            reconciler.find_all(d).empty? && !reconciled.any? { |r| r[:id].to_s == d[:id] }
+            reconciler.find_all(d).to_a.empty? && !reconciled.any? { |r| r[:id].to_s == d[:id] }
           end
           fuzzer = Fuzzer.new(merged_rows, need_reconciling, merger)
           matched = fuzzer.find_all.sort_by { |m| m.last }.reverse

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -27,7 +27,7 @@ class Fuzzer
         nil
       else
         matches = fuzzer.find_all_with_score(incoming_row[@_incoming_field])
-        unless matches
+        unless matches.any?
           warn "No matches for #{incoming_row}"
           next
         end

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -10,8 +10,9 @@
       window.incomingField = <%= Yajl::Encoder.encode(incoming_field, html_safe: true) %>
       window.matches = <%= Yajl::Encoder.encode(matched, html_safe: true) %>;
       window.existingPeople = <%= Yajl::Encoder.encode(existing_people, html_safe: true) %>;
-      window.incomingPeople = <%= Yajl::Encoder.encode(incoming_data, html_safe: true) %>;
+      window.incomingPeople = <%= Yajl::Encoder.encode(need_reconciling, html_safe: true) %>;
       window.votes = [];
+      window.reconciled = <%= Yajl::Encoder.encode(reconciled.map(&:fields), html_safe: true) %>;
     </script>
     <script><%= reconciliation_js %></script>
 

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -47,7 +47,7 @@ var updateProgressBar = function updateProgressBar(){
 var generateCSV = function generateCSV(){
   return Papa.unparse({
     fields: ['id', 'uuid'],
-    data: window.votes
+    data: window.reconciled.concat(window.votes)
   });
 }
 


### PR DESCRIPTION
When there are new people to be reconciled persist the data so that only
the new people have to be reconciled rather than having to do everyone
again.

Closes https://github.com/everypolitician/everypolitician/issues/197