### PR TITLE
Turkey: match on pre-redirect names

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -7868,9 +7868,9 @@
         "slug": "Assembly",
         "sources_directory": "data/Turkey/Assembly/sources",
         "popolo": "data/Turkey/Assembly/ep-popolo-v1.0.json",
-        "lastmod": "1447096467",
+        "lastmod": "1447146657",
         "person_count": 6867,
-        "sha": "daef3ad",
+        "sha": "787cd9b",
         "legislative_periods": [
           {
             "id": "term/25",

--- a/data/Turkey/Assembly/names.csv
+++ b/data/Turkey/Assembly/names.csv
@@ -94,7 +94,6 @@ Abdullah Özer,6fe062f0-7b5d-44d6-b1a2-fbcc03c32f66
 Abdullah İzmen,662d7ca9-0fd1-430f-848d-4c0489ff26e0
 Abdullahs Gils,51704345-f3a1-4eae-912a-85a06bd14622
 Abdullatif Şener,bfcfd01a-8d36-4851-b246-1f44af926a25
-Abdullatif Şener,ffdc2272-5e10-4851-b200-911ec1354d8e
 Abdulmecit Alp,1bd3171c-e53e-4120-9844-739de5c55884
 Abdulmecit Yağan,b2355404-207a-4f00-8a36-4c76a7811534
 Abdulmelik Firat,1c559c84-3c68-4dc2-9516-fc6a0d19497f
@@ -153,6 +152,7 @@ Abdülgani Ensari,28200a47-ef24-423c-9820-0f27fb353028
 Abdülgani Ertan,75640e3c-3f68-441f-8adf-95993274618b
 Abdülgani Türkmen,56d75e45-a00d-4291-a65e-a06d1207a03e
 Abdülhadi Kahya,ade245cf-4661-4463-895d-57650644bc3f
+Abdülhak Adnan Adıvar,3b3a8d81-d52a-4958-90f9-e975ee74f258
 Abdülhak Adnan Adıvar,73bb95f9-84ca-4c76-a779-ec5a3052c806
 Abdülhak Fırat,1820c040-668c-4fbd-8d31-0d278d3a71e2
 Abdülhak Hamit Tarhan,a7d524e4-8594-452d-ae56-ebdd6c8f187b
@@ -184,6 +184,7 @@ Abdülkerim Bayazıt,78cda752-5b0d-4262-9c3e-6d2672aaa550
 Abdülkerim Doğru,c26951d3-63f2-4c1d-b801-c2f8989cc01b
 Abdülkerim Zilan,353f7d6a-efa9-442c-b47b-5441b95d99cd
 Abdüllatif Ensarioğlu,dc20681e-1e02-4590-80cb-4bfe72588682
+Abdüllatif Şener,bfcfd01a-8d36-4851-b246-1f44af926a25
 Abdüllatif Şener,ffdc2272-5e10-4851-b200-911ec1354d8e
 Abdülmelik Fırat,1c559c84-3c68-4dc2-9516-fc6a0d19497f
 Abdülmuttalip Öker,791eaead-266d-42d3-af0f-017ae342d885
@@ -226,7 +227,6 @@ Adil Sağıroğlu,8f86b60a-f250-408f-926c-c4c69d33841c
 Adil Turan,098e39f7-c038-4535-a5ef-45891fc33869
 Adil Zozani,0870036b-cebb-4a7b-b797-585f76666316
 Adnan Adıvar,3b3a8d81-d52a-4958-90f9-e975ee74f258
-Adnan Adıvar,73bb95f9-84ca-4c76-a779-ec5a3052c806
 Adnan Akarca,49d883da-27e1-4e61-9aaa-858008d9308e
 Adnan Akın,08bed157-88b2-4840-94da-d0872d5acde6
 Adnan Akın,67dace0a-f78e-42fa-b7f4-f0200fd15d13
@@ -256,10 +256,15 @@ Agah Erozan,2da867ad-e24b-4cb1-bedd-ec655a2a68e0
 Agah Kafkas,8e048c50-8c6d-4734-80d2-911b8940bb4a
 Agah Oktay Güner,608f680c-cbf9-451a-8064-250ffbf3a6dc
 Agah Sırrı Levent,f1c9fe06-134e-46c6-888a-1eb8e58824a5
+Agâh Sırrı Levent,f1c9fe06-134e-46c6-888a-1eb8e58824a5
+Ahat Andican,e01426f7-4914-4e1d-9a23-18c4f9d6cff9
 Ahilya Moshos,af23c3c5-9917-466f-89e1-2681396b6a12
 Ahmad Dovudoʻgʻli,850865d9-a91f-4e2c-a329-4db339630fb7
+Ahmad Rasim,27ea2b6e-50a1-4bf1-9ad9-b822f82f432b
 Ahmed Ihsan Tokgöz,7a03d191-2f51-431d-b420-bfb8dffd6622
 Ahmed Mükerrem Karaağaç,87be4d60-3c4d-4318-a741-ab664132ed9e
+Ahmed İhsan Kırımlı,b126d94f-b584-4c66-ae8b-9e77c8e6770d
+Ahmed İhsan Qırımlı,b126d94f-b584-4c66-ae8b-9e77c8e6770d
 Ahmer Faruk Ünsal,c4132a19-3729-4595-be7c-d9468e59d873
 Ahmet Agaoglu,2ce86e8c-fd38-4067-910b-bce5e59575db
 Ahmet Akgün Albayrak,56714277-e08a-49ff-b132-d79c723ff264
@@ -320,6 +325,7 @@ Ahmet Cevdet Taflıoğlu,7864da01-77e3-45c7-b386-38f480cead34
 Ahmet Cimbek,45770fd6-e085-4a4a-bfc0-2ddf465a6923
 Ahmet Dallı,e433fbad-1aea-4f4a-b992-0ec71b0ded4d
 Ahmet Davutoğlu,850865d9-a91f-4e2c-a329-4db339630fb7
+Ahmet Demiray,6d65a7d4-ccae-47e6-8376-77f813b0be95
 Ahmet Demircan,3d055ffb-dcc0-480b-9dc8-2b48064afe28
 Ahmet Deniz Bölükbaşı,39df9bc3-a9f3-4685-9bf7-9e42739037ff
 Ahmet Derin,ea829c54-abc5-4e1b-8440-8fb18f65be28
@@ -358,6 +364,7 @@ Ahmet Fırat,c2967bf1-3567-4c64-a008-1a88ac983438
 Ahmet Gökhan Sarıçam,4f509fea-65e3-4b8f-88c9-12585d6225d1
 Ahmet Gültekin Kızılışık,7724d1fd-70ff-4692-8c71-44f0a09c0ac9
 Ahmet Gündoğdu,c2fe3533-b6e7-4f5a-8439-aea5631e7b61
+Ahmet Gündüz Ökçün,a16b220e-69a2-4f00-9833-5ba18c3baff4
 Ahmet Günebakan,171201d6-8d66-403b-a41e-b16c62a60eeb
 Ahmet Güner,bf121f5c-4212-414a-bdc7-817bacc08356
 Ahmet Gürkan,dd89f2c9-adb9-4d2e-9153-4923e14c4805
@@ -475,8 +482,10 @@ Ahmet Piriştina,41e63376-c776-47a2-87bb-d6d6fecbbec0
 Ahmet Ragıp Özdemiroğlu,8bc8823d-dfd1-45cc-933b-db666bab0160
 Ahmet Ramiz Bey,e4421217-3100-4948-be0f-c00b801d1da1
 Ahmet Ramiz Tan,e4421217-3100-4948-be0f-c00b801d1da1
+Ahmet Rasim,27ea2b6e-50a1-4bf1-9ad9-b822f82f432b
 Ahmet Rasim Arık,27ea2b6e-50a1-4bf1-9ad9-b822f82f432b
 Ahmet Rasim Erel,9fc802f7-b6fb-41b9-8466-b6652fe9eaf8
+Ahmet Refik Güran,05f819e7-9d1b-4bd3-be24-9ef2fc9c3989
 Ahmet Remzi Akgöztürk,97ea93d8-a1f2-4a7d-8268-d472b50b4039
 Ahmet Remzi Hatip,abda1513-498e-426d-a0c5-029b6c2001a1
 Ahmet Remzi Yüreğir,87a4b9fb-c35a-4a9e-b48c-36ec3932dfd1
@@ -599,6 +608,7 @@ Ahmet Şükrü Oğuz,b763e08b-ed6e-4674-a4c2-b36ace8232b2
 Ahmet Şükrü Süer,a9248c92-9ebc-49df-92a7-8542febcbe6e
 Ahmet Şükrü Yavuzyılmaz,0ccf4f49-d6c9-4bc8-b4a6-c8e84961141c
 Ahsen Aral,ccd0275f-83a8-47aa-a282-94c06b344fef
+Aka Gündüz,c8eab67a-fe54-44b3-8792-bccb4c6dc468
 Akgün Silivrili,375bf423-c8c8-4280-a980-e52e35173e94
 Akif Akkuş,5bc2b43f-0aa1-431b-8978-fbe0bbcd75bd
 Akif Akyüz,4a36bee9-a5af-409c-bdfa-7b824b8a988c
@@ -616,6 +626,7 @@ Akif Öztürk,93bbbfa6-b695-4c9a-a847-c490c43cb097
 Akil Muhtar Özden,2c71c13c-a528-4118-9d34-ddd92b2389a3
 Akin Birdal,d8c8e8b3-cc82-437d-9f60-b981289feb8f
 Akin Burdal,d8c8e8b3-cc82-437d-9f60-b981289feb8f
+Akçwrïn YUswf,c999f612-40a2-4233-91c4-1e64472f8ac2
 Akın Birdal,d8c8e8b3-cc82-437d-9f60-b981289feb8f
 Akın Gönen,32e4ca66-1d7a-45df-b658-54f230b913cb
 Akın Simav,417ca32a-e8da-493d-82be-34090b4fccd4
@@ -640,12 +651,14 @@ Alfred Bilinsky,960e8167-2473-4871-b019-23dedd113d92
 Algan Hacaloğlu,67f8c4d9-bd98-445a-95f9-cbaa9f71d817
 Ali Abdüssettar İksel,6791bb72-5a4f-4ce4-a8a7-69d31d61fb94
 Ali Acar,058be32b-d5c7-493d-89bc-101da8a34c93
+Ali Adnan Karaküçük,8c1e0186-bf3e-49b4-a5d3-8bad7070bf59
 Ali Ahmet Ertürk,989d7fb3-d8f6-4a74-b394-bbf7663e92d3
 Ali Ak,cc7f8457-8f15-489f-8745-eda6eac8e36d
 Ali Akif Eyidoğan,d6cca78a-a3ff-4513-ac1a-7dab4a5f567d
 Ali Akyıldız,f3798d82-d481-498d-9cde-6d22158c8b4e
 Ali Arabacı,d367f811-c0eb-4554-a2d0-3f82b66de13e
 Ali Arslan,a3f17739-bbce-45bb-94bc-b97f6e008d0f
+Ali Arslan (milletvekili),a3f17739-bbce-45bb-94bc-b97f6e008d0f
 Ali Atalan,a316c6c3-7cf1-4807-937d-a87a0886e8a5
 Ali Avni Turanlı,969569d9-8011-450f-9859-275c18f04205
 Ali Ayağ,bd95f5df-196a-4c61-945c-5ad3c4e411b5
@@ -663,6 +676,7 @@ Ali Bozdoğanoğlu,e8606c41-44a1-4c44-964a-5bd2f47edd1f
 Ali Bozer,61d6dd5b-62bd-4026-96c0-e6189b0fe03b
 Ali Boğa,72e45f96-d480-4651-8277-52b7a477cf45
 Ali Canip Yöntem,84bd52f2-1b6d-4ee7-bf02-5dd7d45dacfb
+Ali Cavit Oral,1adb90dc-9199-44a3-b389-7ade1a7874f2
 Ali Cavit Oral,2cdaaec0-ddef-42e1-8892-b0cc0ffb9077
 Ali Celalettin Topala,91be1695-3b07-48f1-af41-d88b7795a5a9
 Ali Cenani,f6e38a77-3b31-4633-a6c4-0ff002e542dc
@@ -999,8 +1013,9 @@ Ata Atalay,dd05121d-f940-4774-bab8-7083231c0d58
 Ata Bodur,376dc877-1830-4477-89f7-fc860aebfad8
 Ata Topaloğlu,376163f8-44d6-4c25-b5e9-b58c2e03b548
 Atalay Akan,aad7e58e-2045-45ea-ba65-ec797ca7de74
-Atatürk,b0713117-c1a3-4ae4-afba-5928c8ba4331
+Atatürk,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 Ataullah Hamidi,b13608d2-0ee8-479b-a33c-9534a4f556b8
+Ateş Amiklioğlu,92916d06-4004-4e99-8b90-d3a5f0ee6b50
 Atila Emek,af25d23c-c242-4dba-b58b-51f735427013
 Atila Kaya,f4f93782-6f36-469a-81f2-12d6e665ad42
 Atilla Atila,913ce76a-0ccd-456b-aa99-3b69af550451
@@ -1010,6 +1025,7 @@ Atilla Kart,e69c224c-fbcd-4fc7-8712-d7a93121a033
 Atilla Konuk,b42eff62-e109-4446-a326-ec2cd7b55600
 Atilla Koç,ed59fa42-4ad4-47fb-8d12-1dbc6a705fc8
 Atilla Mutman,c77a670b-44b2-4664-9cf7-9629aae3a754
+Atilla Sav,a45f2d28-b020-474c-a6d8-70b4a1138d87
 Atilla Sın,c1e0ed90-81e2-4bbe-ab80-cef62dc43dcf
 Atilla İmamoğlu,e275d7a3-f28b-44ef-a596-cefadda105dc
 Atıf Akgüç,0ec297f1-61c7-4080-a37f-3d9ab604c071
@@ -1042,6 +1058,7 @@ Axmed Dafutoglu,850865d9-a91f-4e2c-a329-4db339630fb7
 Aycan Çakıroğulları,efc2e3c6-a404-4c67-b59e-f04631fe2f88
 Aycan İrmez,16151760-7863-442f-9623-bf05b5301dc7
 Aydın,1298be2e-700e-4a36-80a1-7746e97a4ab5
+Aydın Ayaydın,d0e5894b-b8b2-4991-84bf-985391d26a63
 Aydın Ağan Ayaydın,d0e5894b-b8b2-4991-84bf-985391d26a63
 Aydın Baran,59686593-087b-4c2a-bbb9-67bd2b11df13
 Aydın Bıyıklıoğlu,1461ccd3-c7ba-4149-baea-a654ba05931f
@@ -1070,6 +1087,7 @@ Ayhan Zeynep Tekin,af504fd3-dd73-4d43-b309-9ca2ea15b018
 Ayhan Çevik,4cf9015a-5ffb-42c2-a701-2a6167344296
 Ayhan Çevik (siyasetçi),4cf9015a-5ffb-42c2-a701-2a6167344296
 Aykan Erdemir,b3c699c5-6c9a-49c5-9489-96ebf3047f25
+Aykon Doğan,f783e418-0afd-468a-bc43-9ed84ade6eb5
 Aykut Edibali,a90826f1-6114-41ae-a859-c446765745c0
 Aykut Erdoğdu,c67b729c-6cc4-49c1-bac2-306a2b70edb5
 Ayla Akat Ata,2c0e4373-dd35-4212-b32f-aadc49c29fa8
@@ -1098,7 +1116,7 @@ Ayşe Türkmenoğlu,a6b2aa9c-bbd7-4e07-9043-50ceb9a7985f
 Ayşe Şekibe İnsel,95c560ef-8987-4db1-b22c-b17f18fb167d
 Ayşenur Bahçekapılı,116646dc-9b30-4611-ac3f-197279a894af
 Ayşenur Külahlıoğlu İslam,18253297-802d-4ef2-8dee-58a2e4c7be28
-Ayşenur Külahlıoğlu İslam,b93ff0e7-1d86-4793-97a1-b4989acbaa33
+Ayşenur İslam,18253297-802d-4ef2-8dee-58a2e4c7be28
 Ayşenur İslam,b93ff0e7-1d86-4793-97a1-b4989acbaa33
 Azimet Köylüoğlu,337b4f87-65ea-4008-a571-b91178b1d62c
 Aziz Akgül,7bc3cfed-ee43-46f5-85db-718f94777912
@@ -1139,6 +1157,7 @@ Bahattin Karakoç (politikus),036564f0-d015-4b85-9dd3-f1cf7e1f4064
 Bahattin Taner,04111521-67f5-48af-97e0-7787f2c2dc85
 Bahattin Uzunoğlu,0c0b1db1-a9c6-4b82-b0e2-13d7333e762d
 Bahattin Yücel,6cf9204a-9e56-40ee-82d5-6f6d5368b299
+Bahattin Yücel,d4586d2e-e980-4d6f-90ee-3d3669da003a
 Bahattin Çaloğlu,7306e6e9-a3d5-46af-95f3-738f2d208932
 Bahattin Örnekol,2618375c-28a1-4f3f-91f5-35824b02e87e
 Bahattin Öğütmen,4f374c3f-0516-45eb-a547-a1781face21e
@@ -1172,6 +1191,7 @@ Battal Köksal,4dd3a854-ed22-4729-af6f-2929c465d7f2
 Bayar Ökten,845736c4-a7d8-412d-b4f4-c74ef2e74944
 Bayram Ali Bayramoğlu,ccae83a1-dc2e-46a8-a1a7-b2008c14d85b
 Bayram Fırat Dayanıklı,5a8bc01d-5f11-4bfb-b8f3-ce51e639a861
+Bayram Meral,ae77f0ca-443a-469c-a217-0dc083a59738
 Bayram Turan Çetin,3056f9b2-e361-4726-93ca-f548e1ee4b41
 Bayram Özçelik,f92c5bf9-e6c4-4be6-9b50-a8e7970e45ca
 Bayramali Meral,ae77f0ca-443a-469c-a217-0dc083a59738
@@ -1181,6 +1201,7 @@ Bedrettin Karaerkek,ea191779-931c-415a-91ae-ef2541422fd0
 Bedrettin Yıldırım,56223bca-49b9-41b7-9853-59406db6055c
 Bedri Nedim Göknil,ff99cd2f-de86-4485-b2f2-b83d52da1abd
 Bedri Yaşar,80c5d525-8cfc-4949-8f7f-06ba3e4f4ecc
+Behice Boran,1fd209ed-d891-47a3-9aaa-2bed3f2fb210
 Behice Boran Hatko,1fd209ed-d891-47a3-9aaa-2bed3f2fb210
 Behiç Erkin,e5187887-97bf-4789-8f26-1b51060ba948
 Behiç Sadi Abbasoğlu,4bd8865e-7bb8-4022-b5b0-3504822f43c3
@@ -1231,9 +1252,11 @@ Berhan Şimşek,61c4435b-5c8f-48df-b242-2f5de324a7bc
 Berxan Şimşək,61c4435b-5c8f-48df-b242-2f5de324a7bc
 Berç Keresteciyan Türker,8f295ebd-d42d-4de1-a1fc-9b7f1dc3a1d1
 Berç Türker Keresteciyan,8f295ebd-d42d-4de1-a1fc-9b7f1dc3a1d1
+Besim Atalay,986af966-7743-44f8-a9ae-9bc4f91f551d
 Besim Besin,3a00196b-25f1-4653-aa6f-c397671be53f
 Besim Ömer Akalın,44f220cf-4b49-415e-957b-ba9e591ba958
 Bestami Teke,11d7c03d-2032-41ab-ad4b-0ea873665d8f
+Besïm Atalaý,986af966-7743-44f8-a9ae-9bc4f91f551d
 Beyhan Aslan,050f9f56-1070-4a27-8c74-dd555249c1a4
 Beyti Arda,419dbed5-abb3-4770-85c2-72b18dff105d
 Beytullah Asil,4d1ea554-8e7e-47ce-bb45-ba12a7f330f1
@@ -1303,6 +1326,7 @@ Bülent Belen,a7c6fdad-a2ee-40e4-b3e0-05834e190614
 Bülent Ecevit,c25b1f9d-9104-455b-9bc0-d9492cb16111
 Bülent Ersin Gök,22defa50-d2e8-4016-910b-9ca4d12f14ed
 Bülent Gedikli,19f7af80-9198-449e-b567-e91ffd1290ca
+Bülent Hasan Tanla,3d267c5d-d4a3-46e5-8f67-0aedccc14693
 Bülent Hasan Tanla,86af147e-7f57-47ba-bb13-ec839afab851
 Bülent Kuşoğlu,6852d50a-e20f-4130-b3dc-bd4ab64d2070
 Bülent Osma,afe3e630-e129-45bd-bebd-cbe612fd37d2
@@ -1329,6 +1353,7 @@ Cafer Tufan Yazıcıoğlu,7a1c2ac3-2f66-407f-a749-d268a9597906
 Cafer Tüzel,d5d2b32f-9ea4-4e82-b544-7ca039e81396
 Cafer Özelçi,0aa12b60-750c-4d68-8200-72e4b580021e
 Cahit Angın,98730a4f-b4e2-44aa-af2e-7cba3f51e5d9
+Cahit Aral,453dc3d5-5ce1-44d0-9c41-4e99a764040b
 Cahit Bağcı,aa335341-ef42-4bff-816c-45d5301a55ec
 Cahit Can,3baec5cc-36d0-4f87-943c-ddbb36aa31e7
 Cahit Karakaş,248e0f7b-d4e6-495b-be4f-25d1e02c7127
@@ -1340,6 +1365,7 @@ Cahit Yılmaz,792af068-ebab-49be-9e84-f8d38630f33a
 Cahit Zamangil,dc9b2d7a-a148-48dc-9d74-81ee73c8d5d5
 Cami Baykurt,b0581c40-cb53-47b8-b58d-62d17259f482
 Canan Aritman,e03365d7-5467-4f77-82df-a57a7a2fe538
+Canan Arıtman,3d4d5cad-d3d1-4a71-82d3-19f0038045da
 Canan Candemir Çelik,9ecfbe9d-57aa-4e9e-bb5c-c26c07a6d823
 Canan Kalsın,cc3d9e44-c2bd-4383-98b2-bd8584a8409e
 Candan Yüceer,a2d7b845-1c96-461d-8e4b-5167ab45fa99
@@ -1358,7 +1384,7 @@ Cefi Kamhi,49e05f60-2caa-46f7-a139-dd198c48778e
 Celal Adan,79a13dba-8111-4d84-b40e-6422c7dc3014
 Celal Ahmet Sungur,a13bcd89-5182-4f85-9668-a1de50624fff
 Celal Arat,9b6e96d1-e990-4e08-a481-e9b04a263df3
-Celal Bayar,98dc21b4-167d-4069-b3f2-1ab5cda127e8
+Celal Bayar,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
 Celal Boynuk,3810947d-78ab-49cf-8040-5b8ee23ba89a
 Celal Dağgez,7ccbd87a-026d-4665-92fa-791153b13b7a
 Celal Dinçer,e99a5482-4cdf-435d-92e7-8b638ee4539b
@@ -1389,6 +1415,8 @@ Celalettin Aykar,d0c6834f-8d23-4e47-8100-213d67827278
 Celalettin Uzer,7d4662ba-a29e-4701-abdd-39e35d1f53f7
 Celil Göçer,4bfb8e6a-70e8-4dcb-92b8-4f09f7b1bce2
 Celâl Bayar,98dc21b4-167d-4069-b3f2-1ab5cda127e8
+Celâl Bayar,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
+Celâl Sahir Erozan,7a59a813-b07b-452f-ba43-3813b85116e6
 Cem Kozlu,507119a4-8ecf-4003-a749-e757a379f12b
 Cem Zorlu,a0857856-3318-4a06-b349-4566bcf069d2
 Cemal Aktaş,697b0e3d-d4a5-4bda-95a3-88e24552b798
@@ -1448,6 +1476,7 @@ Cemil Erhan,f7bc5cb7-5d01-48a1-875c-186cc018599e
 Cemil Karahan,954d6e99-0b50-4b58-81cd-fae38ec651fd
 Cemil Sait Barlas,da1e848e-1524-4c94-9c27-546ee783a88f
 Cemil Tüzemen,92c33171-2b92-4c22-8c69-a02d760abf54
+Cemil Uybadın,d0d6895e-8404-4d1c-96b4-1ef5e18b1746
 Cemil Yavaş,ae49d2cc-4451-4b27-be3b-0df251c6effe
 Cemil Yıldırım Türk,aeb6840e-1248-479d-be1a-6ef72f9a7b13
 Cemil Çalgüner,47535ae7-6dca-46c8-97ae-357577975a30
@@ -1486,6 +1515,7 @@ Cevat Küçük,1b382fc1-6836-43aa-8636-d32ad785e347
 Cevat Odyakmaz,0d0169e6-5fb9-4dff-a273-ff6b1ffa1c51
 Cevat Sayın,d6aaff3d-e229-44c5-b23c-09e86ffe826e
 Cevat Yalçın,5ed8d223-90cd-44e3-bacb-49ab88682ed3
+Cevat Çobanlı,b2ee4381-f5fe-48a0-a1e6-492fe3be14aa
 Cevat Önder,3e10bb05-0e22-4dc1-90ef-b20174e3a00a
 Cevat Ülkü,e97a08d2-7f80-408d-8e3b-9aba3a856172
 Cevdet Akçalı,184f9366-4b91-4916-a510-622ef1a4b8b8
@@ -1512,6 +1542,7 @@ Cezmi Erat,795a495a-b4e6-411d-b1e8-80000cb627d0
 Cezmi Erçin,0160d391-e46e-4978-8fae-a724e2491012
 Cezmi Polat,3e536587-d5b3-4ac2-ac50-ca1f6ef0edba
 Cezmi Türk,a31aff32-540e-4dc6-a979-42b36fadf60a
+Cihad Baban,b9c82a94-23ea-4f7d-ace4-e917e539da6a
 Cihadettin Turgut Sunalp,20344484-e5d1-446e-a3af-da5cb8bb6569
 Cihat Baban,b9c82a94-23ea-4f7d-ace4-e917e539da6a
 Cihat Bilgehan,aea395ae-e52f-49a5-85ea-9969e8fb6a4e
@@ -1519,17 +1550,19 @@ Cihat Turgut,3a5cfccd-3afc-42f3-b7c8-f11e64177044
 Coşkun Bayram,81e0c73b-4da6-4c24-94a6-6cc3d20e2a80
 Coşkun Gökalp,dc27aee0-09e0-400c-abdd-829c79f73cc5
 Coşkun Karagözoğlu,6b918803-d9fd-4188-9dec-7bf33ae59809
+Coşkun Kırca,08805097-2a18-46e1-9346-c010a26ac994
 Coşkun Kırca,d084b4f5-9de7-4a63-ba7f-fe94c46b1aa6
 Coşkun Çakır,7149309f-7096-4e0a-b516-487dd507eb82
 Cudi Paşa,a8388bc8-b37d-4e61-8e1f-69a0f5a9c364
 Cuma İçten,6463c660-f4d4-412f-b20f-b87c576ac7ff
 Cumali Durmuş,53a555f9-0942-456e-9c0b-4c86d4507a96
+Cumhur Ersümer,956b8c03-7b12-465b-999a-75d7e18337f0
 Cumhur Keskin,60eaf8a0-c9bd-46d7-858c-81d1760928b0
 Cumhur Ünal,330e171a-5068-4b69-b435-f8bfd0ca8fa0
 Cânân Aritman,3d4d5cad-d3d1-4a71-82d3-19f0038045da
 Cüneyit Karabıyık,44c41905-4953-4739-974e-8918311757b1
 Cüneyt Yüksel,73e50e7b-ce7a-49f9-b0fe-65f95828e8da
-Cəlal Bayar,98dc21b4-167d-4069-b3f2-1ab5cda127e8
+Cəlal Bayar,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
 Cəmil Cahid bəy Toydəmir,eb14c33c-ee94-42e2-94d9-cf989e88e4b2
 Cəmil Çiçək,abe19024-a773-46d4-949c-d109126b7361
 Daniş Yurdakul,2a44aae0-4e01-4265-8e8f-311e7f02048d
@@ -1542,6 +1575,7 @@ Demir Çelik,47abcf9e-aa98-4c53-94a3-8ed580984e2c
 Dengir Mir Mehmet Fırat,7b1c53f9-357a-4d61-9cc1-2e348b032154
 Dengir Mîr Mihemed,7b1c53f9-357a-4d61-9cc1-2e348b032154
 Deniz Baykal,64644586-aaec-42b2-8a12-ca82928feeda
+Deniz Bölükbaşı,39df9bc3-a9f3-4685-9bf7-9e42739037ff
 Denizli,22f7c23f-408c-4f96-8afb-9e4d182d1eba
 Derviş Günday,c0912586-f62a-4992-bdc6-d4a0c6002b31
 Derviş Sevünç,eec4abbf-92fa-4f7d-9f30-374420308253
@@ -1570,6 +1604,7 @@ Doğan Kitaplı,303583a8-3aa1-449c-a8d0-09b35273f357
 Doğan Köymen,a1e536db-a8b2-43b8-be51-75cf9c07162a
 Doğan Onur,831e5abe-0b23-4186-a534-cc7e011582b3
 Doğan Şafak,82ca3ecb-aee7-4387-a89e-b8a86a1c154d
+Doğancan Akyürek,432901db-c64b-497d-abec-43f0c8b588a2
 Dr. Atıf Bey,f5bf22a1-cac0-46ac-8d98-a5d9a9ba219a
 Durdu Mehmet Kastal,7a4118d0-f518-4f7d-9b77-43d5635a379b
 Durdu Turan,4421225e-cc55-4e23-9901-b709d5949604
@@ -1586,8 +1621,8 @@ Dursun Erol,f10d1531-e90f-4c30-bb89-df62c5f2bfb0
 Dursun Çiçek,8295839d-402f-4f0d-9348-6d57043b3724
 Dövlət Baxçalı,e0c3d800-3dc6-477f-8b78-18d8a8760bf6
 Dündar Tekand,318c4af5-f1b9-4c5c-b638-f55ed965b761
-Dželal Bajar,98dc21b4-167d-4069-b3f2-1ab5cda127e8
-Dželals Bajars,98dc21b4-167d-4069-b3f2-1ab5cda127e8
+Dželal Bajar,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
+Dželals Bajars,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
 Dəniz Baykal,64644586-aaec-42b2-8a12-ca82928feeda
 Ebdulhaq Hamid Terxan,a7d524e4-8594-452d-ae56-ebdd6c8f187b
 Ebubekir Akay,9cea6cb3-06b8-4553-b82f-9aa0eae984ba
@@ -1602,8 +1637,10 @@ Edip Alpsar,dde49b8b-d4d9-40d7-8e9f-719545303f1f
 Edip Dinç,bcd4e43f-4062-4111-9feb-d414df94c3da
 Edip Rüştü Akyürek,144dbd7f-9056-4f2d-8e1c-bb7d30016aa7
 Edip Safder Gaydalı,35bd5b58-cff0-4a67-b57b-f73f8720ab5f
+Edip Safter Gaydalı,35bd5b58-cff0-4a67-b57b-f73f8720ab5f
 Edip Semih Yalçın,146dfd7f-1f1d-470b-a2ff-b7cf51196735
 Edip Servet Tör,2f649ab8-dbee-4ccb-87bd-ebf23f3b8a09
+Edip Servet Tör,e9524a9b-7cba-4c05-aca0-ed88468b323e
 Edip Özbaş,3da95bbd-9910-40b0-bb14-f00cf610615a
 Edip Özgenç,45efbf35-859e-4499-a34d-26602d7e8ea8
 Edip İmer,a3843791-0c8d-4389-be7e-8cf6f4e48a69
@@ -1663,6 +1700,7 @@ Emin Erkul,b131ad15-6d3e-4fc1-bb10-f6e4c3f80a69
 Emin Fahrettin Özdilek,a3de10ca-7fac-4bdd-b958-aa300866fee6
 Emin Fikri Eralp,05714462-f621-4def-966c-75a2349ee482
 Emin Gevecioğlu,0789dc9c-2797-4a6a-9867-b58119ebea39
+Emin Halid Onat,0d2afaf6-804c-40c2-8d3f-45ecb41d482d
 Emin Halim Ergun,d581fedb-be87-4cbf-8c83-ae7337341724
 Emin Haluk Ayhan,35db100c-1cc8-4cf8-ac8e-21f6d4eff6b9
 Emin Kalafat,973be44d-574d-4513-8585-26bc10aab302
@@ -1740,6 +1778,7 @@ Erdal Kalkan,48c7fb12-59e0-4dc7-ae05-62aa3d4719cf
 Erdal Karademir,6d64565a-7166-439b-b62d-ffa66eb84f8a
 Erdal Kesebir,bde939c6-f057-4d07-9081-ff136b506ab3
 Erdal İnönü,c7056767-7947-414b-b5b6-e4a229795a12
+Erdem Bayazıt,5535eee1-78bb-4c1d-a952-87036045f90e
 Erdem Ocak,8b9884b1-974a-45a3-936e-d4bd44f6ba2b
 Erdin Bircan,046ede72-5819-4008-9bb7-91167ac8487c
 Erdoğan Bayraktar,53f88793-756d-4ff3-adee-774bb3e5c2b6
@@ -1939,9 +1978,11 @@ Faruk Dırık,e5fb1fe6-8054-41ad-bae8-0f8943e79154
 Faruk Işık,38ee4d47-e769-421a-b2a7-5ac98822c617
 Faruk Koca,4444e84f-9761-4112-9676-29d72c2a3065
 Faruk Küreli,8766a343-e567-4102-850a-79d2e1891ad9
+Faruk Loğoğlu,a17a618b-0ff6-456a-a05d-22a62b3aef02
 Faruk Nafiz Çamlıbel,44f7f890-1740-49e2-a8d8-2ab1a4f5c269
 Faruk Nafiz Özak,146e65d1-5dff-4dd9-b08a-c27b858b749f
 Faruk Nafız Çamlıbel,44f7f890-1740-49e2-a8d8-2ab1a4f5c269
+Faruk Nafız Özak,146e65d1-5dff-4dd9-b08a-c27b858b749f
 Faruk Nafız Özak,15267a5a-bc66-447b-b532-542713f88d6f
 Faruk Saydam,1cf19295-4fc0-4d7e-9732-624fabc6ffc0
 Faruk Septioğlu,60d5b234-d259-4955-8675-e7c5fcbf1a79
@@ -1953,6 +1994,7 @@ Faruk Özlü,864f6d0e-1e29-4537-a164-22e733c266fc
 Faruk İlker,fdfba8f9-db86-425d-ace2-86a00be427e2
 Faruq Nafiz Çamlıbel,44f7f890-1740-49e2-a8d8-2ab1a4f5c269
 Fatih Arıkan,ded23c69-91de-45c5-bd7c-a875702d9ced
+Fatih Atay,17ccebf8-1372-4906-bc90-91b8f1e207a6
 Fatih Atay,e533aac7-3289-4b6e-966e-9520a5e17d14
 Fatih Metin,59b02cce-9dd3-48d4-aee1-3e5e7bda6893
 Fatih Çiftci,5a210e5e-33d6-4a1e-9d7b-fd8e646e971b
@@ -1970,6 +2012,7 @@ Fatma Güldemet Sarı,1ecbbb84-b2fc-4c38-b621-4ac03843e6d5
 Fatma Gülhis Mankut,9a1dfc3f-2876-437b-a7c3-093594408beb
 Fatma Kaplan Hürriyet,8c11bdc3-4467-4741-9e92-a5f287fadccd
 Fatma Kotan,69a2d05e-d59c-40dc-88c7-8b95770e019b
+Fatma Kotan,c2fed048-ac33-41f3-8e0e-9beac8b82631
 Fatma Kurtulan,823a8bad-8c89-4dc3-8d90-fc80489812b6
 Fatma Mihriban Erden,3006a225-1623-499f-a4b9-a4c8cb91ad8a
 Fatma Nur Serter,893db21d-fdef-44c1-af07-8c17e0d7bbf7
@@ -1997,6 +2040,7 @@ Fazıl Şerafettin Bürge,3794ec6c-f702-45c2-97c1-cb24de2abbcb
 Fehim Adak,2cfbf1b5-7267-4bff-b680-eaba4fb27dd7
 Fehmi Açıksöz,1b59a2cd-a6f2-4bf2-8372-6093373b3bc0
 Fehmi Cumalıoğlu,5c6af2e5-e2e5-4605-88f3-0fcce2af12b7
+Fehmi Cumalıoğlu,8967dbfc-a03c-4c92-a3d8-027f10030fe6
 Fehmi Hüsrev Kutlu,f1ee0d39-51dc-4b4c-bb3d-b265ed3f0306
 Fehmi Küpçü,ca295d05-d72f-48a0-af15-f2dbc57864de
 Fehmi Memişoğlu,1d9af52a-b82e-4e84-9aa8-17f282b7e3bc
@@ -2023,6 +2067,7 @@ Feridun Şakir Öğünç,d9cae5e6-a2f2-42e4-829e-e002cbc22c99
 Feriha Fatma Öztürk,07aaaa2e-7363-45d9-bf40-681623e5ecfb
 Ferit Aydın Mirkelam,816b2eb4-8cc5-484d-bc29-32c3982d051f
 Ferit Bora,22c4266e-2233-4004-bb9e-0210286b6b06
+Ferit Celal Güven,8ca617ef-3fe2-4ebf-ad69-800690064006
 Ferit Celal Güven,8d83da17-411e-4de2-ae7f-2d4f5febce95
 Ferit Ecer,a017284d-f141-455e-8ba9-2150e12955d4
 Ferit Gündoğan,fc9b02cc-8ff4-4a94-9ba4-ee304f3a3b8d
@@ -2041,6 +2086,7 @@ Fethi Batur,7f9a0ff2-8198-4c12-8c29-a72afb9242a3
 Fethi Doğançay,8cb8e4e0-5dc3-4f08-9131-87b530fc65fa
 Fethi Erimçağ,62490c53-995b-4b08-ad55-938c6211d96b
 Fethi Mahramlı,2ab4bcc7-2a62-4baf-90ec-74963229b01c
+Fethi Okyar,3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44
 Fethi Çelikbaş,b27a3b64-3887-4f2a-a31e-79fd341bccf1
 Fethi Ülkü,3ac14985-35bc-4eb5-9ccd-f83c56ceccdd
 Fethiye Özver,d24af3c6-d8f4-4d50-b827-4681ae7ce11d
@@ -2074,6 +2120,7 @@ Feyzi Eken,e5099ebd-0dc7-49b5-af98-1ed777f3d166
 Feyzi Kalfagil,12c26af9-ac17-452b-b8f4-ada6e7055215
 Feyzi Pirinççioğlu,aa13fd4d-43fd-4660-bde9-e54efd91dca3
 Feyzi İşbaşaran,5809b956-c77a-4afe-9814-69c1a50cbbe2
+Feyzi İşbaşaran,99e2ce3b-78ee-4434-9727-f64e2b750890
 Feyzullah Değerli,516a039a-a84f-456a-a4fb-daf06fe16a01
 Feyzullah Kıyıklık,5f43f175-2108-413c-9c76-d4a0e913c6e7
 Feyzullah Uslu,bd62f934-d919-415b-abbe-151dbc51be84
@@ -2101,6 +2148,7 @@ Fikri Faik Güngören,a42eac1f-405c-4a24-a680-7e6ec5e33db3
 Fikri Işık,d876144a-c64a-45da-b0ac-d87a290e1b3f
 Fikri Karanis,9ad21f53-c2ec-431b-942a-037c59d648ac
 Fikri Pehlivanlı,c149f203-0c42-4d42-a39f-988c5228b363
+Fikri Sağlar,8d75f83a-982a-45f4-aebf-a7316a52f7f5
 Fikri Şen,0fba3667-9e05-4783-8706-500ebdea7a16
 Fikri Şendur,f2d0d2e9-375a-4c1f-956c-fc7af12c6210
 Filibeli Hilmi,84b44370-46bb-46e7-9c20-7f69d1c1301f
@@ -2115,6 +2163,7 @@ Fuat Ağralı,a30f7417-1944-4ad4-b36b-360164569861
 Fuat Balkan,949197f8-6890-4519-a92c-7eee30064033
 Fuat Bilal,676dcb68-52a4-4fed-b42d-42228faa939e
 Fuat Bol,329609eb-52a9-4c82-8dd6-74a4d29ce1a4
+Fuat Bulca,222a2464-7586-4687-a098-62c9b83764d1
 Fuat Börekçi,4fdbaa85-d280-49ad-91ac-1a5eda3650f4
 Fuat Geçen,75caac98-8b58-48a2-8160-e5b578bce9de
 Fuat Gökbudak,554c9315-0766-492a-8ffc-554724bbce13
@@ -2139,7 +2188,7 @@ Fuat Çobanoğlu,e8fab0b6-2dcc-45cd-84e9-ffc5bb20224f
 Fuat Ölmeztoprak,04f88f7e-3b4b-4d51-8b24-9e8901b69e59
 Fuat Öztekin,9e642884-6f21-440d-bde4-a2fa7bc5fd7a
 Fuat Ümit,127679f5-9fa5-4312-be1d-dd7659e797fa
-Fuod koʻprulu,402dda26-7adf-4019-9211-f1c86178da48
+Fuod koʻprulu,01d9e29d-19fb-4fbb-b23b-ca027d00c45f
 Fürüzan Tekil,d8a74fb7-50d0-406e-b979-f36d1007a245
 Gaffar Yakın,dda47016-4353-49f0-810c-bc717483a193
 Galip Ataç,78bec9ec-7ac0-490b-bc71-fbe8d9b6b9dc
@@ -2221,6 +2270,7 @@ Gürsoy Erol,77fc1533-ce20-485d-8691-a26d5226483e
 Gıyasettin Duman,c4f55a20-d5c8-462d-b59a-79fb9cc36a74
 Gıyasettin Emre,d82d4582-d67a-4be8-bafd-08ec71acbaf8
 Gıyasettin Karaca,a56e6afb-6b50-4b0e-9d5b-df5f8369dd94
+Gıyasettin Karaca,fdd3342d-a40e-493d-b0e7-f87ac73fbc30
 Hacer Dicle,72cb63da-318d-46a1-b5e3-ff27dfbb3e23
 Haci Biner,e13cc99d-7948-4b05-bfd9-42fe5828bbce
 Hacim Muhittin Çarıklı,f37dd435-7336-4c91-9900-b837b38a575d
@@ -2258,8 +2308,11 @@ Hadi Arıbaş,8d692fba-59ff-4cc6-8633-f8e7692e7ac2
 Hadi Hüsman,5c3b1a18-8527-4a0d-9512-cbcd6948bfb7
 Hadi Tan,1b019dd4-9b2d-48c6-add5-2a5fc66adabd
 Hadi Uzer,20fb8bbe-e991-4721-991b-2510af59f58a
+Hafiz Mehmet,2cd9cc56-dc85-4d96-9dca-2baa97782a09
 Hafız Abdullah Tezemir,57033b61-d64e-40ef-8e48-1e6ab4845e17
 Hafız Emin İnankur,35a444f2-69c4-48ee-a6d6-edac355ddc83
+Hafız Mehmed,2cd9cc56-dc85-4d96-9dca-2baa97782a09
+Hafız Mehmet,2cd9cc56-dc85-4d96-9dca-2baa97782a09
 Hafız Mehmet Engin,2cd9cc56-dc85-4d96-9dca-2baa97782a09
 Hafız Mehmet Şahin,8c9242a5-23d2-4b5d-92b3-3f4c75c8edd4
 Hafız İbrahim Demiralay,ee10e749-a615-49a6-8cf8-c6a9f4937458
@@ -2288,6 +2341,7 @@ Hakkı Oğuz Aykut,24171c9a-c82d-458a-85eb-099290001ec8
 Hakkı Saruhan Oluç,3f7eb6e1-6276-4286-9303-df7ac22d4b31
 Hakkı Suha Okay,e0c57f5c-576f-4986-83f8-889c574d3b75
 Hakkı Tarık Us,963d547a-ebd9-4fc1-817e-527e22d28e35
+Hakkı Tunaboylu,d6e2ef29-c570-4ee9-8abf-d4edc8b93dec
 Hakkı Ungan,b85e88b1-46aa-4822-ac9d-a4774a50fdf8
 Hakkı Yemeniciler,5f0a458d-94ae-4f43-9d1d-90f3fdb156ca
 Hakkı Yılmaz Önen,6a599a0c-5e4a-4106-8375-ef87f2ba831d
@@ -2322,6 +2376,7 @@ Halil Etyemez,ceda2e4a-8533-4493-b3e2-11d5c0c711fd
 Halil Fahri Gürmen,45d21b8d-ec42-410d-9432-346ac916653b
 Halil Gürün,1734309e-d1fa-461a-aa49-da53212fa199
 Halil Hilmi Bozca,de5b0bee-e6cb-4b37-96b2-357fefa09b7e
+Halil Hulki Aydın,2e825a8d-4b7b-40e7-8266-37b4eb8c6743
 Halil Hulki Ayrım,2e825a8d-4b7b-40e7-8266-37b4eb8c6743
 Halil Hulusi Efendi,4c66851a-c401-4671-9014-16f53257f940
 Halil Işık,db78d6a3-2803-4896-a438-a49d925eee3f
@@ -2377,11 +2432,13 @@ Halis Soylu,818f2530-afec-4a9f-9b28-c0dbc80b8fee
 Halis Tokdemir,dc420f9d-6c76-4456-8942-04f1a414db54
 Halis Ulusan,457c235a-d9b3-49df-b967-4b5a2a98227e
 Halis Uluç Gürkan,59969c36-a6bf-4110-9295-00a0707326b0
+Halis Uluç Gürkan,ea2a2bd4-8568-4a21-a64a-66690784e4fd
 Halis Öztürk,ce3cb6e1-e303-435b-b879-91bbcf81ae4e
 Halit Akmansü,e367cd7b-91f8-453d-9a22-9001be05ad9f
 Halit Ağanoğlu,dcfd9654-c524-4be7-b2d2-9967440502b8
 Halit Barış Can,1026b628-29fa-42f4-9c48-ea679da0fcbf
 Halit Bayrak,8e63f7dd-e4d7-4f4b-b0aa-96d61afda8a7
+Halit Dağlı,4e4b4fdc-275d-408d-917c-72c0fe6effa4
 Halit Dikmen,21851c41-f77f-413b-9507-57774aea39fc
 Halit Dumankaya,78115425-7cf0-496b-8bf7-11d4c12feba4
 Halit Evliya,2fb5fa71-55b3-4647-aec1-52735ac6b9f1
@@ -2403,6 +2460,7 @@ Haluk Bayülken,a3af99f6-c299-4674-95df-8ebfc8f6829c
 Haluk Eyidoğan,59c61678-6ace-4f08-83de-bf5d0565bc21
 Haluk Karabörklü,987c3a3b-e257-42fe-9f01-100a779ddfaf
 Haluk Koç,093e58e0-a421-46a7-89b0-7e24491b9613
+Haluk Koç,ce4e553c-3391-440f-b5ff-19e985f7665d
 Haluk Nihat Pepeyi,7b2e1dab-4330-4cb4-9aec-376325ec591a
 Haluk Nur Baki,38d8d171-40fb-472f-aeca-a9625f81aa31
 Haluk Pekşen,4000f184-8995-4052-9953-584a47d66d26
@@ -2413,6 +2471,7 @@ Haluk Ökeren,57428ba8-5c41-4713-ad95-82a3f906f8ca
 Haluk Özdalga,dd05785e-e1d7-4b2c-9a57-200da1ff85c4
 Haluk Ülman,8c4819f1-343f-4151-bceb-e0c1d468cb9c
 Haluk İpek,e7ba745b-1463-447b-a62b-1a86e6cdd0b3
+Hamdi Aksoy,c41bb37f-3fb4-4377-94a2-ef4cd191191b
 Hamdi Aksoy,ecaf7ab8-0a58-4cb2-ab36-ba0ead338830
 Hamdi Apaydın,638ac703-d2e6-4333-87b6-b49a05214fd4
 Hamdi Baktır,385733a3-23e5-442c-b221-2a194569b95d
@@ -2437,12 +2496,14 @@ Hamdi Çelen,37c4b73d-aeef-40f5-bfa0-3d3d892281f4
 Hamdi Öner,c700779e-fd75-4585-a00b-04f5e753df55
 Hamdi Özkan,89491a1c-fe71-4bcf-8dbf-fe2b21033a51
 Hamdi Özsoy,398217af-3266-454c-ae61-19361dd0a6ad
+Hamdi Üçpınarlar,89f96507-7cd4-4442-8aa9-9f059775f8a4
 Hamdullah Suphi Tanrıöver,e477a17a-9221-41f4-a14b-827b23a5181c
 Hami Tezkan,1bcce593-0e2f-4a3e-9f28-6348e2e054ef
 Hamid Fendoğlu,d607c9e0-0266-4cb2-8732-e3c45ef870ae
 Hamide Sürücü,f89b34d6-f28f-4bc1-b7e5-e41debc2c700
 Hamit Ali Yöney,ecd8562e-f038-4d7b-a609-e553daa6d4ba
 Hamit Dedelek,f895e494-213d-490f-9ff4-5b893310d52b
+Hamit Fendoğlu,d607c9e0-0266-4cb2-8732-e3c45ef870ae
 Hamit Geylani,027301e4-d9b9-4060-bf44-404818f79ce7
 Hamit Kapancı,d26c82c5-3a5e-448a-baeb-0b1b739fda59
 Hamit Kartal,f72c44c6-ef56-4ef7-896a-a231fa8e69f6
@@ -2673,7 +2734,6 @@ Haydar Günver,0dfc7a45-66b3-46c2-b643-568307cd1f8b
 Haydar Hilmi Vaner,c3029589-4755-4501-890b-bea3dd6b1abb
 Haydar Kemal Kurt,1ff512a3-40f4-41aa-a30d-63db4bf6fd27
 Haydar Koyuncu,4c7918a8-1dec-48c1-aa6b-91493ee3ba95
-Haydar Lütfi Arslan,3a586d95-10e8-4f92-bd82-095c0017c14a
 Haydar Lütfi Arslan,98acd61f-c616-42d5-8ae1-34b3ddc7901e
 Haydar Oymak,e14fd6fe-d675-4871-8e1e-d65c60d90226
 Haydar Ulusoy,f89107e1-326d-4c08-bede-dfb6dfb7279e
@@ -2739,6 +2799,7 @@ Hilmi Biçer,7ebfb888-d6dd-401c-886f-72e9dda72a8b
 Hilmi Develi,3c5d4951-4b02-4d66-a39f-cba433860a1e
 Hilmi Durmaz,630c0122-bc64-4d7f-8dbc-2916ed4185c3
 Hilmi Güldoğan,6795442e-614b-4bec-a805-ed5d38f43f0c
+Hilmi Güler,d2b4d521-55b5-468e-80e8-b0ed9ddd15b1
 Hilmi Gür,b178686d-6a53-4181-ba3b-4e11032737fc
 Hilmi Nalbantoğlu,f4d476e8-9c0a-4216-992a-b04d3bb28972
 Hilmi Oben,56d07d0b-8841-4d71-affa-c9daf23075c6
@@ -2782,6 +2843,7 @@ Hürrem Kubat,5d4189bf-66df-403a-ac17-fe28b79ddc2d
 Hürrem Müftügil,56e736f8-2e95-4f06-9691-6e08c932d5ff
 Hüsamettin Akmumcu,46fec61c-c781-44ff-a5cf-6ecc0737ba78
 Hüsamettin Atabeyli,1489ed57-d987-4f08-95aa-89fef7019f85
+Hüsamettin Atabeyli,deab7666-1598-4fe6-a85d-f262922f907c
 Hüsamettin Başer,b70c6a7c-4cae-45d9-8e9d-6b5f59230264
 Hüsamettin Cindoruk,0179325e-e172-413f-a815-6e5f072732e4
 Hüsamettin Coşkun,e62a65a5-dae1-4f38-898d-6264ab99d61f
@@ -2934,9 +2996,11 @@ Hüseyin Şahin,1cde9283-fe8c-4255-bff2-dc0b481b5e71
 Hüseyin Şahin,4d92f161-f898-43e4-8658-98809f7e0006
 Hüseyin Şen,b1842688-0f1c-4db9-8e21-fb4b49cdd8ad
 Hüseyin Şükrü Özsüt,66b66d05-40c6-4dd7-bfeb-a1f180197f5a
+Hüseyn Rauf Orbay,c897a10b-39ef-4ea8-a585-ddfe834a92a0
 Hüsniye Erdoğan,c769b6a8-25d5-46ac-810a-7e838a1d08c3
 Hüsnü Akşit,522ae2b6-2503-4a30-941d-81ec7c5b5ba0
 Hüsnü Açıksöz,4d1b23a2-d1e0-4282-995f-bd2bd5832503
+Hüsnü Doğan,073fc017-aa70-49b3-a898-7b99b27baf6a
 Hüsnü Doğan,ff685d9b-cd8c-45a2-81de-1fb5f4873868
 Hüsnü Erol Yeşilpınar,2c46a84a-852c-4c42-8466-3cb38f8ba842
 Hüsnü Göktuğ,cb3897df-717c-478f-a99d-ab7332803cd7
@@ -2959,6 +3023,7 @@ Hıdır Aydın,e00a1ae8-1bac-4d61-a03a-e8e04a520c46
 Hıfzı Oğuz Bekata,eead1e2b-c314-48c7-ab3a-a3f2963b1ac0
 Hıfzırrahman Raşit Öymen,49c834c9-37c4-4b99-a513-1906e62a697d
 Hızır Aydın,44d79a3e-8d2d-49e5-ba85-a5193b6b2ca8
+Hızır Aydın,e00a1ae8-1bac-4d61-a03a-e8e04a520c46
 Həmdullah Sübhi Tanrıövər,e477a17a-9221-41f4-a14b-827b23a5181c
 Həsən Hayri Kanko,89af880a-d689-44e2-8acc-e2db1d02d3af
 Həsən Təhsin Banquoğlu,f1e694e1-fc69-4e6a-a2d1-c35d8c8a0096
@@ -3012,6 +3077,7 @@ Kamil Kitapçı,a428794d-d61d-4af7-be9d-1e4788d6cb3c
 Kamil Kotan,e4feaeb8-b027-4088-bd1b-17b20590dd48
 Kamil Kozak,9e980a7f-429a-4105-82e2-8365a75baf57
 Kamil Kırıkoğlu,60ff0bfe-4972-475a-862a-adf2c054959d
+Kamil Miras,5a07eed0-562f-4c96-8a55-ac688230d11f
 Kamil Ocak,a344a182-c8b7-4233-b8bd-8fa85188e847
 Kamil Okyay Sındır,ed32ef7a-cd6f-4d29-83d3-9fb7e9d41825
 Kamil Sürenkök,7ec74c93-70ea-4062-9929-28fe7fad35c8
@@ -3027,6 +3093,7 @@ Kamran Karaman,64e5b7a1-a528-4e0d-a330-d97bb62d2a64
 Kamran Örs,2717e0d4-a042-4e17-b711-f5798246ef1a
 Kamran İnan,b9a2da8f-c106-4280-b461-8c3d2a3240da
 Kamuran Ural,86910d4c-2e52-47d7-9c0b-95c4fff29647
+Kara Vâsıf Bey,e8cd624e-f24f-4d08-89f4-d6a85ea791ae
 Karabey Kadri Karaoğlu,a6cd5829-2eb9-4358-92ea-ff9fc232e61c
 Kars,7f855f1d-6510-4ab6-bcc3-2a86f09dc239
 Kastamonu,da1412a1-e7b2-4d7e-b152-5410c22d2da4
@@ -3080,10 +3147,11 @@ Kemal Akkaya,b2cdfa12-ad45-4bd4-a1d3-951b2a5f3508
 Kemal Aksüyek,274f12da-7513-4fce-9160-ba7951a02ec4
 Kemal Aktaş,ba95af04-095a-410d-9e14-31166b552037
 Kemal Albayrak,2519572e-5439-4076-aecc-c845186f97e2
+Kemal Anadol,70e3dbe5-d5dd-435b-92c9-7c95bbe67325
 Kemal Atakurt,ac9a5811-3d80-4eae-8545-e2c044d008c6
 Kemal Ataman,a381d42c-8dbc-423b-afcd-36010c7d38fa
 Kemal Ataman,d247038d-c9c2-4315-a37a-d308319c720c
-Kemal Atatürk,b0713117-c1a3-4ae4-afba-5928c8ba4331
+Kemal Atatürk,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 Kemal Atay,b5ca8fb5-78df-4822-acaf-6ba0bc4bbac0
 Kemal Aytaç,08e9e269-ea51-4d4d-963b-ac3351db411e
 Kemal Badıllı,eea88740-278c-47d7-85aa-f5f3a5f0b192
@@ -3114,6 +3182,7 @@ Kemal Karhan,09aea8af-4218-4d5e-99e3-2e3acee945bf
 Kemal Kaya,8f33a455-a100-4361-978e-de05d256af03
 Kemal Kayacan,7e4ff578-bdf3-46e9-9c8b-d5b99f506e99
 Kemal Kaçar,f867ef40-9742-434e-af83-0f9bdfba6050
+Kemal Kusun,f4bdf57f-104d-472e-a5da-769df2ecc757
 Kemal Köse,09fec130-0cd3-4e60-bb39-21c7bde39f15
 Kemal Kılıçdaroğlu,86bb007b-cd15-418a-94d2-9324ce7ad822
 Kemal Naci Ekşi,8d947c96-ecb1-4329-954c-01c0dad17fd2
@@ -3129,6 +3198,7 @@ Kemal Sun,9a86dea2-06bc-4892-adf1-2c68419ebae1
 Kemal Tabak,d4077785-718d-41ff-95e9-cb229c8a48ec
 Kemal Tekden,e2d98283-f900-4d91-983a-bfa19f521425
 Kemal Terzioğlu,a9a477ff-192e-4054-84c5-cacc017b6356
+Kemal Turan,52fe9f39-65d8-4a73-a5e3-747ce85e6c52
 Kemal Türkoğlu,c360bc32-6bdc-4a73-b28f-8741af8c44ad
 Kemal Unakıtan,f20e438c-a260-4971-b8c8-fcab9ac84071
 Kemal Vatan,9bc46984-45db-4778-9fe4-41b29cb68f8a
@@ -3187,9 +3257,11 @@ Kudret Bosuter,17760f65-1be0-4ed0-b7b9-42d0bdb5457e
 Kudret Bölükoğlu,adc91d77-acaa-411d-8e45-3cdab18f58de
 Kudret Mavitan,86e06c62-0384-4fb3-93ca-a6bfe0acc59b
 Kutbettin Arzu,abe0959d-2139-4d59-b396-20e2401bf36b
+Kâmil Miras,5a07eed0-562f-4c96-8a55-ac688230d11f
 Kâmran İnan,b9a2da8f-c106-4280-b461-8c3d2a3240da
 Kâzim Bey (Oral),06c305d1-4990-4f71-a513-a2e5b73cd7d8
 Kâzım Karabekir,9a8930ca-406e-48f4-ba0e-fd57882a6e9b
+Kâzım Sevüktekin,a4884bcd-8e0d-4c12-a532-a8804da6c9ed
 Kâzım Özalp,ff08a751-e06c-43bc-bd79-f86c8f5c7c11
 Kâzım İnanç,eb8843c8-4ffd-47bd-95cf-cabda53d89d7
 Köksal Toptan,4dc35dfe-0b34-4198-bca9-7ff1a1a1ecc4
@@ -3229,6 +3301,8 @@ Lütfi Aksoy,e59f5b61-6598-4a41-aac1-4e41ff3e484c
 Lütfi Ceylan,31f3bec0-e7d5-4861-994f-52ee45bf4616
 Lütfi Doğan,ba69a638-2746-41a5-9c69-8d62ea15a603
 Lütfi Doğan,e7a427f7-808e-4714-8f1c-8a06aea6de30
+"Lütfi Doğan (siyasetçi, 1927)",e7a427f7-808e-4714-8f1c-8a06aea6de30
+"Lütfi Doğan (siyasetçi, 1930)",ba69a638-2746-41a5-9c69-8d62ea15a603
 Lütfi Elvan,00110218-2555-47b2-a2b8-a4ae16c75ef2
 Lütfi Evliyaoğlu,51b3100f-de68-4fbf-9f9c-6751a6ea3977
 Lütfi Gören,da46a06b-003c-448e-a058-fe820670e554
@@ -3266,7 +3340,6 @@ Mahmut Ataman,f84804e3-de21-460a-a222-b1758cb86dc8
 Mahmut Bozdoğan,8119c7e0-ea4b-4fa3-ae28-7aadbc68b408
 Mahmut Bozkurt,8aac3341-f943-4c5e-bee5-4fc7a55719a2
 Mahmut Celadet Gaydalı,536f1274-4be7-4860-b1f8-0a34970ce806
-Mahmut Celal Bayar,98dc21b4-167d-4069-b3f2-1ab5cda127e8
 Mahmut Celal Bayar,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
 Mahmut Dede,e6e23fa1-54b9-4de6-ad57-fbcc1275b6b3
 Mahmut Deniz,3e5bd263-ba6d-4fa1-942e-5bfc2d107adc
@@ -3351,6 +3424,7 @@ Mecit Bumin,c0dcf6e7-98e7-421b-9d96-4579cd988495
 Mecit Piruzbeyoğlu,942122a7-7ed6-4b73-8c53-392f2ba7c4be
 Medeni Berk,4f89c96f-b44d-4980-b54c-c01ead581b49
 Medeni Yılmaz,30df5cd8-88e0-43c2-9c64-434dd1fd1177
+Mehdi Eker,aea2f99a-3d32-4a85-9138-9bb4964c7aac
 Mehdi Keskin,0f4bbcb4-2c38-4e02-86b4-e1be66649b3b
 Mehdin Işık,7ec1b687-1e84-4a50-a4e3-011a82c3f090
 Mehmed Refik Kakmacı,fecc8f3e-3ac8-4a2b-86b9-02048b8cc1e8
@@ -3408,6 +3482,8 @@ Mehmet Ali Şahin,07db8d85-b95b-49a4-9db7-6c89481ca0b2
 Mehmet Alim Çınar,40557bc6-220b-469a-aaa4-e78c67dee6fa
 Mehmet Alp,2f9fa196-adea-495d-af40-4fc28975728f
 Mehmet Alp,d152982c-9713-4c42-87e1-a8e29bbbdf3e
+"Mehmet Alp (siyasetçi, 1945)",d152982c-9713-4c42-87e1-a8e29bbbdf3e
+"Mehmet Alp (siyasetçi, 1953)",2f9fa196-adea-495d-af40-4fc28975728f
 Mehmet Altan Karapaşaoğlu,64cce0ee-1ddb-4831-ab82-d27c621fe882
 Mehmet Altay,81a1e981-4e6b-4139-ba96-59d8b5cad623
 Mehmet Altmışyedioğlu,0f154d44-7d83-4d65-90a2-e46295145826
@@ -3415,6 +3491,7 @@ Mehmet Altınsoy,1379711d-53e2-42de-824e-98fd24ae328e
 Mehmet Alğan,2407a556-cba8-4faa-8727-cfca6be2e4a0
 Mehmet Arif Atalay,ec17bb64-f40a-4ad3-9fc7-eb65cc42ce7e
 Mehmet Arif Bey,a692e94f-ddd3-408c-96af-92442c254b1f
+Mehmet Arif Bey (Ayıcı Arif),a692e94f-ddd3-408c-96af-92442c254b1f
 Mehmet Arslan,f1ce9406-f280-477d-a288-ddb78dda5454
 Mehmet Arslantürk,019073c0-e90a-4eb0-b68b-739cbcf47c3e
 Mehmet Aslan,3695cee6-a9a7-4e66-afc7-21eb7bb84275
@@ -3431,9 +3508,11 @@ Mehmet Ay,35f470b3-3063-479f-a158-d8042c4ff1ec
 Mehmet Aydın,62ae678f-c9e3-4719-9c7f-8defb7aad392
 Mehmet Aydın,94960c7e-aa4f-4719-a549-54051f69dcdb
 Mehmet Aydın,c043eaa2-9492-422e-9ca1-deea7cc55e48
+"Mehmet Aydın (siyasetçi, 1928)",62ae678f-c9e3-4719-9c7f-8defb7aad392
 Mehmet Aykaç,838ba1dc-22a5-4914-82eb-ac25fd080c56
 Mehmet Aytuğ,be6a8e96-95ec-4904-929b-711aa7c5de33
 Mehmet Azizoğlu,c731e893-d632-4d70-81ea-7f52b0d96649
+Mehmet Ağar,1a2f06e6-f419-490e-ae2d-520222842a95
 Mehmet Aşkar,405a603a-bd92-4806-98b5-9dc0c14b1f58
 Mehmet Babaoğlu,39986f73-f7f1-4ad8-95a5-062ab844c9c4
 Mehmet Bahaettin Öngören,ecfcb564-1f37-44f0-bab0-9714b0528cb9
@@ -3465,6 +3544,7 @@ Mehmet Cemal Öztaylan,acb993bb-299a-402a-9047-e5240a84feb6
 Mehmet Cemil Bengü,1207aae7-96e2-45d9-8aec-d6c0bd629dd5
 Mehmet Cemil Uybadın,d0d6895e-8404-4d1c-96b4-1ef5e18b1746
 Mehmet Cengiz Güleç,c92df92c-2fbf-4645-ae15-d7d28021d4bc
+Mehmet Cevdet Selvi,8a37ad16-1842-43a4-ae37-fbe8b71d42c6
 Mehmet Cevdet Selvi,f4283185-b9fc-40ba-92c9-a2321b2f29eb
 Mehmet Ceylan,5413a9b9-3d19-45e2-8f41-4f5f80a9c1ad
 Mehmet Ceylan,b5cb052b-b9f6-4459-8d38-b3e7d27407ff
@@ -3518,6 +3598,7 @@ Mehmet Emir,6d956299-b9ad-4b13-8f87-8572b960a155
 Mehmet Emrehan Halıcı,6a87811a-4aa1-412e-b133-4be32a30cea7
 Mehmet Enginün,3bb93fd5-1631-41a7-ae36-633e717fc730
 Mehmet Eraslan,ddf3eecb-0297-4521-a612-75a29dbf58a1
+Mehmet Ercan Vuralhan,ac30230d-d2be-4785-9138-8d726b973be9
 Mehmet Erdal Durukan,2fba1a25-f08d-4dad-bdcd-d312fec8a654
 Mehmet Erdal Koyuncu,99607686-250b-41d3-b73d-c7f2ecf08553
 Mehmet Erdem,4b2c3d73-4efd-4f91-aa1f-5a02971540e7
@@ -3531,6 +3612,7 @@ Mehmet Erdoğan (Muğlalı),d3f8004e-95ee-4875-b39e-2c4fc93118ec
 Mehmet Ergül,200eccf0-4e1f-45b6-9d0b-6d0d8e97e61f
 Mehmet Ergün Dağcıoğlu,61bb0124-57d6-47ad-9bc4-64b4e3a0bab2
 Mehmet Erkazancı,337431dd-0b1d-4dea-909d-449d06018ff9
+Mehmet Ersin Faralyalı,e13c2fa9-0977-4450-b3b5-50a3759c5a47
 Mehmet Ersoy,9467907c-5df4-4e18-a959-238e2e1f6cb3
 Mehmet Ersoy,fe25f282-e2c9-44e5-825f-cefe5b11401d
 Mehmet Erten,43a55189-7019-450f-94e1-993dd5814eaa
@@ -3551,15 +3633,16 @@ Mehmet Fehmi Uyanık,2dcbfb3a-e68b-46d2-8963-f6975cf9930a
 Mehmet Fenni İslimyeli,578c876f-233d-4b94-9b75-2c808c865db6
 Mehmet Fethi Mağara,ccca0890-7ba2-4ce9-ae9a-1185998d5cc7
 Mehmet Fevzi Şıhanlıoğlu,410ca095-eaf4-4900-b7b8-3b16066e52b5
-Mehmet Fuad Koprülü,402dda26-7adf-4019-9211-f1c86178da48
+Mehmet Fuad Koprülü,01d9e29d-19fb-4fbb-b23b-ca027d00c45f
+Mehmet Fuad Köprülü,01d9e29d-19fb-4fbb-b23b-ca027d00c45f
 Mehmet Fuad Köprülü,402dda26-7adf-4019-9211-f1c86178da48
 Mehmet Fuat Carım,8652a3ca-91b9-4029-af8f-95187db61377
 Mehmet Fuat Erçetin,6ebe129c-c322-40e2-a29f-054e314fc9ef
 Mehmet Fuat Fırat,b5dfe1ae-0184-4b4c-9fe8-05b7f806270e
 Mehmet Fuat Köprülü,01d9e29d-19fb-4fbb-b23b-ca027d00c45f
-Mehmet Fuat Köprülü,402dda26-7adf-4019-9211-f1c86178da48
 Mehmet Furtun,be9769ed-197b-4c93-9920-0ea9396dd0db
 Mehmet Galip Ensarioğlu,b232a5c2-f12c-401a-b437-e37feced6ddb
+Mehmet Gazioğlu,da279d78-35c4-49fd-b2d9-d336c1c08184
 Mehmet Gedik,ff731f96-82a5-4d50-a824-e239a7ad847b
 Mehmet Geldi,c3b14316-0652-4249-abd8-016cad62b75f
 Mehmet Geçioğlu,0a067c48-9fc3-43ab-8be2-a566a0f21a18
@@ -3596,6 +3679,7 @@ Mehmet Hikmet Onat,0ee95e52-20d2-439c-a0f0-7797f0d48acd
 Mehmet Hilal Kaplan,5e38e66c-b7d6-4316-b822-337e241f083e
 Mehmet Hilmi Güler,d2b4d521-55b5-468e-80e8-b0ed9ddd15b1
 Mehmet Hilmi İncesulu,1098d721-e13b-4c20-8dcc-8686e29a26f9
+Mehmet Hilmi İncesulu,f920c447-6e9a-4505-9875-b7b10a7eaea5
 Mehmet Hulusi Akyol,545be95d-2525-41fa-bebc-f0d3bd35218b
 Mehmet Hulusi Erdemir,0e7ab8f8-f79a-465f-bb2d-2c7942e0253c
 Mehmet Hulusi Özkul,2e81856a-d7fc-4a1c-b730-5c8c162ed2b4
@@ -3629,6 +3713,7 @@ Mehmet Kemal Gökçora,bfc4bcc5-34f9-45fd-ab25-e15b03263285
 Mehmet Kerim Yıldız,e02d089c-969e-43a1-b95a-a6dc2001b2c9
 Mehmet Kerimoğlu,5ac6e2d6-70e0-4b4b-815b-f82019444d0d
 Mehmet Kesen,bd65fb7c-c6c7-403c-8a9f-858bdca66b36
+Mehmet Kesimoğlu,342f6036-28ad-4bcd-8cfe-380046791321
 Mehmet Kesimoğlu,50b6b532-aca4-44bb-b58d-ca557401a584
 Mehmet Keçeciler,b36afa76-d8f7-40d5-9bcb-c1f4a0f33b9f
 Mehmet Kocabatmaz,b6245fad-fd3f-4c44-977e-93b130c9a5b8
@@ -3753,6 +3838,7 @@ Mehmet Rüştü Şardağ,1d76a886-195e-46c3-bbb4-0feb58ff558c
 Mehmet Rıza Dinçay,a54bd42b-ad62-4600-a0b3-45ab93881f2a
 Mehmet Rıza Çerçel,5d2a2ed9-410b-467c-b118-c555a2c0ac48
 Mehmet Sabit Sağıroğlu,5862b388-6f4a-426b-ace7-1369cd044307
+Mehmet Sabit Sağıroğlu,ed20a0e7-d197-4d38-97cf-ccac305e6a6d
 Mehmet Sabri Dörtkol,3c5c0e8e-6d8b-4c89-8ab4-5d52b141d397
 Mehmet Sabri Güner,f0524a9e-ab63-4844-a3ea-be3ff79b8671
 Mehmet Sabri Kılıç,2fb48e8c-4369-460c-96ea-1059547a2925
@@ -3788,11 +3874,13 @@ Mehmet Sarı (Osmaniyeli),e7ed206f-3679-44cd-bc93-84f9644351ad
 Mehmet Sayım Tekelioğlu,252c3541-58f1-4d93-9177-f3cc32fe0f99
 Mehmet Sağdıç,f0cdb999-67a8-4ff5-a41f-3e4c6961dc64
 Mehmet Sağlam,c8f11a41-0297-4d7c-a7fe-4c37cdf7f6fd
+Mehmet Sedat Aloğlu,bb75fba4-df5e-4ce1-afb3-4257a6bc4ecc
 Mehmet Sedat Turan,fd63d429-5010-4acd-bf6d-eaa34a82d0d2
 Mehmet Sedat Çumralı,d6e831cf-6e5e-4282-b55c-d7ed54ae9571
 Mehmet Sefa Sirmen,26026c48-c74c-496b-af13-795d65192c78
 Mehmet Sekmen,ab2095f3-725a-421d-a4f5-1e42828cd693
 Mehmet Selahattin Kılıç,1c7b61da-fdc1-41ab-9966-f813a6423626
+Mehmet Selahattin Kılıç,e4e679c1-011c-4a46-a10b-b1c2f72006b2
 Mehmet Selahattin Yüksel,9e27638a-8f3b-417e-8aef-7997304dbab1
 Mehmet Selim Ensarioğlu,bf35c68a-f6b1-43ce-9316-8bde4cbb5a06
 Mehmet Semerci,c4d39435-83b7-4b20-a8b7-0d1583c841c3
@@ -3801,7 +3889,9 @@ Mehmet Seven,bdb7410e-7d72-4f19-8239-c65c3c0b35ed
 Mehmet Sevigen,7cf37c40-8ca2-4fb0-bdf8-f8f590406c7a
 Mehmet Seydibeyoğlu,b53c6ce7-cf2e-48bf-96b1-74d09a8ddfcc
 Mehmet Seyfelioğlu,f607a133-e7b1-43dd-ada2-25cd90e1db40
+Mehmet Seyfi Oktay,40853043-aeb9-4a52-8527-879945833044
 Mehmet Seyfi Oktay,47bee7b4-ba62-4b32-9db8-5539a7427a68
+Mehmet Seyit Bey,20501cea-0077-46af-a493-5fbb9a97e778
 Mehmet Sezai Pekuslu,3315ca2a-6c72-409c-9f95-5107f7caa170
 Mehmet Sincar,7fa312fb-1ddf-417e-8fa2-7486c571e173
 Mehmet Siyam Kesimoğlu,342f6036-28ad-4bcd-8cfe-380046791321
@@ -3896,6 +3986,7 @@ Mehmet Zühtü Durukan,45222e99-5e07-4837-addd-75cec4d95d11
 Mehmet Zülfü Tigrel,cb9f4590-e413-4a7c-8a08-e99dfc659232
 Mehmet emin Yurdaqul,d9f6798e-d69e-4adb-9fa9-e90d5389e9be
 Mehmet Âkif Ersoy,f246a75f-6b2d-4d1d-be44-4d91faa339c8
+Mehmet Âkif Hamzaçebi,835f265a-0529-4b66-b8d2-93499bda9967
 Mehmet Çakar,b59cc037-ee74-4ddf-a7ce-9c54a5d9711e
 Mehmet Çakıroğlu,f1c8d52c-7e24-42ab-a5b7-90bb9c7d3419
 Mehmet Çatalbaş,45001153-d0f4-435e-a4c1-3add44ebd27e
@@ -3971,11 +4062,13 @@ Melahat Gedik,d4b04801-4f13-421f-ac3e-e8185a69048c
 Melda Bayer,712ad808-ddf3-4453-8305-81589da41181
 Melda Onur,d92edc5f-b6f1-439f-87fd-bc16038c6804
 Melek Karaca,eacdeb40-3d83-41b1-964c-9a7613615e2a
+Melih Gökçek,bbc9864e-0ece-4845-8930-349209acd700
 Melih Kemal Küçüktepepınar,decf4711-c0d1-432f-a106-6b2ea109b156
 Melih Koçer,50297fb9-0e56-404e-ace0-c49afb171485
 Melih Pabuçcuoğlu,46b21e09-b91b-404a-a187-96b384a026b7
 Meliha Ulaş,141d8530-3546-458e-8824-af8f0a9d3382
 Melike Basmacı,d516c691-277f-4ac9-8dee-075531c82ca6
+Melike Hasefe,bd33077a-52f0-48a7-b4ef-cae854422229
 Melike Tugay Hasefe,bd33077a-52f0-48a7-b4ef-cae854422229
 Memduh Büyükkılıç,2d775b2d-6abb-4a35-aeb1-2da576758976
 Memduh Ekşi,c531d3da-b77f-4c3d-97bb-ccdfb4029cf4
@@ -4001,6 +4094,8 @@ Mesut Güney,8b8c8aa2-8a69-4c2b-b1bd-7069a4b42b44
 Mesut Hulki Önür,2b76890d-5e63-46d8-9c20-088c8ef8881d
 Mesut Ozansü,b95f01d9-eb82-4b09-9412-8ae2c85ae75b
 Mesut Türker,56cd8058-d417-40fd-9005-4d4e1606949d
+Mesut Yilmaz,303d56c9-65c3-4b05-bc87-3f1425406a89
+Mesut Yılmaz,303d56c9-65c3-4b05-bc87-3f1425406a89
 Mete Bülgün,8faa6253-a0c4-430f-af59-c06b3ad55745
 Mete Tan,d1ccee57-b93e-42d8-b887-c92833433322
 Metin Arifağaoğlu,958715fc-a7ea-44eb-ab73-7ca5e95461f3
@@ -4036,6 +4131,7 @@ Mevlüt Ocakcıoğlu,b7e48c00-8116-443a-b5da-9a65cdf80631
 Mevlüt Yılmaz,e087c4fb-e242-44fd-a030-4b0a498508bd
 Mevlüt Çavuşoğlu,0f7eb6e1-ca85-43e8-b7d1-f52bb54e56b9
 Mevlüt Önal,d825e379-0c84-4c59-a0b8-31c872a0b783
+Mihal Kayakoğlu,96b1d015-3bfc-4106-a8fb-34b2cd2c4f7c
 Mihal Kayaoğlu,96b1d015-3bfc-4106-a8fb-34b2cd2c4f7c
 Mihrali Aksu,a004cc19-8349-4e4e-a407-2b1bbdec951f
 Mihri Pektaş,a54889a2-9e35-455b-b463-35f1da74a3d8
@@ -4089,6 +4185,7 @@ Mucip Ataklı,c80e9282-8132-4a45-af41-3904f536c918
 Mucip Kemalyeri,cc06fc86-b5bd-47f1-a9da-2a0e10e7c51e
 Muhammed Murtaza Yetiş,4f21f429-939a-4df5-a2ca-ca681509b0c3
 Muhammed Rıza Yalçınkaya,5402ad3e-f5ee-4ecb-bbc5-c24e5b71ff31
+Muhammed Rıza Yalçınkaya,9f26af5f-3578-4801-a9e6-838db7e69c76
 Muhammed Çetin,0de2eba1-2f2c-478f-8fdc-dfd0bc8e1d9a
 Muhammet Balta,2747bfef-0870-40b5-b1b5-ce085036ca0d
 Muhammet Bilal Macit,89205b13-38bb-487b-8ccc-2c991015316e
@@ -4257,7 +4354,7 @@ Mustafa Duru,215b4613-3b74-4599-bfa3-e2e130d781c5
 Mustafa Dündar,0e11e00d-54d7-4245-92f5-1e23106109af
 Mustafa Düz,dc8bd789-e9f0-495d-a72d-c2ac133cc815
 Mustafa Ebrişimoğlu,c657524c-cf68-474e-802c-56b7cc062617
-Mustafa Edip Servet,2f649ab8-dbee-4ccb-87bd-ebf23f3b8a09
+Mustafa Edip Servet,e9524a9b-7cba-4c05-aca0-ed88468b323e
 Mustafa Edip Tör,e9524a9b-7cba-4c05-aca0-ed88468b323e
 Mustafa Eken,9ae94ee8-947d-46bb-8832-004bd892f3ed
 Mustafa Ekinci,ebb4e890-33a9-4693-9c9c-edcc44950d9b
@@ -4312,7 +4409,7 @@ Mustafa Kabakçı,78d67653-02e7-4511-8711-3481596edd02
 Mustafa Kaftan,cb1ee4a5-3aaf-4f1c-9d5d-0ba0e0a058a3
 Mustafa Kalaycı,0021cf04-06fd-4b43-8177-21113da5c4c3
 Mustafa Kalemli,f046a5d1-23db-4208-a8cc-6bb06757fa8f
-Mustafa Kamal Atatürk,b0713117-c1a3-4ae4-afba-5928c8ba4331
+Mustafa Kamal Atatürk,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 Mustafa Kamalak,55a076e1-8d64-4b7d-aec3-fcd37d3bad7b
 Mustafa Kamil Dursun,fe61a430-358a-4eb4-8074-fe9512abd074
 Mustafa Kani Bürke,0bb9e107-b5ed-4739-b642-e587be1f13ea
@@ -4323,7 +4420,8 @@ Mustafa Karaman,2ceb6c6f-200f-47c5-a36c-d5da0bdba57b
 Mustafa Karslıoğlu,3fb71792-db10-4b6a-9857-06431b626cc9
 Mustafa Kaçmaz,345ce086-baf9-4a1b-b274-ac147e314a0e
 Mustafa Kemal Alver,a40cb813-3841-4d98-bb7a-c247d7c293c9
-Mustafa Kemal Ataturk,b0713117-c1a3-4ae4-afba-5928c8ba4331
+Mustafa Kemal Ataturk,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+Mustafa Kemal Atatürk,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 Mustafa Kemal Atatürk,b0713117-c1a3-4ae4-afba-5928c8ba4331
 Mustafa Kemal Ateş,8f5d306c-0051-446f-b69d-44fba6274114
 Mustafa Kemal Aykurt,9eee164f-1190-42d4-a35f-3546e74d796c
@@ -4345,8 +4443,8 @@ Mustafa Kemal Çilesiz,96867b9c-5dad-4298-9bec-ee7ea026b96d
 Mustafa Kemal Özer,aff4016c-2486-459f-a5ab-e503d39bb9e6
 Mustafa Kemal Şatır,a2542122-e4a2-4fbd-a57f-774688d0ee8c
 Mustafa Kemal Şerbetçioğlu,ae6bdc28-f322-41dd-8bf5-8e6c5138a8fa
-Mustafa Kemalis Atatiurkas,b0713117-c1a3-4ae4-afba-5928c8ba4331
-Mustafa Kemals Ataturks,b0713117-c1a3-4ae4-afba-5928c8ba4331
+Mustafa Kemalis Atatiurkas,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+Mustafa Kemals Ataturks,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 Mustafa Kepir,e258abad-9c9f-4f4d-b39a-d3de8d87054d
 Mustafa Kerem,588c0508-bdfa-45c2-986e-c428ee8d97f2
 Mustafa Korkut,286caaf8-be44-4c9d-a79a-d86a096b5ca5
@@ -4391,11 +4489,13 @@ Mustafa Rona,1d7c5f0a-132c-4dc4-80e5-1a52c8c1ac4c
 Mustafa Runyun,c8b78ce9-c40a-4191-bd0d-9f101055cecb
 Mustafa Rüştü Taşar,54e9738e-8510-4b1e-b4cc-c4c3b1504633
 Mustafa Rıfkı Yaylalı,413a3a46-b2bd-40ee-9f14-68806c572f61
+Mustafa Sabri Baysan,37ba7ffa-c6c7-4d6d-9607-03f5b38280b2
 Mustafa Sabri Güvenç,1a88679d-92ba-4563-9fc2-ba5ff895328e
 Mustafa Sabri Sözeri,da3e8e41-b131-4a33-bbbe-12604e3c9752
 Mustafa Sabri Süsoy,29609f07-f6a1-4554-95b3-213a85e2148f
 Mustafa Said Yazıcıoğlu,e3a5d1e8-36d0-41c7-b3e8-6c6d7ac6c5ef
 Mustafa Sait Gönen,9144df3c-6ace-45d4-8642-a3935a7df593
+Mustafa Sait Yazıcıoğlu,e3a5d1e8-36d0-41c7-b3e8-6c6d7ac6c5ef
 Mustafa Saraç,379d1b04-d404-4feb-83e1-70ef2dce75b4
 Mustafa Sarıgül,6a111fc6-5a6f-493e-a4b8-97835318f3d7
 Mustafa Sayar,4639a57e-99ca-49b2-958f-cee4484e0f4a
@@ -4415,11 +4515,14 @@ Mustafa Tınaz Titiz,c6b91dbb-725e-4f30-9f6c-214cc1722b43
 Mustafa Ulusan,530919e5-2a29-4344-8722-cc17a8f91ffb
 Mustafa Uyar,08cb30c8-a291-4203-b0c7-d9a7f96e76c3
 Mustafa Uğur Ener,43d25158-3ff1-43fb-9f13-5b69438d3c82
+Mustafa Vasfi Süsoy,29609f07-f6a1-4554-95b3-213a85e2148f
+Mustafa Vasıf Karakol,e8cd624e-f24f-4d08-89f4-d6a85ea791ae
 Mustafa Vedat Önsal,52edd7f0-d0cf-45e9-968e-32cab06b70ca
 Mustafa Vehbi Bilgin,8440a3ce-2d6a-4769-abda-b040dc51592f
 Mustafa Verkaya,04021be6-20bb-4fa0-b5e4-2204d5dcf733
 Mustafa Vural,60384f61-cf79-43c3-8f18-f72df517939f
 Mustafa Yaman,5cf24c39-dca8-45b5-b418-2a338ef77c78
+Mustafa Yaman (1949 doğumlu siyasetçi),5cf24c39-dca8-45b5-b418-2a338ef77c78
 Mustafa Yel,95d8402e-61a5-4937-ac53-ba8e4f2eb319
 Mustafa Yeneroğlu,65beb0cc-469c-4ff7-a0ca-42184d3212c4
 Mustafa Yeşil,0e90ac01-fe69-4c1d-9fa5-1c45451a7e2f
@@ -4452,8 +4555,13 @@ Mustafa Öztin,3764cb02-901d-4aaf-b60a-00016702d0a9
 Mustafa Öztürk,2e851bb1-b387-4998-9cc6-83da78a4a03e
 Mustafa Öztürk,744f3ba6-0bbb-4d18-a02c-82835ffe8fac
 Mustafa Öztürk,7510e2e1-0c00-43e1-8bb6-eda6118c1d60
+Mustafa Öztürk,8dded154-7366-41fd-91b5-c895db0b5548
 Mustafa Öztürk,ab3b381c-4233-4a37-aed6-59c8892d9fda
+Mustafa Öztürk (Afyonlu),2e851bb1-b387-4998-9cc6-83da78a4a03e
+Mustafa Öztürk (Bursalı),7510e2e1-0c00-43e1-8bb6-eda6118c1d60
+Mustafa Öztürk (Hataylı),744f3ba6-0bbb-4d18-a02c-82835ffe8fac
 Mustafa Öztürk (Sinoplu),ab3b381c-4233-4a37-aed6-59c8892d9fda
+Mustafa Öztürk (Tuncelili),8dded154-7366-41fd-91b5-c895db0b5548
 Mustafa Özyurt,a31c1a18-5150-4310-be48-830a01029bf4
 Mustafa Özyürek,848f04b0-9d6e-43be-94d9-e7d9ef59a5a0
 Mustafa Ünal,eac46dcc-cb10-4246-92fe-7c11c6371bde
@@ -4476,7 +4584,7 @@ Mustafa Şükrü Bey,9f9d6e55-7e08-436f-8625-59d0964d95ae
 Mustafa Şükrü Elekdağ,9069606b-921c-436c-bdc2-8d69073332d8
 Mustafa Şükrü Koç,3d719bba-b2c5-4c91-899e-12f9772ed0da
 Mustafa Şükrü Nazlı,1f500e18-41a3-476c-ad6f-dc3a7e96926b
-Mustapha Cemal Ataturcus,b0713117-c1a3-4ae4-afba-5928c8ba4331
+Mustapha Cemal Ataturcus,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 Mutlu Menderes,4e9ba70b-0530-49a7-8cca-405d14482f30
 Muzaffer Akalın,f5422597-5a8e-4918-80a8-3f987d6d072e
 Muzaffer Akdoğanlı,adcdd712-34f8-4860-b85d-63e8cc73119f
@@ -4540,6 +4648,7 @@ Müjdat Kuşku,437c9999-e7fd-4308-8968-4c4e23fb79aa
 Mükerrem Hiç,85cc1dd7-6357-4e46-b363-b9d3114b4c1f
 Mükerrem Levent,d3a2d73b-3f30-48eb-a89a-fbf5867ee149
 Mükerrem Sarol,318638e4-2cb8-48ab-8b5d-dbffcc344f5a
+Mükerrem Taşçıoğlu,c0378642-5294-486e-a0cb-545939de368b
 Mükremin Taşkın,cdcd5f47-106d-4190-bd30-64bd9924f27f
 Mülkiye Birtane,7518567a-c046-4fb5-83f3-82d484ed7662
 Mümin Gençoğlu,824d38ae-e389-44a5-a41d-cd510ea7a805
@@ -4549,6 +4658,7 @@ Mümtaz Faik Fenik,fe8d3bd3-cd76-4b8f-b54b-d5e7b430883c
 Mümtaz Güler,8729413d-7dbf-4fde-a6ca-4f8a8cfb7a5a
 Mümtaz Kavalcıoğlu,7d073a34-83cd-40a0-bfab-1ea5ccf2194b
 Mümtaz Kaynak,76ac0a77-ea2b-467a-9561-e391402de457
+Mümtaz Soysal,273004ea-d2e1-4ed2-8b51-595639b7849b
 Mümtaz Soysal,b818f8d3-c869-4224-90e5-6b15554eb23b
 Mümtaz Tarhan,10d7c5c1-d388-4067-a191-da4c9fbb95e1
 Mümtaz Yavuz,21925a49-5212-4361-8302-ff4c7313e403
@@ -4579,9 +4689,11 @@ Müştak Aktan,a0509251-59dc-4ed7-9f99-b02e7953031c
 Müştak Okumuş,e90b8663-d9a3-40eb-8345-b8d5c3ea2dfd
 Müştak Torbo,e2aaac94-bfeb-42f0-b1ff-6541f662f724
 Mıgırdıç Şellefyan,b0a2c35f-3290-4fed-8dc5-43bdd431a968
+Mıstefa Ağa,8dded154-7366-41fd-91b5-c895db0b5548
 Məhməd Əmin Yurdaqul,d9f6798e-d69e-4adb-9fa9-e90d5389e9be
-Məhmət Fuad Köprülü,402dda26-7adf-4019-9211-f1c86178da48
+Məhmət Fuad Köprülü,01d9e29d-19fb-4fbb-b23b-ca027d00c45f
 Məmduh Şövkət Esendal,45967855-639e-42d6-ba6d-fb9682171ddc
+Məsud Yılmaz,303d56c9-65c3-4b05-bc87-3f1425406a89
 Nabi Avcı,a18d5e39-4f1d-42a6-9fcf-cb405bac46af
 Nabi Avçı,a18d5e39-4f1d-42a6-9fcf-cb405bac46af
 Nabi Poyraz,06324fe4-704c-4ef6-a41b-9978fb3a345b
@@ -4592,12 +4704,14 @@ Naci Aslan,a4cdc569-32f7-4ca8-9201-734be909f96a
 Naci Ağbal,37dbc8c3-f7fe-4a67-9782-07035d96a0eb
 Naci Berkman,4c7eb020-3c69-41f1-8488-c6c4a0ffde25
 Naci Bostancı,78ce37eb-6180-4e66-86e4-d6618c34d2ec
+Naci Eldeniz,7de7d51e-03de-4885-9acf-7bafe2554f83
 Naci Eldeniz,c6f10a6c-08e0-4e19-a0b5-ce4115e3456e
 Naci Gacıroğlu,9e0dc3d6-7a3d-451a-85e1-c4d4493001f6
 Naci Güray,6ac3cae8-4984-4c0d-abe4-be6207ada7f6
 Naci Taşel,9e48c340-4c8f-4731-b6eb-4f4277c8c06f
 Naci Terzi,ff067b9d-ae95-4524-aa58-4976f0a669f6
 Naci Tınaz,147464d1-31a3-42ef-8102-e2b054786316
+Naci Tınaz,9256d486-6351-4914-beb2-cb60848d8b6b
 Naci Yıldırım,0cd48b98-9412-4eae-9651-c9673f3ba96a
 Naci Öktem,1d3c9a95-7109-4562-8c66-f339f437789f
 Nadir Kartal,81a314cc-03e6-4009-b98e-e420294b5ae1
@@ -4610,6 +4724,7 @@ Nadir Yavuzkan,2936bfc5-59e2-4f95-a095-9492d23965e9
 Nafi Atuf Kansu,c589fe5e-b215-4dbe-bea4-62d3a0a05d71
 Nafiz Aktın,7aa44374-2059-413b-9ebf-7c0eb604da0d
 Nafiz Giray,1941843e-8388-481b-9a92-cc561e23714c
+Nafiz Kurt,2bf40ac6-6d02-4f4e-bb99-f875f4ebfc1e
 Nafiz Kurt,8a116fae-99da-4495-9d39-4dc7f0946311
 Nafiz Körez,ebf89eb7-2481-4c8d-bd9e-132fcf95f395
 Nafiz Tahralı,47bd84d2-c1e2-400e-b1fa-1ca8f22a0f30
@@ -4655,6 +4770,7 @@ Nazif Okumuş,b08fdce8-4c9b-4ad2-8eaa-f020cbeb25ed
 Nazif Topaloğlu,c8a52cc6-1cb2-419b-ae33-70c40eb6d174
 Nazifi Şerif Nabel,710db25b-61ee-46e6-b3cf-0f9fefde6a63
 Nazire Karakuş,bb67e5e0-e2b3-452a-a822-48035fd257f8
+Nazlı Ilıcak,e3593d74-d206-4fac-aee7-70bd478fca78
 Nazlı Tlabar,e31d3fcb-823a-4edd-ab9e-39b0d4b6fa95
 Nazmi Ataç,a233e043-4959-4d43-8426-89c6d518fbd6
 Nazmi Gür,06a16e5d-a1a7-4b6f-b09d-05692bc3dccb
@@ -4668,6 +4784,7 @@ Nazmi Çiloğlu,0a95b688-f3ec-483a-9708-0e0854b79ba5
 Nazmi Ökten,25f92c30-a7ee-4d4c-a1ea-5883039fd733
 Nazmi Önder,7670346b-d8d3-44c5-8547-ebf7a42945bf
 Nazmi Özoğul,9dca8a8f-718a-40a9-b208-c8856e171e41
+Nazmi İlker,b8fabebf-dbf1-44e8-ba73-d7edd49d7384
 Nazım Ağacıkoğlu,32e9bff1-e799-43f0-b2fa-56aa2795ac9a
 Nazım Batur,58293cfc-a104-4cbd-88d3-5d8644f30738
 Nazım Bayıllıoğlu,001e31c9-b499-4066-8074-86cfe1d43d62
@@ -4678,6 +4795,7 @@ Nazım Resmor,058b303d-b3bb-4897-9ab7-e4d386d0e81c
 Nazım Tanıl,35a62c06-7237-4d63-95f6-b235122162f9
 Nazım Önen,af0e7364-c4bf-48db-ac8c-5515b8789776
 Nazım Öztürk,2e15fa2a-1a76-48ba-ac32-95f805aa03ce
+Naşit Fırat,a7623850-caae-4146-94f2-a91f7c3abc16
 Naşit Fırat,fa4aa08c-d7e3-4239-8a3c-802659b4bfee
 Naşit Hakkı Uluğ,76e36e4d-e5d4-4f0a-baf6-b380f92624ab
 Naşit Sarıca,14ce5bb5-2656-4228-98dd-ce72ea1d474d
@@ -4735,6 +4853,7 @@ Necip Oğuzhan Artukoğlu,7fd9c745-844b-4670-ac50-550510e5be76
 Necip Soydan,1f7872a1-5bd3-4cdb-9c0f-0a0373194414
 Necip Taylan,ed483a65-86bf-47df-af77-6aa7a1c6befe
 Necla Arat,b4bdc633-c236-4fe4-8b4f-f97ba4398835
+Necmeddin Molla Kocataş,2c49670e-8268-4822-add0-1e61e59fa659
 Necmeddin Önder,6193a38c-ed8f-4e15-81b8-dbaa4045081c
 Necmettin Akın,4854e7b9-e78c-41ec-8736-aaacebea6f9c
 Necmettin Aydın,450b71ec-1a35-424d-826f-bf769eba2244
@@ -4747,6 +4866,7 @@ Necmettin Erbakan,1969c424-ef8c-4348-ade8-67e3b3979c96
 Necmettin Gönenç,2d2d70f0-4d9f-4152-82c7-ac5eb153b785
 Necmettin Karaduman,ae8cc313-bca7-415d-9fb5-c1823b718632
 Necmettin Küçüker,01f5cf4d-05f9-47a0-9f39-88fa84221e15
+Necmettin Sadak,a5980128-93fd-428f-9928-f03e76e10b82
 Necmettin Sadık Sadak,a5980128-93fd-428f-9928-f03e76e10b82
 Necmettin Sahir Sılan,319b417b-8bf2-4173-b080-6400d83d1274
 Necmi Arman,18251bf6-ddc8-49b9-82b6-9aa1e3b5e358
@@ -4787,12 +4907,14 @@ Nevzat Ayaz,5ad83370-9447-4438-aef9-558cac9863d9
 Nevzat Bıyıklı,f397db87-9494-4d4f-9725-f007d15f616e
 Nevzat Ceylan,d69d779c-d30d-4eac-be6c-9da62789a72a
 Nevzat Cihat Bilgehan,80a07708-ae6e-43bd-9668-cff2bb1a92a7
+Nevzat Cihat Bilgehan,aea395ae-e52f-49a5-85ea-9969e8fb6a4e
 Nevzat Doğan,64cd5e9a-9be2-44a0-b1c1-300a66d1894b
 Nevzat Durukan,93f75d60-c7ac-4314-85ef-f6691d32a77a
 Nevzat Ercan,d5a07b07-741a-4535-9a86-6b10aee48da3
 Nevzat Güngör,3d1d76dd-a6eb-4924-aae2-e3603dba475e
 Nevzat Köse,8f7d229f-3a7f-4b6d-824c-55536cca4b0a
 Nevzat Köseoğlu,2ea9a300-da32-49ee-99be-c290deecc1cf
+Nevzat Kösoğlu,2ea9a300-da32-49ee-99be-c290deecc1cf
 Nevzat Pakdil,6e3c4c02-675a-41ff-9e42-e9de3741a9e1
 Nevzat Palta,5e57b1fa-4e13-4e4c-9284-151a4aaae0be
 Nevzat Tandoğan,eec968cf-333a-408b-913b-22064197d812
@@ -4810,6 +4932,7 @@ Nezir Büyükcengiz,ee1a9a3b-9b9f-43ee-8b16-d6b3d620b1fc
 Neşet Akkor,8eeef90a-958c-4ce3-a20f-cb15c79ccd70
 Neşet Ömer İrdelp,ed2cb6d1-0c07-413e-843d-13d47f5522d0
 Nidai Seven,4c60a897-adf5-4b37-8070-aefa1ddeddcb
+Nihad Kürşad,a12bcd14-5aea-4677-becd-68ff2691ea0f
 Nihad Matkap,5e220800-d207-442d-8e09-3882917e1b15
 Nihan İlgün,4fb2c390-bec7-4766-89be-c49b09793a75
 Nihat Akdoğan,d8521f9f-f377-45c3-a595-6bb142eb5278
@@ -4874,12 +4997,21 @@ Numan Gültekin,9b8b8ccf-da16-4e4e-ae0e-605fdd936e68
 Numan Kurban,411ccba0-778a-492e-8e79-9438e4e9b663
 Numan Kurtulmuş,1b8b4ab8-406d-4c12-a4fb-cf68b88691b0
 Numan Menemencioğlu,84247e79-7d33-42f7-9c5f-2af622138a01
+Numan Ustalar,1d465f6e-f9f8-4824-a5e9-3f84b640091e
 Numan Uzun,e9624872-0010-45da-8f73-5a81b24395a3
 Nur Doğan Topaloğlu,067c12a9-5350-40dd-97bf-17e6c8923057
+Nur Serter,893db21d-fdef-44c1-af07-8c17e0d7bbf7
+Nur-Ur Din Pacha,70672dee-818c-49a5-84f1-227b49753518
 Nural Karagöz,c281fb26-b372-4bfc-a2c0-5a07826c7560
 Nurcan Dalbudak,bda19350-0652-478a-af29-3a70d1036cb7
 Nurdan Şanlı,920383b8-b001-48f7-b603-b096194b48a4
+Nureddin Ardıçoğlu,50e25215-6212-47b3-a886-01db0ac4a1f5
 Nureddin Nebati,86ee1b1f-f86b-4868-bc77-10c0629a9234
+Nureddin Pascha,70672dee-818c-49a5-84f1-227b49753518
+Nureddin Pasha,70672dee-818c-49a5-84f1-227b49753518
+Nureddin Pasza,70672dee-818c-49a5-84f1-227b49753518
+Nureddin Paşa,70672dee-818c-49a5-84f1-227b49753518
+Nureddin İbrahim Konyar,70672dee-818c-49a5-84f1-227b49753518
 Nurettin Akman,1edb16e4-be07-439d-b365-fa859913da23
 Nurettin Aktaş,8e1d36a6-4623-4162-9a13-aac7f7a26256
 Nurettin Akyurt,3359be03-8cd6-4176-802d-ea00360e4421
@@ -4911,6 +5043,7 @@ Nuri Bayar,fce21154-b624-410d-b6e2-aa8a8d0bac4a
 Nuri Beşer,2cdca3ae-6034-44dc-8cf5-25194d06456a
 Nuri Bozyel,5877488e-9446-4444-b09f-677015b0338a
 Nuri Ciritlioğlu,64ef7623-224e-44fa-93e8-993816009493
+Nuri Conker,4fb43215-aa33-4a48-9438-beedc5cfa945
 Nuri Demirağ,c032a983-64c7-4a40-86eb-2750f09a7747
 Nuri Erdoğan,74abb085-a3c8-4703-afea-9cc17d87f845
 Nuri Eroğan,bb1505f2-18e3-4f81-abdc-39420c720fda
@@ -4929,6 +5062,7 @@ Nuri Turgut Topçuoğlu,0d0d148c-69c9-4444-93c3-82b332dfc569
 Nuri Uslu,58352665-73c7-4e20-947c-526e19e57e5c
 Nuri Yabuz,67cb638f-da4c-405b-8375-ccdfc99736bf
 Nuri Yamut,b44ab38e-8978-4aec-9f38-b20da62e92cd
+Nuri Yamut,c798e817-75b9-4568-8e7c-1b7912ef8842
 Nuri Çelik Yazıcıoğlu,bc6b9226-c7dc-47e7-9c3f-48ad48abccbb
 Nuri Çilingir,8683d750-bb66-4840-8577-91b87867e719
 Nuri Özsan,aff7e1cd-157c-4d35-b8aa-7439d33f4b5d
@@ -4962,6 +5096,7 @@ Oktay Çanak,bc3b1bc5-cbd6-4dd9-b344-65bb15b935b4
 Oktay Öztürk,6f366f5d-06b0-4fc7-906c-9f955aa3da34
 Onur Başaran Öymen,a8cb4f61-456c-4a07-96f3-78ce139374bb
 Onur Kumbaracıbaşı,e4013e45-3c77-4018-9778-182b7cf1e34e
+Onur Öymen,a8cb4f61-456c-4a07-96f3-78ce139374bb
 Onural Şeref Bozkurt,97ea2804-4ffa-4d66-a5df-5ebc83cd66a2
 Onursal Adıgüzel,54b53954-1bee-41d6-a79b-f2f41248efb5
 Oral Mavioğlu,e0919c33-29b3-4f2d-b83b-1383bdb0e473
@@ -4988,8 +5123,10 @@ Orhan Erkanlı,aabefa9d-3d5c-4bf1-8b64-618a4719608e
 Orhan Erzurum,52577bea-01ea-47af-af73-988b0b8cc8d9
 Orhan Eyüboğlu,cda0a945-5016-4118-b116-aed80a6476cd
 Orhan Eyüpoğlu,2a24ac9b-ef31-429e-af03-d69101d1c8fb
+Orhan Eyüpoğlu,3b78e5bb-5217-4959-a2f0-3600af2b5eed
 Orhan Ferruh Eyüpoğlu,3b78e5bb-5217-4959-a2f0-3600af2b5eed
 Orhan Göncüoğlu,d2b16ef1-b7f5-4a16-8589-1ebad57786c4
+Orhan Kabibay,15ef9544-6eb2-418a-9629-f7add0704878
 Orhan Kabibay,711a5e4c-e447-40ad-ac2d-d2683af868e5
 Orhan Karasayar,4b042883-f3d0-48bd-83ba-cc49377059b4
 Orhan Kavuncu,966597de-7f96-4b7f-96c7-16424fcb4292
@@ -5004,6 +5141,7 @@ Orhan Otağ,8cc8b71f-b5af-4144-92ab-f0c6cc56d5ec
 Orhan Oğuz,e5d3b2f9-fb9a-4e45-b80f-b5d2fbb821c3
 Orhan Oğuz (siyasetçi),e5d3b2f9-fb9a-4e45-b80f-b5d2fbb821c3
 Orhan Sarıbal,d784344d-cde7-49e5-ab79-02b63046a0b8
+Orhan Sefa Kilercioğlu,799c2096-6781-46f7-be38-370aeab751d7
 Orhan Seyfi Orhon,7808b408-7710-4163-bbbd-2bdd35e4b004
 Orhan Seyfi Terzibaşıoğlu,0adf5d4c-f18b-455f-a28c-9933f425505f
 Orhan Sezal,fc868b79-e016-4b62-96bb-95672334f77b
@@ -5073,6 +5211,7 @@ Osman Kaptan,1d404fb7-b5bb-4012-b5fd-abb65a6f22b7
 Osman Kavrakoğlu,457758e9-5a84-4c9d-8f2f-3a1b827cb5f8
 Osman Kavuncu,444ece39-5dc9-4017-b79a-346e6ee052a9
 Osman Kaya,3dfe4867-561f-47cf-969a-8e70bdbb192f
+Osman Korutürk,23e9a0fb-98a2-4ec4-b267-a8f7fc241cf8
 Osman Kılıç,9a2bb49c-91a9-4183-9864-d327f493db0e
 Osman Kılıç,f525c32a-e689-4144-a474-3e73be320f4a
 Osman Müderrisoğlu,f62318ca-78ae-407f-bc48-7767cee485e6
@@ -5105,8 +5244,11 @@ Osman Taney Korutürk,23e9a0fb-98a2-4ec4-b267-a8f7fc241cf8
 Osman Tarı,8ae5e4bd-fe2a-48a9-8af2-1394c50bb6c3
 Osman Turan,cb2de2ff-5880-4540-9d36-3349ee143a4d
 Osman Uşşaklı,aecb4a78-0bb6-4a8a-bf07-3d78f77601e7
+Osman Yağmurdereli,4d51ab1c-4124-4df7-9280-054e6b7c0e0b
+Osman Yağmurdərəli,4d51ab1c-4124-4df7-9280-054e6b7c0e0b
 Osman Yeltekin,56354e21-1785-4dce-866f-49710844dfdd
 Osman Yumakoğulları,22d0c260-ca80-4286-ada8-fa917bb8082c
+Osman Yüksel Serdengeçti,8a57a369-3d35-4008-a464-3ff970d8565a
 Osman Yılmaz Karaosmanoğlu,3e692595-7197-412a-8db1-9a6e4697adc0
 Osman Zeki Oktay,ebd02de9-11ce-4c02-873a-d63f44cbc5a2
 Osman Zeki Yüksel,8a57a369-3d35-4008-a464-3ff970d8565a
@@ -5122,6 +5264,7 @@ Osman Özer,07c89e33-42f5-48ff-b1ac-61a85affa6cc
 Osman Özçelik,7e644ef7-618e-476c-9c00-f57c288a8d0e
 Osman Şahinbaş,ccf49bf8-5cb4-40de-a7cc-aace868204e1
 Osman Şahinoğlu,c095e9dd-e744-4813-8b1a-d67fd1ad1b30
+Osman Şefik İnan,b006377f-07b7-4463-9950-94740f8446ae
 Osman Şefik İnan,fec5dcd8-5a68-49ea-b230-98c979ac6ca7
 Osman Şevki Süsoy,21dacacb-95cd-47d8-b5b3-4116b9dec501
 Osman Şevki Uludağ,88f5e7e8-7cb0-42c9-80ab-3b80708b3578
@@ -5161,6 +5304,7 @@ Ragıp Karaosmanoğlu,86156567-225a-4510-97f5-4ab950be20fb
 Ragıp Soysal,850b0f99-01e0-464d-9f42-ca671b3801d0
 Ragıp Yoğun,90d4a60c-06f6-4f8a-95d5-adaae3d22d71
 Ragıp Üner,79869f19-8d21-4960-82b3-3a282e337797
+Rahmi Apak,c5beef1e-2f00-42c9-a53a-a65caf50ef60
 Rahmi Aşkın Türeli,1fd376d3-86d3-4674-8eca-d8880e0f7545
 Rahmi Günay,4efc28ec-283f-4b16-92b5-0cdbb19c8624
 Rahmi Güner,7900c7f6-002c-4809-a817-82ab56b52fff
@@ -5207,9 +5351,11 @@ Rasim İlker,b042cb4f-168f-44cc-a610-fe769838689d
 Ratip Tahir Burak,0563e194-86df-43d6-8810-33a39dfe355e
 Rauf Bayındır,3c439391-edd9-468c-bbfa-56d280974474
 Rauf Benli,ea525dba-5056-4963-87db-8b61fdbb4c4d
+Rauf Bey,c897a10b-39ef-4ea8-a585-ddfe834a92a0
 Rauf Kandemir,02bdaeec-f512-4530-93c8-965f1717f4be
 Rauf Kıray,288f5a6d-96d6-46c9-aaaf-482d6ee1ff9d
 Rauf Onursal,340ae060-55d9-420a-9f9b-b5f7bb8944e9
+Rauf Orbay,c897a10b-39ef-4ea8-a585-ddfe834a92a0
 Ravza Kavakcı Kan,a0f1dffa-4981-4b5f-b7c6-e07daff29ee5
 Razi Soyer,f6aa7323-363b-4150-8b28-479f87c76c1e
 Raşit Börekçi,4da9fc96-a1fc-4d78-a363-f5f15ef05e1c
@@ -5220,6 +5366,7 @@ Recai Berber,98f112c5-e229-49e1-816e-69cce9a71bab
 Recai Birgün,34d4ba95-4f11-4e0c-b956-21b79939e9a2
 Recai Ergüder,39f7a7a9-7afa-4383-b760-23f064307db3
 Recai Güreli,fb04d6c5-d9dd-480a-bd2b-3f1ff20f942e
+Recai Kutan,01b10bd7-2ba2-4d1f-b797-4952863baff5
 Recai Yıldırım,38b0c078-4ec7-4c4c-88dd-783f2fc4fe2b
 Receb Tayyib Erdoğan,8eb878de-9491-47b1-b5a0-a01675095109
 Recep Akdağ,4d11f24c-b61c-491c-ba73-5db808d76627
@@ -5253,6 +5400,7 @@ Refet Sezgin,ce8805d2-1e45-4ae6-b5d6-d33d64aa573b
 Refet Seçkin,5a73c361-0a61-4546-bf0c-44e63f623836
 Refet Tavaslıoğlu,ff653858-301f-41c9-bde9-931398fefef2
 Refet Topçuoğlu,320561fc-f4ea-4e54-8e48-e610a4b8564d
+Refet Ülgen,00a27340-6a1b-4795-8e2a-dbd4b0ec16c4
 Refik Ahmet Sevengil,16188330-1f6d-4bb5-ab5a-e085c9094b47
 Refik Aras,0d255631-980d-4fa0-81f8-939f6613835e
 Refik Arslan,43d33cbc-d2be-4384-8f4d-4a73bdf5656c
@@ -5350,6 +5498,7 @@ Rüştü Pasha,84c5ffed-073a-440d-892e-76becbee9663
 Rüştü Paşa,84c5ffed-073a-440d-892e-76becbee9663
 Rüştü pasa,84c5ffed-073a-440d-892e-76becbee9663
 Rüştü Çetin,a9b1e337-570f-42ea-9811-2fcf2fa04121
+Rüştü Şardağ,1d76a886-195e-46c3-bbb4-0feb58ff558c
 Rıdvan Budak,2ac8986f-e4ae-48af-9c37-2a33ba9f0dd5
 Rıdvan Nafiz Edgüer,993abec9-19fe-471e-90cf-fc4775512bb7
 Rıdvan Turan,4f3edb15-feb4-4d3d-8152-7fd88492f76b
@@ -5387,7 +5536,7 @@ Rıza Türmen,ec36b2de-c587-4c6f-bd8b-249d0a6a9f16
 Rıza Ulucak,254cca9c-4526-4df1-b3c2-73270e087b1b
 Rıza Vamık Uras,b8d6170c-9725-4712-b058-7a3e01eb7207
 Rıza Yalçın,a5674c38-87e1-49fd-bdd0-ae6cd278141a
-Rıza Yalçınkaya,5402ad3e-f5ee-4ecb-bbc5-c24e5b71ff31
+Rıza Yalçınkaya,9f26af5f-3578-4801-a9e6-838db7e69c76
 Rıza Yılmaz,ca53fd52-8365-4c5f-8095-a636f0ffd1cd
 Rıza Çuhadar,daef9c5c-6c22-4ea0-9523-56a0838efc08
 Rıza Öner Çakan,90734faa-939a-4460-a6dd-b76147b854ae
@@ -5418,6 +5567,7 @@ Sabahattin Sönmez,e2e72503-26e8-476d-8310-fa9e323c86cc
 Sabahattin Yıldız,8a412eb5-4e3c-4345-bc55-d3def5d711e2
 Sabahattin Çakmakoğlu,0cdf1deb-6c8b-4269-9922-6df904917980
 Sabahattin Çıracıoğlu,5865c784-eaf7-4d75-afdc-b22309c54401
+Sabahattin Özbek,5d4eab21-5c21-482e-9c97-4fb29d3c1537
 Sabih Duralı,abf9b02f-cd8b-4aa7-9bbf-23982459fb48
 Sabiha Gökçül Erbay,5b582608-3992-4086-b162-b5726bb10233
 Sabiha Görkey,1c0c2b64-49ae-48ca-8f0b-eff0828f1974
@@ -5450,6 +5600,7 @@ Sabri İşbakan,f4a3e9ea-daa8-45f7-aa6e-46d03ac97cd7
 Sacid Yıldız,79386da3-60c6-4eac-8616-d6b49a772812
 Sacit Günbey,fe42a31a-e714-4438-894f-f8af5eb437b6
 Sadettin Ağacık,2ddafa3b-4879-43af-8913-7eb7d3f9e7d4
+Sadettin Bilgiç,0c26ad3b-4521-48a9-a184-edc267badd4b
 Sadettin Bilgiç,24a9619f-ef7c-41c9-b9a4-c2b7758aee8b
 Sadettin Epikmen,db552279-7893-4100-bfe4-5cb3618613ac
 Sadettin Ertur,9221add8-4453-4e1d-a893-5da8f81552fe
@@ -5497,6 +5648,7 @@ Saffet Baştımar,30723bce-ed26-4f28-bd69-46c125230f45
 Saffet Benli,daae59ae-9b9e-4602-aa51-f025cdaa0088
 Saffet Eminağaoğlu,f3a6ba96-3b8b-4bef-8699-7ef65f891968
 Saffet Kaya,e0ada675-ca42-4a29-8da7-ed4bf2810c51
+Saffet Kemaleddin Yetkin,90ba9146-41f7-40e6-8634-b83a906d636e
 Saffet Kemalettin Yetkin,90ba9146-41f7-40e6-8634-b83a906d636e
 Saffet Sakarya,0cef5e1f-fbeb-4e04-b32a-f3c24bc66938
 Saffet Sancaklı,7c42ced8-5873-46ae-92f0-567d1274bd75
@@ -5536,6 +5688,7 @@ Sakallı Nurettin,70672dee-818c-49a5-84f1-227b49753518
 Sakarya,1bbb0f87-78c4-4e8d-a774-7e73d8b00280
 Saki Zorlu,4f63d138-7190-4120-b775-30c31e7f6017
 Sakine Öz,348c0214-52b7-45eb-a5dd-48fc39b2f046
+Salah Cimcoz,db12e7bd-1b75-4aa1-88e9-6a5b1d1b7a7b
 Salah Yargı,3e7413e6-7f66-4c7c-90d9-8f6efd5ca4d0
 Salamon Adato,400721bd-216f-4b00-83b3-981f72bbea6f
 Salih Alcan,11583ade-c6bb-41dc-8634-77b369393f46
@@ -5556,6 +5709,7 @@ Salih Hayali Yaşar,5948c0bf-059d-4645-b17c-a4cb18413cb1
 Salih Kalemcioğlu,b291c240-cf0c-4efe-b062-e5f45d31e00e
 Salih Kapusuz,f0140c12-cc3a-40eb-b664-5e99ce191f7d
 Salih Koca,3de652d1-1e5e-4aaa-a133-f5cad887c482
+Salih Ragıp Üner,79869f19-8d21-4960-82b3-3a282e337797
 Salih Sümer,13e6d0d2-ce0a-47dd-8b08-1c178dbfea9b
 Salih Süreyya Gençağa,ab7ff01e-8f22-4f37-add7-0fa923242b5b
 Salih Torfilli,82fcb788-1ca3-433d-94b3-fa4c901561c9
@@ -5569,6 +5723,7 @@ Salih Çetinkaya,b7371b55-034f-477c-a2a4-41749ccb2875
 Salih Özcan,9acf29ee-6a39-4475-830b-26cce07cfe6d
 Salih İnankur,e2ab612c-487a-4156-943e-afcb72c9ce0e
 Salim Altuğ,c6cf9837-a84f-4d59-a3ad-8f00ffae589c
+Salim Ensarioğlu,bf35c68a-f6b1-43ce-9316-8bde4cbb5a06
 Salim Erel,1a67afe8-8a03-40fa-89b0-7b683cb7e810
 Salim Esen,ef510e53-a2e1-4dbf-b01e-1925ccb36689
 Salim Korkmaz,e60965ef-a61b-47be-9105-b62a5bd89558
@@ -5602,6 +5757,7 @@ Samim Yücedere,6ca31a82-3384-4d94-b36a-65bc06860d29
 Samsun,155cebb2-63ec-4bd9-9d27-bd6701bf9e7f
 Samuel Abravaya Marmaralı,7fbfc043-cb5e-4e08-9ebd-ed606a5d86f4
 Sani Yaver,8d1ea4d6-6978-44d2-8293-71574c6b84d6
+Saruhan Oluç,3f7eb6e1-6276-4286-9303-df7ac22d4b31
 Sebahat Tuncel,2792be99-2d45-4e95-8469-ab4adde9dbf7
 Sebahat Vardar,a3dde381-ce8a-451f-a946-a0d66044b5f6
 Sebahattin Karakelle,7ab478c5-e89d-4e74-a9a0-08476e0b486e
@@ -5613,6 +5769,7 @@ Sedat Akay,ebff61e0-9da0-497c-ba3d-6bb08c6387b5
 Sedat Aloğlu,bb75fba4-df5e-4ce1-afb3-4257a6bc4ecc
 Sedat Baran,08f51446-bd98-4481-8786-c3ca64856cf9
 Sedat Barı,22a7d33c-c530-4894-b913-98e003745242
+Sedat Bucak,96ede054-2b11-4a60-ba8d-5d6a7f05e588
 Sedat Dikmen,c9b96241-0bf3-4a47-910a-00fb82a12bd4
 Sedat Edip Bucak,96ede054-2b11-4a60-ba8d-5d6a7f05e588
 Sedat Kızılcıklı,c70ab7f0-2e85-424b-a0f9-5a85a08a4690
@@ -5675,8 +5832,8 @@ Selim Herkmen,c1ac5adf-65f6-447f-a5c8-268fdd9310b9
 Selim Koçaker,fc39bb00-86b1-4487-bd70-c33a603584e6
 Selim Ragıp Emeç,8033630e-07c9-476f-afca-0fb1739bcb8a
 Selim Rauf Sarper,83be9657-bf66-4d10-bbeb-c6c64dffb412
+Selim Rauf Sarper,d9afdc10-b7a7-48a4-8c1b-a80331669da5
 Selim Sadak,d12b5773-25e2-49b1-a3f9-5cb71a71fc98
-Selim Sarper,83be9657-bf66-4d10-bbeb-c6c64dffb412
 Selim Sarper,d9afdc10-b7a7-48a4-8c1b-a80331669da5
 Selim Seven,56f272d6-402e-4f65-af97-47b94fecf49d
 Selim Soley,5d964c49-b463-433d-8227-eca426b26cc2
@@ -5688,6 +5845,7 @@ Selina Doğan,408bbd88-f4d3-4057-a011-db349c38a588
 Selina Özuzun Doğan,408bbd88-f4d3-4057-a011-db349c38a588
 Selma Aliye Kavaf,786cfc12-7167-4d1d-83f0-c88e229a731b
 Selma Irmak,c166f239-cdff-445f-bff4-565e7d9ae86e
+Selâhattin Köseoğlu,47c80d4f-8679-4c17-b1d3-fffe3a3d3411
 Selâhattin Âdil,384fcaa9-a660-45c7-908d-9d173ad4e344
 Selçuk Akıncı,bf08b94f-1e26-4f76-a9aa-4981b360f9c9
 Selçuk Ayhan,1d86dbd8-763b-46fd-be68-695e757b1f5f
@@ -5759,6 +5917,8 @@ Sezai Ergun,c22a0f87-94d4-4e74-85cc-d35ece9589bc
 Sezai Orkunt,64114d99-1c6f-427a-b957-552589a5bda2
 Sezai Sarpaşar,d507488f-40da-44ba-8ffb-36e711ccbc7d
 Sezai Temelli,c8b21bd0-efeb-4ba5-a3fd-9405be457b70
+Sezgin Tanrikulu,36df5bbc-0c97-4ac0-92b9-3eff4b0a0106
+Sezgin Tanrıkulu,36df5bbc-0c97-4ac0-92b9-3eff4b0a0106
 Seçkin Fırat,48c73b72-28ab-4c5d-a8d3-f7adc5eb45c5
 Sibel Gönül,5050a9dc-7998-4983-ab52-63cc8bb1ca46
 Sibel Yiğitalp,d4723419-4f88-4d22-917f-9d2f7c328ad7
@@ -5789,12 +5949,14 @@ Suat Önal,43102685-dfaa-4104-8e6c-12f135313359
 Sudi Mıhçıoğlu,836cc942-0fa0-46d4-9088-a653cd50837f
 Sudi Neş’e Türel,1e9bf7b2-b988-4df0-bdd9-40f2d2cd6370
 Sudi Reşat Saruhan,849c75ef-08d1-4917-92bc-880fa731e981
+Sudi Türel,1e9bf7b2-b988-4df0-bdd9-40f2d2cd6370
 Sudi Türel,ca4dd506-27c0-4a4f-827f-f9963a162511
 Suha Tanık,2574e958-2e6c-41d4-9915-9b9ed4ed8386
 Suheyp Karafakıoğlu,033265d0-53a0-40d6-b6c6-6bd65c9aabe1
 Suleimanus Demirel,3c495593-df52-4b97-bdb1-87e7c32f38b8
 Sulhiye Serbest,6272eb95-d4c9-40b8-96fe-6df914a52c77
 Suphi Artel,afedfa3e-0f10-4f77-8ab0-f2a7c7e2301f
+Suphi Batur,b3eebe73-3d18-49a5-9338-cbb97497c5a8
 Suphi Baykam,efdfaf1e-8a55-4aef-a7c4-5bad3f592c09
 Suphi Bedir Uluç,c8a7e648-3eed-4fd1-a9fb-d7615fb118a1
 Suphi Ergene,63cd8312-0a91-4478-a392-86a351010900
@@ -5856,6 +6018,7 @@ Süleyman Çağlar,c7c980c6-2625-4943-9960-4c69f3c1fc13
 Süleyman Çelebi,78d335b5-de60-44e5-93fb-2d0eb1c8acc3
 Süleyman Çelebi,954d9ef8-36c9-47bf-95fe-9c567a682e08
 Süleyman Çelebi (sendikacı),954d9ef8-36c9-47bf-95fe-9c567a682e08
+Süleyman Çelebi (siyasetçi),78d335b5-de60-44e5-93fb-2d0eb1c8acc3
 Süleyman Çiloğlu,5d885350-b839-4f54-a9ef-bceb7bbe8739
 Süleyman Özsever,bdff9d16-8197-4882-a3f9-5b2bb727bec2
 Süleyman Ünlü,0cb841a5-9277-4398-858d-0f3ef5e343b3
@@ -5893,6 +6056,7 @@ Sıtkı Salim Burçak,79ba7b37-4126-4091-9a86-b64c44a3dffb
 Sıtkı Turan,63fea29e-fcdc-41ad-b80b-6d48e22f5f5f
 Sıtkı Üke,ae730a8a-2fc9-4aaa-8647-c6226d3cc163
 Sıtkı Şerif Eken,d47cba0f-967e-4c4c-9ff3-7588d22e74f1
+Sədat Edib Bucaq,96ede054-2b11-4a60-ba8d-5d6a7f05e588
 Sədri Maqsudi Arsal,a33d6817-98a8-4467-9fbb-e79009d43c41
 Səməd Ağaoğlu,ead8d1e0-0319-47e6-a0eb-37c847583a0b
 Tacettin Barış,324f1877-21a9-4fda-a073-a940768af592
@@ -5964,6 +6128,7 @@ Tarık Cengiz,4d414d05-e14a-42f7-9ab8-50040e76ab1d
 Tarık Gürerk,d089496a-d853-480a-9c4d-c66964e8925e
 Tarık Kozbek,397535f5-76ae-4a81-a037-58ce02c0d41d
 Tarık Ziya Ekinci,f5210483-1ef5-45ec-ba07-10b4c377bce4
+Tayfun İçli,b87a782f-2eff-4274-b956-0a613e9e009e
 Tayfur Sökmen,da15799c-4c87-4ef4-9bb5-b70285e855fd
 Tayfur Süner,bd3f99c8-bce6-45ee-9001-6353191af600
 Tayfur Ün,910b2ec7-8c75-495b-a1f0-a6e6395b595c
@@ -6023,6 +6188,7 @@ Tewfik Rüstü-Aras,dab79c7e-e965-4935-ae40-9c4422fa0968
 Teyfik Fikret Övet,b092dec9-dc94-462b-942c-9270b27be3f5
 Tezer Taşkıran,785a6a1c-076d-4fb5-9451-ba0e2c920b9b
 Timur Demir,da8fd49c-529e-4f9c-af1d-82ffccbd4018
+Timurçin Savaş,6773fb45-33a1-4bc2-9ef6-06851c38ce34
 Timuçin Savaş,6773fb45-33a1-4bc2-9ef6-06851c38ce34
 Timuçin Turan,b766ccae-3756-4cb2-bb71-08bf48ece041
 Togay Gemalmaz,891d431e-17c5-41fd-ae19-1c3ebc9fee44
@@ -6039,6 +6205,7 @@ Tunca Toskay,3c8f7ef9-4e27-416e-937a-df953c9d458f
 Tuncay Ercenk,8638edb8-1135-440a-a99f-0a2460d19c16
 Tuncay Karaytuğ,9955eb9c-de3c-44e2-874c-2b1985fa6623
 Tuncay Mataracı,1a48746f-c64b-4dff-be3e-cb5049c41947
+Tuncay Özkan,61f10d69-18cc-47f5-b675-3d833a887cdc
 Tuncay Şekercioğlu,d6e9756d-aebb-4268-a27e-36d9dd170ba7
 Tunceli,9eb353aa-4e91-44d4-b26b-6aa4a8b03a45
 Tunç Bilget,c0d3b892-1127-4b1e-b5b5-688494bc2583
@@ -6063,6 +6230,7 @@ Turgut Sera Tirali,2f1fa132-87a8-4234-9d26-40409e121f48
 Turgut Sunalp,c2fc4e81-25be-42c7-9a38-86250555cf9a
 Turgut Sözer,bcec1c30-138f-4192-90cd-7d91403d6262
 Turgut Tekin,5e9cce35-79c9-400e-9ea9-b4e19ae3e90e
+Turgut Toker,04d7e635-aec2-4131-92f5-7c152f27ebba
 Turgut Toker,2f875cfa-49a5-492e-a18a-ba735f010fa1
 Turgut Topaloğlu,2f01c990-02d5-43cd-8d26-bfa55827e7ec
 Turgut Topaloğlu,4e3c727a-d314-4459-9af9-fa3dd79bdbd9
@@ -6105,8 +6273,11 @@ Türkan Miçooğulları,b18051e6-c397-468f-ac34-e049e5600858
 Türkan Seçkin,8e0c6eb2-7cc3-43cf-8c49-096388a9c414
 Türkan Turgut Arıkan,3ce3d803-715b-42b4-8dbe-874305cd6cba
 Türkan Örs Baştuğ,e0a15f90-000a-4458-9f03-8d82d7b35aa8
+Türkân Akyol,ac582dea-3664-4264-9318-b8962a6e10a4
+Türkân Örs Baştuğ,e0a15f90-000a-4458-9f03-8d82d7b35aa8
 Tınaz Titiz,7bbbd2b7-7932-4e3c-8fbf-177c07c6f557
 Ufuk Söylemez,02570212-609c-48eb-8051-26d209813579
+Ufuk Uras,d8d7f6e0-5832-4f7d-801e-bf29c4f6de16
 Ufuk Özkan,e2be5351-680a-4fde-98d2-decd44cf4a6a
 Ufuk Özkan (siyasetçi),e2be5351-680a-4fde-98d2-decd44cf4a6a
 Uluç Gürkan,ea2a2bd4-8568-4a21-a64a-66690784e4fd
@@ -6281,8 +6452,11 @@ Yunus Kılıç,844ffcec-f423-40b8-b8a7-3ab72c653b3e
 Yunus Nadi Abalıoğlu,23852149-e92f-46f9-b592-fa4075b2687e
 Yurdusev Özsökmenler,aa46855f-2a5e-4b30-a68e-b18efac2446d
 Yusif Ziya Ortaç,06b1c10a-b2ef-4e3e-a844-f8b60b56695c
+Yusif bəy Akçuralı,c999f612-40a2-4233-91c4-1e64472f8ac2
 Yusuf Aktimur,a274cda0-0147-4340-b5de-f34868d04719
 Yusuf Akçora,c999f612-40a2-4233-91c4-1e64472f8ac2
+Yusuf Akçura,c999f612-40a2-4233-91c4-1e64472f8ac2
+Yusuf Akčura,c999f612-40a2-4233-91c4-1e64472f8ac2
 Yusuf Aysal,c600dbf6-de8f-4485-ba00-3bc399346ff9
 Yusuf Azizoğlu,632a9e4a-1edb-4889-a645-b292df7ca257
 Yusuf Bacanlı,f31560b4-efe3-49ee-936d-75b652ee3fec
@@ -6301,6 +6475,7 @@ Yusuf Gültekin,9621d362-ce87-4ce3-b9b4-d979eac199fe
 Yusuf Halaçoğlu,e3b4e884-f3be-47cc-9091-4fd87605402e
 Yusuf Hikmet Bayur,388e0ed1-d63b-4e42-9141-c7a7faeb0ae2
 Yusuf Hikmet Bey,388e0ed1-d63b-4e42-9141-c7a7faeb0ae2
+Yusuf Izzet Pasha,b1ae0c60-b4f8-474e-aeee-8d747377029e
 Yusuf Kamil Aktuğ,9862f6eb-d2f5-410e-bed0-a578d3207822
 Yusuf Karslıoğlu,ad12d8bb-99fc-4145-8821-540f8b790b88
 Yusuf Kemal Tengirşenk,e382f965-bc25-42d6-be02-475f53c2a69e
@@ -6319,8 +6494,11 @@ Yusuf Selahattin Beyribey,cf3bee0c-67ef-447e-9ec2-5dc74528dbfa
 Yusuf Ulusoy,084061a9-224a-41b2-a81b-da85f3571ede
 Yusuf Ulusoy,32cb7246-1db6-4494-8655-02efe9d03768
 Yusuf Uysal,4e49cdb2-e8a5-4b92-9d58-0f306dc4356b
+Yusuf Ziya,f7be8f0d-7887-40de-8f64-d5ba7dca2f74
+Yusuf Ziya (Koçzade),f7be8f0d-7887-40de-8f64-d5ba7dca2f74
 Yusuf Ziya Bahadınlı,f66b8d73-1fff-4d4f-b8ff-5f1f59ce8387
 Yusuf Ziya Başara,c79d78b5-e33f-4496-82fe-1d9c8178ef59
+Yusuf Ziya Bey,f7be8f0d-7887-40de-8f64-d5ba7dca2f74
 Yusuf Ziya Eker,dbf438e1-baa1-4ddc-8135-f8b340acc6c6
 Yusuf Ziya Eraydın,8556f304-73f6-49b3-a79e-723bdd02a33c
 Yusuf Ziya Kazancıoğlu,f6082f9f-2b65-4614-87a3-2c28906d4384
@@ -6341,8 +6519,10 @@ Yusuf Ziya İrbeç,22dc35d6-7d8d-4e01-b8da-6d64275adc22
 Yusuf Ziya İsfendiyaroğlu,5986a0ce-1086-4706-a291-903ffb95869c
 Yusuf Öztop,9c23f14b-981a-499a-af08-11699cb32dd5
 Yusuf Öztürkmen,767df6da-b56d-422f-9c9a-343da7964cde
+Yusuf İzzet,b1ae0c60-b4f8-474e-aeee-8d747377029e
 Yusuf İzzet Akçal,ae596547-2a27-4950-a034-f04a9f93a74e
 Yusuf İzzet Met,b1ae0c60-b4f8-474e-aeee-8d747377029e
+Yûsif Ziya,f7be8f0d-7887-40de-8f64-d5ba7dca2f74
 Yücel Artantaş,a6d93b0f-46aa-4a68-9aa0-fd35d47721a0
 Yücel Dirik,1f8eb5d5-9161-4fe0-b652-4a7fcc027cae
 Yücel Erdener,563df044-8156-4ded-8395-0dbf322ef978
@@ -6362,6 +6542,7 @@ Yıldıray Sapan,3d6486be-2481-48fa-a79e-906255b292a6
 Yıldırım Akbulut,ca255c61-008b-42f9-bdd1-adb3697e786e
 Yıldırım Aktuna,c5ac3178-c009-4248-aed5-e51a34e61d95
 Yıldırım Aktürk,39c62369-a376-48c3-9eb6-3783cedb572c
+Yıldırım Avcı,3d5f1713-8468-4b4f-83fe-8c95546f736a
 Yıldırım Mehmet Ramazanoğlu,e3176904-ed03-4818-a812-e0c5a064d6f8
 Yıldırım Tuğrul Türkeş,9d0d8eda-9b01-4a59-821f-bd24959b774e
 Yıldırım Tuğrul Türkeş,c6b87b15-4c3a-43af-ab04-8ff0633e7f5e
@@ -6382,6 +6563,7 @@ Yılmaz Sanioğlu,b18e9428-3cf1-4ec3-a5c1-6180e6b139ed
 Yılmaz Tankut,45fc40b8-3931-4e34-9ff9-e12cd180089e
 Yılmaz Tezcan,9b718827-6d77-49bf-98f6-5c23ab1bab70
 Yılmaz Tunç,1a1f4201-7962-48bb-870e-d45e3cb085d8
+Yılmaz Öztuna,88ac40ec-1671-43d0-b3a7-fe3c063edba8
 Yılmaz İhsan Hastürk,d48f78b6-ce4f-4200-8b4e-75c8417519ac
 Yəhya Kamal Bəyatlı,fdd92963-1e3a-4a88-aac6-5ebf8cd3d453
 Zafer Gökçer,7521853c-9b00-40f4-aaa7-261dee8c75de
@@ -6389,6 +6571,7 @@ Zafer Güler,78477c29-8c1f-4e61-b38e-adab51a48118
 Zafer Hıdıroğlu,e7583361-75a2-4d91-9cbe-d14352b19eb4
 Zafer Nihat Özel,cfba247a-a3b7-4fa0-a0a2-cb32780489c7
 Zafer Çağlayan,d7f5cc4f-1224-4cd9-893b-65e6ab26252d
+Zafer Üskül,73824f9a-a53b-48b3-b4a8-ba907d9c2e2f
 Zahit Akdağ,148d786f-d7f4-46e5-b81c-a3ef1c822266
 Zakar Tarver,9270cb36-cbc5-41e4-8d5a-6182c575dfb6
 Zamir Arıkoğlu,64c6fc7f-37f8-4bf3-8412-6e653809aa3d
@@ -6426,6 +6609,7 @@ Zeki Mesut Alsan,1821b27d-f286-426d-9d9d-c6863b73fedc
 Zeki Mesut Sezer,39427702-f028-4985-a5c0-e70bdf0942a2
 Zeki Nacitarhan,39c9baa9-ca23-4ab2-b76f-41b1d64aacd7
 Zeki Rıza Sporel,67652d95-582c-45cd-972a-32c2a566ff45
+Zeki Sezer,c1e74b88-9ea5-47ae-b2b9-e89d86863fcc
 Zeki Tarhan,30feece4-7ca6-4522-99ff-a9c21d849238
 Zeki Yavuztürk,0930ba46-8975-4b0f-bcd5-d6894cd5bbd5
 Zeki Yağmurdereli,d9c0fa17-d7d7-4d1a-9742-8f7b93e054b2
@@ -6491,6 +6675,7 @@ Ziya Çalışkan,4fcfef49-3c37-4321-9a44-b805b4a8d1b4
 Ziyad Ebüzziya,718e51a0-a836-403c-b0fd-0a3dcf0026be
 Ziyaeddin Gözübüyük,f84c56dc-db84-4188-9fcf-ffffa58ca69e
 Ziyaeddin Selçuk Maruflu,2ce8bebd-1217-445b-9085-93ab2deef618
+Ziyaettin Tokar,ef12bb2b-0ee7-4d9e-80f6-16f442dc1398
 Ziyattin Yağcı,7539bf1f-4b56-47b0-9d45-38c61c95813a
 Ziyo koʻkalp,cd79d45b-a944-4666-9df4-68a0d43901f4
 Zonguldak,a67b5c86-d20e-401f-84d3-9b43746adf12
@@ -6498,7 +6683,7 @@ Zuhal Topçu,f93c19f2-9461-47ef-bc25-b1d026fcb7f5
 Zuhuri Danışman,6adacf80-9050-4cd1-bf11-23f5b4612fd7
 Zübeyir Aydar,76d16e68-8910-4202-971a-1f35073a0168
 Zühal Topcu,e9858714-9237-4298-ba45-bfb2fde2671c
-Zühal Topçu,e9858714-9237-4298-ba45-bfb2fde2671c
+Zühal Topçu,f93c19f2-9461-47ef-bc25-b1d026fcb7f5
 Züheyir Amber,bbabd99b-48cd-417b-94db-07f9942e668a
 Zühtü Akın,fb7d5c57-9566-4b8b-bf6a-900725f40ad8
 Zühtü Hilmi Velibeşe,2e0adecb-7868-474f-81f9-2d8e848e6d82
@@ -6507,6 +6692,7 @@ Zühtü Uray,1e14afb7-beb3-4564-83c5-2791b6aec88a
 Zülfikar Gazi,3d738133-23c7-484e-8951-23693a9e3b80
 Zülfikar İnönü Tümer,8883688d-6e5a-45a2-a744-aa22a1cdb657
 Zülfü Demirbağ,b3b37a6b-a6a8-4633-8452-08f3a56b9c46
+Zülfü Livaneli,66c29288-d499-44a8-8bb5-e66ed24f4716
 Zülfükar İzol,70f4c419-a09f-4e3a-ac06-b10151032c1f
 derin DE RIN,b1d14954-da1b-4038-b90d-cf92d3adeb91
 ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
@@ -6515,6 +6701,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 Çağla Aktemur Özyavuz,f1c836e2-8827-4100-906f-ce195282cdda
 Çağlar Demirel,14b5c944-cbcc-4882-adb7-e37250c73946
 Çağlayan Ege,a20f1861-8d34-4421-b6fe-2833c3da38b3
+Çerkes Reşit,41a21c68-523a-47dc-83c7-742e59c665ed
 Çerkes Reşit,c35eacc7-57f5-4a91-b464-8690d9ff4066
 Çetin Altan,95f39678-1b6a-4255-908a-58bdf7e20b9e
 Çetin Arık,11f8072c-19be-4bd2-ba73-192baba0c91d
@@ -6631,6 +6818,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 Ülker Can,9e2a1f72-a97c-45e3-9f34-cc70ee321751
 Ülker Güzel,a205f409-1773-4ddc-85ef-f81e55cd46b0
 Ülkü Gökalp Güney,c870a674-ba5a-40d2-a450-035ec8c05d29
+Ülkü Güney,c870a674-ba5a-40d2-a450-035ec8c05d29
 Ülkü Söylemezoğlu,344e2e7a-e359-42df-aa05-99da96108ee0
 Ümit Canuyar,2ecde1e2-039b-4af7-a219-daf82ac27adc
 Ümit Haluk Bayülken,a6b6777b-33d7-4ec4-818f-d066ce0dc45a
@@ -6717,6 +6905,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 İbrahim Melih Gökçek,bbc9864e-0ece-4845-8930-349209acd700
 İbrahim Mete,92a4a133-d629-468a-9db8-e91cb8cacfbe
 İbrahim Mete Doğruer,50cdd929-afbc-46f6-a3ca-4f2cd84250f2
+İbrahim Nami Çağan,5647f7d4-688e-4a0c-a90d-067299330465
 İbrahim Nami Çağan,d8c94f59-fd91-4df8-bb3a-5a2d248ecbae
 İbrahim Necmi Dilmen,88958625-acf0-4232-ae93-88fac3fa0e81
 İbrahim Rauf Ayaşlı,bf972e4e-bfb6-4fde-a452-832e3957344c
@@ -6740,6 +6929,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 İbrahim Turan,37273a58-58e4-4429-9f9c-fea7fa14e275
 İbrahim Turan,d075f325-b8ca-4efa-bfee-2dd9391c35da
 İbrahim Turhan,7c0c7a85-36eb-4684-8ec0-7752ab77492c
+İbrahim Turhan,d1c04c7e-1726-40ff-85e5-7fd7bc749f96
 İbrahim Tâlî Öngören,d25bfb00-b230-4c2f-a499-338ff1917821
 İbrahim Us,86194f33-a9e4-4e6d-898e-f038f245c33f
 İbrahim Vecdi Aksakal,39809bba-814d-437c-86ae-e23c7510706e
@@ -6753,6 +6943,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 İbrahim Çebi,4c4403b8-7de4-4176-aa16-604669457fea
 İbrahim Çirkin,abbb8cd7-b89a-4db3-9939-8f18dd99adc2
 İbrahim Çolak,2d299924-f560-4205-b3da-338f78a84bb7
+İbrahim Öktem,003a330a-cda8-4bd6-9b84-5edbd4bb0a9a
 İbrahim Öktem,5abfe84a-d540-4329-ac31-5ef38d88f6c0
 İbrahim Özbıyık,cffccc7b-7654-4b4d-8f78-a2f9b7c48537
 İbrahim Özdemir,29829de3-ad21-4e3a-a6e6-5f1cb2f7a080
@@ -6776,6 +6967,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 İdris Sami Tandoğdu,c176d5c2-ea71-46a1-84d8-1d1093f5ae5a
 İdris Yıldız,dda15fd3-b96e-4edf-8ebd-1cdfd8ab0b3d
 İdris Şahin,debbf480-1c98-4136-9cb9-f73654408653
+İhan Egemen Darendelioğlu,f8e681a5-ca08-447a-bcc2-3cb5619220ce
 İhsan Ada,8eccbb18-7fdd-44b4-8955-5f420a4d7966
 İhsan Akhun,eabb3b54-cad2-45ae-9864-48e84fea7cb6
 İhsan Aktürel,d3727993-53ab-44d7-8023-c9ae393738e1
@@ -6792,6 +6984,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 İhsan Gürak,1e0702ae-5f3b-494a-9606-91d5dd677be3
 İhsan Gürbüz,51a66122-728c-4eaf-9e9c-23e57242efee
 İhsan Gürsan,2efab9a9-0c2a-479c-a41a-9ee8f2334c37
+İhsan Gürsan,ea7bfae3-e487-44c8-9156-2c2897a368f2
 İhsan Hamit Tiğrel,d3866b31-a12a-4673-8499-8090b21d7376
 İhsan Kabadayı,2d5ea0dc-cb88-4d04-a9db-e5414bf6744d
 İhsan Karasioğlu,78a2dfca-c991-4f5a-bea6-0d62af4e965f
@@ -6805,6 +6998,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 İhsan Sökmen,03ceb289-7357-4d48-91aa-c579a66a65c2
 İhsan Tav,e3daaeb1-3d16-4bf7-886c-62114a36cff0
 İhsan Toksarı,f9842d48-d53e-414c-8298-eee986bb3d7f
+İhsan Tombuş,1ccdf1d4-bb53-401d-8a7b-b82045db8ee7
 İhsan Tombuş,a0713c74-04f2-45ef-aa63-5c23d0a34303
 İhsan Yalkın,53aa6f90-f75d-4bef-9afd-0f7e35d2d515
 İhsan Yalçın,b77c632f-67cd-44a2-86f1-7ef0d940d3ee
@@ -6816,6 +7010,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 İhsan Şerif Özgen,a4825efb-af22-4960-95d4-a7d4ec326a73
 İkram Dinçer,0ea2aade-c855-4b02-bb03-bca00d6b9a68
 İlhami Binici,5da02b94-6ed4-4486-9af8-541410115470
+İlhami Sancar,76ccda6b-2c78-409f-9064-b873dbb2622f
 İlhami Sancar,9d914fe6-5d6a-47d0-a560-eb24f60ec9f6
 İlhami Yılmaz,bcb6565a-8669-40cc-9f0e-bd0e1c6fb992
 İlhami Çetin,72aaff1e-4f7a-4b3a-9f94-42e48d3c3417
@@ -6831,6 +7026,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 İlhan Demiröz,993d1bd6-6634-4c82-a396-f1010d7a4619
 İlhan Dinçel,3fcbf297-c6b9-48df-a7a5-f59938ce271d
 İlhan Dizdar,27cb3f04-023d-4505-9b27-ac2286b86531
+İlhan Egemen Darendelioğlu,f8e681a5-ca08-447a-bcc2-3cb5619220ce
 İlhan Ersoy,a7488fec-7456-4f34-8dee-56cd71e2a8ae
 İlhan Evcin,a380ce33-b4f4-4836-a98b-4e90a5651093
 İlhan Işık,e73a9468-11a1-4b60-8e1a-995ecfbe3f55
@@ -6920,11 +7116,13 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 İsmail Güneş,53d658e4-ba36-4530-8dec-6a9fbf80acbd
 İsmail Güven,55036a67-e3c3-4e41-bd05-121df17188fe
 İsmail Habib Sevük,ccbfaef2-8c17-4265-8c5a-389961bcea1c
+İsmail Habip Sevük,ccbfaef2-8c17-4265-8c5a-389961bcea1c
 İsmail Hadımlıoğlu,bd6a5445-624f-4b36-b9d6-8495f4979d6c
 İsmail Hakkı Akdoğan,78391ed1-c941-4965-aadd-6bf29c96d443
 İsmail Hakkı Akyüz,82b94563-9560-4b20-ba9c-c1c79f1353fa
 İsmail Hakkı Alaca,6f80d2a1-3f3c-4449-b4b0-d201da07b1de
 İsmail Hakkı Altan,897ec2be-7b0a-418b-ad7a-a50093fffd9e
+İsmail Hakkı Amasyalı,36d3eb30-2aba-4bad-8041-9d744f255e09
 İsmail Hakkı Arar,a9011892-d2d3-4641-8976-f966c78bffb6
 İsmail Hakkı Baltacıoğlu,69603703-2a83-460b-9423-6652ad5cfc63
 İsmail Hakkı Baykal,5ff79c4b-43cd-4d59-adc3-ed910e79cd42
@@ -7198,6 +7396,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 Şükrü Abbasoğlu,797f7e0f-5214-48ec-8efa-40ce3d3c4ac7
 Şükrü Akkan,8d9d5de3-4333-40ba-8b93-1266a7291a3e
 Şükrü Ayalan,f22d273f-9f7e-473d-a19e-db414cd9032b
+Şükrü Aydındağ,e73dff7a-e86e-4cfd-8b17-f535296616ab
 Şükrü Babacan,b07415c3-5f20-4255-8455-66365976e070
 Şükrü Bütün,d3962dd9-4ca2-4630-b186-27f7b7308338
 Şükrü Elekdağ,9069606b-921c-436c-bdc2-8d69073332d8
@@ -7211,9 +7410,9 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 Şükrü Naili Gökberk,5d2d2333-9faa-40c5-92a4-4ea94fa71da8
 Şükrü Saracoğlu,1f1bd5fa-b3fc-43bf-9d00-328db7c85c80
 Şükrü Sina Gürel,748c7735-d628-45cc-b704-c4124247e8ff
+Şükrü Sökmen Süer,46b6dce2-d0fe-486d-8e5a-736c09cd4cf1
 Şükrü Sökmen Süer,79332aca-a306-4bcb-be0c-83a2a82af473
 Şükrü Sökmensüer,46b6dce2-d0fe-486d-8e5a-736c09cd4cf1
-Şükrü Sökmensüer,79332aca-a306-4bcb-be0c-83a2a82af473
 Şükrü Uluçay,b85b31d6-9918-4704-918e-095f28940635
 Şükrü Yürür,4ae2eec9-ec44-40b4-ba08-4057fdd66689
 Şükrü Yüzbaşıoğlu,b8b50bce-ac45-4c31-be2e-eb8ea1ab9235
@@ -7242,28 +7441,33 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 Ισμέτ Ινονού,0f6a5be4-39cb-404f-b94a-aecc5753fb56
 Ισμαήλ Τζεμ,07d1070f-9bd2-44a2-add9-01c6f365788b
 Κεμάλ Κιλιτσντάρογλου,86bb007b-cd15-418a-94d2-9324ce7ad822
+Μελίχ Γκιοκτσέκ,bbc9864e-0ece-4845-8930-349209acd700
 Μεντερέζ Τουρέλ,0cc121c8-72d7-4e50-8a4f-cc52045e8aac
+Μεσούτ Γιλμάζ,303d56c9-65c3-4b05-bc87-3f1425406a89
 Μεχμέτ Ακίφ Ερσόι,f246a75f-6b2d-4d1d-be44-4d91faa339c8
-Μουσταφά Κεμάλ Ατατούρκ,b0713117-c1a3-4ae4-afba-5928c8ba4331
+Μουσταφά Κεμάλ Ατατούρκ,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 Μπουλέντ Ετζεβίτ,c25b1f9d-9104-455b-9bc0-d9492cb16111
 Μπουλέντ Ουλουσού,8d1c2cfa-2fee-47ba-914f-05ba2efdf1ef
 Νετσμεττίν Ερμπακάν,1969c424-ef8c-4348-ade8-67e3b3979c96
 Νιχάτ Ερίμ,f36f723f-1815-4c1c-9987-14d2600e2867
-Νούρι Γιαμούτ,b44ab38e-8978-4aec-9f38-b20da62e92cd
+Νούρι Γιαμούτ,c798e817-75b9-4568-8e7c-1b7912ef8842
+Νούρι Κονκέρ,4fb43215-aa33-4a48-9438-beedc5cfa945
 Ντενίζ Μπαϊκάλ,64644586-aaec-42b2-8a12-ca82928feeda
 Ρετζέπ Ταγίπ Ερντογάν,8eb878de-9491-47b1-b5a0-a01675095109
 Σουκρού Σαράτζογλου,1f1bd5fa-b3fc-43bf-9d00-328db7c85c80
 Σουλεϊμάν Ντεμιρέλ,3c495593-df52-4b97-bdb1-87e7c32f38b8
 Τανσού Τσιλέρ,e263b3b5-38d1-4d48-b098-35927318f8d2
 Τζαφέρ Ταγιάρ,19f45bc6-6e01-448f-a802-1188e9786b34
-Τζελάλ Μπαγιάρ,98dc21b4-167d-4069-b3f2-1ab5cda127e8
+Τζελάλ Μπαγιάρ,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
 Τουργκούτ Οζάλ,dbf83637-216e-4791-9039-9c5596865224
 Φεβζί Τσακμάκ,34526313-174b-4586-bcd1-4e7eda014629
+Φουάτ Μπουλκά,222a2464-7586-4687-a098-62c9b83764d1
 Χασάν Αλί Γιουτζέλ,b7529ce0-f8b1-4c08-89c0-5e5853af0f5b
+Χουσεΐν Ραούφ Μπέη,c897a10b-39ef-4ea8-a585-ddfe834a92a0
 Ісмет Іненю,0f6a5be4-39cb-404f-b94a-aecc5753fb56
 Јахја Кемал Бејатли,fdd92963-1e3a-4a88-aac6-5ebf8cd3d453
 Џевдет Јилмаз,2e18c3e7-6cd8-435d-b3a1-6593e0615dcd
-Џелал Бајар,98dc21b4-167d-4069-b3f2-1ab5cda127e8
+Џелал Бајар,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
 Џемил Чичек,abe19024-a773-46d4-949c-d109126b7361
 Абдула Ѓул,51704345-f3a1-4eae-912a-85a06bd14622
 Абдула Гюль,51704345-f3a1-4eae-912a-85a06bd14622
@@ -7276,19 +7480,25 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 Аднан Мендерес,53fb1443-3f41-414c-b1bb-007c533633c7
 Айдын Мендерес,2c5ccb5e-2451-4a21-93ff-32c4259a3e54
 Акиф Ердемгил,e3c6b751-908c-4cd5-a4ff-fe36a4a39bc3
+Акчура Юсуф,c999f612-40a2-4233-91c4-1e64472f8ac2
+Акчурин Юсуф,c999f612-40a2-4233-91c4-1e64472f8ac2
 Али Бабаджан,1f627461-0944-41d3-a886-a2395424d062
 Али Бабаџан,1f627461-0944-41d3-a886-a2395424d062
 Али Мюниф Йегенага,c9d0b855-f254-4851-88aa-e8fc29ad3291
 Али Саит Акбайтоган,22c58439-1206-4875-849e-1c068c321cd4
 Али Танръяр,cc79894d-d725-48b5-996a-31030057aec9
+Али Фетхи Окьяр,3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44
+Али Фетхи Окяр,3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44
+Али Фетхи Окјар,3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44
 Алпарслан Туркеш,db85d160-ae11-4a45-b806-8558aeb63c07
 Алпарслан Түркеш,db85d160-ae11-4a45-b806-8558aeb63c07
 "Арик, Ремзи Огуз",3cf18d1d-3d9d-4861-96da-eaefaa97a311
-Ататюрк,b0713117-c1a3-4ae4-afba-5928c8ba4331
-Ататюрк Мустафа Кемаль,b0713117-c1a3-4ae4-afba-5928c8ba4331
-Ататүрк,b0713117-c1a3-4ae4-afba-5928c8ba4331
-Ататӱрк,b0713117-c1a3-4ae4-afba-5928c8ba4331
+Ататюрк,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+Ататюрк Мустафа Кемаль,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+Ататүрк,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+Ататӱрк,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 АхІмад Давудогълу,850865d9-a91f-4e2c-a329-4db339630fb7
+Ахмед Іхсан Киримли,b126d94f-b584-4c66-ae8b-9e77c8e6770d
 Ахмед Мухтар-бей Моллаогли,6edde5fe-a49f-4cec-924a-33a782474384
 Ахмед Решид бей,f51ce3fe-d6ae-4fc3-af86-7831246e1093
 Ахмед Сойдемир,50081ead-0f06-48f6-b35c-2bce95a73609
@@ -7299,9 +7509,10 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 "Байюлкен, Халук",a3af99f6-c299-4674-95df-8ebfc8f6829c
 "Бахчели, Девлет",e0c3d800-3dc6-477f-8b78-18d8a8760bf6
 "Баюр, Юсуф Хикмет",388e0ed1-d63b-4e42-9141-c7a7faeb0ae2
-Баяр,98dc21b4-167d-4069-b3f2-1ab5cda127e8
-"Баяр, Махмуд Джеляль",98dc21b4-167d-4069-b3f2-1ab5cda127e8
+Баяр,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
+"Баяр, Махмуд Джеляль",dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
 Бекір-Самі Кундух,a0e7f4a4-ae7c-42c2-b41a-426b61981846
+Бесим Аталай,986af966-7743-44f8-a9ae-9bc4f91f551d
 Бешир Аталај,8054b008-fe6f-45f8-84ae-52249810ee8d
 "Бирдал, Акын",d8c8e8b3-cc82-437d-9f60-b981289feb8f
 Булент Аринч,741e71ba-8649-4fe6-bb14-b131e10aea6f
@@ -7317,6 +7528,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 Гюль,51704345-f3a1-4eae-912a-85a06bd14622
 Гюль Абдулла,51704345-f3a1-4eae-912a-85a06bd14622
 "Гюль, Абдулла",51704345-f3a1-4eae-912a-85a06bd14622
+"Гюндюз, Ака",c8eab67a-fe54-44b3-8792-bccb4c6dc468
 "Гюнтекин, Решад Нури",3ef93178-40b3-448f-bc64-2e3e079f7d1e
 "Гюнтекин, Решат Нури",3ef93178-40b3-448f-bc64-2e3e079f7d1e
 Гӧкалп,cd79d45b-a944-4666-9df4-68a0d43901f4
@@ -7340,6 +7552,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 Зия Гёкальп,cd79d45b-a944-4666-9df4-68a0d43901f4
 Зия ГӨКАЛП,cd79d45b-a944-4666-9df4-68a0d43901f4
 Зия Гөкалп,cd79d45b-a944-4666-9df4-68a0d43901f4
+Зюлфю Ливанели,66c29288-d499-44a8-8bb5-e66ed24f4716
 Ибрахим Рефет Беле,364075d5-ba05-4694-8fd4-0b5496f00435
 Ибрахим Чолак,2d299924-f560-4205-b3da-338f78a84bb7
 Инёню,0f6a5be4-39cb-404f-b94a-aecc5753fb56
@@ -7349,7 +7562,10 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 Исмет Иньоню,0f6a5be4-39cb-404f-b94a-aecc5753fb56
 Исмет Йылмаз,9948b890-51de-448a-9707-a36f83f0f802
 "Ихсаноглу, Экмеледдин",308158bf-f96a-4142-8568-75cb295f9a77
+Йосыф Акчура,c999f612-40a2-4233-91c4-1e64472f8ac2
 Йылдырым Акбулут,ca255c61-008b-42f9-bdd1-adb3697e786e
+Йылмаз,303d56c9-65c3-4b05-bc87-3f1425406a89
+"Йылмаз, Месут",303d56c9-65c3-4b05-bc87-3f1425406a89
 Кадри Алтай,e7fdafcb-a71b-4923-8f29-b6866749c0a8
 "Карабекир, Кязым Муса",9a8930ca-406e-48f4-ba0e-fd57882a6e9b
 "Кая, Али",428bbd28-e1fb-42a4-b6c4-b0709babdaab
@@ -7359,36 +7575,40 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 Къуындыхаты Бечыр,a0e7f4a4-ae7c-42c2-b41a-426b61981846
 "Кылычдароглу, Кемаль",86bb007b-cd15-418a-94d2-9324ce7ad822
 Кязим Йозалп,ff08a751-e06c-43bc-bd79-f86c8f5c7c11
-"Кёпрюлю, Мехмет Фуат",402dda26-7adf-4019-9211-f1c86178da48
+"Кёпрюлю, Мехмет Фуат",01d9e29d-19fb-4fbb-b23b-ca027d00c45f
+"Левенд, Агях Сырры",f1c9fe06-134e-46c6-888a-1eb8e58824a5
+"Ливанели, Зюльфю",66c29288-d499-44a8-8bb5-e66ed24f4716
 "Максудов, Садретдин Низаметдинович",a33d6817-98a8-4467-9fbb-e79009d43c41
 "Максудов, Садретдин Низаметдины фырт",a33d6817-98a8-4467-9fbb-e79009d43c41
 Максуді Садрі,a33d6817-98a8-4467-9fbb-e79009d43c41
-Махмуд Баяр,98dc21b4-167d-4069-b3f2-1ab5cda127e8
-Махмуд Джеляль Баяр,98dc21b4-167d-4069-b3f2-1ab5cda127e8
+Махмуд Баяр,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
+Махмуд Джеляль Баяр,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
 Мақсұдов Садреддин,a33d6817-98a8-4467-9fbb-e79009d43c41
 Мевлют Чавушоглу,0f7eb6e1-ca85-43e8-b7d1-f52bb54e56b9
 "Мендерес, Аднан",53fb1443-3f41-414c-b1bb-007c533633c7
 "Мерсинли, Мехмет Джемаль",30753cee-cd84-48a5-87de-ac657c0a42e1
+Месут Јилмаз,303d56c9-65c3-4b05-bc87-3f1425406a89
+Месут Йилмаз,303d56c9-65c3-4b05-bc87-3f1425406a89
 Мехмед Тефик Билге бей,b820846d-eab2-4918-a9bf-8ee12bf62ccc
 Мехмет Акиф Ерсој,f246a75f-6b2d-4d1d-be44-4d91faa339c8
 Мехмет Али Шахин,07db8d85-b95b-49a4-9db7-6c89481ca0b2
 Мехмет Шимшек,f2c90f9f-1701-447a-b849-4a4640af1017
 Мехмет Эмин Юрдaкул,d9f6798e-d69e-4adb-9fa9-e90d5389e9be
 Мидхад Шюкрю Бледа,806b0ea2-c319-4fde-b5c8-69b4670c5883
-Мостафа Кәмал Ататөрк,b0713117-c1a3-4ae4-afba-5928c8ba4331
+Мостафа Кәмал Ататөрк,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 Мустафа Исмет Инени,0f6a5be4-39cb-404f-b94a-aecc5753fb56
-Мустафа Камал Ататуьрк,b0713117-c1a3-4ae4-afba-5928c8ba4331
-Мустафа Кемал Aтатурк,b0713117-c1a3-4ae4-afba-5928c8ba4331
-Мустафа Кемал Ататурк,b0713117-c1a3-4ae4-afba-5928c8ba4331
-Мустафа Кемал Ататюрк,b0713117-c1a3-4ae4-afba-5928c8ba4331
-Мустафа Кемал Ататүрк,b0713117-c1a3-4ae4-afba-5928c8ba4331
-Мустафа Кемаль Ататурк,b0713117-c1a3-4ae4-afba-5928c8ba4331
-Мустафа Кемаль Ататюрк,b0713117-c1a3-4ae4-afba-5928c8ba4331
-Мустафа Кемаль Атацюрк,b0713117-c1a3-4ae4-afba-5928c8ba4331
-Мюмтаз Сойзал,b818f8d3-c869-4224-90e5-6b15554eb23b
-Мұстафа Кәмәл Ататүрік,b0713117-c1a3-4ae4-afba-5928c8ba4331
-Наджи Елдениз,c6f10a6c-08e0-4e19-a0b5-ce4115e3456e
-Наджи Тъназ,147464d1-31a3-42ef-8102-e2b054786316
+Мустафа Камал Ататуьрк,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+Мустафа Кемал Aтатурк,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+Мустафа Кемал Ататурк,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+Мустафа Кемал Ататюрк,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+Мустафа Кемал Ататүрк,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+Мустафа Кемаль Ататурк,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+Мустафа Кемаль Ататюрк,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+Мустафа Кемаль Атацюрк,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+Мюмтаз Сойзал,273004ea-d2e1-4ed2-8b51-595639b7849b
+Мұстафа Кәмәл Ататүрік,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+Наджи Елдениз,7de7d51e-03de-4885-9acf-7bafe2554f83
+Наджи Тъназ,9256d486-6351-4914-beb2-cb60848d8b6b
 "Нафиз, Фарук Чамлыбель",44f7f890-1740-49e2-a8d8-2ab1a4f5c269
 Неджметин Ербакан,1969c424-ef8c-4348-ade8-67e3b3979c96
 Неджметтін Ербакан,1969c424-ef8c-4348-ade8-67e3b3979c96
@@ -7396,11 +7616,16 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 Нимет Баш,6817b68b-02b5-4774-86a3-4e011b1c5e97
 Нихат Ергун,26a88992-29ff-483c-bce1-3ec4c8191d8d
 Нихат Ерим,f36f723f-1815-4c1c-9987-14d2600e2867
+Нуреддин-паша,70672dee-818c-49a5-84f1-227b49753518
+Нури Джонкер,4fb43215-aa33-4a48-9438-beedc5cfa945
 Озал,dbf83637-216e-4791-9039-9c5596865224
 Озал Тургут,dbf83637-216e-4791-9039-9c5596865224
 "Озал, Тургут",dbf83637-216e-4791-9039-9c5596865224
 Орxaн Сейфи Орxон,7808b408-7710-4163-bbbd-2bdd35e4b004
+"Орбай, Рауф",c897a10b-39ef-4ea8-a585-ddfe834a92a0
 Ражаб ТIайип Эрдогъан,8eb878de-9491-47b1-b5a0-a01675095109
+Расим,27ea2b6e-50a1-4bf1-9ad9-b822f82f432b
+"Расим, Ахмет",27ea2b6e-50a1-4bf1-9ad9-b822f82f432b
 Реджеп Пекер,aea8e1ed-3593-4016-b804-ace53d3321d0
 Реджеп Тайип Ердоган,8eb878de-9491-47b1-b5a0-a01675095109
 Реджеп Тайип Эрдоған,8eb878de-9491-47b1-b5a0-a01675095109
@@ -7437,8 +7662,9 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 "Тюркеш, Йылдырым Тугрул",c6b87b15-4c3a-43af-ab04-8ff0633e7f5e
 Тұрғыт Озал,dbf83637-216e-4791-9039-9c5596865224
 "Уджа, Фелекнас",e60d8517-4183-44e9-8cf3-49f4966f8d59
-Фарук Нафиз Озак,15267a5a-bc66-447b-b532-542713f88d6f
+Фарук Нафиз Озак,146e65d1-5dff-4dd9-b08a-c27b858b749f
 Фарук Челик,be45c5c7-bae9-48eb-b335-22cf4572e890
+Фуат Булджа,222a2464-7586-4687-a098-62c9b83764d1
 Хайдар бей,4d73cd4b-6d7b-4a79-aeea-1da3a2007399
 Хакан Шукур,421981d8-d67f-4cfe-a2e8-f307e86ddb04
 Хакан Шюкюр,421981d8-d67f-4cfe-a2e8-f307e86ddb04
@@ -7451,6 +7677,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 Чaмлыбел,44f7f890-1740-49e2-a8d8-2ab1a4f5c269
 "Чакмак, Мустафа Февзи",34526313-174b-4586-bcd1-4e7eda014629
 "Чиллер, Тансу",e263b3b5-38d1-4d48-b098-35927318f8d2
+"Чобанлы, Исмаил Джеват",b2ee4381-f5fe-48a0-a1e6-492fe3be14aa
 "Шукюр, Хакан",421981d8-d67f-4cfe-a2e8-f307e86ddb04
 Шюкрю Наили Гьокберк,5d2d2333-9faa-40c5-92a4-4ea94fa71da8
 Шюкрю Сараджоглу,1f1bd5fa-b3fc-43bf-9d00-328db7c85c80
@@ -7458,13 +7685,16 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 "Эджевит, Бюлент",c25b1f9d-9104-455b-9bc0-d9492cb16111
 Экмеледдин Ихсаноғлы,308158bf-f96a-4142-8568-75cb295f9a77
 "Эрбакан, Неджметтин",1969c424-ef8c-4348-ade8-67e3b3979c96
+Эрдем Бaйaзыт,5535eee1-78bb-4c1d-a952-87036045f90e
 "Эрдоган, Реджеп Тайип",8eb878de-9491-47b1-b5a0-a01675095109
 "Эрдогъан, Ражаб ТIайип",8eb878de-9491-47b1-b5a0-a01675095109
 Эрдоған Рәжәп Тайип,8eb878de-9491-47b1-b5a0-a01675095109
 "Эркмен, Хайреттин",2149e18e-dc63-43d7-b716-abdd4364a0a0
 "Эрсой, Мехмет Акиф",f246a75f-6b2d-4d1d-be44-4d91faa339c8
 "Юксекдаг, Фиген",708682e6-4529-4011-bdcd-8b442618d72b
+Юсуф Акчурин,c999f612-40a2-4233-91c4-1e64472f8ac2
 Юсуф Зия Ортaч,06b1c10a-b2ef-4e3e-a844-f8b60b56695c
+Юсуф Хасанович Акчурин,c999f612-40a2-4233-91c4-1e64472f8ac2
 "Языджы, Тахсин",a0a3265c-b23f-4368-a8e3-534e9dc52a9a
 Яхия Кемал Беятлъ,fdd92963-1e3a-4a88-aac6-5ebf8cd3d453
 Яшар Нури Йозтюрк,1529b9fd-6cfb-4eb8-8a69-f93090651515
@@ -7481,8 +7711,8 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 Էքմելեդին Իհսանօղլու,308158bf-f96a-4142-8568-75cb295f9a77
 Իսմեթ Ինյոնյու,0f6a5be4-39cb-404f-b94a-aecc5753fb56
 Հալիդե Էդիբ,8b82db12-9646-461e-8706-89fd5038f1cf
-Մուստաֆա Քեմալ Աթաթուրք,b0713117-c1a3-4ae4-afba-5928c8ba4331
-Ջելալ Բայար,98dc21b4-167d-4069-b3f2-1ab5cda127e8
+Մուստաֆա Քեմալ Աթաթուրք,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+Ջելալ Բայար,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
 Ռեջեփ Թայիփ Էրդողան,8eb878de-9491-47b1-b5a0-a01675095109
 Սադըկ Քոչաշ,eefb3cd7-18c0-4337-a100-954ff448c9e3
 Սամի Բեքիր,a0e7f4a4-ae7c-42c2-b41a-426b61981846
@@ -7495,30 +7725,34 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 אדנאן מנדרס,53fb1443-3f41-414c-b1bb-007c533633c7
 אהמט דבוטואולו,850865d9-a91f-4e2c-a329-4db339630fb7
 איסמט אינני,0f6a5be4-39cb-404f-b94a-aecc5753fb56
+אלי פטהי אוקיאר,3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44
 אלפארסלן טירקש,db85d160-ae11-4a45-b806-8558aeb63c07
 בולנט אג'וויט,c25b1f9d-9104-455b-9bc0-d9492cb16111
-ג'לל באייר,98dc21b4-167d-4069-b3f2-1ab5cda127e8
+ג'לל באייר,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
 הקאן שוקור,421981d8-d67f-4cfe-a2e8-f307e86ddb04
 זיא גקאלפ,cd79d45b-a944-4666-9df4-68a0d43901f4
 טורגוט אזאל,dbf83637-216e-4791-9039-9c5596865224
 טנסו צ'ילר,e263b3b5-38d1-4d48-b098-35927318f8d2
+ילמז אזטונה,88ac40ec-1671-43d0-b3a7-fe3c063edba8
 יקופ קדרי קראוסמאנאולו,95f285e7-32e4-4fb0-bbc2-0e8497dffb82
 מוסה קזם קראבקיר,9a8930ca-406e-48f4-ba0e-fd57882a6e9b
-מוסטאפא קעמאל אטאטורק,b0713117-c1a3-4ae4-afba-5928c8ba4331
-מוסטפא כמאל אטאטורק,b0713117-c1a3-4ae4-afba-5928c8ba4331
-נורי יאמוט,b44ab38e-8978-4aec-9f38-b20da62e92cd
+מוסטאפא קעמאל אטאטורק,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+מוסטפא כמאל אטאטורק,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+מסוט ילמז,303d56c9-65c3-4b05-bc87-3f1425406a89
+נורי יאמוט,c798e817-75b9-4568-8e7c-1b7912ef8842
 ניהט ארים,f36f723f-1815-4c1c-9987-14d2600e2867
 סוליימאן דמירל,3c495593-df52-4b97-bdb1-87e7c32f38b8
 סלהאטין דמירטאש,a6db1e42-3a69-48e6-981a-8b512d0f1376
 עבדוללה גול,51704345-f3a1-4eae-912a-85a06bd14622
 פליה ריפקי אטאיי,6b202a8c-8c4a-4c01-b75a-2ebb0e84df0d
 רג'פ טאיפ ארדואן,8eb878de-9491-47b1-b5a0-a01675095109
-آتاتورک,b0713117-c1a3-4ae4-afba-5928c8ba4331
+آتاتورک,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 آتیلا کایا,f4f93782-6f36-469a-81f2-12d6e665ad42
 آلپ ارسلان تورکش,db85d160-ae11-4a45-b806-8558aeb63c07
 آلپ‌ارسلان تورکش,db85d160-ae11-4a45-b806-8558aeb63c07
 أحمد داود أوغلو,850865d9-a91f-4e2c-a329-4db339630fb7
 أديبة سوزان,c27fa39b-2ca6-4d7f-b7c9-7e4c1e1a522f
+أكا غوندوز,c8eab67a-fe54-44b3-8792-bccb4c6dc468
 أكمل الدين إحسان أوغلو,308158bf-f96a-4142-8568-75cb295f9a77
 أمر الله اشلر,773c7d27-d171-4de3-b92c-c9512f60000f
 أمينة أولكر طرحان,44111b5b-3b53-487d-a3a8-f3bf0d6ba570
@@ -7532,6 +7766,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 ئاکن بردال,d8c8e8b3-cc82-437d-9f60-b981289feb8f
 ئاڵپ ئەرسلان تورکەش,db85d160-ae11-4a45-b806-8558aeb63c07
 ئایلائا کاتئا تا,2c0e4373-dd35-4212-b32f-aadc49c29fa8
+ئوفوکئو راس,d8d7f6e0-5832-4f7d-801e-bf29c4f6de16
 ئىسمەت ئىنۆنۈ,0f6a5be4-39cb-404f-b94a-aecc5753fb56
 ئۆرهان دۆگان,a712cb2b-2081-4e36-84a3-aa6682d411b1
 ئۆرهان مرۆğلو,d8482b83-713a-46ae-9ec7-24907394ca1b
@@ -7550,9 +7785,12 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 احمد فکری توزر,32089e16-b4e3-44b3-9689-23dca1057857
 اردال اینونو,c7056767-7947-414b-b5b6-e4a229795a12
 اسعد محمود كاراكورت,aa05465b-ee4b-43e1-a8b0-eb8b908b34f0
+اكتشۋرىين يۋسۋف,c999f612-40a2-4233-91c4-1e64472f8ac2
 الپارسلان تۇركەش,db85d160-ae11-4a45-b806-8558aeb63c07
+اوفوک اوراس,d8d7f6e0-5832-4f7d-801e-bf29c4f6de16
 اکمل‌الدین احسان‌اوغلو,308158bf-f96a-4142-8568-75cb295f9a77
 بلند ایجوت,c25b1f9d-9104-455b-9bc0-d9492cb16111
+بهيجة بوران,1fd209ed-d891-47a3-9aaa-2bed3f2fb210
 بولنت أجاويد,c25b1f9d-9104-455b-9bc0-d9492cb16111
 بولنت اجویت,c25b1f9d-9104-455b-9bc0-d9492cb16111
 بولنت ارينج,741e71ba-8649-4fe6-bb14-b131e10aea6f
@@ -7560,6 +7798,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 بولەنتئە جەڤیت,c25b1f9d-9104-455b-9bc0-d9492cb16111
 بيرجُل أيمن جولر,8b48dec2-e811-4d0f-8cf2-67a854feb0c7
 بيرفن بولدان,09582ef1-18fb-4567-b3ab-ddd47f5b1bf5
+بەسىيم اتالاي,986af966-7743-44f8-a9ae-9bc4f91f551d
 بەنگ یıلدıز,71d84558-254b-4aa7-a8a4-3e2a967f5844
 تانسو تشيلر,e263b3b5-38d1-4d48-b098-35927318f8d2
 تانسو چللەر,e263b3b5-38d1-4d48-b098-35927318f8d2
@@ -7571,15 +7810,18 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 تورگوت اوزال,dbf83637-216e-4791-9039-9c5596865224
 تۇرعىت وزال,dbf83637-216e-4791-9039-9c5596865224
 تۇرغۇت ئۆزال,dbf83637-216e-4791-9039-9c5596865224
-جلال بایار,98dc21b4-167d-4069-b3f2-1ab5cda127e8
-جەلال بایار,98dc21b4-167d-4069-b3f2-1ab5cda127e8
+جلال بایار,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
+جلال ساهر,7a59a813-b07b-452f-ba43-3813b85116e6
+جەلال بایار,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
 حüسامەتتن جندۆروک,0179325e-e172-413f-a815-6e5f072732e4
 حاتیب دجلە,2b02499c-af34-4586-adca-e6a16e6c64b1
 حسن السقا,3faa93f5-e7e2-4af8-97d3-8a62a5da9a27
 حسن بولاتكان,9474aecd-7522-4def-9b50-f159d9d5cb38
 حسن ساکا,3faa93f5-e7e2-4af8-97d3-8a62a5da9a27
+حسين رؤوف أورباي,c897a10b-39ef-4ea8-a585-ddfe834a92a0
 حسين رحمى جوربينار,dc88f973-6086-4bf3-a31e-43475bd6505b
 حسين رحمي قوربنار,dc88f973-6086-4bf3-a31e-43475bd6505b
+حلمي غولار,d2b4d521-55b5-468e-80e8-b0ed9ddd15b1
 حمزه یرلی‌کایا,89e4cea8-1d41-4085-b5d2-7cfc6e60e790
 حکمەت چەتن,9a012381-5aaa-4f81-baee-697b75c77f10
 خالدة أديب,8b82db12-9646-461e-8706-89fd5038f1cf
@@ -7592,6 +7834,8 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 دەنز بایکال,64644586-aaec-42b2-8a12-ca82928feeda
 دەنیز بایکاڵ,64644586-aaec-42b2-8a12-ca82928feeda
 دەوڵەت باخچەلی,e0c3d800-3dc6-477f-8b78-18d8a8760bf6
+رؤف اوربے,c897a10b-39ef-4ea8-a585-ddfe834a92a0
+رئوف اربای,c897a10b-39ef-4ea8-a585-ddfe834a92a0
 رجب اكدغان,4d11f24c-b61c-491c-ba73-5db808d76627
 رجب طيب أردوغان,8eb878de-9491-47b1-b5a0-a01675095109
 رجب طيب اردوغان,8eb878de-9491-47b1-b5a0-a01675095109
@@ -7620,9 +7864,11 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 سلیمان دمیرل,3c495593-df52-4b97-bdb1-87e7c32f38b8
 سلیمان دیمیرل,3c495593-df52-4b97-bdb1-87e7c32f38b8
 سنان اوغان,ba622e2a-385d-4743-907f-a31469e5b849
+سيفات شوبانلي,b2ee4381-f5fe-48a0-a1e6-492fe3be14aa
 سۇلايمان دېمىرەل,3c495593-df52-4b97-bdb1-87e7c32f38b8
 سۇلەيمەن دەمىيرەل,3c495593-df52-4b97-bdb1-87e7c32f38b8
 سەباھەت تونجەل,2792be99-2d45-4e95-8469-ab4adde9dbf7
+سەداتئە دپ بوجاک,96ede054-2b11-4a60-ba8d-5d6a7f05e588
 سەلاهەدین دەمرتاش,a6db1e42-3a69-48e6-981a-8b512d0f1376
 سەلیم ساداک,d12b5773-25e2-49b1-a3f9-5cb71a71fc98
 سەڵاحەدین دەمیرتاش,a6db1e42-3a69-48e6-981a-8b512d0f1376
@@ -7639,7 +7885,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 ضياء كوك ألب,cd79d45b-a944-4666-9df4-68a0d43901f4
 ضیا گوک آلپ,cd79d45b-a944-4666-9df4-68a0d43901f4
 ضیاء گوک الپ,cd79d45b-a944-4666-9df4-68a0d43901f4
-عائشة نور إسلام,b93ff0e7-1d86-4793-97a1-b4989acbaa33
+عائشة نور إسلام,18253297-802d-4ef2-8dee-58a2e4c7be28
 عبد الحق حامد,a7d524e4-8594-452d-ae56-ebdd6c8f187b
 عبد الخالق ريندا,81747339-ad31-49a1-8c9d-7ee9997fa5f2
 عبد الله غل,51704345-f3a1-4eae-912a-85a06bd14622
@@ -7648,7 +7894,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 عبدالله گل,51704345-f3a1-4eae-912a-85a06bd14622
 عبدالله گول,51704345-f3a1-4eae-912a-85a06bd14622
 عثمان توران,cb2de2ff-5880-4540-9d36-3349ee143a4d
-عدنان اديوار,73bb95f9-84ca-4c76-a779-ec5a3052c806
+عدنان اديوار,3b3a8d81-d52a-4958-90f9-e975ee74f258
 عدنان قهوجي,966dd911-d817-4c5d-8588-a5521b7a746e
 عدنان مندرس,53fb1443-3f41-414c-b1bb-007c533633c7
 عدنان مندريس,53fb1443-3f41-414c-b1bb-007c533633c7
@@ -7660,7 +7906,9 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 عصمت یلماز,9948b890-51de-448a-9707-a36f83f0f802
 علي باباجان,1f627461-0944-41d3-a886-a2395424d062
 علي فؤاد باشا,7da075c8-1f09-40b1-a9f4-957caa15a55e
+علي فتحي أوكيار,3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44
 علی بوزر,61d6dd5b-62bd-4026-96c0-e6189b0fe03b
+علی فتحی اوکیار,3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44
 علی فواد,7da075c8-1f09-40b1-a9f4-957caa15a55e
 عمر سلیک,38cb391f-bb87-4295-b121-47179b8c1d58
 عوسمان بایدەمیر,00851ff7-21e3-4848-9d36-a80c5e635a16
@@ -7676,6 +7924,7 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 فوضی پاشا,34526313-174b-4586-bcd1-4e7eda014629
 فيغين يوكسيكداغ,708682e6-4529-4011-bdcd-8b442618d72b
 فیگەن یوکسەکداغ,708682e6-4529-4011-bdcd-8b442618d72b
+فەتهئۆ کیار,3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44
 فەلەکناس ئوجا,e60d8517-4183-44e9-8cf3-49f4966f8d59
 فەڤز چاکماک,34526313-174b-4586-bcd1-4e7eda014629
 كمال كيليتشدار أوغلو,86bb007b-cd15-418a-94d2-9324ce7ad822
@@ -7683,32 +7932,38 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 لیلا زانا,d7da69f3-5fcd-430f-b0ab-114499477061
 لەیلا زانا,d7da69f3-5fcd-430f-b0ab-114499477061
 محمد أمين يورداكول,d9f6798e-d69e-4adb-9fa9-e90d5389e9be
+محمد رجائي قوطان,01b10bd7-2ba2-4d1f-b797-4952863baff5
 محمد شيمشك,f2c90f9f-1701-447a-b849-4a4640af1017
 محمد عاكف آرصوي,f246a75f-6b2d-4d1d-be44-4d91faa339c8
 محمد عاکف ارسوی,f246a75f-6b2d-4d1d-be44-4d91faa339c8
 محمد عاکف ارصوی,f246a75f-6b2d-4d1d-be44-4d91faa339c8
 محمد عاکیف ارسوی,f246a75f-6b2d-4d1d-be44-4d91faa339c8
-محمد فؤاد كوبرولو,402dda26-7adf-4019-9211-f1c86178da48
-محمد فواد کوپرولو,402dda26-7adf-4019-9211-f1c86178da48
-محمود جلال بايار,98dc21b4-167d-4069-b3f2-1ab5cda127e8
+محمد فؤاد كوبرولو,01d9e29d-19fb-4fbb-b23b-ca027d00c45f
+محمد فواد کوپرولو,01d9e29d-19fb-4fbb-b23b-ca027d00c45f
+محمود جلال بايار,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
 محەممەد عاکیف ئرسوی,f246a75f-6b2d-4d1d-be44-4d91faa339c8
-مصطفا کمال اتاترک,b0713117-c1a3-4ae4-afba-5928c8ba4331
-مصطفى كمال أتاتورك,b0713117-c1a3-4ae4-afba-5928c8ba4331
-مصطفى كمال اتاتورك,b0713117-c1a3-4ae4-afba-5928c8ba4331
-مصطفٰی کمال اتاترک,b0713117-c1a3-4ae4-afba-5928c8ba4331
-مصطفی کمال آتاترک,b0713117-c1a3-4ae4-afba-5928c8ba4331
-مصطفی کمال اتاتورک,b0713117-c1a3-4ae4-afba-5928c8ba4331
+مسعود ییلماز,303d56c9-65c3-4b05-bc87-3f1425406a89
+مصطفا کمال اتاترک,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+مصطفى كمال أتاتورك,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+مصطفى كمال اتاتورك,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+مصطفٰی کمال اتاترک,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+مصطفی کمال آتاترک,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+مصطفی کمال اتاتورک,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+مليح غوكجك,bbc9864e-0ece-4845-8930-349209acd700
+ملیح گوکچک,bbc9864e-0ece-4845-8930-349209acd700
 موستافا بالبای,9f766444-bccc-4728-a979-3ade4bbe4d64
-موستەفا کەمال ئاتاتورک,b0713117-c1a3-4ae4-afba-5928c8ba4331
+موستەفا کەمال ئاتاتورک,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 موسی کاظم قرہ بکر,9a8930ca-406e-48f4-ba0e-fd57882a6e9b
 موسیٰ کاظم قرہ بکر,9a8930ca-406e-48f4-ba0e-fd57882a6e9b
-موصطافا کامال آتاتورک,b0713117-c1a3-4ae4-afba-5928c8ba4331
+موصطافا کامال آتاتورک,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 مولود تشاويش أوغلو,0f7eb6e1-ca85-43e8-b7d1-f52bb54e56b9
 مولود چاووش‌اوغلو,0f7eb6e1-ca85-43e8-b7d1-f52bb54e56b9
 موهسن یازıجıۆğلو,1433124c-4ff9-4d2d-95dd-06fa253c600b
-مۇستاپا كامال,b0713117-c1a3-4ae4-afba-5928c8ba4331
+مۇستاپا كامال,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+مەهمەتئا ğار,1a2f06e6-f419-490e-ae2d-520222842a95
 مەهمەتئا کفئە رسۆی,f246a75f-6b2d-4d1d-be44-4d91faa339c8
 مەھمەت شىمشەك,f2c90f9f-1701-447a-b849-4a4640af1017
+ناظلى اليجاق,e3593d74-d206-4fac-aee7-70bd478fca78
 نجم الدين أربكان,1969c424-ef8c-4348-ade8-67e3b3979c96
 نجم الدین اربکان,1969c424-ef8c-4348-ade8-67e3b3979c96
 نجم‌الدین اربکان,1969c424-ef8c-4348-ade8-67e3b3979c96
@@ -7724,6 +7979,8 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 يحي كمال بياتلي,fdd92963-1e3a-4a88-aac6-5ebf8cd3d453
 يشار ياكيش,40e5bb2c-9b5e-4b45-a004-d1e76603a8ef
 يلدرم محمد رمضان أوغلو,e3176904-ed03-4818-a812-e0c5a064d6f8
+يلماز أوزتونا,88ac40ec-1671-43d0-b3a7-fe3c063edba8
+يوسف آقجورا,c999f612-40a2-4233-91c4-1e64472f8ac2
 پروین بولدان,09582ef1-18fb-4567-b3ab-ddd47f5b1bf5
 پەروین بولدان,09582ef1-18fb-4567-b3ab-ddd47f5b1bf5
 پەرڤن بولدان,09582ef1-18fb-4567-b3ab-ddd47f5b1bf5
@@ -7743,56 +8000,59 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 یعقوب قدری قراعثمان اوغلو,95f285e7-32e4-4fb0-bbc2-0e8497dffb82
 ییلدیریم آک‌بولوت,ca255c61-008b-42f9-bdd1-adb3697e786e
 ەكمەلەددىين ىيحسانوعلى,308158bf-f96a-4142-8568-75cb295f9a77
-ܡܘܨܛܦܐ ܟܡܐܠ ܐܛܐܛܘܪܩ,b0713117-c1a3-4ae4-afba-5928c8ba4331
+ܡܘܨܛܦܐ ܟܡܐܠ ܐܛܐܛܘܪܩ,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 अब्दुल्लाह ग्युल,51704345-f3a1-4eae-912a-85a06bd14622
-कमाल अतातुर्क,b0713117-c1a3-4ae4-afba-5928c8ba4331
-केमेल अतातुर्क,b0713117-c1a3-4ae4-afba-5928c8ba4331
+कमाल अतातुर्क,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+केमेल अतातुर्क,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 तान्सु सिलर,e263b3b5-38d1-4d48-b098-35927318f8d2
 निहात एरिम,f36f723f-1815-4c1c-9987-14d2600e2867
 ब्युलेंट एसेव्हिट,c25b1f9d-9104-455b-9bc0-d9492cb16111
-मुस्तफा कमाल अतातुर्क,b0713117-c1a3-4ae4-afba-5928c8ba4331
-मुस्ताफ़ा केमल्,b0713117-c1a3-4ae4-afba-5928c8ba4331
+मुस्तफा कमाल अतातुर्क,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+मुस्ताफ़ा केमल्,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 रेसेप तईप ईरदोगन,8eb878de-9491-47b1-b5a0-a01675095109
 रेसेप तय्यिप एर्दोगान,8eb878de-9491-47b1-b5a0-a01675095109
-কামাল আতাতুর্ক,b0713117-c1a3-4ae4-afba-5928c8ba4331
+কামাল আতাতুর্ক,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 নাজিমদ্দিন এরবাকান,1969c424-ef8c-4348-ade8-67e3b3979c96
 মুহিদ্দিন আকুজ,66e5ef11-70ad-403e-9330-9e2cf69fd35f
 রিসেপ তায়িপ এরদোয়ান,8eb878de-9491-47b1-b5a0-a01675095109
 হাকান শুকুর,421981d8-d67f-4cfe-a2e8-f307e86ddb04
-ਮੁਸਤਫ਼ਾ ਕਮਾਲ ਅਤਾਤੁਰਕ,b0713117-c1a3-4ae4-afba-5928c8ba4331
-કમાલ મુસ્તફા અતાતુર્ક,b0713117-c1a3-4ae4-afba-5928c8ba4331
+ਮੁਸਤਫ਼ਾ ਕਮਾਲ ਅਤਾਤੁਰਕ,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+કમાલ મુસ્તફા અતાતુર્ક,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 அப்துல்லா குல்,51704345-f3a1-4eae-912a-85a06bd14622
-முஸ்தாபா கெமால் அத்தாதுர்க்,b0713117-c1a3-4ae4-afba-5928c8ba4331
-ముస్తఫా కమాల్ అతాతుర్క్,b0713117-c1a3-4ae4-afba-5928c8ba4331
-ಮುಸ್ತಫಾ ಕೆಮಾಲ್ ಅಟಟುರಕ್,b0713117-c1a3-4ae4-afba-5928c8ba4331
+முஸ்தாபா கெமால் அத்தாதுர்க்,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+ముస్తఫా కమాల్ అతాతుర్క్,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+ಮುಸ್ತಫಾ ಕೆಮಾಲ್ ಅಟಟುರಕ್,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 അബ്ദുള്ള ഗുൽ,51704345-f3a1-4eae-912a-85a06bd14622
 താൻസു ചില്ലർ,e263b3b5-38d1-4d48-b098-35927318f8d2
 തുർഗുത് ഓസൽ,dbf83637-216e-4791-9039-9c5596865224
 നെജ്മത്തിൻ എർബകാൻ,1969c424-ef8c-4348-ade8-67e3b3979c96
 ബുലന്ത് എജവിത്,c25b1f9d-9104-455b-9bc0-d9492cb16111
-മുസ്തഫ കമാൽ അത്താതുർക്ക്,b0713117-c1a3-4ae4-afba-5928c8ba4331
+മുസ്തഫ കമാൽ അത്താതുർക്ക്,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 റെജപ് തയ്യിപ്‌ എർദ്വാൻ,8eb878de-9491-47b1-b5a0-a01675095109
 സുലെയ്മാൻ ദെമിറേൽ,3c495593-df52-4b97-bdb1-87e7c32f38b8
-มุสตาฟา เคมาล อตาเติร์ก,b0713117-c1a3-4ae4-afba-5928c8ba4331
+มุสตาฟา เคมาล อตาเติร์ก,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 ฮาคาน ชูเคอร์,421981d8-d67f-4cfe-a2e8-f307e86ddb04
 ເລເຈບ ໄຕຢິບ ແອໂດກັນ,8eb878de-9491-47b1-b5a0-a01675095109
-ကီးမား အာတာတပ်,b0713117-c1a3-4ae4-afba-5928c8ba4331
+ကီးမား အာတာတပ်,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 აბდულა გიული,51704345-f3a1-4eae-912a-85a06bd14622
+აქა გუნდუზი,c8eab67a-fe54-44b3-8792-bccb4c6dc468
 ბიულენთ ეჯევითი,c25b1f9d-9104-455b-9bc0-d9492cb16111
 ედიფ ადივარ ჰალიდე,8b82db12-9646-461e-8706-89fd5038f1cf
+ზიულფიუ ლივანელი,66c29288-d499-44a8-8bb5-e66ed24f4716
 თანსუ ჩილერი,e263b3b5-38d1-4d48-b098-35927318f8d2
 თურგუთ ოზალი,dbf83637-216e-4791-9039-9c5596865224
 ისმეთ ინენიუ,0f6a5be4-39cb-404f-b94a-aecc5753fb56
 ლეილა ზანა,d7da69f3-5fcd-430f-b0ab-114499477061
-მუსტაფა ქემალ ათათურქი,b0713117-c1a3-4ae4-afba-5928c8ba4331
+მელიჰ გიოქჩექი,bbc9864e-0ece-4845-8930-349209acd700
+მუსტაფა ქემალ ათათურქი,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 რეჯეფ თაიფ ერდოღანი,8eb878de-9491-47b1-b5a0-a01675095109
 სერვერ-ბეგ ათაბაგი,f5756189-5a6a-40bc-bd38-c6ce3ea9f2b2
 სულეიმან დემირელი,3c495593-df52-4b97-bdb1-87e7c32f38b8
-ქემალ ათათურქი,b0713117-c1a3-4ae4-afba-5928c8ba4331
-ჯელალ ბაიარი,98dc21b4-167d-4069-b3f2-1ab5cda127e8
+ქემალ ათათურქი,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+ჯელალ ბაიარი,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
 ჰაქან შუქური,421981d8-d67f-4cfe-a2e8-f307e86ddb04
 ჰუსეინ რაჰმი გურფინარი,dc88f973-6086-4bf3-a31e-43475bd6505b
-ሙስታፋ ኬማል አታቱርክ,b0713117-c1a3-4ae4-afba-5928c8ba4331
+ሙስታፋ ኬማል አታቱርክ,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 アドナン・メンデレス,53fb1443-3f41-414c-b1bb-007c533633c7
 アフメット・ハムディ・タンプナル,8c144c75-1ac4-4c7f-b8ca-cf46f02cf8e0
 アフメト・ダウトオール,850865d9-a91f-4e2c-a329-4db339630fb7
@@ -7809,12 +8069,15 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 サーリフ・ボゾク,8868c010-fb05-4abc-9f8c-c88ddfe51fd8
 シェムセッティン・ギュナルタイ,96dc5539-a0cf-4a95-9dcb-51cefa60c59c
 シュクリュ・サラジオウル,1f1bd5fa-b3fc-43bf-9d00-328db7c85c80
-ジェラル・バヤル,98dc21b4-167d-4069-b3f2-1ab5cda127e8
+ジェラル・バヤル,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
+ジェヴァト・チョバンル,b2ee4381-f5fe-48a0-a1e6-492fe3be14aa
 スアト・ハイリ・ウルギュプリュ,67ddb199-7c5f-4c06-af6b-9a1e5e70dfe6
 スュレイマン・デミレル,3c495593-df52-4b97-bdb1-87e7c32f38b8
 タンス・チルレル,e263b3b5-38d1-4d48-b098-35927318f8d2
 トゥルグト・オザル,dbf83637-216e-4791-9039-9c5596865224
 ニハト・エリム,f36f723f-1815-4c1c-9987-14d2600e2867
+ヌーリ・ジョンケル,4fb43215-aa33-4a48-9438-beedc5cfa945
+ヌーレッディン・パシャ,70672dee-818c-49a5-84f1-227b49753518
 ネジメッティン・エルバカン,1969c424-ef8c-4348-ade8-67e3b3979c96
 ハカン・シュキュル,421981d8-d67f-4cfe-a2e8-f307e86ddb04
 ハサン・サカ,3faa93f5-e7e2-4af8-97d3-8a62a5da9a27
@@ -7822,10 +8085,15 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 ハリト・アクマンスュ,e367cd7b-91f8-453d-9a22-9001be05ad9f
 ビュレント・ウルス,8d1c2cfa-2fee-47ba-914f-05ba2efdf1ef
 ビュレント・エジェヴィト,c25b1f9d-9104-455b-9bc0-d9492cb16111
+フアト・ブルジャ,222a2464-7586-4687-a098-62c9b83764d1
+フェトヒ・オクヤル,3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44
 フェリト・メレン,f699685c-9328-4e9d-a4a9-ac051adde14f
 フェヴズィ・チャクマク,34526313-174b-4586-bcd1-4e7eda014629
-ムスタファ・ケマル・アタテュルク,b0713117-c1a3-4ae4-afba-5928c8ba4331
+ムスタファ・ケマル・アタテュルク,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+メスト・ユルマズ,303d56c9-65c3-4b05-bc87-3f1425406a89
 ユルドゥルム・アクブルト,ca255c61-008b-42f9-bdd1-adb3697e786e
+ユースフ・アクチュラ,c999f612-40a2-4233-91c4-1e64472f8ac2
+ラウフ・オルバイ,c897a10b-39ef-4ea8-a585-ddfe834a92a0
 ラグプ・ギュミュシュパラ,3a944bfa-7475-4e12-b068-9a44a9461e1a
 レイラ・ザーナ,d7da69f3-5fcd-430f-b0ab-114499477061
 レジェップ・タイイップ・エルドアン,8eb878de-9491-47b1-b5a0-a01675095109
@@ -7834,8 +8102,9 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 レフィク・サイダム,f669c61b-05bf-4ebb-bc4d-c496e21c5bab
 伊斯麥特·伊諾努,0f6a5be4-39cb-404f-b94a-aecc5753fb56
 伊斯麦特·伊诺努,0f6a5be4-39cb-404f-b94a-aecc5753fb56
-傑拉勒·拜亞爾,98dc21b4-167d-4069-b3f2-1ab5cda127e8
-凱末爾,b0713117-c1a3-4ae4-afba-5928c8ba4331
+傑拉勒·拜亞爾,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
+優素福·阿克楚拉,c999f612-40a2-4233-91c4-1e64472f8ac2
+凱末爾,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 哈坎·苏克,421981d8-d67f-4cfe-a2e8-f307e86ddb04
 哈坎·蘇克,421981d8-d67f-4cfe-a2e8-f307e86ddb04
 哈根·蘇古,421981d8-d67f-4cfe-a2e8-f307e86ddb04
@@ -7846,11 +8115,12 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 坦苏·奇莱尔,e263b3b5-38d1-4d48-b098-35927318f8d2
 塞姆斯丁·居納爾塔伊,96dc5539-a0cf-4a95-9dcb-51cefa60c59c
 尼哈特·埃里姆,f36f723f-1815-4c1c-9987-14d2600e2867
-慕斯他化·克麥·阿塔突,b0713117-c1a3-4ae4-afba-5928c8ba4331
-杰拉勒·拜亚尔,98dc21b4-167d-4069-b3f2-1ab5cda127e8
+慕斯他化·克麥·阿塔突,97c30e2d-aa11-4b98-9b19-7873a6e4b580
+杰拉勒·拜亚尔,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
+梅苏特·耶尔马兹,303d56c9-65c3-4b05-bc87-3f1425406a89
 比伦特·埃杰维特,c25b1f9d-9104-455b-9bc0-d9492cb16111
 比倫特·埃傑維特,c25b1f9d-9104-455b-9bc0-d9492cb16111
-穆斯塔法·凯末尔·阿塔图尔克,b0713117-c1a3-4ae4-afba-5928c8ba4331
+穆斯塔法·凯末尔·阿塔图尔克,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 耶尔德勒姆·阿克布卢特,ca255c61-008b-42f9-bdd1-adb3697e786e
 耶爾德勒姆·阿克布盧特,ca255c61-008b-42f9-bdd1-adb3697e786e
 艾哈迈德·达武特奥卢,850865d9-a91f-4e2c-a329-4db339630fb7
@@ -7865,16 +8135,19 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 阿卜杜拉·居尔,51704345-f3a1-4eae-912a-85a06bd14622
 阿德南·曼德列斯,53fb1443-3f41-414c-b1bb-007c533633c7
 阿爾普阿爾斯蘭·圖爾克斯,db85d160-ae11-4a45-b806-8558aeb63c07
+阿里·费特希·奥克亚尔,3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44
 雷傑普·塔伊普·埃爾多安,8eb878de-9491-47b1-b5a0-a01675095109
 雷杰普·佩克尔,aea8e1ed-3593-4016-b804-ace53d3321d0
 雷杰普·塔伊普·埃尔多安,8eb878de-9491-47b1-b5a0-a01675095109
 雷菲克·赛达姆,f669c61b-05bf-4ebb-bc4d-c496e21c5bab
 네즈메틴 에르바칸,1969c424-ef8c-4348-ade8-67e3b3979c96
+라우프 오르바이,c897a10b-39ef-4ea8-a585-ddfe834a92a0
 레제프 타이이프 에르도안,8eb878de-9491-47b1-b5a0-a01675095109
 레피크 사이담,f669c61b-05bf-4ebb-bc4d-c496e21c5bab
 메블뤼트 차우쇼을루,0f7eb6e1-ca85-43e8-b7d1-f52bb54e56b9
+메수트 이을마즈,303d56c9-65c3-4b05-bc87-3f1425406a89
 무스타파 압뒬할리크 렌다,81747339-ad31-49a1-8c9d-7ee9997fa5f2
-무스타파 케말 아타튀르크,b0713117-c1a3-4ae4-afba-5928c8ba4331
+무스타파 케말 아타튀르크,97c30e2d-aa11-4b98-9b19-7873a6e4b580
 무히딘 파샤,66e5ef11-70ad-403e-9330-9e2cf69fd35f
 바흐리예 위초크,1c8b5c29-cee1-47c4-914c-e6e35a6eb4d6
 뷜렌트 아른츠,741e71ba-8649-4fe6-bb14-b131e10aea6f
@@ -7889,7 +8162,8 @@ ismail qemal vlora,4e7f14c4-1192-4331-a56c-468cbc82cdc3
 에크멜레딘 이흐사노글루,308158bf-f96a-4142-8568-75cb295f9a77
 이스메트 이뇌뉘,0f6a5be4-39cb-404f-b94a-aecc5753fb56
 이을드름 아크불루트,ca255c61-008b-42f9-bdd1-adb3697e786e
-젤랄 바야르,98dc21b4-167d-4069-b3f2-1ab5cda127e8
+제바트 파샤,b2ee4381-f5fe-48a0-a1e6-492fe3be14aa
+젤랄 바야르,dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890
 타흐신 야즈즈,a0a3265c-b23f-4368-a8e3-534e9dc52a9a
 탄수 칠레르,e263b3b5-38d1-4d48-b098-35927318f8d2
 투르구트 외잘,dbf83637-216e-4791-9039-9c5596865224

--- a/data/Turkey/Assembly/sources/instructions.json
+++ b/data/Turkey/Assembly/sources/instructions.json
@@ -20,7 +20,7 @@
       "source": "http://wikidata.org/",
       "type": "wikidata",
       "merge": { 
-        "incoming_field": "wikipedia__tr",
+        "incoming_field": "orig",
         "existing_field": "wikipedia__tk"
       }
     },

--- a/data/Turkey/Assembly/sources/morph/data.csv
+++ b/data/Turkey/Assembly/sources/morph/data.csv
@@ -10330,7 +10330,7 @@ Sait Yüce,"",Amasya,Adalet ve Kalkınma Partisi,AKP,25,https://tr.wikipedia.org
 Mustafa Tuncer,"",Amasya,Cumhuriyet Halk Partisi,CHP,25,https://tr.wikipedia.org/wiki/TBMM_25._d%C3%B6nem_milletvekilleri_listesi,mustafa_tuncer
 Yalçın Akdoğan,Yalçın Akdoğan,Ankara,Adalet ve Kalkınma Partisi,AKP,25,https://tr.wikipedia.org/wiki/TBMM_25._d%C3%B6nem_milletvekilleri_listesi,yalçın_akdoğan
 Ahmet Gündoğdu,"",Ankara,Adalet ve Kalkınma Partisi,AKP,25,https://tr.wikipedia.org/wiki/TBMM_25._d%C3%B6nem_milletvekilleri_listesi,ahmet_gündoğdu
-Ali İhsan Arslan,"",Ankara,Adalet ve Kalkınma Partisi,AKP,25,https://tr.wikipedia.org/wiki/TBMM_25._d%C3%B6nem_milletvekilleri_listesi,ali_İhsan_arslan
+Ali İhsan Arslan,Ali İhsan Arslan,Ankara,Adalet ve Kalkınma Partisi,AKP,25,https://tr.wikipedia.org/wiki/TBMM_25._d%C3%B6nem_milletvekilleri_listesi,ali_İhsan_arslan
 Jülide Sarıeroğlu,"",Ankara,Adalet ve Kalkınma Partisi,AKP,25,https://tr.wikipedia.org/wiki/TBMM_25._d%C3%B6nem_milletvekilleri_listesi,jülide_sarıeroğlu
 Murat Alparslan,"",Ankara,Adalet ve Kalkınma Partisi,AKP,25,https://tr.wikipedia.org/wiki/TBMM_25._d%C3%B6nem_milletvekilleri_listesi,murat_alparslan
 Ertan Aydın,"",Ankara,Adalet ve Kalkınma Partisi,AKP,25,https://tr.wikipedia.org/wiki/TBMM_25._d%C3%B6nem_milletvekilleri_listesi,ertan_aydın
@@ -12205,7 +12205,7 @@ Yılmaz Altuğ,Yılmaz Altuğ,Sivas,Anavatan Partisi,ANAP,18,https://tr.wikipedi
 Ömer Günbulut,"",Sivas,Anavatan Partisi,ANAP,18,https://tr.wikipedia.org/wiki/TBMM_18._d%C3%B6nem_milletvekilleri_listesi,Ömer_günbulut
 Ekrem Kangal,Ekrem Kangal,Sivas,Sosyaldemokrat Halkçı Parti,SHP,18,https://tr.wikipedia.org/wiki/TBMM_18._d%C3%B6nem_milletvekilleri_listesi,ekrem_kangal
 Mahmut Karabulut,Mahmut Karabulut,Sivas,Anavatan Partisi,ANAP,18,https://tr.wikipedia.org/wiki/TBMM_18._d%C3%B6nem_milletvekilleri_listesi,mahmut_karabulut
-Kaya Opan,Kaya Opan,Sivas,Anavatan Partisi,ANAP,18,https://tr.wikipedia.org/wiki/TBMM_18._d%C3%B6nem_milletvekilleri_listesi,kaya_opan
+Kaya Opan,"",Sivas,Anavatan Partisi,ANAP,18,https://tr.wikipedia.org/wiki/TBMM_18._d%C3%B6nem_milletvekilleri_listesi,kaya_opan
 Şakir Şeker,Şakir Şeker,Sivas,Anavatan Partisi,ANAP,18,https://tr.wikipedia.org/wiki/TBMM_18._d%C3%B6nem_milletvekilleri_listesi,Şakir_Şeker
 Mehmet Mükerrem Taşçıoğlu,Mehmet Mükerrem Taşçıoğlu,Sivas,Anavatan Partisi,ANAP,18,https://tr.wikipedia.org/wiki/TBMM_18._d%C3%B6nem_milletvekilleri_listesi,mehmet_mükerrem_taşçıoğlu
 Aziz Bülent Öncel,Aziz Bülent Öncel,Şanlıurfa,Anavatan Partisi,ANAP,18,https://tr.wikipedia.org/wiki/TBMM_18._d%C3%B6nem_milletvekilleri_listesi,aziz_bülent_Öncel

--- a/data/Turkey/Assembly/term-1.csv
+++ b/data/Turkey/Assembly/term-1.csv
@@ -15,7 +15,7 @@ db580384-5c70-479d-a452-14eab7780b61,Abdullah Servet Akdağ,Abdullah Servet Akda
 747e8e69-d96f-40d1-9db7-46465b17b9b1,Abdülhak Tevfik Gençtürk,Abdülhak Tevfik Gençtürk,,,,Cumhuriyet Halk Partisi,CHP,area/dersim_(tunceli),Dersim (Tunceli),Grand National Assembly,1,,,,male
 e0e6b807-73d6-465b-b512-cdf5813da5f8,Abdülhalim Çelebi,Abdülhalim Çelebi,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,1,,,,
 def22ebd-a880-42e1-9171-f72279cc0518,Abdülkadir Kemali Öğütçü,Abdülkadir Kemali Öğütçü,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,1,,,,male
-3b3a8d81-d52a-4958-90f9-e975ee74f258,Adnan Adıvar,Adnan Adıvar,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,1,,,,
+3b3a8d81-d52a-4958-90f9-e975ee74f258,Adnan Adıvar,Adnan Adıvar,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/1/16/Adnan_Bey.jpg,male
 ddd2e62e-b371-47c1-90d7-07f268bf57ee,Ahmet Baydar,Ahmet Baydar,,,,Cumhuriyet Halk Partisi,CHP,area/bozok_(yozgat),Bozok (Yozgat),Grand National Assembly,1,,,,male
 986af966-7743-44f8-a9ae-9bc4f91f551d,Ahmet Besim Atalay,Ahmet Besim Atalay,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,1,,,,
 d3fdd8b6-48e1-43a3-850e-393dcd8404de,Ahmet Cemalettin Çelebi,Ahmet Cemalettin Çelebi,,,,Cumhuriyet Halk Partisi,CHP,area/kırşehir,Kırşehir,Grand National Assembly,1,,,,male
@@ -45,7 +45,7 @@ b763e08b-ed6e-4674-a4c2-b36ace8232b2,Ahmet Şükrü Oğuz,Ahmet Şükrü Oğuz,,
 f6e38a77-3b31-4633-a6c4-0ff002e542dc,Ali Cenani,Ali Cenani,,,,Cumhuriyet Halk Partisi,CHP,area/ayıntab_(antep),Ayıntab (Antep),Grand National Assembly,1,,,,
 0ea91963-bb32-489d-b0a7-2318181e2c75,Ali Cevdet Seçkin,Ali Cevdet Seçkin,,,,Cumhuriyet Halk Partisi,CHP,area/kırşehir,Kırşehir,Grand National Assembly,1,,,,
 9542d87b-05ae-408e-b461-e65a79c935ce,Ali Enver Tekand,Ali Enver Tekand,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,1,,,,male
-3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44,Ali Fethi Okyar,Ali Fethi Okyar,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,1,,,,
+3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44,Ali Fethi Okyar,Ali Fethi Okyar,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/9/99/Ali_Fethi_Okyar.jpg,male
 7da075c8-1f09-40b1-a9f4-957caa15a55e,Ali Fuat Cebesoy,Ali Fuat Cebesoy,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/0/09/Ali_Fuat_Pasha.jpg,male
 08635871-af64-474f-80ba-9ea2077a82ed,Ali Haydar Bey,Ali Haydar Bey,,,,Cumhuriyet Halk Partisi,CHP,area/genç,Genç,Grand National Assembly,1,,,,
 121935b4-269b-4542-a503-e93de0bfd649,Ali Kılıç,Ali Kılıç,,,,Cumhuriyet Halk Partisi,CHP,area/ayıntab_(antep),Ayıntab (Antep),Grand National Assembly,1,,,,male
@@ -84,7 +84,7 @@ b0581c40-cb53-47b8-b58d-62d17259f482,Cami Baykurt,Cami Baykurt,,,,Cumhuriyet Hal
 cc0de41b-90b6-4447-8e4d-09d127edd7e3,Celal Nuri İleri,Celal Nuri İleri,,,,Cumhuriyet Halk Partisi,CHP,area/gelibolu,Gelibolu,Grand National Assembly,1,,,,
 b792caaa-52d3-4b5d-98e3-8a30788a508d,Celalettin Arif,Celalettin Arif,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,1,,,,
 d0c6834f-8d23-4e47-8100-213d67827278,Celalettin Aykar,Celalettin Aykar,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,1,,,,
-98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Cumhuriyet Halk Partisi,CHP,area/saruhan_(manisa),Saruhan (Manisa),Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/9/9b/Celal_bayar.jpg,male
+98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Cumhuriyet Halk Partisi,CHP,area/saruhan_(manisa),Saruhan (Manisa),Grand National Assembly,1,,,,
 30753cee-cd84-48a5-87de-ac657c0a42e1,Cemal Mersinli,Cemal Mersinli,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/3/3c/Mersinli_Cemal.jpg,male
 addff976-3139-4782-83ce-507dc1ddceda,Cemil Altay,Cemil Altay,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,1,,,,
 cef6dbcf-01c2-4d0b-8973-a7e6db9c9227,Cevat Abbas Gürer,Cevat Abbas Gürer,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/d/d9/Cevat_Abbas_Gürer.jpg,male
@@ -137,12 +137,12 @@ bbb7a145-4381-4316-8432-57a866cfc743,Hacı Mehmet Önay,Hacı Mehmet Önay,,,,Cu
 50a2b4d9-9f72-42d5-9f16-c2da06cee923,Hacı Mustafa,Hacı Mustafa,,,,Cumhuriyet Halk Partisi,CHP,area/urfa,Urfa,Grand National Assembly,1,,,,
 a6337aa9-1b51-45d4-b496-15abe0a3d2ee,Hacı Mustafa Beynamlı,Hacı Mustafa Beynamlı,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,1,,,,male
 ee4c157d-675b-4de5-91b2-99b1a1e0f82b,Hacı Mustafa Efendi,Hacı Mustafa Efendi,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,1,,,,
-37ba7ffa-c6c7-4d6d-9607-03f5b38280b2,Hacı Mustafa Sabri Baysan,Hacı Mustafa Sabri Baysan,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,1,,,,
+37ba7ffa-c6c7-4d6d-9607-03f5b38280b2,Hacı Mustafa Sabri Baysan,Hacı Mustafa Sabri Baysan,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,1,,,,male
 97f8df59-9c14-4262-890f-9c8623f1137c,Hacı Süleyman Efendi,Hacı Süleyman Efendi,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,1,,,,male
 15d7df42-d907-4bfb-a89e-58c2f045977d,Hacı Tevfik Efendi,Hacı Tevfik Efendi,,,,Cumhuriyet Halk Partisi,CHP,area/kangırı_(Çankırı),Kangırı (Çankırı),Grand National Assembly,1,,,,
 e73dff7a-e86e-4cfd-8b17-f535296616ab,Hacı Şükrü Aydındağ,Hacı Şükrü Aydındağ,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbekir,Diyarbekir,Grand National Assembly,1,,,,
 57033b61-d64e-40ef-8e48-1e6ab4845e17,Hafız Abdullah Tezemir,Hafız Abdullah Tezemir,,,,Cumhuriyet Halk Partisi,CHP,area/İzmit_(kocaeli),İzmit (Kocaeli),Grand National Assembly,1,,,,
-2cd9cc56-dc85-4d96-9dca-2baa97782a09,Hafız Mehmet Engin,Hafız Mehmet Engin,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,1,,,,
+2cd9cc56-dc85-4d96-9dca-2baa97782a09,Hafız Mehmet Engin,Hafız Mehmet Engin,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/4/41/Hafız_Mehmet_Bey.jpg,male
 8c9242a5-23d2-4b5d-92b3-3f4c75c8edd4,Hafız Mehmet Şahin,Hafız Mehmet Şahin,,,,Cumhuriyet Halk Partisi,CHP,area/ayıntab_(antep),Ayıntab (Antep),Grand National Assembly,1,,,,male
 ee10e749-a615-49a6-8cf8-c6a9f4937458,Hafız İbrahim Demiralay,Hafız İbrahim Demiralay,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,1,,,,
 a7a5bea8-1850-46b5-9fd0-a86156f5bd70,Hahutzade Ahmet Nuri Efendi,Hahutzade Ahmet Nuri Efendi,,,,Cumhuriyet Halk Partisi,CHP,area/batum,Batum,Grand National Assembly,1,,,,male
@@ -150,14 +150,14 @@ a7a5bea8-1850-46b5-9fd0-a86156f5bd70,Hahutzade Ahmet Nuri Efendi,Hahutzade Ahmet
 42cdb25c-e0a9-4014-aafd-73975d64342c,Hakkı Hami Ulukan,Hakkı Hami Ulukan,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,1,,,,male
 b85e88b1-46aa-4822-ac9d-a4774a50fdf8,Hakkı Ungan,Hakkı Ungan,,,,Cumhuriyet Halk Partisi,CHP,area/van,Van,Grand National Assembly,1,,,,male
 de5b0bee-e6cb-4b37-96b2-357fefa09b7e,Halil Hilmi Bozca,Halil Hilmi Bozca,,,,Cumhuriyet Halk Partisi,CHP,area/karahisar-ı_sahib_(afyonkarahisar),Karahisar-ı Sahib (Afyonkarahisar),Grand National Assembly,1,,,,male
-2e825a8d-4b7b-40e7-8266-37b4eb8c6743,Halil Hulki Ayrım,Halil Hulki Ayrım,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,1,,,,
+2e825a8d-4b7b-40e7-8266-37b4eb8c6743,Halil Hulki Ayrım,Halil Hulki Ayrım,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,1,,,,male
 4c66851a-c401-4671-9014-16f53257f940,Halil Hulusi Efendi,Halil Hulusi Efendi,,,,Cumhuriyet Halk Partisi,CHP,area/burdur,Burdur,Grand National Assembly,1,,,,
 db78d6a3-2803-4896-a438-a49d925eee3f,Halil Işık,Halil Işık,,,,Cumhuriyet Halk Partisi,CHP,area/ertuğrul_(bilecik),Ertuğrul (Bilecik),Grand National Assembly,1,,,,male
 2317d81c-efef-450c-91ba-c53c869fb40a,Halil İbrahim Gürsoy,Halil İbrahim Gürsoy,,,,Cumhuriyet Halk Partisi,CHP,area/İzmit_(kocaeli),İzmit (Kocaeli),Grand National Assembly,1,,,,
 ea6c57e9-736e-4f27-ad68-0b8d4464331b,Halil İbrahim Nakıpoğlu,Halil İbrahim Nakıpoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,1,,,,male
 52b9d2b4-7334-4df2-ae70-e80416e35d74,Halil İbrahim Sipahioğlu,Halil İbrahim Sipahioğlu,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,1,,,,male
 c60b8a49-b74e-48d8-8750-aa1cbdc42e73,Halil İbrahim Özkaya,Halil İbrahim Özkaya,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,1,,,,male
-ecaf7ab8-0a58-4cb2-ab36-ba0ead338830,Hamdi Aksoy,Hamdi Aksoy,,,,Cumhuriyet Halk Partisi,CHP,area/ertuğrul_(bilecik),Ertuğrul (Bilecik),Grand National Assembly,1,,,,male
+ecaf7ab8-0a58-4cb2-ab36-ba0ead338830,Hamdi Aksoy,Hamdi Aksoy,,,,Cumhuriyet Halk Partisi,CHP,area/ertuğrul_(bilecik),Ertuğrul (Bilecik),Grand National Assembly,1,,,,
 bbecad46-3ef0-4fec-b7a3-cedcc7e4c701,Hamdi Hamit Karaosmanoğlu,Hamdi Hamit Karaosmanoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/biga,Biga,Grand National Assembly,1,,,,male
 902f8379-a8fb-4055-91b0-37e7a6209474,Hamdi Namık Gör,Hamdi Namık Gör,,,,Cumhuriyet Halk Partisi,CHP,area/İzmit_(kocaeli),İzmit (Kocaeli),Grand National Assembly,1,,,,male
 3497b843-92d8-4bae-9ada-1fbd28bb13ba,Hamdi Yılmaz,Hamdi Yılmaz,,,,Cumhuriyet Halk Partisi,CHP,area/genç,Genç,Grand National Assembly,1,,,,
@@ -195,8 +195,8 @@ babf0000-768e-4f4b-b3ca-bab551c685f3,Hüseyin Hüsnü Işık,Hüseyin Hüsnü I�
 1e88456d-ff8e-4089-994e-9f0e31d68b81,Hüseyin Hüsnü Konay,Hüseyin Hüsnü Konay,,,,Cumhuriyet Halk Partisi,CHP,area/mersin,Mersin,Grand National Assembly,1,,,,male
 57e6fe7b-1bbe-4cdf-bd4b-4663077348f0,Hüseyin Hüsnü Orakçıoğlu,Hüseyin Hüsnü Orakçıoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/bitlis,Bitlis,Grand National Assembly,1,,,,
 df5d46c7-fce5-487f-8323-198732f202a1,Hüseyin Hüsnü Özdamar,Hüseyin Hüsnü Özdamar,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/e/e7/Hussein_Husnu_Efendi.jpg,male
-c897a10b-39ef-4ea8-a585-ddfe834a92a0,Hüseyin Rauf Orbay,Hüseyin Rauf Orbay,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,1,,,,
-47c80d4f-8679-4c17-b1d3-fffe3a3d3411,Hüseyin Selâhattin Köseoğlu,Hüseyin Selâhattin Köseoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/mersin,Mersin,Grand National Assembly,1,,,,
+c897a10b-39ef-4ea8-a585-ddfe834a92a0,Hüseyin Rauf Orbay,Hüseyin Rauf Orbay,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,1,,,,male
+47c80d4f-8679-4c17-b1d3-fffe3a3d3411,Hüseyin Selâhattin Köseoğlu,Hüseyin Selâhattin Köseoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/mersin,Mersin,Grand National Assembly,1,,,,male
 8527bee3-f2ff-4a78-a9c5-4f4deb52b47f,Hüseyin Sırrı Bellioğlu,Hüseyin Sırrı Bellioğlu,,,,Cumhuriyet Halk Partisi,CHP,area/İzmit_(kocaeli),İzmit (Kocaeli),Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/7/70/Hüseyin_Sırrı_Bellioğlu.jpg,male
 b18e154e-ae35-4149-93aa-1ed20647f9ac,Hüseyin Sıtkı Gür,Hüseyin Sıtkı Gür,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,1,,,,
 4b005354-1f1d-492f-8980-3576e6277eed,Hüseyin Çelik,Hüseyin Çelik,,,,Cumhuriyet Halk Partisi,CHP,area/kozan,Kozan,Grand National Assembly,1,,,,male
@@ -204,7 +204,7 @@ fd4fb680-3b52-4d9e-851d-737c6d7638ab,Hüsrev Gerede,Hüsrev Gerede,,,,Cumhuriyet
 d7d65767-330d-48c2-8a37-6f5b0054588b,Hüsrev Sami Kızıldoğan,Hüsrev Sami Kızıldoğan,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,1,,,,
 2a09e54b-e115-4ac3-88d7-a96d1b5ad614,Kadri Bey,Kadri Bey,,,,Cumhuriyet Halk Partisi,CHP,area/ergani,Ergani,Grand National Assembly,1,,,,
 d6cfaf38-765d-4d54-804b-0d651e75b13a,Kadri Oktay,Kadri Oktay,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,1,,,,
-5a07eed0-562f-4c96-8a55-ac688230d11f,Kamil Efendi,Kamil Efendi,,,,Cumhuriyet Halk Partisi,CHP,area/van,Van,Grand National Assembly,1,,,,
+5a07eed0-562f-4c96-8a55-ac688230d11f,Kamil Efendi,Kamil Efendi,,,,Cumhuriyet Halk Partisi,CHP,area/van,Van,Grand National Assembly,1,,,,male
 5f4946f6-b064-40d5-841f-db36a95de7c6,Kasım Nuri Bey,Kasım Nuri Bey,,,,Cumhuriyet Halk Partisi,CHP,area/menteşe_(muğla),Menteşe (Muğla),Grand National Assembly,1,,,,
 9cc988ae-ee5c-4b73-ac19-523a45533ae9,Kazım Dede,Kazım Dede,,,,Cumhuriyet Halk Partisi,CHP,area/muş,Muş,Grand National Assembly,1,,,,
 f31cced9-1f65-4461-a693-3784ff4ec4a6,Kazım Özalp,Kazım Özalp,,,,Cumhuriyet Halk Partisi,CHP,area/karesi_(balıkesir),Karesi (Balıkesir),Grand National Assembly,1,,,,
@@ -230,7 +230,7 @@ d1f293cc-96c4-4140-94b0-56489965f427,Mehmet Emin Erkut,Mehmet Emin Erkut,,,,Cumh
 50b891cb-b1c3-4165-9722-57a43ec91088,Mehmet Emin Lekili,Mehmet Emin Lekili,,,,Cumhuriyet Halk Partisi,CHP,area/erzincan,Erzincan,Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/3/34/Mehmed_Emin_Bey_Lekili.jpg,male
 43a55189-7019-450f-94e1-993dd5814eaa,Mehmet Erten,Mehmet Erten,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,1,,,,male
 774155e8-cc13-45c8-9761-0957ba65ba4b,Mehmet Esat İleri,Mehmet Esat İleri,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,1,,,,male
-8652a3ca-91b9-4029-af8f-95187db61377,Mehmet Fuat Carım,Mehmet Fuat Carım,,,,Cumhuriyet Halk Partisi,CHP,area/İzmit_(kocaeli),İzmit (Kocaeli),Grand National Assembly,1,,,,
+8652a3ca-91b9-4029-af8f-95187db61377,Mehmet Fuat Carım,Mehmet Fuat Carım,,,,Cumhuriyet Halk Partisi,CHP,area/İzmit_(kocaeli),İzmit (Kocaeli),Grand National Assembly,1,,,,male
 34dde07f-3b7e-46d1-8515-ab8d00a8d3f4,Mehmet Hamdi İzgi,Mehmet Hamdi İzgi,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,1,,,,male
 545be95d-2525-41fa-bebc-f0d3bd35218b,Mehmet Hulusi Akyol,Mehmet Hulusi Akyol,,,,Cumhuriyet Halk Partisi,CHP,area/bozok_(yozgat),Bozok (Yozgat),Grand National Assembly,1,,,,male
 0e7ab8f8-f79a-465f-bb2d-2c7942e0253c,Mehmet Hulusi Erdemir,Mehmet Hulusi Erdemir,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,1,,,,male
@@ -276,7 +276,7 @@ f31b354f-0f8b-42a8-8755-0ccfd2187051,Muhittin Çöteli,Muhittin Çöteli,,,,Cumh
 2aa949eb-8769-4bf2-8e0d-874fab847286,Muhtar Fikri Güçüm,Muhtar Fikri Güçüm,,,,Cumhuriyet Halk Partisi,CHP,area/mersin,Mersin,Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/b/b9/Muhtar_Fikri_Bey.jpg,male
 3e2def16-3aa8-4704-b8ed-92326cffc04f,Musa Kazım Onar,Musa Kazım Onar,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,1,,,,male
 0f3858de-6649-4bb5-b01f-85f907bf9d00,Mustafa Akif Tütenk,Mustafa Akif Tütenk,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbekir,Diyarbekir,Grand National Assembly,1,,,,male
-8dded154-7366-41fd-91b5-c895db0b5548,Mustafa Ağa,Mustafa Ağa,,,,Cumhuriyet Halk Partisi,CHP,area/dersim_(tunceli),Dersim (Tunceli),Grand National Assembly,1,,,,
+8dded154-7366-41fd-91b5-c895db0b5548,Mustafa Ağa,Mustafa Ağa,,,,Cumhuriyet Halk Partisi,CHP,area/dersim_(tunceli),Dersim (Tunceli),Grand National Assembly,1,,,,male
 082ccd52-f478-49c9-8b86-970ae3b1928e,Mustafa Bengisu,Mustafa Bengisu,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,1,,,,male
 742a7bb8-c9b3-479a-aa37-60237f09ab8e,Mustafa Cantekin,Mustafa Cantekin,,,,Cumhuriyet Halk Partisi,CHP,area/kozan,Kozan,Grand National Assembly,1,,,,male
 669f7eb7-eb90-4848-b521-bf4be66fc702,Mustafa Darman,Mustafa Darman,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,1,,,,
@@ -289,10 +289,10 @@ c657524c-cf68-474e-802c-56b7cc062617,Mustafa Ebrişimoğlu,Mustafa Ebrişimoğlu
 d2ba9c59-8b2f-4e4c-b2db-3300994d21e0,Mustafa Hilmi Çayırlıoğlu,Mustafa Hilmi Çayırlıoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,1,,,,male
 fc4a2651-c125-425a-abdc-65af452ab980,Mustafa Hulusi Çalgüner,Mustafa Hulusi Çalgüner,,,,Cumhuriyet Halk Partisi,CHP,area/karahisar-ı_sahib_(afyonkarahisar),Karahisar-ı Sahib (Afyonkarahisar),Grand National Assembly,1,,,,male
 5403c731-f5a9-4422-acba-70bc8ebe6609,Mustafa Kemal Güney,Mustafa Kemal Güney,,,,Cumhuriyet Halk Partisi,CHP,area/ertuğrul_(bilecik),Ertuğrul (Bilecik),Grand National Assembly,1,,,,male
-97c30e2d-aa11-4b98-9b19-7873a6e4b580,Mustafa Kemal Paşa,Mustafa Kemal Paşa,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,1,,,,
+97c30e2d-aa11-4b98-9b19-7873a6e4b580,Mustafa Kemal Paşa,Mustafa Kemal Paşa,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/c/cc/MustafaKemalAtaturk_crop.jpg,male
 63da302f-c01c-48e0-8d9a-60fb29f7f5b3,Mustafa Lütfi Azer,Mustafa Lütfi Azer,,,,Cumhuriyet Halk Partisi,CHP,area/siverek,Siverek,Grand National Assembly,1,,,,male
 416ce349-1b6a-4620-ac9d-de41edafa2ab,Mustafa Necati Uğural,Mustafa Necati Uğural,,,,Cumhuriyet Halk Partisi,CHP,area/saruhan_(manisa),Saruhan (Manisa),Grand National Assembly,1,,,,male
-29609f07-f6a1-4554-95b3-213a85e2148f,Mustafa Sabri Süsoy,Mustafa Sabri Süsoy,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,1,,,,
+29609f07-f6a1-4554-95b3-213a85e2148f,Mustafa Sabri Süsoy,Mustafa Sabri Süsoy,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/6/6b/Mustafa_Vasfi_Bey_Süsoy.jpg,male
 fda900ad-bfb7-4437-8d70-2f391703de7c,Mustafa Serdaroğlu,Mustafa Serdaroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/karahisar-ı_Şarki_(Şebinkarahisar),Karahisar-ı Şarki (Şebinkarahisar),Grand National Assembly,1,,,,male
 692a6cf6-3556-4ee9-a493-c42ca8029b69,Mustafa Soylu,Mustafa Soylu,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,1,,,,male
 e04313df-339a-4ec0-9ac3-772a2ef323b9,Mustafa Taki Doğruyol,Mustafa Taki Doğruyol,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,1,,,,male
@@ -329,7 +329,7 @@ f669c61b-05bf-4ebb-bc4d-c496e21c5bab,Refik Saydam,Refik Saydam,,,,Cumhuriyet Hal
 1c65aac7-fceb-4b3a-b034-38c13128b7d9,Refik Şevket İnce,Refik Şevket İnce,,,,Cumhuriyet Halk Partisi,CHP,area/saruhan_(manisa),Saruhan (Manisa),Grand National Assembly,1,,,,
 7f70e8d3-4349-4e28-9fdf-89c24d81f54a,Reşit Ağar,Reşit Ağar,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,1,,,,
 f51ce3fe-d6ae-4fc3-af86-7831246e1093,Reşit Bey,Reşit Bey,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,1,,,,male
-41a21c68-523a-47dc-83c7-742e59c665ed,Reşit Kayalı,Reşit Kayalı,,,,Cumhuriyet Halk Partisi,CHP,area/saruhan_(manisa),Saruhan (Manisa),Grand National Assembly,1,,,,
+41a21c68-523a-47dc-83c7-742e59c665ed,Reşit Kayalı,Reşit Kayalı,,,,Cumhuriyet Halk Partisi,CHP,area/saruhan_(manisa),Saruhan (Manisa),Grand National Assembly,1,,,,male
 ce834032-88bf-4b0e-af82-810f59994558,Reşit Paşa,Reşit Paşa,,,,Cumhuriyet Halk Partisi,CHP,area/kozan,Kozan,Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/0/0a/Reshid_Pasha_Ronabar.jpg,male
 d6148576-d7f0-42d6-8964-9b9133863355,Rüstem Hamşioğlu,Rüstem Hamşioğlu,,,,Cumhuriyet Halk Partisi,CHP,area/oltu[15],Oltu[15],Grand National Assembly,1,,,,
 9b379485-45c0-40c3-b78a-99678398d272,Rüştü Bozkurt,Rüştü Bozkurt,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,1,,,,
@@ -369,7 +369,7 @@ c46825cd-896d-4a3b-b853-b462a3a9f262,Taşpınarlı Hacı Atıf,Taşpınarlı Hac
 dab79c7e-e965-4935-ae40-9c4422fa0968,Tevfik Rüştü Aras,Tevfik Rüştü Aras,,,,Cumhuriyet Halk Partisi,CHP,area/menteşe_(muğla),Menteşe (Muğla),Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/7/77/Ahmet_Tevfik_Rüştü_Aras.jpg,male
 7044f0e9-5b5a-4829-8ce5-481677d222e4,Tufan Ülker,Tufan Ülker,,,,Cumhuriyet Halk Partisi,CHP,area/hakkâri,Hakkâri,Grand National Assembly,1,,,,
 2311a734-a5c6-4f0e-9163-bb9193f02e67,Tunalı Hilmi,Tunalı Hilmi,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,1,,,,
-e8cd624e-f24f-4d08-89f4-d6a85ea791ae,Vasıf Karakol,Vasıf Karakol,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,1,,,,
+e8cd624e-f24f-4d08-89f4-d6a85ea791ae,Vasıf Karakol,Vasıf Karakol,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,1,,,,male
 71ee134b-5d3d-41b5-ad42-e763ed292611,Vehbi Çorakçı,Vehbi Çorakçı,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,1,,,,
 f59b7847-e1da-49e5-8871-1d940b6fcafb,Vehbi Öztekin,Vehbi Öztekin,,,,Cumhuriyet Halk Partisi,CHP,area/bitlis,Bitlis,Grand National Assembly,1,,,,
 013858b0-88e3-485e-92d6-861f9735d821,Veli Saltıkgil,Veli Saltıkgil,,,,Cumhuriyet Halk Partisi,CHP,area/burdur,Burdur,Grand National Assembly,1,,,,
@@ -384,9 +384,9 @@ f9d793a6-3dcb-4bf2-9b64-a9066d19932c,Yusuf Başkaya,Yusuf Başkaya,,,,Cumhuriyet
 e382f965-bc25-42d6-be02-475f53c2a69e,Yusuf Kemal Tengirşenk,Yusuf Kemal Tengirşenk,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,1,,,,male
 c79d78b5-e33f-4496-82fe-1d9c8178ef59,Yusuf Ziya Başara,Yusuf Ziya Başara,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,1,,,,male
 8556f304-73f6-49b3-a79e-723bdd02a33c,Yusuf Ziya Eraydın,Yusuf Ziya Eraydın,,,,Cumhuriyet Halk Partisi,CHP,area/mersin,Mersin,Grand National Assembly,1,,,,male
-f7be8f0d-7887-40de-8f64-d5ba7dca2f74,Yusuf Ziya Koçoğlu,Yusuf Ziya Koçoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/bitlis,Bitlis,Grand National Assembly,1,,,,
+f7be8f0d-7887-40de-8f64-d5ba7dca2f74,Yusuf Ziya Koçoğlu,Yusuf Ziya Koçoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/bitlis,Bitlis,Grand National Assembly,1,,,,male
 5986a0ce-1086-4706-a291-903ffb95869c,Yusuf Ziya İsfendiyaroğlu,Yusuf Ziya İsfendiyaroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/kangırı_(Çankırı),Kangırı (Çankırı),Grand National Assembly,1,,,,male
-b1ae0c60-b4f8-474e-aeee-8d747377029e,Yusuf İzzet Met,Yusuf İzzet Met,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,1,,,,
+b1ae0c60-b4f8-474e-aeee-8d747377029e,Yusuf İzzet Met,Yusuf İzzet Met,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/6/6f/Yusuf_Izzet_Pasha.jpg,male
 95cbf8da-e248-48d9-b9cc-e46519115e88,Zamir Damar Arıkoğlu,Zamir Damar Arıkoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,1,,,,
 0db0193f-c123-40b5-a6d9-188e4a3a62eb,Zekai Apaydın,Zekai Apaydın,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/b/b9/Aziz_Zekai_Bey.jpg,male
 10b7b19f-4ff9-4023-a81d-180720aee0ca,Zeynel Abidin Atak,Zeynel Abidin Atak,,,,Cumhuriyet Halk Partisi,CHP,area/lazistan_(rize),Lazistan (Rize),Grand National Assembly,1,,,,
@@ -395,7 +395,7 @@ b60bed17-522b-4e5b-a69c-37b2a72b368c,Zeynel Abidin Bayhan,Zeynel Abidin Bayhan,,
 f94dd275-5027-4818-97cf-0ed1125f0e9e,Ziya Hurşit,Ziya Hurşit,,,,Cumhuriyet Halk Partisi,CHP,area/lazistan_(rize),Lazistan (Rize),Grand National Assembly,1,,,,male
 0026e257-553b-41b8-9134-d9f211bcba11,Ziya Tuğlu,Ziya Tuğlu,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,1,,,,
 f84c56dc-db84-4188-9fcf-ffffa58ca69e,Ziyaeddin Gözübüyük,Ziyaeddin Gözübüyük,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,1,,,,
-c35eacc7-57f5-4a91-b464-8690d9ff4066,Çerkes Reşit,Çerkes Reşit,,,,Cumhuriyet Halk Partisi,CHP,area/saruhan_(manisa),Saruhan (Manisa),Grand National Assembly,1,,,,male
+c35eacc7-57f5-4a91-b464-8690d9ff4066,Çerkes Reşit,Çerkes Reşit,,,,Cumhuriyet Halk Partisi,CHP,area/saruhan_(manisa),Saruhan (Manisa),Grand National Assembly,1,,,,
 15a0abc2-fe87-460d-8dab-3858f559ad12,Çilzade Fahreddin,Çilzade Fahreddin,,,,Cumhuriyet Halk Partisi,CHP,area/burdur,Burdur,Grand National Assembly,1,,,,
 363f4c78-90bf-424e-9d4c-81b907cfd31e,Çölemerikli Ömer Efendi,Çölemerikli Ömer Efendi,,,,Cumhuriyet Halk Partisi,CHP,area/hakkâri,Hakkâri,Grand National Assembly,1,,,,
 086b0fe9-e2f9-4b61-b930-adc1bd363af8,Ömer Lütfi Argeşo,Ömer Lütfi Argeşo,,,,Cumhuriyet Halk Partisi,CHP,area/karahisar-ı_sahib_(afyonkarahisar),Karahisar-ı Sahib (Afyonkarahisar),Grand National Assembly,1,,,https://upload.wikimedia.org/wikipedia/commons/1/1f/Ömer_Lütfi_Bey_Argeşo.jpg,male
@@ -410,7 +410,7 @@ ccd6df17-2572-4fe7-910a-edd04f203f58,İbrahim Cevdet Yörük,İbrahim Cevdet Yö
 31a2d185-3ea2-4d7a-8cb1-29f459e47bad,İbrahim Hakkı Akgün,İbrahim Hakkı Akgün,,,,Cumhuriyet Halk Partisi,CHP,area/ergani,Ergani,Grand National Assembly,1,,,,
 a29126c1-7dbf-4c0c-a527-0e167b487bde,İbrahim Ruşen Oktar,İbrahim Ruşen Oktar,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,1,,,,
 e9baac67-ea0c-44f1-8760-5d6ae28caef1,İbrahim Süreyya Yiğit,İbrahim Süreyya Yiğit,,,,Cumhuriyet Halk Partisi,CHP,area/saruhan_(manisa),Saruhan (Manisa),Grand National Assembly,1,,,,male
-7c0c7a85-36eb-4684-8ec0-7752ab77492c,İbrahim Turhan,İbrahim Turhan,,,,Cumhuriyet Halk Partisi,CHP,area/mardin,Mardin,Grand National Assembly,1,,,,
+7c0c7a85-36eb-4684-8ec0-7752ab77492c,İbrahim Turhan,İbrahim Turhan,,,,Cumhuriyet Halk Partisi,CHP,area/mardin,Mardin,Grand National Assembly,1,,,,male
 18356b6f-52e5-4ebc-8136-8bf28a8d58ad,İbrahim Şevki Tüzün,İbrahim Şevki Tüzün,,,,Cumhuriyet Halk Partisi,CHP,area/lazistan_(rize),Lazistan (Rize),Grand National Assembly,1,,,,male
 cab3e683-f12d-4488-a403-7f71dbc345ad,İhsan Eryavuz,İhsan Eryavuz,,,,Cumhuriyet Halk Partisi,CHP,area/cebel-i_bereket_(osmaniye),Cebel-i Bereket (Osmaniye),Grand National Assembly,1,,,,male
 5b0261d5-9fa7-47c4-bd9a-38aae1072414,İhsan Sağlam,İhsan Sağlam,,,,Cumhuriyet Halk Partisi,CHP,area/siverek,Siverek,Grand National Assembly,1,,,,male

--- a/data/Turkey/Assembly/term-10.csv
+++ b/data/Turkey/Assembly/term-10.csv
@@ -51,7 +51,7 @@ d893bf22-f970-4e86-8f44-3ae263037064,Ahmet Özel,Ahmet Özel,,,,Demokrat Parti,D
 937625d4-ba08-4c78-a3ef-745bf376e221,Ahmet İhsan Gürsoy,Ahmet İhsan Gürsoy,,,,Demokrat Parti,DP46,area/kütahya,Kütahya,Grand National Assembly,10,,,,male
 ffb36105-b1bb-4872-9f91-22f6d179b214,Akif Sarıoğlu,Akif Sarıoğlu,,,,Demokrat Parti,DP46,area/muğla,Muğla,Grand National Assembly,10,,,,
 2cd880f7-5b91-49a0-97d9-68a4b9acd58c,Aleksandros Hacopulos,Aleksandros Hacopulos,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,10,,,,male
-2cdaaec0-ddef-42e1-8892-b0cc0ffb9077,Ali Cavit Oral,Ali Cavit Oral,,,,Cumhuriyet Halk Partisi,CHP,area/seyhan_(adana),Seyhan (Adana),Grand National Assembly,10,,,,male
+2cdaaec0-ddef-42e1-8892-b0cc0ffb9077,Ali Cavit Oral,Ali Cavit Oral,,,,Cumhuriyet Halk Partisi,CHP,area/seyhan_(adana),Seyhan (Adana),Grand National Assembly,10,,,,
 3f180aec-d6b9-4247-9f94-9ea724283726,Ali Enver Güreli,Ali Enver Güreli,,,,Demokrat Parti,DP46,area/balıkesir,Balıkesir,Grand National Assembly,10,,,,
 9e71570b-02ef-43b7-8857-0cdeee9b018a,Ali Ferruh Yücel,Ali Ferruh Yücel,,,,Demokrat Parti,DP46,area/bursa,Bursa,Grand National Assembly,10,,,,
 7da075c8-1f09-40b1-a9f4-957caa15a55e,Ali Fuat Cebesoy,Ali Fuat Cebesoy,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,10,,,https://upload.wikimedia.org/wikipedia/commons/0/09/Ali_Fuat_Pasha.jpg,male
@@ -97,7 +97,7 @@ e6b4f318-cedd-462c-b399-fa53e4a601b2,Behzat Bilgin,Behzat Bilgin,,,,Demokrat Par
 d85fda45-004c-4d5f-8e79-b77cd6c0e874,Celal Ramazanoğlu,Celal Ramazanoğlu,,,,Demokrat Parti,DP46,area/hatay,Hatay,Grand National Assembly,10,,,,
 5b67f397-8bd9-44c7-b12d-ae43c1633dee,Celal Türkgeldi,Celal Türkgeldi,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,10,,,,
 760dd0d3-5b40-4545-930b-2e2c1834510e,Celal Öncel,Celal Öncel,,,,Demokrat Parti,DP46,area/urfa,Urfa,Grand National Assembly,10,,,,
-98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,10,,,https://upload.wikimedia.org/wikipedia/commons/9/9b/Celal_bayar.jpg,male
+98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,10,,,,
 b6f12988-0a98-4e66-9380-052aeb40bd4e,Cemal Köprülü,Cemal Köprülü,,,,Demokrat Parti,DP46,area/edirne,Edirne,Grand National Assembly,10,,,,
 97127725-f24c-49f9-985d-d1f5d2305997,Cemal Kıpçak,Cemal Kıpçak,,,,Demokrat Parti,DP46,area/zonguldak,Zonguldak,Grand National Assembly,10,,,,male
 363e2170-9c80-4efb-866a-38a7fbe8daf6,Cemal Tüzün,Cemal Tüzün,,,,Demokrat Parti,DP46,area/kocaeli,Kocaeli,Grand National Assembly,10,,,,
@@ -106,7 +106,7 @@ b6f12988-0a98-4e66-9380-052aeb40bd4e,Cemal Köprülü,Cemal Köprülü,,,,Demokr
 e97a08d2-7f80-408d-8e3b-9aba3a856172,Cevat Ülkü,Cevat Ülkü,,,,Demokrat Parti,DP46,area/aydın,Aydın,Grand National Assembly,10,,,,
 3a9312d0-65b1-4962-b518-cc323fc5c299,Cevdet San,Cevdet San,,,,Demokrat Parti,DP46,area/gaziantep,Gaziantep,Grand National Assembly,10,,,,
 30949694-d001-4227-97a0-c1f5f4395113,Cevdet Öztürk,Cevdet Öztürk,,,,Demokrat Parti,DP46,area/mardin,Mardin,Grand National Assembly,10,,,,
-b9c82a94-23ea-4f7d-ace4-e917e539da6a,Cihat Baban,Cihat Baban,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,10,,,,
+b9c82a94-23ea-4f7d-ace4-e917e539da6a,Cihat Baban,Cihat Baban,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,10,,,,male
 b48290fd-71a1-427d-88c4-fc977b30d6ac,Danyal Akbel,Danyal Akbel,,,,Demokrat Parti,DP46,area/yozgat,Yozgat,Grand National Assembly,10,,,,
 dccd7541-26bf-472a-8ec2-5ea917f8bba2,Dağıstan Binerbay,Dağıstan Binerbay,,,,Demokrat Parti,DP46,area/ankara,Ankara,Grand National Assembly,10,,,,
 a1e536db-a8b2-43b8-be51-75cf9c07162a,Doğan Köymen,Doğan Köymen,,,,Demokrat Parti,DP46,area/giresun,Giresun,Grand National Assembly,10,,,,
@@ -119,7 +119,7 @@ d7f6c410-5d7e-4ea9-860a-4fbcac0b5052,Ekrem Ocaklı,Ekrem Ocaklı,,,,Demokrat Par
 0b5202c9-a28a-4dd6-b7cb-985afe5b4cd3,Ekrem Yıldız,Ekrem Yıldız,,,,Demokrat Parti,DP46,area/bingöl,Bingöl,Grand National Assembly,10,,,,
 aa543e6f-ae84-480b-8cfd-9cea1be0fd47,Emin Develioğlu,Emin Develioğlu,,,,Demokrat Parti,DP46,area/kayseri,Kayseri,Grand National Assembly,10,,,,male
 973be44d-574d-4513-8585-26bc10aab302,Emin Kalafat,Emin Kalafat,,,,Demokrat Parti,DP46,area/Çanakkale,Çanakkale,Grand National Assembly,10,,,,male
-0d2afaf6-804c-40c2-8d3f-45ecb41d482d,Emin Onat,Emin Onat,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,10,,,,
+0d2afaf6-804c-40c2-8d3f-45ecb41d482d,Emin Onat,Emin Onat,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,10,,,,male
 cbe4cfe9-c277-4629-9f25-33a8a5f32719,Emrullah Nutku,Emrullah Nutku,,,,Demokrat Parti,DP46,area/trabzon,Trabzon,Grand National Assembly,10,,,,
 6ae42018-3de4-435d-8768-aff3ecd26c8b,Enver Batumlu,Enver Batumlu,,,,Demokrat Parti,DP46,area/seyhan_(adana),Seyhan (Adana),Grand National Assembly,10,,,,male
 2c7c36ca-a135-4418-ad74-18fd3fa68b2a,Enver Karan,Enver Karan,,,,Demokrat Parti,DP46,area/antalya,Antalya,Grand National Assembly,10,,,,male
@@ -218,7 +218,7 @@ ffe64262-cd10-468e-97d9-30710a6f7e84,Hüseyin Çimen,Hüseyin Çimen,,,,Demokrat
 cb3897df-717c-478f-a99d-ab7332803cd7,Hüsnü Göktuğ,Hüsnü Göktuğ,,,,Demokrat Parti,DP46,area/elazığ,Elazığ,Grand National Assembly,10,,,,
 667df839-73ba-46f3-b282-db7923b5fbd4,Hüsnü Çanakçı,Hüsnü Çanakçı,,,,Demokrat Parti,DP46,area/erzincan,Erzincan,Grand National Assembly,10,,,,
 dc8e7183-e319-4c12-8aed-390508b4f04a,Kamil Gündeş,Kamil Gündeş,,,,Demokrat Parti,DP46,area/kayseri,Kayseri,Grand National Assembly,10,,,,male
-60ff0bfe-4972-475a-862a-adf2c054959d,Kamil Kırıkoğlu,Kamil Kırıkoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,10,,,,
+60ff0bfe-4972-475a-862a-adf2c054959d,Kamil Kırıkoğlu,Kamil Kırıkoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,10,,,,male
 7c78ef00-42d5-4c31-b4d7-26cef0830f30,Kasım Küfrevi,Kasım Küfrevi,,,,Demokrat Parti,DP46,area/ağrı,Ağrı,Grand National Assembly,10,,,,
 6742a1fb-f343-4e62-bb93-7a2c6b6add59,Kazım Meriç,Kazım Meriç,,,,Demokrat Parti,DP46,area/kocaeli,Kocaeli,Grand National Assembly,10,,,,
 c4368386-91c2-4ce1-a5df-357f3531455c,Kazım Oskay,Kazım Oskay,,,,Demokrat Parti,DP46,area/sivas,Sivas,Grand National Assembly,10,,,,
@@ -254,7 +254,7 @@ d34955c1-ef3c-4e02-9a31-a0bb90abb1e6,Mehmet Daim Süalp,Mehmet Daim Süalp,,,,De
 3bb93fd5-1631-41a7-ae36-633e717fc730,Mehmet Enginün,Mehmet Enginün,,,,Demokrat Parti,DP46,area/edirne,Edirne,Grand National Assembly,10,,,,
 46ded72c-2910-4496-904d-49f8a0346f5d,Mehmet Fahri Mete,Mehmet Fahri Mete,,,,Demokrat Parti,DP46,area/ordu,Ordu,Grand National Assembly,10,,,,male
 8b6270a3-d31d-469d-ba71-bb6e3eefc768,Mehmet Fahri Oral,Mehmet Fahri Oral,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,10,,,,
-402dda26-7adf-4019-9211-f1c86178da48,Mehmet Fuad Köprülü,Mehmet Fuad Köprülü,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,10,,,https://upload.wikimedia.org/wikipedia/commons/f/fd/Mehmet_Fuat_Köprülü.jpg,male
+402dda26-7adf-4019-9211-f1c86178da48,Mehmet Fuad Köprülü,Mehmet Fuad Köprülü,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,10,,,,
 d699b243-4827-432c-a26f-d1bf29a21db6,Mehmet Hatipoğlu,Mehmet Hatipoğlu,,,,Demokrat Parti,DP46,area/urfa,Urfa,Grand National Assembly,10,,,,
 7ca07c3a-f0e7-43ee-81dc-8b881bf83eb6,Mehmet Hazer,Mehmet Hazer,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,10,,,,male
 b4b01ec4-7279-49ef-805b-a42d8c23983e,Mehmet Hüsrev Ünal,Mehmet Hüsrev Ünal,,,,Demokrat Parti,DP46,area/diyarbakır,Diyarbakır,Grand National Assembly,10,,,,
@@ -266,7 +266,7 @@ e052109b-c4f7-42fa-a171-62b516f2947d,Mehmet Muhlis Ete,Mehmet Muhlis Ete,,,,Demo
 c37951e8-3e4a-4534-9204-f44e0dc2ba45,Mehmet Mutlugil,Mehmet Mutlugil,,,,Demokrat Parti,DP46,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,10,,,,
 10d7c5c1-d388-4067-a191-da4c9fbb95e1,Mehmet Mümtaz Tarhan,Mehmet Mümtaz Tarhan,,,,Demokrat Parti,DP46,area/ankara,Ankara,Grand National Assembly,10,,,,male
 0a9d4c31-35de-46ce-87ec-4128f03e59c6,Mehmet Nuri Turgay,Mehmet Nuri Turgay,,,,Demokrat Parti,DP46,area/sivas,Sivas,Grand National Assembly,10,,,,
-c798e817-75b9-4568-8e7c-1b7912ef8842,Mehmet Nuri Yamut,Mehmet Nuri Yamut,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,10,,,,
+c798e817-75b9-4568-8e7c-1b7912ef8842,Mehmet Nuri Yamut,Mehmet Nuri Yamut,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,10,,,,male
 2bd34ba3-04a2-44f5-9af8-ef7fb38a4c4a,Mehmet Rüştü Özal,Mehmet Rüştü Özal,,,,Demokrat Parti,DP46,area/konya,Konya,Grand National Assembly,10,,,,male
 5d2a2ed9-410b-467c-b118-c555a2c0ac48,Mehmet Rıza Çerçel,Mehmet Rıza Çerçel,,,,Demokrat Parti,DP46,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,10,,,,male
 79db1e3a-93bf-433d-9908-b967900a98e0,Mehmet Zeki Tulunay,Mehmet Zeki Tulunay,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,10,,,,male
@@ -499,7 +499,7 @@ ab0e3e8f-f8eb-49eb-a3d9-5b12b6bcd84c,İbrahim Ethem Menderes,İbrahim Ethem Mend
 54dc5c1c-93b9-4e8a-8ab8-f16539cd09d5,İbrahim Kirazoğlu,İbrahim Kirazoğlu,,,,Demokrat Parti,DP46,area/kayseri,Kayseri,Grand National Assembly,10,,,,male
 45a176a8-1e24-40af-8eeb-8e2d4b13266e,İbrahim Sıtkı Yırcalı,İbrahim Sıtkı Yırcalı,,,,Demokrat Parti,DP46,area/balıkesir,Balıkesir,Grand National Assembly,10,,,,male
 86194f33-a9e4-4e6d-898e-f038f245c33f,İbrahim Us,İbrahim Us,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,10,,,,male
-5abfe84a-d540-4329-ac31-5ef38d88f6c0,İbrahim Öktem,İbrahim Öktem,,,,Demokrat Parti,DP46,area/bursa,Bursa,Grand National Assembly,10,,,,male
+5abfe84a-d540-4329-ac31-5ef38d88f6c0,İbrahim Öktem,İbrahim Öktem,,,,Demokrat Parti,DP46,area/bursa,Bursa,Grand National Assembly,10,,,,
 d3727993-53ab-44d7-8023-c9ae393738e1,İhsan Aktürel,İhsan Aktürel,,,,Demokrat Parti,DP46,area/yozgat,Yozgat,Grand National Assembly,10,,,,
 f8bb8714-6d8d-48d7-a233-1872e0f1906b,İhsan Baç,İhsan Baç,,,,Demokrat Parti,DP46,area/tokat,Tokat,Grand National Assembly,10,,,,
 9a5f30c1-1082-491e-aa0a-3b5735081557,İhsan Dai,İhsan Dai,,,,Demokrat Parti,DP46,area/gaziantep,Gaziantep,Grand National Assembly,10,,,,male

--- a/data/Turkey/Assembly/term-11.csv
+++ b/data/Turkey/Assembly/term-11.csv
@@ -103,7 +103,7 @@ e6b4f318-cedd-462c-b399-fa53e4a601b2,Behzat Bilgin,Behzat Bilgin,,,,Demokrat Par
 c25b1f9d-9104-455b-9bc0-d9492cb16111,Bülent Ecevit,Bülent Ecevit,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,11,,,https://upload.wikimedia.org/wikipedia/commons/f/ff/Bülent_Ecevit-Davos_2000_cropped.jpg,male
 2f0e04e6-17e6-445d-90a2-ba755825a388,Celal Dora,Celal Dora,,,,Cumhuriyet Halk Partisi,CHP,area/elazığ,Elazığ,Grand National Assembly,11,,,,
 d85fda45-004c-4d5f-8e79-b77cd6c0e874,Celal Ramazanoğlu,Celal Ramazanoğlu,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,11,,,,
-98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,11,,,https://upload.wikimedia.org/wikipedia/commons/9/9b/Celal_bayar.jpg,male
+98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,11,,,,
 eb7c86e2-2304-4a6a-b598-3152b04ebfaa,Cemal Işık,Cemal Işık,,,,Cumhuriyet Halk Partisi,CHP,area/erzincan,Erzincan,Grand National Assembly,11,,,,
 363e2170-9c80-4efb-866a-38a7fbe8daf6,Cemal Tüzün,Cemal Tüzün,,,,Demokrat Parti,DP46,area/kocaeli,Kocaeli,Grand National Assembly,11,,,,
 017169d1-a3ba-459b-ba55-6f8b917dce13,Cemal Zühtü Aysan,Cemal Zühtü Aysan,,,,Demokrat Parti,DP46,area/zonguldak,Zonguldak,Grand National Assembly,11,,,,
@@ -245,7 +245,7 @@ ec6563bd-cee0-433e-983e-745fc65ec178,Kadir Kocaeli,Kadir Kocaeli,,,,Demokrat Par
 ec2543b2-c812-4d88-9adb-acab0ca171dd,Kadrettin Oğuzalıcı,Kadrettin Oğuzalıcı,,,,Demokrat Parti,DP46,area/edirne,Edirne,Grand National Assembly,11,,,,
 9f9d08ad-311f-4d30-801d-f8482ca27ecd,Kahraman Sağra,Kahraman Sağra,,,,Cumhuriyet Halk Partisi,CHP,area/ordu,Ordu,Grand National Assembly,11,,,,
 dc8e7183-e319-4c12-8aed-390508b4f04a,Kamil Gündeş,Kamil Gündeş,,,,Demokrat Parti,DP46,area/kayseri,Kayseri,Grand National Assembly,11,,,,male
-60ff0bfe-4972-475a-862a-adf2c054959d,Kamil Kırıkoğlu,Kamil Kırıkoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,11,,,,
+60ff0bfe-4972-475a-862a-adf2c054959d,Kamil Kırıkoğlu,Kamil Kırıkoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,11,,,,male
 7ec74c93-70ea-4062-9929-28fe7fad35c8,Kamil Sürenkök,Kamil Sürenkök,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,11,,,,
 3b31e558-2afc-4766-98ac-d1f2cb304659,Kamil Tabak,Kamil Tabak,,,,Cumhuriyet Halk Partisi,CHP,area/Çankırı,Çankırı,Grand National Assembly,11,,,,
 0fce0c25-fa87-4cb8-af1a-33aca0b14869,Kamil Tayşi,Kamil Tayşi,,,,Demokrat Parti,DP46,area/diyarbakır,Diyarbakır,Grand National Assembly,11,,,,male
@@ -333,7 +333,7 @@ c8b78ce9-c40a-4191-bd0d-9f101055cecb,Mustafa Runyun,Mustafa Runyun,,,,Demokrat P
 0e90ac01-fe69-4c1d-9fa5-1c45451a7e2f,Mustafa Yeşil,Mustafa Yeşil,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,11,,,,
 eee45d59-cf4c-4dec-860c-4a81fbb7e903,Mustafa Zeren,Mustafa Zeren,,,,Demokrat Parti,DP46,area/erzurum,Erzurum,Grand National Assembly,11,,,,male
 e4fceced-29bf-4aa5-8a63-16568f95b0a8,Mustafa Çürük,Mustafa Çürük,,,,Demokrat Parti,DP46,area/eskişehir,Eskişehir,Grand National Assembly,11,,,,
-2e851bb1-b387-4998-9cc6-83da78a4a03e,Mustafa Öztürk,Mustafa Öztürk,,,,Demokrat Parti,DP46,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,11,,,,
+2e851bb1-b387-4998-9cc6-83da78a4a03e,Mustafa Öztürk,Mustafa Öztürk,,,,Demokrat Parti,DP46,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,11,,,,male
 adcdd712-34f8-4860-b85d-63e8cc73119f,Muzaffer Akdoğanlı,Muzaffer Akdoğanlı,,,,Demokrat Parti,DP46,area/kastamonu,Kastamonu,Grand National Assembly,11,,,,
 b961b845-2714-488f-9452-f71aee5eae80,Muzaffer Emiroğlu,Muzaffer Emiroğlu,,,,Demokrat Parti,DP46,area/balıkesir,Balıkesir,Grand National Assembly,11,,,,
 12ed7aa8-76e3-47b3-a6fa-dab3b37c8bef,Muzaffer Kurbanoğlu,Muzaffer Kurbanoğlu,,,,Demokrat Parti,DP46,area/manisa,Manisa,Grand National Assembly,11,,,,male
@@ -389,7 +389,7 @@ a05b78d9-d073-4776-8cbd-bfc6f8ce968e,Nizamettin Ali Sav,Nizamettin Ali Sav,,,,De
 b0b66757-20e5-4825-89b5-51afddfea6a5,Nurettin Manyas,Nurettin Manyas,,,,Demokrat Parti,DP46,area/edirne,Edirne,Grand National Assembly,11,,,,
 64ef7623-224e-44fa-93e8-993816009493,Nuri Ciritlioğlu,Nuri Ciritlioğlu,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,11,,,,
 52f5137d-0097-4732-9ec7-c86a39f92816,Nuri Togay,Nuri Togay,,,,Demokrat Parti,DP46,area/Çanakkale,Çanakkale,Grand National Assembly,11,,,,
-b44ab38e-8978-4aec-9f38-b20da62e92cd,Nuri Yamut,Nuri Yamut,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,11,,,,male
+b44ab38e-8978-4aec-9f38-b20da62e92cd,Nuri Yamut,Nuri Yamut,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,11,,,,
 aff7e1cd-157c-4d35-b8aa-7439d33f4b5d,Nuri Özsan,Nuri Özsan,,,,Demokrat Parti,DP46,area/muğla,Muğla,Grand National Assembly,11,,,,male
 4e16d602-1566-44aa-a10f-f96de43c9727,Nuriye Pınar,Nuriye Pınar,,,,Demokrat Parti,DP46,area/İzmir,İzmir,Grand National Assembly,11,,,,
 bb0c5405-9710-4f4a-ac2d-34350c4e2ce2,Nurullah İhsan Tolon,Nurullah İhsan Tolon,,,,Demokrat Parti,DP46,area/bursa,Bursa,Grand National Assembly,11,,,,
@@ -572,7 +572,7 @@ b42ca71a-6fb3-4f6e-94b1-4be5e8adf8f7,İsak Altabev,İsak Altabev,,,,Demokrat Par
 55036a67-e3c3-4e41-bd05-121df17188fe,İsmail Güven,İsmail Güven,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,11,,,,male
 bd6a5445-624f-4b36-b9d6-8495f4979d6c,İsmail Hadımlıoğlu,İsmail Hadımlıoğlu,,,,Demokrat Parti,DP46,area/denizli,Denizli,Grand National Assembly,11,,,,
 6e3e0a3a-782d-495e-ae04-f47189d500ae,İsmail Hakkı Talay,İsmail Hakkı Talay,,,,Cumhuriyet Halk Partisi,CHP,area/elazığ,Elazığ,Grand National Assembly,11,,,,
-d6e2ef29-c570-4ee9-8abf-d4edc8b93dec,İsmail Hakkı Tunaboylu,İsmail Hakkı Tunaboylu,,,,Demokrat Parti,DP46,area/yozgat,Yozgat,Grand National Assembly,11,,,,
+d6e2ef29-c570-4ee9-8abf-d4edc8b93dec,İsmail Hakkı Tunaboylu,İsmail Hakkı Tunaboylu,,,,Demokrat Parti,DP46,area/yozgat,Yozgat,Grand National Assembly,11,,,,male
 08745386-5c65-429c-bb54-73167d05b5c0,İsmail Hilmi Dura,İsmail Hilmi Dura,,,,Demokrat Parti,DP46,area/kastamonu,Kastamonu,Grand National Assembly,11,,,,male
 0c26b449-afa6-4288-a554-d249f63cadf9,İsmail Rüştü Aksal,İsmail Rüştü Aksal,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,11,,,,male
 404d4e77-50b3-4ecf-a121-32bcb523e884,İsmail Özdoyuran,İsmail Özdoyuran,,,,Demokrat Parti,DP46,area/tekirdağ,Tekirdağ,Grand National Assembly,11,,,,male

--- a/data/Turkey/Assembly/term-12.csv
+++ b/data/Turkey/Assembly/term-12.csv
@@ -31,7 +31,7 @@ ce0a6d7d-9a4f-4355-9037-67575e80191c,Ahmet Türkel,Ahmet Türkel,,,,Adalet Parti
 e522375b-29b1-40b2-b735-b4f8ff4c6a63,Ahmet Zeydan,Ahmet Zeydan,,,,Cumhuriyet Halk Partisi,CHP,area/hakkâri,Hakkâri,Grand National Assembly,12,,,,male
 588af5b7-6069-47e7-838b-c0dca222b468,Ahmet Çakmak,Ahmet Çakmak,,,,Yeni Türkiye Partisi,YTP,area/bolu,Bolu,Grand National Assembly,12,,,,male
 bfaf1533-a686-42d2-820c-debd7599127a,Ahmet Üstün,Ahmet Üstün,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,12,,,,male
-b126d94f-b584-4c66-ae8b-9e77c8e6770d,Ahmet İhsan Kırımlı,Ahmet İhsan Kırımlı,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,12,,,,
+b126d94f-b584-4c66-ae8b-9e77c8e6770d,Ahmet İhsan Kırımlı,Ahmet İhsan Kırımlı,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,12,,,,male
 ec7fce46-1731-4c6b-a22f-b0afdb44d8d1,Ahmet Şener,Ahmet Şener,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,12,,,,male
 75490c28-2fbc-42e9-a821-edc1313a1a19,Alaettin Eriş,Alaettin Eriş,,,,Yeni Türkiye Partisi,YTP,area/kırklareli,Kırklareli,Grand National Assembly,12,,,,
 969569d9-8011-450f-9859-275c18f04205,Ali Avni Turanlı,Ali Avni Turanlı,,,,Yeni Türkiye Partisi,YTP,area/adıyaman,Adıyaman,Grand National Assembly,12,,,,
@@ -76,7 +76,7 @@ aad7e58e-2045-45ea-ba65-ec797ca7de74,Atalay Akan,Atalay Akan,,,,Cumhuriyet Halk 
 23bad636-0f8e-4fbb-a5a2-907b5ad752c2,Burhan Bozdoğan,Burhan Bozdoğan,,,,Adalet Partisi,AP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,12,,,,
 c1010f2d-1ba6-4205-97b2-19482e99102a,Cafer Sadık Kutlay,Cafer Sadık Kutlay,,,,Cumhuriyet Halk Partisi,CHP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,12,,,,
 792af068-ebab-49be-9e84-f8d38630f33a,Cahit Yılmaz,Cahit Yılmaz,,,,Adalet Partisi,AP,area/konya,Konya,Grand National Assembly,12,,,,
-1adb90dc-9199-44a3-b389-7ade1a7874f2,Cavit Oral,Cavit Oral,,,,Adalet Partisi,AP,area/adana,Adana,Grand National Assembly,12,,,,
+1adb90dc-9199-44a3-b389-7ade1a7874f2,Cavit Oral,Cavit Oral,,,,Adalet Partisi,AP,area/adana,Adana,Grand National Assembly,12,,,,male
 875bd22f-ba16-45fb-bf01-285cc587ed2a,Cavit Şadi Pehlivanoğlu,Cavit Şadi Pehlivanoğlu,,,,Adalet Partisi,AP,area/ordu,Ordu,Grand National Assembly,12,,,,
 a13bcd89-5182-4f85-9668-a1de50624fff,Celal Ahmet Sungur,Celal Ahmet Sungur,,,,Cumhuriyet Halk Partisi,CHP,area/yozgat,Yozgat,Grand National Assembly,12,,,,
 8fdcd2f8-4723-4355-a552-02fd264ba938,Celal Kılıç,Celal Kılıç,,,,Adalet Partisi,AP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,12,,,,
@@ -91,10 +91,10 @@ ee159dfb-dbb1-49c6-89b4-95f637c0f294,Cevat Kanpulat,Cevat Kanpulat,,,,Adalet Par
 3e10bb05-0e22-4dc1-90ef-b20174e3a00a,Cevat Önder,Cevat Önder,,,,Yeni Türkiye Partisi,YTP,area/erzurum,Erzurum,Grand National Assembly,12,,,,
 c50b95f3-5284-4d1c-a5a3-40be45530dcd,Cevdet Oskay,Cevdet Oskay,,,,Adalet Partisi,AP,area/muğla,Muğla,Grand National Assembly,12,,,,
 9db13553-e45a-43bd-8e3d-769aadb46444,Cevdet Perin,Cevdet Perin,,,,Adalet Partisi,AP,area/bursa,Bursa,Grand National Assembly,12,,,,
-b9c82a94-23ea-4f7d-ace4-e917e539da6a,Cihat Baban,Cihat Baban,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,12,,,,
-aea395ae-e52f-49a5-85ea-9969e8fb6a4e,Cihat Bilgehan,Cihat Bilgehan,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,12,,,,
+b9c82a94-23ea-4f7d-ace4-e917e539da6a,Cihat Baban,Cihat Baban,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,12,,,,male
+aea395ae-e52f-49a5-85ea-9969e8fb6a4e,Cihat Bilgehan,Cihat Bilgehan,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,12,,,,male
 3a5cfccd-3afc-42f3-b7c8-f11e64177044,Cihat Turgut,Cihat Turgut,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,12,,,,
-d084b4f5-9de7-4a63-ba7f-fe94c46b1aa6,Coşkun Kırca,Coşkun Kırca,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,12,,,,male
+d084b4f5-9de7-4a63-ba7f-fe94c46b1aa6,Coşkun Kırca,Coşkun Kırca,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,12,,,,
 144dbd7f-9056-4f2d-8e1c-bb7d30016aa7,Edip Rüştü Akyürek,Edip Rüştü Akyürek,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,12,,,,
 df5ac660-62c0-41f4-8d03-378e5be2cc97,Ekrem Alican,Ekrem Alican,,,,Yeni Türkiye Partisi,YTP,area/sakarya,Sakarya,Grand National Assembly,12,,,,male
 84d188f9-1008-49e6-922c-5aa0c6642f87,Ekrem Dikmen,Ekrem Dikmen,,,,Adalet Partisi,AP,area/trabzon,Trabzon,Grand National Assembly,12,,,,
@@ -130,7 +130,7 @@ e3648205-bcb5-4160-944b-ea50074e2da5,Fuat Arna,Fuat Arna,,,,Cumhuriyetçi Köyl�
 127679f5-9fa5-4312-be1d-dd7659e797fa,Fuat Ümit,Fuat Ümit,,,,Yeni Türkiye Partisi,YTP,area/bolu,Bolu,Grand National Assembly,12,,,,
 db5cdfda-e7c6-48d1-af5d-065291aebefc,Gökhan Evliyaoğlu,Gökhan Evliyaoğlu,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,12,,,,
 b704f9ba-8630-47c3-836a-e41e025b7415,Güner Sarısözen,Güner Sarısözen,,,,Yeni Türkiye Partisi,YTP,area/sivas,Sivas,Grand National Assembly,12,,,,
-a56e6afb-6b50-4b0e-9d5b-df5f8369dd94,Gıyasettin Karaca,Gıyasettin Karaca,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,12,,,,female
+a56e6afb-6b50-4b0e-9d5b-df5f8369dd94,Gıyasettin Karaca,Gıyasettin Karaca,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,12,,,,
 44b3691d-2821-4f63-8d48-168830808ab3,Hacı Ali Cüceoğlu,Hacı Ali Cüceoğlu,,,,Cumhuriyetçi Köylü Millet Partisi,CKMP,area/giresun,Giresun,Grand National Assembly,12,,,,male
 7a22adab-4975-4e11-8a02-f4d28e7771ec,Hacı Ali Dizman,Hacı Ali Dizman,,,,Yeni Türkiye Partisi,YTP,area/tokat,Tokat,Grand National Assembly,12,,,,
 8c4bf9b5-8af7-4cd1-9e38-74c4cbc9d47b,Haldun Kısayol,Haldun Kısayol,,,,Adalet Partisi,AP,area/kocaeli,Kocaeli,Grand National Assembly,12,,,,
@@ -159,7 +159,7 @@ c04310ea-da6c-4480-b3b3-050640061a1b,Hilmi Aydınçer,Hilmi Aydınçer,,,,Adalet
 6795442e-614b-4bec-a805-ed5d38f43f0c,Hilmi Güldoğan,Hilmi Güldoğan,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,12,,,,
 56d07d0b-8841-4d71-affa-c9daf23075c6,Hilmi Oben,Hilmi Oben,,,,Adalet Partisi,AP,area/İstanbul,İstanbul,Grand National Assembly,12,,,,
 8e9db97d-e311-4b98-9ee5-10706038d5b5,Hilmi Okçu,Hilmi Okçu,,,,Adalet Partisi,AP,area/manisa,Manisa,Grand National Assembly,12,,,,
-f920c447-6e9a-4505-9875-b7b10a7eaea5,Hilmi İncesulu,Hilmi İncesulu,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,12,,,,
+f920c447-6e9a-4505-9875-b7b10a7eaea5,Hilmi İncesulu,Hilmi İncesulu,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,12,,,,male
 5d4189bf-66df-403a-ac17-fe28b79ddc2d,Hürrem Kubat,Hürrem Kubat,,,,Adalet Partisi,AP,area/manisa,Manisa,Grand National Assembly,12,,,,
 56e736f8-2e95-4f06-9691-6e08c932d5ff,Hürrem Müftügil,Hürrem Müftügil,,,,Cumhuriyet Halk Partisi,CHP,area/elazığ,Elazığ,Grand National Assembly,12,,,,male
 1489ed57-d987-4f08-95aa-89fef7019f85,Hüsamettin Atabeyli,Hüsamettin Atabeyli,,,,Yeni Türkiye Partisi,YTP,area/erzincan,Erzincan,Grand National Assembly,12,,,,
@@ -282,7 +282,7 @@ a12bcd14-5aea-4677-becd-68ff2691ea0f,Nihat Kürşat,Nihat Kürşat,,,,Adalet Par
 6d8a7cc1-2ac8-4516-86ce-5c8a72e0c963,Nizamettin Erkmen,Nizamettin Erkmen,,,,Yeni Türkiye Partisi,YTP,area/giresun,Giresun,Grand National Assembly,12,,,,male
 d38784fc-4ed2-42e0-bfbd-5e152dcd558a,Nuh Mehmet Sağlam,Nuh Mehmet Sağlam,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,12,,,,
 3359be03-8cd6-4176-802d-ea00360e4421,Nurettin Akyurt,Nurettin Akyurt,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,12,,,,
-50e25215-6212-47b3-a886-01db0ac4a1f5,Nurettin Ardıçoğlu,Nurettin Ardıçoğlu,,,,Cumhuriyetçi Köylü Millet Partisi,CKMP,area/elazığ,Elazığ,Grand National Assembly,12,,,,
+50e25215-6212-47b3-a886-01db0ac4a1f5,Nurettin Ardıçoğlu,Nurettin Ardıçoğlu,,,,Cumhuriyetçi Köylü Millet Partisi,CKMP,area/elazığ,Elazığ,Grand National Assembly,12,,,,male
 10f17f1d-2454-4eda-96be-9520b339a9a6,Nurettin Bulak,Nurettin Bulak,,,,Adalet Partisi,AP,area/İstanbul,İstanbul,Grand National Assembly,12,,,,
 d5e67339-2132-4aec-91a0-c279e2bc9731,Nurettin Ceritoğlu,Nurettin Ceritoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,12,,,,
 7216a2c8-1dfe-48d7-aa86-59d4d9ce28a5,Nurettin Ok,Nurettin Ok,,,,Cumhuriyetçi Köylü Millet Partisi,CKMP,area/Çankırı,Çankırı,Grand National Assembly,12,,,,
@@ -342,7 +342,7 @@ f3a6ba96-3b8b-4bef-8699-7ef65f891968,Saffet Eminağaoğlu,Saffet Eminağaoğlu,,
 144dd0e2-36cf-4e90-a886-5a9fcce6f5e6,Samet Kuzucu,Samet Kuzucu,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,12,,,,
 fab76acd-23da-44ef-916c-4ac717dd0e53,Sami Öztürk,Sami Öztürk,,,,Yeni Türkiye Partisi,YTP,area/muş,Muş,Grand National Assembly,12,,,,
 5ec9fbf0-e5d7-489f-9306-cd67bac4b7af,Selahattin Güven,Selahattin Güven,,,,Adalet Partisi,AP,area/trabzon,Trabzon,Grand National Assembly,12,,,,male
-d9afdc10-b7a7-48a4-8c1b-a80331669da5,Selim Sarper,Selim Sarper,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,12,,,,
+d9afdc10-b7a7-48a4-8c1b-a80331669da5,Selim Sarper,Selim Sarper,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,12,,,,male
 427bbc4c-61b1-42cc-9590-57ed8ee2833c,Selçuk Aytan,Selçuk Aytan,,,,Yeni Türkiye Partisi,YTP,area/konya,Konya,Grand National Assembly,12,,,,
 c7d24a7f-e103-448f-ab97-2c9ef9daf2eb,Seyfi Güneştan,Seyfi Güneştan,,,,Yeni Türkiye Partisi,YTP,area/mardin,Mardin,Grand National Assembly,12,,,,
 d98adedf-dc67-4c5f-93d2-26d1df67612f,Seyfi Öztürk,Seyfi Öztürk,,,,Cumhuriyetçi Köylü Millet Partisi,CKMP,area/eskişehir,Eskişehir,Grand National Assembly,12,,,,male
@@ -402,14 +402,14 @@ dab44c05-6dd1-41e2-b187-029289a5b644,İbrahim Göker,İbrahim Göker,,,,Cumhuriy
 03290e47-b8b2-42bb-8dd9-36d6da41fa18,İbrahim Kocatürk,İbrahim Kocatürk,,,,Adalet Partisi,AP,area/denizli,Denizli,Grand National Assembly,12,,,,
 334ef6e6-247f-498e-9dc0-abe1127d9fd0,İbrahim Sıtkı Hatipoğlu,İbrahim Sıtkı Hatipoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,12,,,,male
 89e3f0a0-6ca5-4590-9617-834d1bb20b30,İbrahim Tekin,İbrahim Tekin,,,,Adalet Partisi,AP,area/adana,Adana,Grand National Assembly,12,,,,male
-5abfe84a-d540-4329-ac31-5ef38d88f6c0,İbrahim Öktem,İbrahim Öktem,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,12,,,,male
+5abfe84a-d540-4329-ac31-5ef38d88f6c0,İbrahim Öktem,İbrahim Öktem,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,12,,,,
 5851bcab-397b-4e04-989e-48406773ff75,İbrahim İmirzalıoğlu,İbrahim İmirzalıoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,12,,,,male
 b93e545c-9f42-4a3b-acf9-79b5347cb681,İhsan Ataöv,İhsan Ataöv,,,,Adalet Partisi,AP,area/antalya,Antalya,Grand National Assembly,12,,,,male
 0107329b-da29-4a44-90e6-614830321e14,İhsan Bedirhanoğlu,İhsan Bedirhanoğlu,,,,Yeni Türkiye Partisi,YTP,area/van,Van,Grand National Assembly,12,,,,male
-2efab9a9-0c2a-479c-a41a-9ee8f2334c37,İhsan Gürsan,İhsan Gürsan,,,,Adalet Partisi,AP,area/İzmir,İzmir,Grand National Assembly,12,,,,male
+2efab9a9-0c2a-479c-a41a-9ee8f2334c37,İhsan Gürsan,İhsan Gürsan,,,,Adalet Partisi,AP,area/İzmir,İzmir,Grand National Assembly,12,,,,
 2d5ea0dc-cb88-4d04-a9db-e5414bf6744d,İhsan Kabadayı,İhsan Kabadayı,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,12,,,,male
 e5544773-d081-49d7-b6d6-f1a23f50a767,İhsan Köknel,İhsan Köknel,,,,Adalet Partisi,AP,area/ankara,Ankara,Grand National Assembly,12,,,,male
-a0713c74-04f2-45ef-aa63-5c23d0a34303,İhsan Tombuş,İhsan Tombuş,,,,Adalet Partisi,AP,area/Çorum,Çorum,Grand National Assembly,12,,,,male
+a0713c74-04f2-45ef-aa63-5c23d0a34303,İhsan Tombuş,İhsan Tombuş,,,,Adalet Partisi,AP,area/Çorum,Çorum,Grand National Assembly,12,,,,
 15fb7f20-f9e9-492d-bf65-0df6af40ba42,İhsan Önal,İhsan Önal,,,,Adalet Partisi,AP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,12,,,,male
 0df2f89b-455b-405d-bd5a-6b741591fb92,İhsan Şeref Dura,İhsan Şeref Dura,,,,Yeni Türkiye Partisi,YTP,area/kastamonu,Kastamonu,Grand National Assembly,12,,,,male
 9d914fe6-5d6a-47d0-a560-eb24f60ec9f6,İlhami Sancar,İlhami Sancar,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,12,,,,
@@ -436,7 +436,7 @@ de675383-3eb1-4309-acce-1372dcbcd1bf,İsmail Yılmaz,İsmail Yılmaz,,,,Adalet P
 473ded7b-3d3b-492c-82e6-499334656fc8,Şadi Binay,Şadi Binay,,,,Adalet Partisi,AP,area/bilecik,Bilecik,Grand National Assembly,12,,,,
 92f70a91-2448-49df-a68c-cb30065cf161,Şahabettin Bilgisu,Şahabettin Bilgisu,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,12,,,,
 18b7adf7-da29-4fd1-aade-40ac33e0e814,Şahabettin Orhon,Şahabettin Orhon,,,,Adalet Partisi,AP,area/İstanbul,İstanbul,Grand National Assembly,12,,,,
-b006377f-07b7-4463-9950-94740f8446ae,Şefik İnan,Şefik İnan,,,,Cumhuriyet Halk Partisi,CHP,area/Çanakkale,Çanakkale,Grand National Assembly,12,,,,
+b006377f-07b7-4463-9950-94740f8446ae,Şefik İnan,Şefik İnan,,,,Cumhuriyet Halk Partisi,CHP,area/Çanakkale,Çanakkale,Grand National Assembly,12,,,,male
 08af3549-2b38-4305-8d57-4952ed09620e,Şekip İnal,Şekip İnal,,,,Yeni Türkiye Partisi,YTP,area/hatay,Hatay,Grand National Assembly,12,,,,
 cb450b76-90c8-49e2-8b8f-064237e60ded,Şerafettin Korunay,Şerafettin Korunay,,,,Cumhuriyetçi Köylü Millet Partisi,CKMP,area/erzurum,Erzurum,Grand National Assembly,12,,,,
 401a2287-b543-48bb-bec5-0d9d1a172d1b,Şeref Bakşık,Şeref Bakşık,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,12,,,,

--- a/data/Turkey/Assembly/term-13.csv
+++ b/data/Turkey/Assembly/term-13.csv
@@ -15,7 +15,7 @@ dc20681e-1e02-4590-80cb-4bfe72588682,Abdüllatif Ensarioğlu,Abdüllatif Ensario
 4f188828-b526-4b3a-88ee-c6fc28a445dd,Ahmet Atıf Hacıpaşaoğlu,Ahmet Atıf Hacıpaşaoğlu,,,,Adalet Partisi,AP,area/kayseri,Kayseri,Grand National Assembly,13,,,,
 384c3ee1-a819-4996-b19e-271b0be0899f,Ahmet Bilgin,Ahmet Bilgin,,,,Millet Partisi,MP,area/edirne,Edirne,Grand National Assembly,13,,,,male
 5675a3d5-2689-4f3c-90c1-76fd7b46992a,Ahmet Can Bilgin,Ahmet Can Bilgin,,,,Adalet Partisi,AP,area/kütahya,Kütahya,Grand National Assembly,13,,,,
-6d65a7d4-ccae-47e6-8376-77f813b0be95,Ahmet Can Demiray,Ahmet Can Demiray,,,,Cumhuriyet Halk Partisi,CHP,area/amasya,Amasya,Grand National Assembly,13,,,,
+6d65a7d4-ccae-47e6-8376-77f813b0be95,Ahmet Can Demiray,Ahmet Can Demiray,,,,Cumhuriyet Halk Partisi,CHP,area/amasya,Amasya,Grand National Assembly,13,,,,male
 e433fbad-1aea-4f4a-b992-0ec71b0ded4d,Ahmet Dallı,Ahmet Dallı,,,,Adalet Partisi,AP,area/ankara,Ankara,Grand National Assembly,13,,,,male
 201ab919-55d4-4ff0-bea3-02df3c96aceb,Ahmet Hayri Başar,Ahmet Hayri Başar,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,13,,,,male
 52a700e5-37ed-4eb6-b021-b04cf49d43f8,Ahmet Muslihittin Gürer,Ahmet Muslihittin Gürer,,,,Adalet Partisi,AP,area/sakarya,Sakarya,Grand National Assembly,13,,,,
@@ -30,7 +30,7 @@ ce0a6d7d-9a4f-4355-9037-67575e80191c,Ahmet Türkel,Ahmet Türkel,,,,Adalet Parti
 311bbb4d-8e0c-4a89-8ead-8696aff20ba9,Ahmet Çebi,Ahmet Çebi,,,,Millet Partisi,MP,area/trabzon,Trabzon,Grand National Assembly,13,,,,
 bfaf1533-a686-42d2-820c-debd7599127a,Ahmet Üstün,Ahmet Üstün,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,13,,,,male
 e7e8de18-a6b4-4c64-89bd-dbf9c89b4d89,Ahmet İhsan Birincioğlu,Ahmet İhsan Birincioğlu,,,,Adalet Partisi,AP,area/trabzon,Trabzon,Grand National Assembly,13,,,,male
-b126d94f-b584-4c66-ae8b-9e77c8e6770d,Ahmet İhsan Kırımlı,Ahmet İhsan Kırımlı,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,13,,,,
+b126d94f-b584-4c66-ae8b-9e77c8e6770d,Ahmet İhsan Kırımlı,Ahmet İhsan Kırımlı,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,13,,,,male
 ec7fce46-1731-4c6b-a22f-b0afdb44d8d1,Ahmet Şener,Ahmet Şener,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,13,,,,male
 8e97326e-0892-49b1-a117-2b39241c09f1,Ahmet Şevket Bohça,Ahmet Şevket Bohça,,,,Adalet Partisi,AP,area/kastamonu,Kastamonu,Grand National Assembly,13,,,,
 6791bb72-5a4f-4ce4-a8a7-69d31d61fb94,Ali Abdüssettar İksel,Ali Abdüssettar İksel,,,,Adalet Partisi,AP,area/İzmir,İzmir,Grand National Assembly,13,,,,male
@@ -38,7 +38,7 @@ ec7fce46-1731-4c6b-a22f-b0afdb44d8d1,Ahmet Şener,Ahmet Şener,,,,Cumhuriyet Hal
 5fdff9ac-d106-4df8-a961-67445da4b461,Ali Baran Numanoğlu,Ali Baran Numanoğlu,,,,Millet Partisi,MP,area/nevşehir,Nevşehir,Grand National Assembly,13,,,,
 e8606c41-44a1-4c44-964a-5bd2f47edd1f,Ali Bozdoğanoğlu,Ali Bozdoğanoğlu,,,,Adalet Partisi,AP,area/adana,Adana,Grand National Assembly,13,,,,
 91be1695-3b07-48f1-af41-d88b7795a5a9,Ali Celalettin Topala,Ali Celalettin Topala,,,,Adalet Partisi,AP,area/amasya,Amasya,Grand National Assembly,13,,,,
-08805097-2a18-46e1-9346-c010a26ac994,Ali Coşkun Kırca,Ali Coşkun Kırca,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,13,,,,
+08805097-2a18-46e1-9346-c010a26ac994,Ali Coşkun Kırca,Ali Coşkun Kırca,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,13,,,,male
 3f180aec-d6b9-4247-9f94-9ea724283726,Ali Enver Güreli,Ali Enver Güreli,,,,Cumhuriyet Halk Partisi,CHP,area/balıkesir,Balıkesir,Grand National Assembly,13,,,,
 6e00a528-4b92-4588-a489-fe2f10d18693,Ali Esat Birol,Ali Esat Birol,,,,Adalet Partisi,AP,area/İstanbul,İstanbul,Grand National Assembly,13,,,,
 9c6f1506-4f64-4d59-be9f-59dccd8c1e86,Ali Fuat Alişan,Ali Fuat Alişan,,,,Adalet Partisi,AP,area/samsun,Samsun,Grand National Assembly,13,,,,
@@ -72,7 +72,7 @@ aad7e58e-2045-45ea-ba65-ec797ca7de74,Atalay Akan,Atalay Akan,,,,Cumhuriyet Halk 
 076b289a-45e3-40f4-b34e-629845bc7317,Bahri Yazır,Bahri Yazır,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,13,,,,
 98091f19-c018-492f-860f-9537c0d124cc,Barlas Küntay,Barlas Küntay,,,,Adalet Partisi,AP,area/bursa,Bursa,Grand National Assembly,13,,,,male
 ea191779-931c-415a-91ae-ef2541422fd0,Bedrettin Karaerkek,Bedrettin Karaerkek,,,,Adalet Partisi,AP,area/tokat,Tokat,Grand National Assembly,13,,,,
-1fd209ed-d891-47a3-9aaa-2bed3f2fb210,Behice Boran Hatko,Behice Boran Hatko,,,,Türkiye İşçi Partisi,TİP,area/urfa,Urfa,Grand National Assembly,13,,,,
+1fd209ed-d891-47a3-9aaa-2bed3f2fb210,Behice Boran Hatko,Behice Boran Hatko,,,,Türkiye İşçi Partisi,TİP,area/urfa,Urfa,Grand National Assembly,13,,,,female
 4c782f10-f1f9-4aed-aa32-6526d047db43,Bekir Tünay,Bekir Tünay,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,13,,,,
 5d68f40e-1796-4099-92ce-54b3acba5bd7,Budak Mursaloğlu,Budak Mursaloğlu,,,,Cumhuriyet Halk Partisi,CHP,area/hatay,Hatay,Grand National Assembly,13,,,,
 23bad636-0f8e-4fbb-a5a2-907b5ad752c2,Burhan Bozdoğan,Burhan Bozdoğan,,,,Adalet Partisi,AP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,13,,,,
@@ -124,7 +124,7 @@ c4f55a20-d5c8-462d-b59a-79fb9cc36a74,Gıyasettin Duman,Gıyasettin Duman,,,,Mill
 919f3f95-f3ed-43db-b26e-b52a8c5c4a35,Halil İbrahim Cop,Halil İbrahim Cop,,,,Adalet Partisi,AP,area/bolu,Bolu,Grand National Assembly,13,,,,
 d3b15b01-f671-43c2-9502-4df8a2756e85,Hamdi Mağden,Hamdi Mağden,,,,Adalet Partisi,AP,area/ordu,Ordu,Grand National Assembly,13,,,,
 1bcce593-0e2f-4a3e-9f28-6348e2e054ef,Hami Tezkan,Hami Tezkan,,,,Adalet Partisi,AP,area/bolu,Bolu,Grand National Assembly,13,,,,
-d607c9e0-0266-4cb2-8732-e3c45ef870ae,Hamid Fendoğlu,Hamid Fendoğlu,,,,Adalet Partisi,AP,area/malatya,Malatya,Grand National Assembly,13,,,,
+d607c9e0-0266-4cb2-8732-e3c45ef870ae,Hamid Fendoğlu,Hamid Fendoğlu,,,,Adalet Partisi,AP,area/malatya,Malatya,Grand National Assembly,13,,,,male
 daa4b559-bb89-4f02-90b5-7e4d45dfe644,Hasan Aksay,Hasan Aksay,,,,Adalet Partisi,AP,area/adana,Adana,Grand National Assembly,13,,,,male
 7a4f66c1-3eef-4aba-ac6e-c66b96c301b0,Hasan Akçalıoğlu,Hasan Akçalıoğlu,,,,Adalet Partisi,AP,area/antalya,Antalya,Grand National Assembly,13,,,,
 1252bef4-5956-46c3-aa2c-2eb6d217e8f9,Hasan Değer,Hasan Değer,,,,Adalet Partisi,AP,area/diyarbakır,Diyarbakır,Grand National Assembly,13,,,,male
@@ -160,7 +160,7 @@ eb16e2b2-9967-4895-a1ce-ad0bcda433b0,Hüseyin Avni Akın,Hüseyin Avni Akın,,,,
 87a4637d-dc67-4ec8-91d6-629a8a86bccd,Hüsnü Özkan,Hüsnü Özkan,,,,Cumhuriyet Halk Partisi,CHP,area/hatay,Hatay,Grand National Assembly,13,,,,
 3a5c1ddb-c854-4b30-bb08-e6df252de46c,Kadir Çetin,Kadir Çetin,,,,Adalet Partisi,AP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,13,,,,
 f3058d9f-aad1-4f3b-9549-f67e65ec5d5a,Kadri Eroğan,Kadri Eroğan,,,,Adalet Partisi,AP,area/sakarya,Sakarya,Grand National Assembly,13,,,,
-60ff0bfe-4972-475a-862a-adf2c054959d,Kamil Kırıkoğlu,Kamil Kırıkoğlu,,,,Millet Partisi,MP,area/zonguldak,Zonguldak,Grand National Assembly,13,,,,
+60ff0bfe-4972-475a-862a-adf2c054959d,Kamil Kırıkoğlu,Kamil Kırıkoğlu,,,,Millet Partisi,MP,area/zonguldak,Zonguldak,Grand National Assembly,13,,,,male
 44e58f92-3a7f-426b-b4b8-6ab0b1619ede,Kamil Özsarıyıldız,Kamil Özsarıyıldız,,,,Adalet Partisi,AP,area/muş,Muş,Grand National Assembly,13,,,,male
 a32d1134-9753-4df1-beb0-99c200d56a42,Kamran Evliyaoğlu,Kamran Evliyaoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,13,,,,male
 4f6202c4-d900-48f5-831c-109060bc99dd,Kasım Gülek,Kasım Gülek,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,13,,,,male
@@ -212,19 +212,19 @@ bf310e36-eabf-425a-8244-66c5471754bb,Mehmet Faruk Sükan,Mehmet Faruk Sükan,,,,
 578c876f-233d-4b94-9b75-2c808c865db6,Mehmet Fenni İslimyeli,Mehmet Fenni İslimyeli,,,,Cumhuriyet Halk Partisi,CHP,area/balıkesir,Balıkesir,Grand National Assembly,13,,,,
 98196683-719f-41b3-9da2-7eeac4f96495,Mehmet Göbekli,Mehmet Göbekli,,,,Adalet Partisi,AP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,13,,,,
 c69f7f93-38c9-4237-8380-c77db657b100,Mehmet Güver,Mehmet Güver,,,,Adalet Partisi,AP,area/kırşehir,Kırşehir,Grand National Assembly,13,,,,
-fdd3342d-a40e-493d-b0e7-f87ac73fbc30,Mehmet Gıyasettin Karaca,Mehmet Gıyasettin Karaca,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,13,,,,
-1098d721-e13b-4c20-8dcc-8686e29a26f9,Mehmet Hilmi İncesulu,Mehmet Hilmi İncesulu,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,13,,,,male
+fdd3342d-a40e-493d-b0e7-f87ac73fbc30,Mehmet Gıyasettin Karaca,Mehmet Gıyasettin Karaca,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,13,,,,female
+1098d721-e13b-4c20-8dcc-8686e29a26f9,Mehmet Hilmi İncesulu,Mehmet Hilmi İncesulu,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,13,,,,
 a344a182-c8b7-4233-b8bd-8fa85188e847,Mehmet Kamil Ocak,Mehmet Kamil Ocak,,,,Adalet Partisi,AP,area/giresun,Giresun,Grand National Assembly,13,,,,male
 5d2ea625-5ce7-45ec-ac1e-5cd6331547ab,Mehmet Muhittin Güven,Mehmet Muhittin Güven,,,,Adalet Partisi,AP,area/İstanbul,İstanbul,Grand National Assembly,13,,,,male
 f9c38886-c79a-4e9d-a1da-4d9cb8c19d4f,Mehmet Necati Kalaycıoğlu,Mehmet Necati Kalaycıoğlu,,,,Adalet Partisi,AP,area/konya,Konya,Grand National Assembly,13,,,,male
 4379f3cb-b797-4f7e-898f-50fb4b4fc14d,Mehmet Nuri Kodamanoğlu,Mehmet Nuri Kodamanoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/yozgat,Yozgat,Grand National Assembly,13,,,,male
-15ef9544-6eb2-418a-9629-f7add0704878,Mehmet Orhan Kabibay,Mehmet Orhan Kabibay,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,13,,,,
+15ef9544-6eb2-418a-9629-f7add0704878,Mehmet Orhan Kabibay,Mehmet Orhan Kabibay,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,13,,,,male
 9a85874f-e760-4152-9b9c-694e46d48b65,Mehmet Orhan Türkkan,Mehmet Orhan Türkkan,,,,Adalet Partisi,AP,area/kırklareli,Kırklareli,Grand National Assembly,13,,,,
 d4c9b0d2-d11e-4cd6-8a53-ea6cecb039b7,Mehmet Reşat Özarda,Mehmet Reşat Özarda,,,,Adalet Partisi,AP,area/aydın,Aydın,Grand National Assembly,13,,,,male
 0c26ad3b-4521-48a9-a184-edc267badd4b,Mehmet Sadettin Bilgiç,Mehmet Sadettin Bilgiç,,,,Adalet Partisi,AP,area/İstanbul,İstanbul,Grand National Assembly,13,,,,
 3f460c84-3b77-4dc7-a30f-a999d6cb94e0,Mehmet Salih Baydil,Mehmet Salih Baydil,,,,Adalet Partisi,AP,area/denizli,Denizli,Grand National Assembly,13,,,,
 02deaef0-5bf1-416f-9f3e-afdc7807d4d0,Mehmet Salih Yıldız,Mehmet Salih Yıldız,,,,Cumhuriyet Halk Partisi,CHP,area/van,Van,Grand National Assembly,13,,,,male
-1c7b61da-fdc1-41ab-9966-f813a6423626,Mehmet Selahattin Kılıç,Mehmet Selahattin Kılıç,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,13,,,,male
+1c7b61da-fdc1-41ab-9966-f813a6423626,Mehmet Selahattin Kılıç,Mehmet Selahattin Kılıç,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,13,,,,
 af9dc064-593c-4e48-97b0-b96456bdeeb2,Mehmet Turan Bilgin,Mehmet Turan Bilgin,,,,Adalet Partisi,AP,area/erzurum,Erzurum,Grand National Assembly,13,,,,male
 9de35b9f-cafb-4480-919c-a34840da40dc,Mehmet Turan Şahin,Mehmet Turan Şahin,,,,Cumhuriyet Halk Partisi,CHP,area/muğla,Muğla,Grand National Assembly,13,,,,male
 c3e352a2-b09d-45ac-8110-e4e433f1e610,Mehmet Turgut,Mehmet Turgut,,,,Adalet Partisi,AP,area/bursa,Bursa,Grand National Assembly,13,,,,male
@@ -232,7 +232,7 @@ c3e352a2-b09d-45ac-8110-e4e433f1e610,Mehmet Turgut,Mehmet Turgut,,,,Adalet Parti
 52aa0733-d7c4-4066-9de1-1c4d021e95a5,Mehmet Yüceler,Mehmet Yüceler,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,13,,,,male
 a5fd305c-bc27-490e-b521-84eb594c24aa,Mehmet Zeki Yücetürk,Mehmet Zeki Yücetürk,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,13,,,,
 a55d0aa3-b4f1-4aa3-9697-c47a4190bab9,Mehmet Ziyaettin İzerdem,Mehmet Ziyaettin İzerdem,,,,Adalet Partisi,AP,area/konya,Konya,Grand National Assembly,13,,,,
-ea7bfae3-e487-44c8-9156-2c2897a368f2,Mehmet İhsan Gürsan,Mehmet İhsan Gürsan,,,,Adalet Partisi,AP,area/İzmir,İzmir,Grand National Assembly,13,,,,
+ea7bfae3-e487-44c8-9156-2c2897a368f2,Mehmet İhsan Gürsan,Mehmet İhsan Gürsan,,,,Adalet Partisi,AP,area/İzmir,İzmir,Grand National Assembly,13,,,,male
 732729f1-fb25-479b-adbe-1d555199fb72,Mehmet İlhami Ertem,Mehmet İlhami Ertem,,,,Adalet Partisi,AP,area/edirne,Edirne,Grand National Assembly,13,,,,male
 76ccda6b-2c78-409f-9064-b873dbb2622f,Mehmet İlhami Sancar,Mehmet İlhami Sancar,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,13,,,,
 76683361-df90-45b3-bce1-da47e636d3fd,Mehmet İsmet Angı,Mehmet İsmet Angı,,,,Adalet Partisi,AP,area/eskişehir,Eskişehir,Grand National Assembly,13,,,,
@@ -287,7 +287,7 @@ fab713c5-989c-4ef1-abf4-fb790cbb9b2c,Necmettin Cevheri,Necmettin Cevheri,,,,Adal
 196e4a71-a8a7-4f10-9021-f390ab75404b,Nedim Metin Cizreli,Nedim Metin Cizreli,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,13,,,,
 80ba35b2-65f3-4ddc-be01-b2351472b6cd,Nejdet Yücer,Nejdet Yücer,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,13,,,,
 3ba73d14-a53e-4090-86a3-3fab688fc047,Neriman Ağaoğlu,Neriman Ağaoğlu,,,,Adalet Partisi,AP,area/manisa,Manisa,Grand National Assembly,13,,,,female
-80a07708-ae6e-43bd-9668-cff2bb1a92a7,Nevzat Cihat Bilgehan,Nevzat Cihat Bilgehan,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,13,,,,male
+80a07708-ae6e-43bd-9668-cff2bb1a92a7,Nevzat Cihat Bilgehan,Nevzat Cihat Bilgehan,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,13,,,,
 3d1d76dd-a6eb-4924-aae2-e3603dba475e,Nevzat Güngör,Nevzat Güngör,,,,Adalet Partisi,AP,area/ağrı,Ağrı,Grand National Assembly,13,,,,
 a8fa6334-d18d-4689-9cab-53d413ca4d53,Nevzat Şener,Nevzat Şener,,,,Adalet Partisi,AP,area/amasya,Amasya,Grand National Assembly,13,,,,male
 72135fa2-f4f8-42d9-9125-6372fec0cbaf,Nihat Bayramoğlu,Nihat Bayramoğlu,,,,Adalet Partisi,AP,area/bolu,Bolu,Grand National Assembly,13,,,,
@@ -298,7 +298,7 @@ a12bcd14-5aea-4677-becd-68ff2691ea0f,Nihat Kürşat,Nihat Kürşat,,,,Adalet Par
 8c82c074-f968-4bb5-964f-2f0931597bc8,Nilüfer Gürsoy,Nilüfer Gürsoy,,,,Adalet Partisi,AP,area/bursa,Bursa,Grand National Assembly,13,,,,
 9c2a144c-e2c4-405a-9a79-1c5d9fbc6c6d,Niyazi Özgüç,Niyazi Özgüç,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,13,,,,
 6d8a7cc1-2ac8-4516-86ce-5c8a72e0c963,Nizamettin Erkmen,Nizamettin Erkmen,,,,Adalet Partisi,AP,area/giresun,Giresun,Grand National Assembly,13,,,,male
-50e25215-6212-47b3-a886-01db0ac4a1f5,Nurettin Ardıçoğlu,Nurettin Ardıçoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/elazığ,Elazığ,Grand National Assembly,13,,,,
+50e25215-6212-47b3-a886-01db0ac4a1f5,Nurettin Ardıçoğlu,Nurettin Ardıçoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/elazığ,Elazığ,Grand National Assembly,13,,,,male
 10f17f1d-2454-4eda-96be-9520b339a9a6,Nurettin Bulak,Nurettin Bulak,,,,Adalet Partisi,AP,area/İstanbul,İstanbul,Grand National Assembly,13,,,,
 7216a2c8-1dfe-48d7-aa86-59d4d9ce28a5,Nurettin Ok,Nurettin Ok,,,,Adalet Partisi,AP,area/Çankırı,Çankırı,Grand National Assembly,13,,,,
 bb1505f2-18e3-4f81-abdc-39420c720fda,Nuri Eroğan,Nuri Eroğan,,,,Adalet Partisi,AP,area/İstanbul,İstanbul,Grand National Assembly,13,,,,
@@ -308,7 +308,7 @@ bb1505f2-18e3-4f81-abdc-39420c720fda,Nuri Eroğan,Nuri Eroğan,,,,Adalet Partisi
 76c4b20d-ed35-4ab1-8093-1f881ec8ec27,Orhan Dengiz,Orhan Dengiz,,,,Adalet Partisi,AP,area/uşak,Uşak,Grand National Assembly,13,,,,male
 682bee47-032b-4afb-a943-865dfb4cec74,Orhan Eren,Orhan Eren,,,,Adalet Partisi,AP,area/ankara,Ankara,Grand National Assembly,13,,,,male
 aabefa9d-3d5c-4bf1-8b64-618a4719608e,Orhan Erkanlı,Orhan Erkanlı,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,13,,,,male
-3b78e5bb-5217-4959-a2f0-3600af2b5eed,Orhan Ferruh Eyüpoğlu,Orhan Ferruh Eyüpoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,13,,,,
+3b78e5bb-5217-4959-a2f0-3600af2b5eed,Orhan Ferruh Eyüpoğlu,Orhan Ferruh Eyüpoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,13,,,,male
 7808b408-7710-4163-bbbd-2bdd35e4b004,Orhan Seyfi Orhon,Orhan Seyfi Orhon,,,,Adalet Partisi,AP,area/İstanbul,İstanbul,Grand National Assembly,13,,,,male
 fe5374c9-f451-45d1-a5cb-f5a71b24f6d9,Orhan Öztrak,Orhan Öztrak,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,13,,,,male
 85ac68dd-1556-4c81-a096-8a508756eb2b,Osman Attilâ,Osman Attilâ,,,,Adalet Partisi,AP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,13,,,,male
@@ -319,10 +319,10 @@ bd9a7516-2722-4105-a50a-feba657a1dd1,Osman Bölükbaşı,Osman Bölükbaşı,,,,
 cb2de2ff-5880-4540-9d36-3349ee143a4d,Osman Turan,Osman Turan,,,,Adalet Partisi,AP,area/trabzon,Trabzon,Grand National Assembly,13,,,,male
 56354e21-1785-4dce-866f-49710844dfdd,Osman Yeltekin,Osman Yeltekin,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,13,,,,
 ebd02de9-11ce-4c02-873a-d63f44cbc5a2,Osman Zeki Oktay,Osman Zeki Oktay,,,,Adalet Partisi,AP,area/kastamonu,Kastamonu,Grand National Assembly,13,,,,
-8a57a369-3d35-4008-a464-3ff970d8565a,Osman Zeki Yüksel,Osman Zeki Yüksel,,,,Adalet Partisi,AP,area/antalya,Antalya,Grand National Assembly,13,,,,
+8a57a369-3d35-4008-a464-3ff970d8565a,Osman Zeki Yüksel,Osman Zeki Yüksel,,,,Adalet Partisi,AP,area/antalya,Antalya,Grand National Assembly,13,,,,male
 07c89e33-42f5-48ff-b1ac-61a85affa6cc,Osman Özer,Osman Özer,,,,Adalet Partisi,AP,area/İstanbul,İstanbul,Grand National Assembly,13,,,,
 c095e9dd-e744-4813-8b1a-d67fd1ad1b30,Osman Şahinoğlu,Osman Şahinoğlu,,,,Adalet Partisi,AP,area/samsun,Samsun,Grand National Assembly,13,,,,
-fec5dcd8-5a68-49ea-b230-98c979ac6ca7,Osman Şefik İnan,Osman Şefik İnan,,,,Cumhuriyet Halk Partisi,CHP,area/Çanakkale,Çanakkale,Grand National Assembly,13,,,,male
+fec5dcd8-5a68-49ea-b230-98c979ac6ca7,Osman Şefik İnan,Osman Şefik İnan,,,,Cumhuriyet Halk Partisi,CHP,area/Çanakkale,Çanakkale,Grand National Assembly,13,,,,
 05265440-b68f-4412-a711-a6896f992d95,Oğuzdemir Tüzün,Oğuzdemir Tüzün,,,,Millet Partisi,MP,area/niğde,Niğde,Grand National Assembly,13,,,,
 2db2c470-6baf-41df-8c9b-d8b1614d5097,Rafet Eker,Rafet Eker,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,13,,,,
 a75915d3-1f11-49bf-b87f-13fc6ae40934,Raif Aybar,Raif Aybar,,,,Yeni Türkiye Partisi,YTP,area/ordu,Ordu,Grand National Assembly,13,,,,
@@ -351,7 +351,7 @@ ff969757-0858-4642-97b3-dd66e3a489f5,Salih Ekmel Çetiner,Salih Ekmel Çetiner,,
 ebff61e0-9da0-497c-ba3d-6bb08c6387b5,Sedat Akay,Sedat Akay,,,,Adalet Partisi,AP,area/kocaeli,Kocaeli,Grand National Assembly,13,,,,
 5ec9fbf0-e5d7-489f-9306-cd67bac4b7af,Selahattin Güven,Selahattin Güven,,,,Adalet Partisi,AP,area/trabzon,Trabzon,Grand National Assembly,13,,,,male
 ab4ee067-721c-4f70-b0d3-6c46385221f4,Selahattin Hakkı Esatoğlu,Selahattin Hakkı Esatoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/nevşehir,Nevşehir,Grand National Assembly,13,,,,
-83be9657-bf66-4d10-bbeb-c6c64dffb412,Selim Rauf Sarper,Selim Rauf Sarper,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,13,,,,male
+83be9657-bf66-4d10-bbeb-c6c64dffb412,Selim Rauf Sarper,Selim Rauf Sarper,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,13,,,,
 427bbc4c-61b1-42cc-9590-57ed8ee2833c,Selçuk Aytan,Selçuk Aytan,,,,Adalet Partisi,AP,area/konya,Konya,Grand National Assembly,13,,,,
 c7d24a7f-e103-448f-ab97-2c9ef9daf2eb,Seyfi Güneştan,Seyfi Güneştan,,,,Yeni Türkiye Partisi,YTP,area/mardin,Mardin,Grand National Assembly,13,,,,
 4388e096-cf12-4f09-bbe9-4257fd7309a1,Seyfi Kurtbek,Seyfi Kurtbek,,,,Adalet Partisi,AP,area/sivas,Sivas,Grand National Assembly,13,,,,male
@@ -408,13 +408,13 @@ afbc59be-b0d8-4957-9e61-859f83fd7228,İbrahim Aytaç,İbrahim Aytaç,,,,Adalet P
 e8563ff1-bcad-4491-adc9-2947019eb7a9,İbrahim Etem Kılıçoğlu,İbrahim Etem Kılıçoğlu,,,,Adalet Partisi,AP,area/giresun,Giresun,Grand National Assembly,13,,,,male
 31072718-bbdc-49eb-b891-fbb614baeb8c,İbrahim Ethem Boz,İbrahim Ethem Boz,,,,Adalet Partisi,AP,area/nevşehir,Nevşehir,Grand National Assembly,13,,,,
 637d1875-d300-4384-a012-14de33cf24e5,İbrahim Halil Balkıs,İbrahim Halil Balkıs,,,,Yeni Türkiye Partisi,YTP,area/urfa,Urfa,Grand National Assembly,13,,,,
-003a330a-cda8-4bd6-9b84-5edbd4bb0a9a,İbrahim Hulusi Öktem,İbrahim Hulusi Öktem,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,13,,,,
+003a330a-cda8-4bd6-9b84-5edbd4bb0a9a,İbrahim Hulusi Öktem,İbrahim Hulusi Öktem,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,13,,,,male
 334ef6e6-247f-498e-9dc0-abe1127d9fd0,İbrahim Sıtkı Hatipoğlu,İbrahim Sıtkı Hatipoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,13,,,,male
 89e3f0a0-6ca5-4590-9617-834d1bb20b30,İbrahim Tekin,İbrahim Tekin,,,,Adalet Partisi,AP,area/adana,Adana,Grand National Assembly,13,,,,male
 eabb3b54-cad2-45ae-9864-48e84fea7cb6,İhsan Akhun,İhsan Akhun,,,,Adalet Partisi,AP,area/Çorum,Çorum,Grand National Assembly,13,,,,
 b93e545c-9f42-4a3b-acf9-79b5347cb681,İhsan Ataöv,İhsan Ataöv,,,,Adalet Partisi,AP,area/antalya,Antalya,Grand National Assembly,13,,,,male
 2d5ea0dc-cb88-4d04-a9db-e5414bf6744d,İhsan Kabadayı,İhsan Kabadayı,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,13,,,,male
-a0713c74-04f2-45ef-aa63-5c23d0a34303,İhsan Tombuş,İhsan Tombuş,,,,Adalet Partisi,AP,area/Çorum,Çorum,Grand National Assembly,13,,,,male
+a0713c74-04f2-45ef-aa63-5c23d0a34303,İhsan Tombuş,İhsan Tombuş,,,,Adalet Partisi,AP,area/Çorum,Çorum,Grand National Assembly,13,,,,
 81ee3249-379a-4035-a5b5-91edae86214e,İlhan Tekinalp,İlhan Tekinalp,,,,Adalet Partisi,AP,area/muğla,Muğla,Grand National Assembly,13,,,,
 10b91124-4420-4b13-9d1b-e915e5402c6a,İlyas Demir,İlyas Demir,,,,Adalet Partisi,AP,area/tekirdağ,Tekirdağ,Grand National Assembly,13,,,,
 27ab018a-07fd-442e-bc14-ea7c9eee238e,İlyas Kılıç,İlyas Kılıç,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,13,,,,

--- a/data/Turkey/Assembly/term-14.csv
+++ b/data/Turkey/Assembly/term-14.csv
@@ -28,12 +28,12 @@ ce0a6d7d-9a4f-4355-9037-67575e80191c,Ahmet Türkel,Ahmet Türkel,,,,Adalet Parti
 e522375b-29b1-40b2-b735-b4f8ff4c6a63,Ahmet Zeydan,Ahmet Zeydan,,,,Cumhuriyetçi Güven Partisi,CGP,area/hakkâri,Hakkâri,Grand National Assembly,14,,,,male
 588af5b7-6069-47e7-838b-c0dca222b468,Ahmet Çakmak,Ahmet Çakmak,,,,Adalet Partisi,AP,area/bolu,Bolu,Grand National Assembly,14,,,,male
 e7e8de18-a6b4-4c64-89bd-dbf9c89b4d89,Ahmet İhsan Birincioğlu,Ahmet İhsan Birincioğlu,,,,Adalet Partisi,AP,area/trabzon,Trabzon,Grand National Assembly,14,,,,male
-b126d94f-b584-4c66-ae8b-9e77c8e6770d,Ahmet İhsan Kırımlı,Ahmet İhsan Kırımlı,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,14,,,,
+b126d94f-b584-4c66-ae8b-9e77c8e6770d,Ahmet İhsan Kırımlı,Ahmet İhsan Kırımlı,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,14,,,,male
 ec7fce46-1731-4c6b-a22f-b0afdb44d8d1,Ahmet Şener,Ahmet Şener,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,14,,,,male
 375bf423-c8c8-4280-a980-e52e35173e94,Akgün Silivrili,Akgün Silivrili,,,,Adalet Partisi,AP,area/İstanbul,İstanbul,Grand National Assembly,14,,,,
 57672e98-3d90-4682-a09a-a79bf5f62aef,Akın Özdemir,Akın Özdemir,,,,Adalet Partisi,AP,area/İzmir,İzmir,Grand National Assembly,14,,,,
 969569d9-8011-450f-9859-275c18f04205,Ali Avni Turanlı,Ali Avni Turanlı,,,,Bağımsız,ind,area/adıyaman,Adıyaman,Grand National Assembly,14,,,,
-2cdaaec0-ddef-42e1-8892-b0cc0ffb9077,Ali Cavit Oral,Ali Cavit Oral,,,,Adalet Partisi,AP,area/adana,Adana,Grand National Assembly,14,,,,male
+2cdaaec0-ddef-42e1-8892-b0cc0ffb9077,Ali Cavit Oral,Ali Cavit Oral,,,,Adalet Partisi,AP,area/adana,Adana,Grand National Assembly,14,,,,
 cdda3227-8c1f-4af4-9e03-c76a3488e290,Ali Döğerli,Ali Döğerli,,,,Cumhuriyet Halk Partisi,CHP,area/muğla,Muğla,Grand National Assembly,14,,,,
 a4e8bcd8-b9c7-4bbb-a745-4c93df3e64c8,Ali Erbek,Ali Erbek,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,14,,,,
 65949c38-3441-4940-b020-1f818addcbf0,Ali Mesut Erez,Ali Mesut Erez,,,,Adalet Partisi,AP,area/kütahya,Kütahya,Grand National Assembly,14,,,,
@@ -81,7 +81,7 @@ e421f593-2da8-40de-baef-a720b539cacf,Cevat Eroğlu,Cevat Eroğlu,,,,Millet Parti
 d6aaff3d-e229-44c5-b23c-09e86ffe826e,Cevat Sayın,Cevat Sayın,,,,Cumhuriyet Halk Partisi,CHP,area/edirne,Edirne,Grand National Assembly,14,,,,
 3e10bb05-0e22-4dc1-90ef-b20174e3a00a,Cevat Önder,Cevat Önder,,,,Adalet Partisi,AP,area/erzurum,Erzurum,Grand National Assembly,14,,,,
 184f9366-4b91-4916-a510-622ef1a4b8b8,Cevdet Akçalı,Cevdet Akçalı,,,,Adalet Partisi,AP,area/adana,Adana,Grand National Assembly,14,,,,male
-aea395ae-e52f-49a5-85ea-9969e8fb6a4e,Cihat Bilgehan,Cihat Bilgehan,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,14,,,,
+aea395ae-e52f-49a5-85ea-9969e8fb6a4e,Cihat Bilgehan,Cihat Bilgehan,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,14,,,,male
 6b918803-d9fd-4188-9dec-7bf33ae59809,Coşkun Karagözoğlu,Coşkun Karagözoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,14,,,,
 303583a8-3aa1-449c-a8d0-09b35273f357,Doğan Kitaplı,Doğan Kitaplı,,,,Adalet Partisi,AP,area/samsun,Samsun,Grand National Assembly,14,,,,male
 84d188f9-1008-49e6-922c-5aa0c6642f87,Ekrem Dikmen,Ekrem Dikmen,,,,Adalet Partisi,AP,area/trabzon,Trabzon,Grand National Assembly,14,,,,
@@ -109,7 +109,7 @@ d383e54f-384b-4061-8399-83189efa0dc1,Fuat Ak,Fuat Ak,,,,Adalet Partisi,AP,area/z
 e1907ce9-0890-4c2b-914a-fbe496b96a6d,Fuat Avcı,Fuat Avcı,,,,Adalet Partisi,AP,area/denizli,Denizli,Grand National Assembly,14,,,,male
 ed1e25c5-b1c9-4ae6-a8a0-01db6f7f2270,Fuat Türkoğlu,Fuat Türkoğlu,,,,Adalet Partisi,AP,area/van,Van,Grand National Assembly,14,,,,
 e544a529-fb05-4dde-8d4c-387f1502823b,Güngör Hun,Güngör Hun,,,,Adalet Partisi,AP,area/sakarya,Sakarya,Grand National Assembly,14,,,,
-a56e6afb-6b50-4b0e-9d5b-df5f8369dd94,Gıyasettin Karaca,Gıyasettin Karaca,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,14,,,,female
+a56e6afb-6b50-4b0e-9d5b-df5f8369dd94,Gıyasettin Karaca,Gıyasettin Karaca,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,14,,,,
 61d4cfc3-22c5-4562-bfc5-644f7f3d7330,Hakkı Gökçe,Hakkı Gökçe,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,14,,,,male
 af514a19-4b65-4d04-9e0b-c6c8a7c1c772,Halil Akgöl,Halil Akgöl,,,,Adalet Partisi,AP,area/hatay,Hatay,Grand National Assembly,14,,,,
 919f3f95-f3ed-43db-b26e-b52a8c5c4a35,Halil İbrahim Cop,Halil İbrahim Cop,,,,Adalet Partisi,AP,area/bolu,Bolu,Grand National Assembly,14,,,,
@@ -155,7 +155,7 @@ affaca79-b2dc-4da2-849b-886fc64222cb,Hüseyin Özalp,Hüseyin Özalp,,,,Adalet P
 87a4637d-dc67-4ec8-91d6-629a8a86bccd,Hüsnü Özkan,Hüsnü Özkan,,,,Cumhuriyet Halk Partisi,CHP,area/hatay,Hatay,Grand National Assembly,14,,,,
 3a5c1ddb-c854-4b30-bb08-e6df252de46c,Kadir Çetin,Kadir Çetin,,,,Adalet Partisi,AP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,14,,,,
 f3058d9f-aad1-4f3b-9549-f67e65ec5d5a,Kadri Eroğan,Kadri Eroğan,,,,Adalet Partisi,AP,area/sivas,Sivas,Grand National Assembly,14,,,,
-60ff0bfe-4972-475a-862a-adf2c054959d,Kamil Kırıkoğlu,Kamil Kırıkoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/adıyaman,Adıyaman,Grand National Assembly,14,,,,
+60ff0bfe-4972-475a-862a-adf2c054959d,Kamil Kırıkoğlu,Kamil Kırıkoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/adıyaman,Adıyaman,Grand National Assembly,14,,,,male
 911ff65a-9e7c-4125-b230-ea740aabfd3e,Kamil Şahinoğlu,Kamil Şahinoğlu,,,,Adalet Partisi,AP,area/manisa,Manisa,Grand National Assembly,14,,,,
 a32d1134-9753-4df1-beb0-99c200d56a42,Kamran Evliyaoğlu,Kamran Evliyaoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,14,,,,male
 6d696c57-dccf-45e8-b8ce-583d9b562bfd,Kasım Emre,Kasım Emre,,,,Bağımsız,ind,area/muş,Muş,Grand National Assembly,14,,,,
@@ -213,7 +213,7 @@ f9c38886-c79a-4e9d-a1da-4d9cb8c19d4f,Mehmet Necati Kalaycıoğlu,Mehmet Necati K
 5d2a2ed9-410b-467c-b118-c555a2c0ac48,Mehmet Rıza Çerçel,Mehmet Rıza Çerçel,,,,Adalet Partisi,AP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,14,,,,male
 b984dd05-7064-4286-a484-5dc0f4774c0c,Mehmet Sait Reşa,Mehmet Sait Reşa,,,,Cumhuriyet Halk Partisi,CHP,area/hatay,Hatay,Grand National Assembly,14,,,,male
 02deaef0-5bf1-416f-9f3e-afdc7807d4d0,Mehmet Salih Yıldız,Mehmet Salih Yıldız,,,,Cumhuriyetçi Güven Partisi,CGP,area/van,Van,Grand National Assembly,14,,,,male
-1c7b61da-fdc1-41ab-9966-f813a6423626,Mehmet Selahattin Kılıç,Mehmet Selahattin Kılıç,,,,Adalet Partisi,AP,area/adana,Adana,Grand National Assembly,14,,,,male
+1c7b61da-fdc1-41ab-9966-f813a6423626,Mehmet Selahattin Kılıç,Mehmet Selahattin Kılıç,,,,Adalet Partisi,AP,area/adana,Adana,Grand National Assembly,14,,,,
 b53c6ce7-cf2e-48bf-96b1-74d09a8ddfcc,Mehmet Seydibeyoğlu,Mehmet Seydibeyoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,14,,,,male
 0c380f68-e125-412b-b310-7fc43041381b,Mehmet Sıddık Aydar,Mehmet Sıddık Aydar,,,,Bağımsız,ind,area/bingöl,Bingöl,Grand National Assembly,14,,,,male
 af9dc064-593c-4e48-97b0-b96456bdeeb2,Mehmet Turan Bilgin,Mehmet Turan Bilgin,,,,Adalet Partisi,AP,area/erzurum,Erzurum,Grand National Assembly,14,,,,male
@@ -308,8 +308,8 @@ e6edc48c-f908-41a8-bc35-4268eff28d9b,Orhan Ali Deniz,Orhan Ali Deniz,,,,Adalet P
 2f91aed3-f443-4831-b571-a8cba2caa5f1,Orhan Demir Sorguç,Orhan Demir Sorguç,,,,Adalet Partisi,AP,area/İzmir,İzmir,Grand National Assembly,14,,,,male
 76c4b20d-ed35-4ab1-8093-1f881ec8ec27,Orhan Dengiz,Orhan Dengiz,,,,Adalet Partisi,AP,area/uşak,Uşak,Grand National Assembly,14,,,,male
 682bee47-032b-4afb-a943-865dfb4cec74,Orhan Eren,Orhan Eren,,,,Adalet Partisi,AP,area/ankara,Ankara,Grand National Assembly,14,,,,male
-2a24ac9b-ef31-429e-af03-d69101d1c8fb,Orhan Eyüpoğlu,Orhan Eyüpoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,14,,,,male
-711a5e4c-e447-40ad-ac2d-d2683af868e5,Orhan Kabibay,Orhan Kabibay,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,14,,,,male
+2a24ac9b-ef31-429e-af03-d69101d1c8fb,Orhan Eyüpoğlu,Orhan Eyüpoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,14,,,,
+711a5e4c-e447-40ad-ac2d-d2683af868e5,Orhan Kabibay,Orhan Kabibay,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,14,,,,
 c0f52745-9097-47b6-806a-2470923bb252,Orhan Okay,Orhan Okay,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,14,,,,
 e5d3b2f9-fb9a-4e45-b80f-b5d2fbb821c3,Orhan Oğuz,Orhan Oğuz,,,,Adalet Partisi,AP,area/eskişehir,Eskişehir,Grand National Assembly,14,,,,male
 d9316647-0873-4c12-853b-b97cc8e889ba,Orhan Vural,Orhan Vural,,,,Cumhuriyet Halk Partisi,CHP,area/ordu,Ordu,Grand National Assembly,14,,,,male
@@ -359,7 +359,7 @@ cadaa6b7-989c-429d-8fd5-b1d9bf9415cc,Sinan Fevzi Fırat,Sinan Fevzi Fırat,,,,Ad
 7281b50c-42b9-47bb-a97e-3efbd80c7029,Süleyman Mutlu,Süleyman Mutlu,,,,Cumhuriyet Halk Partisi,CHP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,14,,,,male
 bb854388-a1ad-4035-add6-9ca8d4fec3dc,Süleyman Çağlar,Süleyman Çağlar,,,,Adalet Partisi,AP,area/manisa,Manisa,Grand National Assembly,14,,,,male
 5d885350-b839-4f54-a9ef-bceb7bbe8739,Süleyman Çiloğlu,Süleyman Çiloğlu,,,,Adalet Partisi,AP,area/antalya,Antalya,Grand National Assembly,14,,,,
-88ac40ec-1671-43d0-b3a7-fe3c063edba8,Tahsin Yılmaz Öztuna,Tahsin Yılmaz Öztuna,,,,Adalet Partisi,AP,area/konya,Konya,Grand National Assembly,14,,,,
+88ac40ec-1671-43d0-b3a7-fe3c063edba8,Tahsin Yılmaz Öztuna,Tahsin Yılmaz Öztuna,,,,Adalet Partisi,AP,area/konya,Konya,Grand National Assembly,14,,,,male
 e9df6780-b73a-4160-8079-251464aeca9f,Talat Asal,Talat Asal,,,,Adalet Partisi,AP,area/samsun,Samsun,Grand National Assembly,14,,,,
 8e619b84-ec94-415e-a50b-e3d256ccde05,Talat Köseoğlu,Talat Köseoğlu,,,,Adalet Partisi,AP,area/hatay,Hatay,Grand National Assembly,14,,,,
 c73b5c4a-3d03-4f8f-bb67-561d7e7ad71f,Talat Orhon,Talat Orhon,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,14,,,,
@@ -412,12 +412,12 @@ e8563ff1-bcad-4491-adc9-2947019eb7a9,İbrahim Etem Kılıçoğlu,İbrahim Etem K
 37cfd14b-6a9c-400a-9e09-646c5762c3ee,İbrahim Kayhan Naipoğlu,İbrahim Kayhan Naipoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/giresun,Giresun,Grand National Assembly,14,,,,
 334ef6e6-247f-498e-9dc0-abe1127d9fd0,İbrahim Sıtkı Hatipoğlu,İbrahim Sıtkı Hatipoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,14,,,,male
 abbb8cd7-b89a-4db3-9939-8f18dd99adc2,İbrahim Çirkin,İbrahim Çirkin,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,14,,,,
-5abfe84a-d540-4329-ac31-5ef38d88f6c0,İbrahim Öktem,İbrahim Öktem,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,14,,,,male
+5abfe84a-d540-4329-ac31-5ef38d88f6c0,İbrahim Öktem,İbrahim Öktem,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,14,,,,
 3e05839a-a59a-4671-92bb-43e35162283c,İbrahim Öztürk,İbrahim Öztürk,,,,Bağımsız,ind,area/maraş,Maraş,Grand National Assembly,14,,,,male
 b93e545c-9f42-4a3b-acf9-79b5347cb681,İhsan Ataöv,İhsan Ataöv,,,,Adalet Partisi,AP,area/antalya,Antalya,Grand National Assembly,14,,,,male
-2efab9a9-0c2a-479c-a41a-9ee8f2334c37,İhsan Gürsan,İhsan Gürsan,,,,Adalet Partisi,AP,area/İzmir,İzmir,Grand National Assembly,14,,,,male
+2efab9a9-0c2a-479c-a41a-9ee8f2334c37,İhsan Gürsan,İhsan Gürsan,,,,Adalet Partisi,AP,area/İzmir,İzmir,Grand National Assembly,14,,,,
 2d5ea0dc-cb88-4d04-a9db-e5414bf6744d,İhsan Kabadayı,İhsan Kabadayı,,,,Cumhuriyetçi Güven Partisi,CGP,area/konya,Konya,Grand National Assembly,14,,,,male
-a0713c74-04f2-45ef-aa63-5c23d0a34303,İhsan Tombuş,İhsan Tombuş,,,,Adalet Partisi,AP,area/Çorum,Çorum,Grand National Assembly,14,,,,male
+a0713c74-04f2-45ef-aa63-5c23d0a34303,İhsan Tombuş,İhsan Tombuş,,,,Adalet Partisi,AP,area/Çorum,Çorum,Grand National Assembly,14,,,,
 9d914fe6-5d6a-47d0-a560-eb24f60ec9f6,İlhami Sancar,İlhami Sancar,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,14,,,,
 fe1cad10-bd25-407a-9f66-efcfd1c333c2,İlhan Açıkalın,İlhan Açıkalın,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,14,,,,
 f8e681a5-ca08-447a-bcc2-3cb5619220ce,İlhan Darendelioğlu,İlhan Darendelioğlu,,,,Adalet Partisi,AP,area/İstanbul,İstanbul,Grand National Assembly,14,,,,

--- a/data/Turkey/Assembly/term-15.csv
+++ b/data/Turkey/Assembly/term-15.csv
@@ -33,7 +33,7 @@ c4fd23d8-86ed-4d60-bed9-31a2e318edbe,Ahmet Topaloğlu,Ahmet Topaloğlu,,,,Adalet
 ce0a6d7d-9a4f-4355-9037-67575e80191c,Ahmet Türkel,Ahmet Türkel,,,,Adalet Partisi,AP,area/bursa,Bursa,Grand National Assembly,15,,,,male
 8cc182a8-85e8-4685-b7d8-7ae7942ee454,Ahmet Yılmaz,Ahmet Yılmaz,,,,Cumhuriyet Halk Partisi,CHP,area/uşak,Uşak,Grand National Assembly,15,,,,male
 588af5b7-6069-47e7-838b-c0dca222b468,Ahmet Çakmak,Ahmet Çakmak,,,,Adalet Partisi,AP,area/bolu,Bolu,Grand National Assembly,15,,,,male
-b126d94f-b584-4c66-ae8b-9e77c8e6770d,Ahmet İhsan Kırımlı,Ahmet İhsan Kırımlı,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,15,,,,
+b126d94f-b584-4c66-ae8b-9e77c8e6770d,Ahmet İhsan Kırımlı,Ahmet İhsan Kırımlı,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,15,,,,male
 ec7fce46-1731-4c6b-a22f-b0afdb44d8d1,Ahmet Şener,Ahmet Şener,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,15,,,,male
 e5930dd3-2528-40fd-ab4c-737ce25fba8e,Alev Coşkun,Alev Coşkun,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,15,,,,
 058be32b-d5c7-493d-89bc-101da8a34c93,Ali Acar,Ali Acar,,,,Millî Selamet Partisi,MSP,area/samsun,Samsun,Grand National Assembly,15,,,,
@@ -81,7 +81,7 @@ e7335c7a-92e3-4bc4-a48d-6fc4e982c5f2,Cemil Ünal,Cemil Ünal,,,,Adalet Partisi,A
 d6aaff3d-e229-44c5-b23c-09e86ffe826e,Cevat Sayın,Cevat Sayın,,,,Cumhuriyet Halk Partisi,CHP,area/edirne,Edirne,Grand National Assembly,15,,,,
 5ed8d223-90cd-44e3-bacb-49ab88682ed3,Cevat Yalçın,Cevat Yalçın,,,,Adalet Partisi,AP,area/rize,Rize,Grand National Assembly,15,,,,
 3e10bb05-0e22-4dc1-90ef-b20174e3a00a,Cevat Önder,Cevat Önder,,,,Demokratik Parti,DP70,area/ankara,Ankara,Grand National Assembly,15,,,,
-aea395ae-e52f-49a5-85ea-9969e8fb6a4e,Cihat Bilgehan,Cihat Bilgehan,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,15,,,,
+aea395ae-e52f-49a5-85ea-9969e8fb6a4e,Cihat Bilgehan,Cihat Bilgehan,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,15,,,,male
 6b918803-d9fd-4188-9dec-7bf33ae59809,Coşkun Karagözoğlu,Coşkun Karagözoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,15,,,,
 b8a97178-4ba7-4ea9-98fd-5e1729394961,Davut Aksu,Davut Aksu,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,15,,,,
 64644586-aaec-42b2-8a12-ca82928feeda,Deniz Baykal,Deniz Baykal,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,15,,,https://upload.wikimedia.org/wikipedia/commons/5/58/Deniz_Baykal_TBMM.jpg,male
@@ -111,7 +111,7 @@ c149f203-0c42-4d42-a39f-988c5228b363,Fikri Pehlivanlı,Fikri Pehlivanlı,,,,Adal
 e1907ce9-0890-4c2b-914a-fbe496b96a6d,Fuat Avcı,Fuat Avcı,,,,Adalet Partisi,AP,area/denizli,Denizli,Grand National Assembly,15,,,,male
 20482f1a-b0c9-40dd-b398-2f0fa5860bc2,Fuat Uysal,Fuat Uysal,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,15,,,,
 6dfdab03-245c-4cef-9072-248d2fad9e91,Gündüz Sevilgen,Gündüz Sevilgen,,,,Millî Selamet Partisi,MSP,area/manisa,Manisa,Grand National Assembly,15,,,,
-a56e6afb-6b50-4b0e-9d5b-df5f8369dd94,Gıyasettin Karaca,Gıyasettin Karaca,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,15,,,,female
+a56e6afb-6b50-4b0e-9d5b-df5f8369dd94,Gıyasettin Karaca,Gıyasettin Karaca,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,15,,,,
 61d4cfc3-22c5-4562-bfc5-644f7f3d7330,Hakkı Gökçe,Hakkı Gökçe,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,15,,,,male
 2f3bb7d7-1000-40de-8547-0f5a68acb085,Halil Ağar,Halil Ağar,,,,Adalet Partisi,AP,area/adıyaman,Adıyaman,Grand National Assembly,15,,,,male
 82c0f6e3-169d-4552-93a1-8f6f2a08f2fc,Halil Başol,Halil Başol,,,,Adalet Partisi,AP,area/tekirdağ,Tekirdağ,Grand National Assembly,15,,,,male
@@ -164,7 +164,7 @@ ec338c49-1def-47f3-aedd-38c989b39b1b,Hüseyin Deniz,Hüseyin Deniz,,,,Cumhuriyet
 affaca79-b2dc-4da2-849b-886fc64222cb,Hüseyin Özalp,Hüseyin Özalp,,,,Adalet Partisi,AP,area/samsun,Samsun,Grand National Assembly,15,,,,male
 e397da80-c973-4a03-91e1-f639f622335e,Hüseyin Özdemir,Hüseyin Özdemir,,,,Adalet Partisi,AP,area/İstanbul,İstanbul,Grand National Assembly,15,,,,
 e1ba26c7-8d6b-48a4-a814-0207d3f18ada,Kadir Özpak,Kadir Özpak,,,,Cumhuriyet Halk Partisi,CHP,area/uşak,Uşak,Grand National Assembly,15,,,,
-60ff0bfe-4972-475a-862a-adf2c054959d,Kamil Kırıkoğlu,Kamil Kırıkoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,15,,,,
+60ff0bfe-4972-475a-862a-adf2c054959d,Kamil Kırıkoğlu,Kamil Kırıkoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,15,,,,male
 44e58f92-3a7f-426b-b4b8-6ab0b1619ede,Kamil Özsarıyıldız,Kamil Özsarıyıldız,,,,Adalet Partisi,AP,area/kayseri,Kayseri,Grand National Assembly,15,,,,male
 6d696c57-dccf-45e8-b8ce-583d9b562bfd,Kasım Emre,Kasım Emre,,,,Bağımsız,ind,area/muş,Muş,Grand National Assembly,15,,,,
 f7f7de8d-af52-4145-8d91-eafd35d84547,Kasım Parlar,Kasım Parlar,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,15,,,,
@@ -183,7 +183,7 @@ b9a36c3b-7a21-4cdb-a892-9195906c04b3,Kemalettin Gökakın,Kemalettin Gökakın,,
 1dc59e59-ae74-4cc4-a1ad-e2dbd00c5757,Kerem Şahin,Kerem Şahin,,,,Adalet Partisi,AP,area/ağrı,Ağrı,Grand National Assembly,15,,,,
 abf6af96-ee1b-4839-b825-9e37d3968370,Kinyas Kartal,Kinyas Kartal,,,,Adalet Partisi,AP,area/van,Van,Grand National Assembly,15,,,,male
 e2e0a2e4-6aa0-4e56-813e-5039c3fa951c,Korkut Özal,Korkut Özal,,,,Millî Selamet Partisi,MSP,area/erzurum,Erzurum,Grand National Assembly,15,,,,
-70e3dbe5-d5dd-435b-92c9-7c95bbe67325,Kıvılcım Kemal Anadol,Kıvılcım Kemal Anadol,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,15,,,,
+70e3dbe5-d5dd-435b-92c9-7c95bbe67325,Kıvılcım Kemal Anadol,Kıvılcım Kemal Anadol,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,15,,,,male
 2613c42b-2bb4-406f-9c12-342d42254698,Lütfi Köktaş,Lütfi Köktaş,,,,Millî Selamet Partisi,MSP,area/trabzon,Trabzon,Grand National Assembly,15,,,,
 2683bbcf-8a19-4b04-9e46-0bd5e9629cea,Mahmut Kepolu,Mahmut Kepolu,,,,Adalet Partisi,AP,area/diyarbakır,Diyarbakır,Grand National Assembly,15,,,,
 12084c46-8103-4b6b-ad40-df248580897d,Mahmut Türkmenoğlu,Mahmut Türkmenoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,15,,,,male
@@ -220,7 +220,7 @@ c3b9fb43-db19-4a22-922c-67618410d5bd,Mehmet Oğuz Atalay,Mehmet Oğuz Atalay,,,,
 9dceb288-b1b8-4773-b4b4-51c2c53623f9,Mehmet Said Erbil,Mehmet Said Erbil,,,,Cumhuriyet Halk Partisi,CHP,area/ordu,Ordu,Grand National Assembly,15,,,,
 b984dd05-7064-4286-a484-5dc0f4774c0c,Mehmet Sait Reşa,Mehmet Sait Reşa,,,,Cumhuriyet Halk Partisi,CHP,area/hatay,Hatay,Grand National Assembly,15,,,,male
 02deaef0-5bf1-416f-9f3e-afdc7807d4d0,Mehmet Salih Yıldız,Mehmet Salih Yıldız,,,,Cumhuriyetçi Güven Partisi,CGP,area/van,Van,Grand National Assembly,15,,,,male
-1c7b61da-fdc1-41ab-9966-f813a6423626,Mehmet Selahattin Kılıç,Mehmet Selahattin Kılıç,,,,Adalet Partisi,AP,area/adana,Adana,Grand National Assembly,15,,,,male
+1c7b61da-fdc1-41ab-9966-f813a6423626,Mehmet Selahattin Kılıç,Mehmet Selahattin Kılıç,,,,Adalet Partisi,AP,area/adana,Adana,Grand National Assembly,15,,,,
 8a17af79-46c1-4e51-aa4d-885e04b9d7ba,Mehmet Sönmez,Mehmet Sönmez,,,,Cumhuriyet Halk Partisi,CHP,area/hatay,Hatay,Grand National Assembly,15,,,,male
 c3e352a2-b09d-45ac-8110-e4e433f1e610,Mehmet Turgut,Mehmet Turgut,,,,Demokratik Parti,DP70,area/bursa,Bursa,Grand National Assembly,15,,,,male
 ee1f361a-6524-4db3-a11b-46ea33844733,Mehmet Turhan Akyol,Mehmet Turhan Akyol,,,,Millî Selamet Partisi,MSP,area/malatya,Malatya,Grand National Assembly,15,,,,
@@ -316,7 +316,7 @@ e42df297-106e-4e08-9e82-19dd637abb9b,Orhan Üretmen,Orhan Üretmen,,,,Cumhuriyet
 2d2b8a9b-20c4-470b-91bf-50f2cc261907,Oğuz Aygün,Oğuz Aygün,,,,Adalet Partisi,AP,area/ankara,Ankara,Grand National Assembly,15,,,,
 b6e72dee-ffbf-4848-b2a7-18ebaffe18b1,Oğuz Söğütlü,Oğuz Söğütlü,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,15,,,,male
 faa4bb12-d625-4f59-a8f7-b5a5b08fafdf,Oğuzhan Asiltürk,Oğuzhan Asiltürk,,,,Millî Selamet Partisi,MSP,area/ankara,Ankara,Grand National Assembly,15,,,,
-79869f19-8d21-4960-82b3-3a282e337797,Ragıp Üner,Ragıp Üner,,,,Adalet Partisi,AP,area/nevşehir,Nevşehir,Grand National Assembly,15,,,,
+79869f19-8d21-4960-82b3-3a282e337797,Ragıp Üner,Ragıp Üner,,,,Adalet Partisi,AP,area/nevşehir,Nevşehir,Grand National Assembly,15,,,,male
 dfb42bd6-b36e-4c40-ac0c-e49ae986d73e,Ramazan Yıldırım,Ramazan Yıldırım,,,,Cumhuriyet Halk Partisi,CHP,area/adıyaman,Adıyaman,Grand National Assembly,15,,,,
 9c842656-485a-456d-a13d-98a4ac89db12,Rasim Cinisli,Rasim Cinisli,,,,Demokratik Parti,DP70,area/erzurum,Erzurum,Grand National Assembly,15,,,,
 427ab71e-9390-47b8-aadc-47c69e5e6ad9,Rasim Gürsoy,Rasim Gürsoy,,,,Adalet Partisi,AP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,15,,,,
@@ -423,7 +423,7 @@ c88c56d2-08ea-4ac2-a4c7-365850b9148a,İhsan Arslan,İhsan Arslan,,,,Demokratik P
 b93e545c-9f42-4a3b-acf9-79b5347cb681,İhsan Ataöv,İhsan Ataöv,,,,Adalet Partisi,AP,area/antalya,Antalya,Grand National Assembly,15,,,,male
 0107329b-da29-4a44-90e6-614830321e14,İhsan Bedirhanoğlu,İhsan Bedirhanoğlu,,,,Cumhuriyetçi Güven Partisi,CGP,area/van,Van,Grand National Assembly,15,,,,male
 f9842d48-d53e-414c-8298-eee986bb3d7f,İhsan Toksarı,İhsan Toksarı,,,,Adalet Partisi,AP,area/İstanbul,İstanbul,Grand National Assembly,15,,,,male
-a0713c74-04f2-45ef-aa63-5c23d0a34303,İhsan Tombuş,İhsan Tombuş,,,,Demokratik Parti,DP70,area/Çorum,Çorum,Grand National Assembly,15,,,,male
+a0713c74-04f2-45ef-aa63-5c23d0a34303,İhsan Tombuş,İhsan Tombuş,,,,Demokratik Parti,DP70,area/Çorum,Çorum,Grand National Assembly,15,,,,
 9d914fe6-5d6a-47d0-a560-eb24f60ec9f6,İlhami Sancar,İlhami Sancar,,,,Cumhuriyetçi Güven Partisi,CGP,area/İstanbul,İstanbul,Grand National Assembly,15,,,,
 72aaff1e-4f7a-4b3a-9f94-42e48d3c3417,İlhami Çetin,İlhami Çetin,,,,Cumhuriyet Halk Partisi,CHP,area/yozgat,Yozgat,Grand National Assembly,15,,,,male
 98120fa8-b0bd-4c8f-920a-ba64b98c2e71,İlhan Aytekin,İlhan Aytekin,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,15,,,,

--- a/data/Turkey/Assembly/term-16.csv
+++ b/data/Turkey/Assembly/term-16.csv
@@ -140,10 +140,10 @@ dd7937e1-7fe9-458c-b6f2-dc515340d71f,Galip Kaya,Galip Kaya,,,,Adalet Partisi,AP,
 50307c4e-89df-44df-985a-245a9bc5ca7d,Galip Çetin,Galip Çetin,,,,Adalet Partisi,AP,area/uşak,Uşak,Grand National Assembly,16,,,,
 00ffd105-ce7c-4c59-9465-409ec150120f,Günay Yalın,Günay Yalın,,,,Cumhuriyet Halk Partisi,CHP,area/ordu,Ordu,Grand National Assembly,16,,,,
 990dd002-5560-4e1f-b2b3-eacef0aed11d,Gündüz Onat,Gündüz Onat,,,,Cumhuriyet Halk Partisi,CHP,area/kırklareli,Kırklareli,Grand National Assembly,16,,,,
-a16b220e-69a2-4f00-9833-5ba18c3baff4,Gündüz Ökçün,Gündüz Ökçün,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,16,,,,
+a16b220e-69a2-4f00-9833-5ba18c3baff4,Gündüz Ökçün,Gündüz Ökçün,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,16,,,,male
 f40139b0-fe6a-4536-b2d7-d4e493d89f09,Güneş Öngüt,Güneş Öngüt,,,,Adalet Partisi,AP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,16,,,,
 e544a529-fb05-4dde-8d4c-387f1502823b,Güngör Hun,Güngör Hun,,,,Adalet Partisi,AP,area/sakarya,Sakarya,Grand National Assembly,16,,,,
-a56e6afb-6b50-4b0e-9d5b-df5f8369dd94,Gıyasettin Karaca,Gıyasettin Karaca,,,,Adalet Partisi,AP,area/erzurum,Erzurum,Grand National Assembly,16,,,,female
+a56e6afb-6b50-4b0e-9d5b-df5f8369dd94,Gıyasettin Karaca,Gıyasettin Karaca,,,,Adalet Partisi,AP,area/erzurum,Erzurum,Grand National Assembly,16,,,,
 c947a89e-b43d-4f64-bbe5-fb8d0ffc9ce5,Halil Akgül,Halil Akgül,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,16,,,,
 2f3bb7d7-1000-40de-8547-0f5a68acb085,Halil Ağar,Halil Ağar,,,,Adalet Partisi,AP,area/adıyaman,Adıyaman,Grand National Assembly,16,,,,male
 82c0f6e3-169d-4552-93a1-8f6f2a08f2fc,Halil Başol,Halil Başol,,,,Adalet Partisi,AP,area/tekirdağ,Tekirdağ,Grand National Assembly,16,,,,male
@@ -204,7 +204,7 @@ abf6af96-ee1b-4839-b825-9e37d3968370,Kinyas Kartal,Kinyas Kartal,,,,Adalet Parti
 e2e0a2e4-6aa0-4e56-813e-5039c3fa951c,Korkut Özal,Korkut Özal,,,,Millî Selamet Partisi,MSP,area/erzurum,Erzurum,Grand National Assembly,16,,,,
 4dc35dfe-0b34-4198-bca9-7ff1a1a1ecc4,Köksal Toptan,Köksal Toptan,,,,Adalet Partisi,AP,area/zonguldak,Zonguldak,Grand National Assembly,16,,,,male
 84307500-7d71-4f10-bfd8-da71e58c773d,Kılıç Sorgucu,Kılıç Sorgucu,,,,Cumhuriyet Halk Partisi,CHP,area/kırşehir,Kırşehir,Grand National Assembly,16,,,,
-70e3dbe5-d5dd-435b-92c9-7c95bbe67325,Kıvılcım Kemal Anadol,Kıvılcım Kemal Anadol,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,16,,,,
+70e3dbe5-d5dd-435b-92c9-7c95bbe67325,Kıvılcım Kemal Anadol,Kıvılcım Kemal Anadol,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,16,,,,male
 e7a427f7-808e-4714-8f1c-8a06aea6de30,Lütfi Doğan,Lütfi Doğan,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,16,,,,
 2613c42b-2bb4-406f-9c12-342d42254698,Lütfi Köktaş,Lütfi Köktaş,,,,Millî Selamet Partisi,MSP,area/trabzon,Trabzon,Grand National Assembly,16,,,,
 06f5dd16-0fec-49bf-b2f5-0681528c7c86,Lütfi Şahin,Lütfi Şahin,,,,Cumhuriyet Halk Partisi,CHP,area/erzincan,Erzincan,Grand National Assembly,16,,,,
@@ -230,7 +230,7 @@ b9c71312-ee60-44f0-8fad-d18185c2493a,Mehmet Kazım Özeke,Mehmet Kazım Özeke,,
 d27b5726-8e7a-43ab-9aa7-29f784cf05f4,Mehmet Nebil Oktay,Mehmet Nebil Oktay,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,16,,,,male
 f9c38886-c79a-4e9d-a1da-4d9cb8c19d4f,Mehmet Necati Kalaycıoğlu,Mehmet Necati Kalaycıoğlu,,,,Adalet Partisi,AP,area/konya,Konya,Grand National Assembly,16,,,,male
 c3b9fb43-db19-4a22-922c-67618410d5bd,Mehmet Oğuz Atalay,Mehmet Oğuz Atalay,,,,Adalet Partisi,AP,area/konya,Konya,Grand National Assembly,16,,,,male
-01b10bd7-2ba2-4d1f-b797-4952863baff5,Mehmet Recai Kutan,Mehmet Recai Kutan,,,,Millî Selamet Partisi,MSP,area/malatya,Malatya,Grand National Assembly,16,,,,
+01b10bd7-2ba2-4d1f-b797-4952863baff5,Mehmet Recai Kutan,Mehmet Recai Kutan,,,,Millî Selamet Partisi,MSP,area/malatya,Malatya,Grand National Assembly,16,,,https://upload.wikimedia.org/wikipedia/commons/d/d9/Recai_Kutan_2009_crop.jpg,male
 2fb48e8c-4369-460c-96ea-1059547a2925,Mehmet Sabri Kılıç,Mehmet Sabri Kılıç,,,,Cumhuriyet Halk Partisi,CHP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,16,,,,
 08215078-ca9c-4604-9c22-3de852fbb955,Mehmet Sadık Erdem,Mehmet Sadık Erdem,,,,Adalet Partisi,AP,area/antalya,Antalya,Grand National Assembly,16,,,,
 b984dd05-7064-4286-a484-5dc0f4774c0c,Mehmet Sait Reşa,Mehmet Sait Reşa,,,,Adalet Partisi,AP,area/hatay,Hatay,Grand National Assembly,16,,,,male
@@ -297,8 +297,8 @@ dcec4cfe-973d-47c1-8764-988fdeb1ab50,Mustafa Üstündağ,Mustafa Üstündağ,,,,
 fab713c5-989c-4ef1-abf4-fb790cbb9b2c,Necmettin Cevheri,Necmettin Cevheri,,,,Adalet Partisi,AP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,16,,,,
 1969c424-ef8c-4348-ade8-67e3b3979c96,Necmettin Erbakan,Necmettin Erbakan,,,,Millî Selamet Partisi,MSP,area/konya,Konya,Grand National Assembly,16,,,https://upload.wikimedia.org/wikipedia/commons/0/0e/Necmettin-Erbakan.jpg,male
 f44ab8aa-3f89-4b4e-bd28-c9d2a192a48a,Nedim Tarhan,Nedim Tarhan,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,16,,,,
-80a07708-ae6e-43bd-9668-cff2bb1a92a7,Nevzat Cihat Bilgehan,Nevzat Cihat Bilgehan,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,16,,,,male
-2ea9a300-da32-49ee-99be-c290deecc1cf,Nevzat Köseoğlu,Nevzat Köseoğlu,,,,Milliyetçi Hareket Partisi,MHP,area/erzurum,Erzurum,Grand National Assembly,16,,,,
+80a07708-ae6e-43bd-9668-cff2bb1a92a7,Nevzat Cihat Bilgehan,Nevzat Cihat Bilgehan,,,,Adalet Partisi,AP,area/balıkesir,Balıkesir,Grand National Assembly,16,,,,
+2ea9a300-da32-49ee-99be-c290deecc1cf,Nevzat Köseoğlu,Nevzat Köseoğlu,,,,Milliyetçi Hareket Partisi,MHP,area/erzurum,Erzurum,Grand National Assembly,16,,,,male
 4fb2c390-bec7-4766-89be-c49b09793a75,Nihan İlgün,Nihan İlgün,,,,Adalet Partisi,AP,area/tekirdağ,Tekirdağ,Grand National Assembly,16,,,,male
 ae7d8352-aa7a-4f5b-8c15-0e0a4c99109d,Nihat Kaya,Nihat Kaya,,,,Adalet Partisi,AP,area/İstanbul,İstanbul,Grand National Assembly,16,,,,
 8c82c074-f968-4bb5-964f-2f0931597bc8,Nilüfer Gürsoy,Nilüfer Gürsoy,,,,Adalet Partisi,AP,area/İstanbul,İstanbul,Grand National Assembly,16,,,,
@@ -347,7 +347,7 @@ d3c49c89-b001-4d62-88a9-4aa673fc86b5,Sabri Tığlı,Sabri Tığlı,,,,Cumhuriyet
 6ac4f6ad-6c61-4b2a-8d75-c0ea0221e01b,Sami Kumbasar,Sami Kumbasar,,,,Cumhuriyet Halk Partisi,CHP,area/rize,Rize,Grand National Assembly,16,,,,
 69484054-c44c-4ab9-8845-2224eaadf10a,Sebati Ataman,Sebati Ataman,,,,Adalet Partisi,AP,area/ankara,Ankara,Grand National Assembly,16,,,,
 be4d4036-6502-432b-9847-69bb69e36daa,Selahattin Gürdrama,Selahattin Gürdrama,,,,Adalet Partisi,AP,area/sakarya,Sakarya,Grand National Assembly,16,,,,
-e4e679c1-011c-4a46-a10b-b1c2f72006b2,Selahattin Kılıç,Selahattin Kılıç,,,,Adalet Partisi,AP,area/adana,Adana,Grand National Assembly,16,,,,
+e4e679c1-011c-4a46-a10b-b1c2f72006b2,Selahattin Kılıç,Selahattin Kılıç,,,,Adalet Partisi,AP,area/adana,Adana,Grand National Assembly,16,,,,male
 009751fd-d53e-46b5-b768-ca318f60db56,Selahattin Öcal,Selahattin Öcal,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,16,,,,
 463ebe02-a6d3-4a72-bd0c-cf1986dfd2cf,Selami Görgüç,Selami Görgüç,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,16,,,,
 dfb6b97c-1110-4593-8848-4a1eeb06898c,Selçuk Erverdi,Selçuk Erverdi,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,16,,,,

--- a/data/Turkey/Assembly/term-17.csv
+++ b/data/Turkey/Assembly/term-17.csv
@@ -5,55 +5,55 @@ d6c5a2a6-9a51-4bfd-ae0b-5e68746b799f,Abdulkerim Yılmaz Erdem,Abdulkerim Yılmaz
 338369f4-6429-46bc-adae-b0f1c401410f,Abdullah Altıntaş,Abdullah Altıntaş,,,,Anavatan Partisi,ANAP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,17,,,,male
 c28586f5-1e8f-4d14-af23-e4e4d3e96efb,Abdullah Cengiz Dağyar,Abdullah Cengiz Dağyar,,,,Anavatan Partisi,ANAP,area/antalya,Antalya,Grand National Assembly,17,,,,male
 0e28f1f3-07fc-4f0a-9107-42e53c1db774,Abdullah Tenekeci,Abdullah Tenekeci,,,,Anavatan Partisi,ANAP,area/konya,Konya,Grand National Assembly,17,,,,male
-95883e96-a63b-4e2c-b72f-c57cf1c11df4,Abdullah Çakırefe,Abdullah Çakırefe,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 95883e96-a63b-4e2c-b72f-c57cf1c11df4,Abdullah Çakırefe,Abdullah Çakırefe,,,,Halkçı Parti,HP,area/manisa,Manisa,Grand National Assembly,17,,,,
-f273b4ca-aad6-49ec-9c54-894dd07e6f7e,Abdurrahman Bozkır,Abdurrahman Bozkır,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+95883e96-a63b-4e2c-b72f-c57cf1c11df4,Abdullah Çakırefe,Abdullah Çakırefe,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 f273b4ca-aad6-49ec-9c54-894dd07e6f7e,Abdurrahman Bozkır,Abdurrahman Bozkır,,,,Anavatan Partisi,ANAP,area/konya,Konya,Grand National Assembly,17,,,,
-e9467984-a238-4706-a263-dc855032e186,Abdurrahman Demirtaş,Abdurrahman Demirtaş,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+f273b4ca-aad6-49ec-9c54-894dd07e6f7e,Abdurrahman Bozkır,Abdurrahman Bozkır,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 e9467984-a238-4706-a263-dc855032e186,Abdurrahman Demirtaş,Abdurrahman Demirtaş,,,,Milliyetçi Demokrasi Partisi,MDP,area/hatay,Hatay,Grand National Assembly,17,,,,
+e9467984-a238-4706-a263-dc855032e186,Abdurrahman Demirtaş,Abdurrahman Demirtaş,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 6d4c147a-276a-4077-b54b-ee5845a32071,Abdurrahman Necati Kara'a,Abdurrahman Necati Kara'a,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 6d4c147a-276a-4077-b54b-ee5845a32071,Abdurrahman Necati Kara'a,Abdurrahman Necati Kara'a,,,,Milliyetçi Demokrasi Partisi,MDP,area/kütahya,Kütahya,Grand National Assembly,17,,,,
 e4fe9022-1dc6-4a84-8751-b2c5b4ea3f79,Adana,Adana,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 4e09ed45-215e-4e54-ab8d-02f6bd844ae1,Adıyaman,Adıyaman,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 3e186f34-630c-4de1-ac44-fb1dfd7d873b,Afyonkarahisar,Afyonkarahisar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 56714277-e08a-49ff-b132-d79c723ff264,Ahmet Akgün Albayrak,Ahmet Akgün Albayrak,,,,Anavatan Partisi,ANAP,area/adana,Adana,Grand National Assembly,17,,,,male
-d5222db3-3e77-4dcf-89a9-ba72642a1301,Ahmet Altıntaş,Ahmet Altıntaş,,,,Anavatan Partisi,ANAP,area/muğla,Muğla,Grand National Assembly,17,,,,
+d5222db3-3e77-4dcf-89a9-ba72642a1301,Ahmet Altıntaş,Ahmet Altıntaş,,,,Anavatan Partisi,ANAP,area/muğla,Muğla,Grand National Assembly,17,,,,male
 8c7c0deb-fb0f-461a-8a84-d05ee4ea1f07,Ahmet Ata Aksu,Ahmet Ata Aksu,,,,Anavatan Partisi,ANAP,area/gaziantep,Gaziantep,Grand National Assembly,17,,,,
 af4d9979-d862-4aab-827b-f43636ae41ce,Ahmet Bağçeci,Ahmet Bağçeci,,,,Anavatan Partisi,ANAP,area/yozgat,Yozgat,Grand National Assembly,17,,,,
 fec1894d-9ac1-4722-b680-d643ee618322,Ahmet Büyükuğur,Ahmet Büyükuğur,,,,Anavatan Partisi,ANAP,area/kütahya,Kütahya,Grand National Assembly,17,,,,
-c7eb8755-d682-402d-b317-80e32b76b241,Ahmet Cevdet Karslı,Ahmet Cevdet Karslı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 c7eb8755-d682-402d-b317-80e32b76b241,Ahmet Cevdet Karslı,Ahmet Cevdet Karslı,,,,Halkçı Parti,HP,area/giresun,Giresun,Grand National Assembly,17,,,,male
+c7eb8755-d682-402d-b317-80e32b76b241,Ahmet Cevdet Karslı,Ahmet Cevdet Karslı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 b28a958a-0e94-4484-99ef-2236eaf22475,Ahmet Doğru,Ahmet Doğru,,,,Anavatan Partisi,ANAP,area/artvin,Artvin,Grand National Assembly,17,,,,
-5174e1b4-e92b-420a-af3d-49c2b96e2265,Ahmet Ekici,Ahmet Ekici,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 5174e1b4-e92b-420a-af3d-49c2b96e2265,Ahmet Ekici,Ahmet Ekici,,,,Anavatan Partisi,ANAP,area/kütahya,Kütahya,Grand National Assembly,17,,,,
+5174e1b4-e92b-420a-af3d-49c2b96e2265,Ahmet Ekici,Ahmet Ekici,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 aef676b6-da4e-4f7e-a7af-2ef601f7506e,Ahmet Karaevli,Ahmet Karaevli,,,,Anavatan Partisi,ANAP,area/tekirdağ,Tekirdağ,Grand National Assembly,17,,,,male
 39677c86-9f84-4528-ab8d-72dde683e5c3,Ahmet Kemal Aydar,Ahmet Kemal Aydar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 39677c86-9f84-4528-ab8d-72dde683e5c3,Ahmet Kemal Aydar,Ahmet Kemal Aydar,,,,Halkçı Parti,HP,area/ankara,Ankara,Grand National Assembly,17,,,,male
 c3e50a8e-53db-4d3e-bb2c-4612e20ee501,Ahmet Kurtcebe Alptemoçin,Ahmet Kurtcebe Alptemoçin,,,,Anavatan Partisi,ANAP,area/bursa,Bursa,Grand National Assembly,17,,,,male
-49e45d63-1a30-4f89-afbc-215cad28d8a2,Ahmet Memduh Yaşa,Ahmet Memduh Yaşa,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 49e45d63-1a30-4f89-afbc-215cad28d8a2,Ahmet Memduh Yaşa,Ahmet Memduh Yaşa,,,,Milliyetçi Demokrasi Partisi,MDP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,male
-303d56c9-65c3-4b05-bc87-3f1425406a89,Ahmet Mesut Yılmaz,Ahmet Mesut Yılmaz,,,,Anavatan Partisi,ANAP,area/rize,Rize,Grand National Assembly,17,,,,
-835b9fbe-21cf-4d96-9236-0b5a8780d625,Ahmet Remzi Çerçi,Ahmet Remzi Çerçi,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+49e45d63-1a30-4f89-afbc-215cad28d8a2,Ahmet Memduh Yaşa,Ahmet Memduh Yaşa,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+303d56c9-65c3-4b05-bc87-3f1425406a89,Ahmet Mesut Yılmaz,Ahmet Mesut Yılmaz,,,,Anavatan Partisi,ANAP,area/rize,Rize,Grand National Assembly,17,,,,male
 835b9fbe-21cf-4d96-9236-0b5a8780d625,Ahmet Remzi Çerçi,Ahmet Remzi Çerçi,,,,Anavatan Partisi,ANAP,area/adana,Adana,Grand National Assembly,17,,,,
+835b9fbe-21cf-4d96-9236-0b5a8780d625,Ahmet Remzi Çerçi,Ahmet Remzi Çerçi,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 5d4eab21-5c21-482e-9c97-4fb29d3c1537,Ahmet Sabahattin Özbek,Ahmet Sabahattin Özbek,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 5d4eab21-5c21-482e-9c97-4fb29d3c1537,Ahmet Sabahattin Özbek,Ahmet Sabahattin Özbek,,,,Milliyetçi Demokrasi Partisi,MDP,area/bursa,Bursa,Grand National Assembly,17,,,,
-4c9693ca-24f4-45e5-abd4-7b1572bec6f4,Ahmet Sarp,Ahmet Sarp,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 4c9693ca-24f4-45e5-abd4-7b1572bec6f4,Ahmet Sarp,Ahmet Sarp,,,,Milliyetçi Demokrasi Partisi,MDP,area/diyarbakır,Diyarbakır,Grand National Assembly,17,,,,male
+4c9693ca-24f4-45e5-abd4-7b1572bec6f4,Ahmet Sarp,Ahmet Sarp,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 37c55c85-ead5-4645-a137-f53e43b6cc14,Ahmet Süter,Ahmet Süter,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 37c55c85-ead5-4645-a137-f53e43b6cc14,Ahmet Süter,Ahmet Süter,,,,Milliyetçi Demokrasi Partisi,MDP,area/İzmir,İzmir,Grand National Assembly,17,,,,
-28005e87-c46c-43bf-8d2b-a2453aba5f78,Ahmet Sırrı Özbek,Ahmet Sırrı Özbek,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 28005e87-c46c-43bf-8d2b-a2453aba5f78,Ahmet Sırrı Özbek,Ahmet Sırrı Özbek,,,,Halkçı Parti,HP,area/adıyaman,Adıyaman,Grand National Assembly,17,,,,
-47eb8b2f-a8b3-457b-9b4e-9366e9188a84,Ahmet Turan Soğancıoğlu,Ahmet Turan Soğancıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+28005e87-c46c-43bf-8d2b-a2453aba5f78,Ahmet Sırrı Özbek,Ahmet Sırrı Özbek,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 47eb8b2f-a8b3-457b-9b4e-9366e9188a84,Ahmet Turan Soğancıoğlu,Ahmet Turan Soğancıoğlu,,,,Anavatan Partisi,ANAP,area/sivas,Sivas,Grand National Assembly,17,,,,
+47eb8b2f-a8b3-457b-9b4e-9366e9188a84,Ahmet Turan Soğancıoğlu,Ahmet Turan Soğancıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 fcab4a3e-838d-4ece-ac11-dc134356337a,Ahmet Yılmaz,Ahmet Yılmaz,,,,Anavatan Partisi,ANAP,area/giresun,Giresun,Grand National Assembly,17,,,,male
 888434d4-5dcc-4ffe-ba59-c1bcdec76698,Ahmet Özkan,Ahmet Özkan,,,,Anavatan Partisi,ANAP,area/Çankırı,Çankırı,Grand National Assembly,17,,,,
 9202d797-2a6c-4f90-bf01-2c55011d99b6,Ahmet İlhami Kösem,Ahmet İlhami Kösem,,,,Anavatan Partisi,ANAP,area/malatya,Malatya,Grand National Assembly,17,,,,
 bd780172-917f-4099-b417-c28120b2de52,Ahmet Şamil Kazokoğlu,Ahmet Şamil Kazokoğlu,,,,Anavatan Partisi,ANAP,area/bolu,Bolu,Grand National Assembly,17,,,,
-f6682d3e-a2ee-4cdc-965f-be085b47319c,Ahmet Şevket Gedik,Ahmet Şevket Gedik,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 f6682d3e-a2ee-4cdc-965f-be085b47319c,Ahmet Şevket Gedik,Ahmet Şevket Gedik,,,,Anavatan Partisi,ANAP,area/adana,Adana,Grand National Assembly,17,,,,male
+f6682d3e-a2ee-4cdc-965f-be085b47319c,Ahmet Şevket Gedik,Ahmet Şevket Gedik,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 89c76d5a-29bd-4a55-9f9f-fa4d4e3dc213,Akif Kocaman,Akif Kocaman,,,,Anavatan Partisi,ANAP,area/gümüşhane,Gümüşhane,Grand National Assembly,17,,,,
-32e4ca66-1d7a-45df-b658-54f230b913cb,Akın Gönen,Akın Gönen,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 32e4ca66-1d7a-45df-b658-54f230b913cb,Akın Gönen,Akın Gönen,,,,Anavatan Partisi,ANAP,area/vahit_melih_halefoğlu,Vahit Melih Halefoğlu,Grand National Assembly,17,,,,
+32e4ca66-1d7a-45df-b658-54f230b913cb,Akın Gönen,Akın Gönen,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 0cd9de27-cfd1-4444-9fbe-aa6aa6d05209,Alaattin Fırat,Alaattin Fırat,,,,Anavatan Partisi,ANAP,area/muş,Muş,Grand National Assembly,17,,,,
 babcbccd-f8b6-4002-a75e-0cbcdb7131c6,Alaeddin Kısakürek,Alaeddin Kısakürek,,,,Anavatan Partisi,ANAP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,17,,,,
 93acd010-f600-4ca0-bbb0-e3243be14739,Ali Ayhan Çetin,Ali Ayhan Çetin,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
@@ -69,8 +69,8 @@ bcbdbf23-dc85-4128-af22-9c0110a12a82,Ali Hüsrev Bozer,Ali Hüsrev Bozer,,,,Anav
 94053962-9a56-4b3b-a741-db81e66deaf3,Ali Mazhar Haznedar,Ali Mazhar Haznedar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 94053962-9a56-4b3b-a741-db81e66deaf3,Ali Mazhar Haznedar,Ali Mazhar Haznedar,,,,Milliyetçi Demokrasi Partisi,MDP,area/ordu,Ordu,Grand National Assembly,17,,,,male
 a865b359-ed13-4ed9-98e0-1f2dfc91b0d4,Ali Rıdvan Yıldırım,Ali Rıdvan Yıldırım,,,,Halkçı Parti,HP,area/tunceli,Tunceli,Grand National Assembly,17,,,,
-e13abf72-a908-4d74-998d-59c53f69e0c1,Ali Rıfkı Atasever,Ali Rıfkı Atasever,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 e13abf72-a908-4d74-998d-59c53f69e0c1,Ali Rıfkı Atasever,Ali Rıfkı Atasever,,,,Anavatan Partisi,ANAP,area/tekirdağ,Tekirdağ,Grand National Assembly,17,,,,
+e13abf72-a908-4d74-998d-59c53f69e0c1,Ali Rıfkı Atasever,Ali Rıfkı Atasever,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 b4a32790-c3ff-47aa-9a03-b9ef4f56000f,Ali Rıza Akaydın,Ali Rıza Akaydın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 b4a32790-c3ff-47aa-9a03-b9ef4f56000f,Ali Rıza Akaydın,Ali Rıza Akaydın,,,,Halkçı Parti,HP,area/Çorum,Çorum,Grand National Assembly,17,,,,
 cc79894d-d725-48b5-996a-31030057aec9,Ali Tanrıyar,Ali Tanrıyar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
@@ -81,33 +81,33 @@ cc79894d-d725-48b5-996a-31030057aec9,Ali Tanrıyar,Ali Tanrıyar,,,,Anavatan Par
 20b429f3-8ba4-4588-b427-68aad86d3481,Ali İhsan Elgin,Ali İhsan Elgin,,,,Halkçı Parti,HP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,17,,,,
 49cd0fc5-8636-4b56-9c1c-8e17b67862e4,Alpaslan Pehlivanlı,Alpaslan Pehlivanlı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 49cd0fc5-8636-4b56-9c1c-8e17b67862e4,Alpaslan Pehlivanlı,Alpaslan Pehlivanlı,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,17,,,,
-cfe79bc4-659c-4915-a7ef-fbb0bc860dff,Altan Kavak,Altan Kavak,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 cfe79bc4-659c-4915-a7ef-fbb0bc860dff,Altan Kavak,Altan Kavak,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
-81f37913-79f9-4c8f-b105-e6e7da5df62f,Altınok Esen,Altınok Esen,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+cfe79bc4-659c-4915-a7ef-fbb0bc860dff,Altan Kavak,Altan Kavak,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 81f37913-79f9-4c8f-b105-e6e7da5df62f,Altınok Esen,Altınok Esen,,,,Anavatan Partisi,ANAP,area/konya,Konya,Grand National Assembly,17,,,,
+81f37913-79f9-4c8f-b105-e6e7da5df62f,Altınok Esen,Altınok Esen,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 17544af5-0a85-418b-8c84-a111fe1325ae,Amasya,Amasya,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-dfd2ec75-a4f9-43a8-8f55-3fa6e7284287,Ankara,Ankara,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 dfd2ec75-a4f9-43a8-8f55-3fa6e7284287,Ankara,Ankara,,,,Anavatan Partisi,ANAP,area/vahit_melih_halefoğlu,Vahit Melih Halefoğlu,Grand National Assembly,17,,,,
+dfd2ec75-a4f9-43a8-8f55-3fa6e7284287,Ankara,Ankara,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 8622e536-97d5-46a8-8532-12b7809b6b82,Antalya,Antalya,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 a93bfb40-9738-44dd-9bf4-abb7266a1c47,Arif Ağaoğlu,Arif Ağaoğlu,,,,Anavatan Partisi,ANAP,area/adıyaman,Adıyaman,Grand National Assembly,17,,,,male
 1c48fa30-dcb4-4aa3-ba2b-12c234f0cd41,Arif Toprak,Arif Toprak,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1c48fa30-dcb4-4aa3-ba2b-12c234f0cd41,Arif Toprak,Arif Toprak,,,,Halkçı Parti,HP,area/niğde,Niğde,Grand National Assembly,17,,,,
-851648d5-fe58-4965-a191-67bd7a2ba5e8,Arif Şevket Bilgin,Arif Şevket Bilgin,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 851648d5-fe58-4965-a191-67bd7a2ba5e8,Arif Şevket Bilgin,Arif Şevket Bilgin,,,,Anavatan Partisi,ANAP,area/rize,Rize,Grand National Assembly,17,,,,male
+851648d5-fe58-4965-a191-67bd7a2ba5e8,Arif Şevket Bilgin,Arif Şevket Bilgin,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 bc0264c3-944d-416b-b703-5878f26ed269,Arife Necla Tekinel,Arife Necla Tekinel,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 bc0264c3-944d-416b-b703-5878f26ed269,Arife Necla Tekinel,Arife Necla Tekinel,,,,Milliyetçi Demokrasi Partisi,MDP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
 bcb8a58b-4c54-4569-ae5b-1d6903b9cf4c,Arsan Savaş Arpacıoğlu,Arsan Savaş Arpacıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 bcb8a58b-4c54-4569-ae5b-1d6903b9cf4c,Arsan Savaş Arpacıoğlu,Arsan Savaş Arpacıoğlu,,,,Halkçı Parti,HP,area/amasya,Amasya,Grand National Assembly,17,,,,
 55e4da16-985d-43a7-99dc-1ad38f642a84,Artvin,Artvin,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-c1e0ed90-81e2-4bbe-ab80-cef62dc43dcf,Atilla Sın,Atilla Sın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 c1e0ed90-81e2-4bbe-ab80-cef62dc43dcf,Atilla Sın,Atilla Sın,,,,Anavatan Partisi,ANAP,area/muş,Muş,Grand National Assembly,17,,,,
+c1e0ed90-81e2-4bbe-ab80-cef62dc43dcf,Atilla Sın,Atilla Sın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 efc2e3c6-a404-4c67-b59e-f04631fe2f88,Aycan Çakıroğulları,Aycan Çakıroğulları,,,,Anavatan Partisi,ANAP,area/denizli,Denizli,Grand National Assembly,17,,,,
 1298be2e-700e-4a36-80a1-7746e97a4ab5,Aydın,Aydın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 59686593-087b-4c2a-bbb9-67bd2b11df13,Aydın Baran,Aydın Baran,,,,Anavatan Partisi,ANAP,area/siirt,Siirt,Grand National Assembly,17,,,,
-e8f3409a-a8a1-4810-a5c1-613d92c42800,Aydın Güven Gürkan,Aydın Güven Gürkan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 e8f3409a-a8a1-4810-a5c1-613d92c42800,Aydın Güven Gürkan,Aydın Güven Gürkan,,,,Halkçı Parti,HP,area/antalya,Antalya,Grand National Assembly,17,,,,male
-269c8686-25fe-4082-b91d-a9e488f0b8e5,Ayhan Fırat,Ayhan Fırat,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+e8f3409a-a8a1-4810-a5c1-613d92c42800,Aydın Güven Gürkan,Aydın Güven Gürkan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 269c8686-25fe-4082-b91d-a9e488f0b8e5,Ayhan Fırat,Ayhan Fırat,,,,Halkçı Parti,HP,area/malatya,Malatya,Grand National Assembly,17,,,,
+269c8686-25fe-4082-b91d-a9e488f0b8e5,Ayhan Fırat,Ayhan Fırat,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 41868a9a-6fb3-4919-8d80-be2207f5039f,Ayhan Sakallıoğlu,Ayhan Sakallıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 41868a9a-6fb3-4919-8d80-be2207f5039f,Ayhan Sakallıoğlu,Ayhan Sakallıoğlu,,,,Milliyetçi Demokrasi Partisi,MDP,area/sakarya,Sakarya,Grand National Assembly,17,,,,male
 8c1eeb61-01ef-4856-aec8-ee5b214ca833,Ayhan Uysal,Ayhan Uysal,,,,Anavatan Partisi,ANAP,area/Çanakkale,Çanakkale,Grand National Assembly,17,,,,
@@ -122,8 +122,8 @@ e119f33c-386b-436e-b054-284f0d632f73,Aziz Bülent Öncel,Aziz Bülent Öncel,,,,
 1c8b5c29-cee1-47c4-914c-e6e35a6eb4d6,Bahriye Üçok,Bahriye Üçok,,,,Halkçı Parti,HP,area/ordu,Ordu,Grand National Assembly,17,,,https://upload.wikimedia.org/wikipedia/commons/d/d8/Bahriye_Üçok_heykeli.JPG,female
 1827334b-b60b-4495-b2bc-7482a3632483,Balıkesir,Balıkesir,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 07fc7d25-9d51-44b7-b304-d68089c2e229,Barlas Doğu,Barlas Doğu,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,17,,,,
-432901db-c64b-497d-abec-43f0c8b588a2,Bedrettin Doğancan Akyürek,Bedrettin Doğancan Akyürek,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 432901db-c64b-497d-abec-43f0c8b588a2,Bedrettin Doğancan Akyürek,Bedrettin Doğancan Akyürek,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
+432901db-c64b-497d-abec-43f0c8b588a2,Bedrettin Doğancan Akyürek,Bedrettin Doğancan Akyürek,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 4bd8865e-7bb8-4022-b5b0-3504822f43c3,Behiç Sadi Abbasoğlu,Behiç Sadi Abbasoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 4bd8865e-7bb8-4022-b5b0-3504822f43c3,Behiç Sadi Abbasoğlu,Behiç Sadi Abbasoğlu,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
 766dd04c-3a81-4b04-a48d-37b1103627fc,Berati Erdoğan,Berati Erdoğan,,,,Anavatan Partisi,ANAP,area/samsun,Samsun,Grand National Assembly,17,,,,
@@ -139,18 +139,18 @@ e040a554-89eb-41eb-bb29-77aa436b016c,Bingöl,Bingöl,,,,Anavatan Partisi,ANAP,,,
 4299f65c-b323-408b-a898-2acc09634e6a,Burcan Emirbayer,Burcan Emirbayer,,,,Halkçı Parti,HP,area/İzmir,İzmir,Grand National Assembly,17,,,,
 5aab1ada-6474-4caf-b600-ab9844e56840,Burdur,Burdur,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 4736b3b8-ee78-4f08-9420-bb562e596c57,Burhan Cahit Gündüz,Burhan Cahit Gündüz,,,,Anavatan Partisi,ANAP,area/İzmir,İzmir,Grand National Assembly,17,,,,
-a28257c8-017a-484f-ae3b-999c4af631c6,Burhan Kara,Burhan Kara,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 a28257c8-017a-484f-ae3b-999c4af631c6,Burhan Kara,Burhan Kara,,,,Anavatan Partisi,ANAP,area/giresun,Giresun,Grand National Assembly,17,,,,male
+a28257c8-017a-484f-ae3b-999c4af631c6,Burhan Kara,Burhan Kara,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 e4420c79-663f-47ec-a72c-bd45e43c8b22,Bursa,Bursa,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 8d1c2cfa-2fee-47ba-914f-05ba2efdf1ef,Bülend Ulusu,Bülend Ulusu,,,,Milliyetçi Demokrasi Partisi,MDP,area/İstanbul,İstanbul,Grand National Assembly,17,,,https://upload.wikimedia.org/wikipedia/commons/c/c1/BulendUlusu.jpg,male
-6a5cfa74-acfb-4123-a0ac-4caa18d366d5,Bülent Akarcalı,Bülent Akarcalı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 6a5cfa74-acfb-4123-a0ac-4caa18d366d5,Bülent Akarcalı,Bülent Akarcalı,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,male
-fec987e5-63e5-4a63-a778-780a7480557a,Cafer Tayyar Sadıklar,Cafer Tayyar Sadıklar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+6a5cfa74-acfb-4123-a0ac-4caa18d366d5,Bülent Akarcalı,Bülent Akarcalı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 fec987e5-63e5-4a63-a778-780a7480557a,Cafer Tayyar Sadıklar,Cafer Tayyar Sadıklar,,,,Milliyetçi Demokrasi Partisi,MDP,area/Çanakkale,Çanakkale,Grand National Assembly,17,,,,
-248e0f7b-d4e6-495b-be4f-25d1e02c7127,Cahit Karakaş,Cahit Karakaş,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+fec987e5-63e5-4a63-a778-780a7480557a,Cafer Tayyar Sadıklar,Cafer Tayyar Sadıklar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 248e0f7b-d4e6-495b-be4f-25d1e02c7127,Cahit Karakaş,Cahit Karakaş,,,,Halkçı Parti,HP,area/zonguldak,Zonguldak,Grand National Assembly,17,,,,male
-cad458e8-5011-4821-90c9-154fe9ea6f0e,Cahit Tutum,Cahit Tutum,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+248e0f7b-d4e6-495b-be4f-25d1e02c7127,Cahit Karakaş,Cahit Karakaş,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 cad458e8-5011-4821-90c9-154fe9ea6f0e,Cahit Tutum,Cahit Tutum,,,,Halkçı Parti,HP,area/balıkesir,Balıkesir,Grand National Assembly,17,,,,male
+cad458e8-5011-4821-90c9-154fe9ea6f0e,Cahit Tutum,Cahit Tutum,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 30d547d1-4485-4a18-8c89-4b052778090c,Cemal Büyükbaş,Cemal Büyükbaş,,,,Anavatan Partisi,ANAP,area/eskişehir,Eskişehir,Grand National Assembly,17,,,,male
 ae8ef3d1-6dbd-41c5-b3fa-6b08df54ad3d,Cemal Özbilen,Cemal Özbilen,,,,Anavatan Partisi,ANAP,area/kırklareli,Kırklareli,Grand National Assembly,17,,,,male
 a308cd82-2dca-453b-8266-b864b553398c,Cemal Özdemir,Cemal Özdemir,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
@@ -158,29 +158,29 @@ a308cd82-2dca-453b-8266-b864b553398c,Cemal Özdemir,Cemal Özdemir,,,,Halkçı P
 9080e2bc-9d58-41bb-af34-97e91e22e84e,Cengiz Tuncer,Cengiz Tuncer,,,,Anavatan Partisi,ANAP,area/kayseri,Kayseri,Grand National Assembly,17,,,,
 307c829e-2ce6-4f66-9048-03dafd0e33e4,Cevdet Karakurt,Cevdet Karakurt,,,,Anavatan Partisi,ANAP,area/diyarbakır,Diyarbakır,Grand National Assembly,17,,,,
 20344484-e5d1-446e-a3af-da5cb8bb6569,Cihadettin Turgut Sunalp,Cihadettin Turgut Sunalp,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-81e0c73b-4da6-4c24-94a6-6cc3d20e2a80,Coşkun Bayram,Coşkun Bayram,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 81e0c73b-4da6-4c24-94a6-6cc3d20e2a80,Coşkun Bayram,Coşkun Bayram,,,,Halkçı Parti,HP,area/adana,Adana,Grand National Assembly,17,,,,
+81e0c73b-4da6-4c24-94a6-6cc3d20e2a80,Coşkun Bayram,Coşkun Bayram,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 251a7d70-811e-45de-a178-d7e0ca3c7bc8,Davut Abacıgil,Davut Abacıgil,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 251a7d70-811e-45de-a178-d7e0ca3c7bc8,Davut Abacıgil,Davut Abacıgil,,,,Halkçı Parti,HP,area/balıkesir,Balıkesir,Grand National Assembly,17,,,,
 22f7c23f-408c-4f96-8afb-9e4d182d1eba,Denizli,Denizli,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 b4fccfe6-6891-4d01-aa26-fb80dd013026,Diyarbakır,Diyarbakır,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 6d1ed51a-9dd7-4c2e-a553-cbb3b1257913,Doğan Kasaroğlu,Doğan Kasaroğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,https://upload.wikimedia.org/wikipedia/commons/c/c5/Tara0046.jpg,male
 6d1ed51a-9dd7-4c2e-a553-cbb3b1257913,Doğan Kasaroğlu,Doğan Kasaroğlu,,,,Milliyetçi Demokrasi Partisi,MDP,area/İstanbul,İstanbul,Grand National Assembly,17,,,https://upload.wikimedia.org/wikipedia/commons/c/c5/Tara0046.jpg,male
-8d75f83a-982a-45f4-aebf-a7316a52f7f5,Durmuş Fikri Sağlar,Durmuş Fikri Sağlar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-8d75f83a-982a-45f4-aebf-a7316a52f7f5,Durmuş Fikri Sağlar,Durmuş Fikri Sağlar,,,,Halkçı Parti,HP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,17,,,,
+8d75f83a-982a-45f4-aebf-a7316a52f7f5,Durmuş Fikri Sağlar,Durmuş Fikri Sağlar,,,,Halkçı Parti,HP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,17,,,,male
+8d75f83a-982a-45f4-aebf-a7316a52f7f5,Durmuş Fikri Sağlar,Durmuş Fikri Sağlar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 9cea6cb3-06b8-4553-b82f-9aa0eae984ba,Ebubekir Akay,Ebubekir Akay,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 9cea6cb3-06b8-4553-b82f-9aa0eae984ba,Ebubekir Akay,Ebubekir Akay,,,,Milliyetçi Demokrasi Partisi,MDP,area/erzurum,Erzurum,Grand National Assembly,17,,,,
 45efbf35-859e-4499-a34d-26602d7e8ea8,Edip Özgenç,Edip Özgenç,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 45efbf35-859e-4499-a34d-26602d7e8ea8,Edip Özgenç,Edip Özgenç,,,,Halkçı Parti,HP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,17,,,,male
 e4d917e0-5151-4a07-b48a-b9dc1fcb3d42,Edirne,Edirne,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 b02dba56-0f37-4613-89fd-2b46a9477dc8,Elazığ,Elazığ,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-ca7f4446-4a0d-48b4-aeed-71395a599b5f,Emin Alpkaya,Emin Alpkaya,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 ca7f4446-4a0d-48b4-aeed-71395a599b5f,Emin Alpkaya,Emin Alpkaya,,,,Milliyetçi Demokrasi Partisi,MDP,area/niğde,Niğde,Grand National Assembly,17,,,,male
-a3de10ca-7fac-4bdd-b958-aa300866fee6,Emin Fahrettin Özdilek,Emin Fahrettin Özdilek,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+ca7f4446-4a0d-48b4-aeed-71395a599b5f,Emin Alpkaya,Emin Alpkaya,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 a3de10ca-7fac-4bdd-b958-aa300866fee6,Emin Fahrettin Özdilek,Emin Fahrettin Özdilek,,,,Halkçı Parti,HP,area/konya,Konya,Grand National Assembly,17,,,,male
+a3de10ca-7fac-4bdd-b958-aa300866fee6,Emin Fahrettin Özdilek,Emin Fahrettin Özdilek,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 9313ed1a-42d0-41e3-88df-4bd08c57228b,Engin Cansızoğlu,Engin Cansızoğlu,,,,Anavatan Partisi,ANAP,area/zonguldak,Zonguldak,Grand National Assembly,17,,,,
-cd14a925-f2ae-4881-b39f-49f13ec55d5c,Enver Özcan,Enver Özcan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 cd14a925-f2ae-4881-b39f-49f13ec55d5c,Enver Özcan,Enver Özcan,,,,Halkçı Parti,HP,area/tokat,Tokat,Grand National Assembly,17,,,,
+cd14a925-f2ae-4881-b39f-49f13ec55d5c,Enver Özcan,Enver Özcan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 c7056767-7947-414b-b5b6-e4a229795a12,Erdal İnönü,Erdal İnönü,,,,Sosyaldemokrat Halkçı Parti,SHP,,,Grand National Assembly,17,,,,male
 a9befedf-e5dc-4e53-aa81-73a1fa7a52c4,Erol Ağagil,Erol Ağagil,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 a9befedf-e5dc-4e53-aa81-73a1fa7a52c4,Erol Ağagil,Erol Ağagil,,,,Halkçı Parti,HP,area/kırklareli,Kırklareli,Grand National Assembly,17,,,,
@@ -191,92 +191,92 @@ b3c2f0d9-0283-4028-937d-3fb39445e7cf,Erzincan,Erzincan,,,,Anavatan Partisi,ANAP,
 978b8e57-e4be-449f-b70c-0517a05e2ccf,Erzurum,Erzurum,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 d7aef0bb-13f0-4bd0-993d-c5aa77a6fe68,Eskişehir,Eskişehir,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 3b5fb2ea-3ad5-432a-bf08-75599501a3a2,Eyüp Aşık,Eyüp Aşık,,,,Anavatan Partisi,ANAP,area/trabzon,Trabzon,Grand National Assembly,17,,,,male
-9233553a-a934-464a-8e76-599ac1c04824,Eşref Akıncı,Eşref Akıncı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 9233553a-a934-464a-8e76-599ac1c04824,Eşref Akıncı,Eşref Akıncı,,,,Milliyetçi Demokrasi Partisi,MDP,area/ankara,Ankara,Grand National Assembly,17,,,,male
+9233553a-a934-464a-8e76-599ac1c04824,Eşref Akıncı,Eşref Akıncı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 0d4e4414-56b5-4469-badb-6953dd973af1,Fahir Sabuniş,Fahir Sabuniş,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 0d4e4414-56b5-4469-badb-6953dd973af1,Fahir Sabuniş,Fahir Sabuniş,,,,Anavatan Partisi,ANAP,area/bursa,Bursa,Grand National Assembly,17,,,,
-438396f6-90c1-405d-afd7-331ef4877f32,Fahrettin Kurt,Fahrettin Kurt,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 438396f6-90c1-405d-afd7-331ef4877f32,Fahrettin Kurt,Fahrettin Kurt,,,,Anavatan Partisi,ANAP,area/trabzon,Trabzon,Grand National Assembly,17,,,,
+438396f6-90c1-405d-afd7-331ef4877f32,Fahrettin Kurt,Fahrettin Kurt,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 08dc3cea-576e-47c8-95e4-d618c1fb21c8,Fahrettin Uluç,Fahrettin Uluç,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 08dc3cea-576e-47c8-95e4-d618c1fb21c8,Fahrettin Uluç,Fahrettin Uluç,,,,Halkçı Parti,HP,area/samsun,Samsun,Grand National Assembly,17,,,,
-e4168a0f-f581-467d-a366-59604081a352,Fahri Şahin,Fahri Şahin,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 e4168a0f-f581-467d-a366-59604081a352,Fahri Şahin,Fahri Şahin,,,,Anavatan Partisi,ANAP,area/malatya,Malatya,Grand National Assembly,17,,,,
+e4168a0f-f581-467d-a366-59604081a352,Fahri Şahin,Fahri Şahin,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 e33f2a9e-6df2-4e90-ba26-ed5614e4afb0,Faik Tarımcıoğlu,Faik Tarımcıoğlu,,,,Milliyetçi Demokrasi Partisi,MDP,area/bitlis,Bitlis,Grand National Assembly,17,,,,
-e5fb1fe6-8054-41ad-bae8-0f8943e79154,Faruk Dırık,Faruk Dırık,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 e5fb1fe6-8054-41ad-bae8-0f8943e79154,Faruk Dırık,Faruk Dırık,,,,Anavatan Partisi,ANAP,area/nevşehir,Nevşehir,Grand National Assembly,17,,,,
+e5fb1fe6-8054-41ad-bae8-0f8943e79154,Faruk Dırık,Faruk Dırık,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 3006a225-1623-499f-a4b9-a4c8cb91ad8a,Fatma Mihriban Erden,Fatma Mihriban Erden,,,,Anavatan Partisi,ANAP,area/isparta,Isparta,Grand National Assembly,17,,,,female
 b182d5cc-3e7a-4cf5-85ed-f5b7ff0b1859,Fatma Rezan Şahinkaya,Fatma Rezan Şahinkaya,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 b182d5cc-3e7a-4cf5-85ed-f5b7ff0b1859,Fatma Rezan Şahinkaya,Fatma Rezan Şahinkaya,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,17,,,,
-cbe564ed-d0e2-4861-9912-42644498c059,Fazıl Osman Yöney,Fazıl Osman Yöney,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 cbe564ed-d0e2-4861-9912-42644498c059,Fazıl Osman Yöney,Fazıl Osman Yöney,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
+cbe564ed-d0e2-4861-9912-42644498c059,Fazıl Osman Yöney,Fazıl Osman Yöney,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1d9af52a-b82e-4e84-9aa8-17f282b7e3bc,Fehmi Memişoğlu,Fehmi Memişoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1d9af52a-b82e-4e84-9aa8-17f282b7e3bc,Fehmi Memişoğlu,Fehmi Memişoğlu,,,,Milliyetçi Demokrasi Partisi,MDP,area/rize,Rize,Grand National Assembly,17,,,,
-d9cae5e6-a2f2-42e4-829e-e002cbc22c99,Feridun Şakir Öğünç,Feridun Şakir Öğünç,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 d9cae5e6-a2f2-42e4-829e-e002cbc22c99,Feridun Şakir Öğünç,Feridun Şakir Öğünç,,,,Halkçı Parti,HP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
-f699685c-9328-4e9d-a4a9-ac051adde14f,Ferit Melen,Ferit Melen,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+d9cae5e6-a2f2-42e4-829e-e002cbc22c99,Feridun Şakir Öğünç,Feridun Şakir Öğünç,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 f699685c-9328-4e9d-a4a9-ac051adde14f,Ferit Melen,Ferit Melen,,,,Milliyetçi Demokrasi Partisi,MDP,area/van,Van,Grand National Assembly,17,,,,male
-b27a3b64-3887-4f2a-a31e-79fd341bccf1,Fethi Çelikbaş,Fethi Çelikbaş,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+f699685c-9328-4e9d-a4a9-ac051adde14f,Ferit Melen,Ferit Melen,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 b27a3b64-3887-4f2a-a31e-79fd341bccf1,Fethi Çelikbaş,Fethi Çelikbaş,,,,Anavatan Partisi,ANAP,area/burdur,Burdur,Grand National Assembly,17,,,,
+b27a3b64-3887-4f2a-a31e-79fd341bccf1,Fethi Çelikbaş,Fethi Çelikbaş,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1d104a0f-e8f6-4ff5-9071-5cca7a6395a3,Fevzi Necdet Erdinç,Fevzi Necdet Erdinç,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1d104a0f-e8f6-4ff5-9071-5cca7a6395a3,Fevzi Necdet Erdinç,Fevzi Necdet Erdinç,,,,Milliyetçi Demokrasi Partisi,MDP,area/van,Van,Grand National Assembly,17,,,,
-d8b0c0e4-ef1d-4622-a168-589067187885,Feyzullah Yıldırır,Feyzullah Yıldırır,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 d8b0c0e4-ef1d-4622-a168-589067187885,Feyzullah Yıldırır,Feyzullah Yıldırır,,,,Milliyetçi Demokrasi Partisi,MDP,area/gaziantep,Gaziantep,Grand National Assembly,17,,,,
+d8b0c0e4-ef1d-4622-a168-589067187885,Feyzullah Yıldırır,Feyzullah Yıldırır,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 46e8984b-d01d-4371-a882-f5315614b5a4,Fikret Ertan,Fikret Ertan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 46e8984b-d01d-4371-a882-f5315614b5a4,Fikret Ertan,Fikret Ertan,,,,Halkçı Parti,HP,area/İzmir,İzmir,Grand National Assembly,17,,,,
 9e642884-6f21-440d-bde4-a2fa7bc5fd7a,Fuat Öztekin,Fuat Öztekin,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 9e642884-6f21-440d-bde4-a2fa7bc5fd7a,Fuat Öztekin,Fuat Öztekin,,,,Anavatan Partisi,ANAP,area/bolu,Bolu,Grand National Assembly,17,,,,
-f7ffe9cc-265c-43d1-bad4-c0fb841befb5,Galip Deniz,Galip Deniz,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 f7ffe9cc-265c-43d1-bad4-c0fb841befb5,Galip Deniz,Galip Deniz,,,,Milliyetçi Demokrasi Partisi,MDP,area/gaziantep,Gaziantep,Grand National Assembly,17,,,,
+f7ffe9cc-265c-43d1-bad4-c0fb841befb5,Galip Deniz,Galip Deniz,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 7d53333c-c0f2-4a59-ad92-7e4376eaa90e,Gaziantep,Gaziantep,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 f8697e80-ab29-438d-9b91-ad96b4724889,Giresun,Giresun,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-8ce37d9c-6bff-45fa-8a8b-40bccfcc6e89,Göksel Kalaycıoğlu,Göksel Kalaycıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 8ce37d9c-6bff-45fa-8a8b-40bccfcc6e89,Göksel Kalaycıoğlu,Göksel Kalaycıoğlu,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,17,,,,
-2d90e94a-08c9-4137-8799-57d50a337183,Gülami Erdoğan,Gülami Erdoğan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+8ce37d9c-6bff-45fa-8a8b-40bccfcc6e89,Göksel Kalaycıoğlu,Göksel Kalaycıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 2d90e94a-08c9-4137-8799-57d50a337183,Gülami Erdoğan,Gülami Erdoğan,,,,Anavatan Partisi,ANAP,area/samsun,Samsun,Grand National Assembly,17,,,,
+2d90e94a-08c9-4137-8799-57d50a337183,Gülami Erdoğan,Gülami Erdoğan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 d4a1451e-e32a-41dd-ba4a-07ba5131037a,Gümüşhane,Gümüşhane,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-4a43dffc-ebb3-46f1-bede-70acf7cbc38d,Günseli Özkaya,Günseli Özkaya,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 4a43dffc-ebb3-46f1-bede-70acf7cbc38d,Günseli Özkaya,Günseli Özkaya,,,,Halkçı Parti,HP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
+4a43dffc-ebb3-46f1-bede-70acf7cbc38d,Günseli Özkaya,Günseli Özkaya,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 e51ce896-f21f-4366-bdd7-dae3b63259d1,Hacı Turan Öztürk,Hacı Turan Öztürk,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 e51ce896-f21f-4366-bdd7-dae3b63259d1,Hacı Turan Öztürk,Hacı Turan Öztürk,,,,Anavatan Partisi,ANAP,area/nevşehir,Nevşehir,Grand National Assembly,17,,,,
 e3ddbad0-1c90-46c4-9605-7729ab83f3cf,Hakkâri,Hakkâri,,,,Halkçı Parti,HP,,,Grand National Assembly,17,,,,
 4d195df3-52c6-45af-aac5-bddb1f1aafac,Hakkı Artukarslan,Hakkı Artukarslan,,,,Anavatan Partisi,ANAP,area/bingöl,Bingöl,Grand National Assembly,17,,,,
 6a599a0c-5e4a-4106-8375-ef87f2ba831d,Hakkı Yılmaz Önen,Hakkı Yılmaz Önen,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 6a599a0c-5e4a-4106-8375-ef87f2ba831d,Hakkı Yılmaz Önen,Hakkı Yılmaz Önen,,,,Halkçı Parti,HP,area/İzmir,İzmir,Grand National Assembly,17,,,,male
-28af2922-9294-4445-b8a4-63ba6a3dd2c4,Halil Nüzhet Goral,Halil Nüzhet Goral,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 28af2922-9294-4445-b8a4-63ba6a3dd2c4,Halil Nüzhet Goral,Halil Nüzhet Goral,,,,Halkçı Parti,HP,area/aydın,Aydın,Grand National Assembly,17,,,,male
+28af2922-9294-4445-b8a4-63ba6a3dd2c4,Halil Nüzhet Goral,Halil Nüzhet Goral,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 0bae3c4d-b624-4e23-a246-60e6bd47d17f,Halil Orhan Ergüder,Halil Orhan Ergüder,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 0bae3c4d-b624-4e23-a246-60e6bd47d17f,Halil Orhan Ergüder,Halil Orhan Ergüder,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,male
 a789682b-27ac-48a6-a6fe-290482d5c897,Halil İbrahim Karal,Halil İbrahim Karal,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 a789682b-27ac-48a6-a6fe-290482d5c897,Halil İbrahim Karal,Halil İbrahim Karal,,,,Halkçı Parti,HP,area/ankara,Ankara,Grand National Assembly,17,,,,male
 4781d030-9538-4557-b5cd-c56c5d98f19b,Halil İbrahim Şahin,Halil İbrahim Şahin,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 4781d030-9538-4557-b5cd-c56c5d98f19b,Halil İbrahim Şahin,Halil İbrahim Şahin,,,,Halkçı Parti,HP,area/denizli,Denizli,Grand National Assembly,17,,,,male
-a6e11b96-4611-4a45-9473-bf82b10551be,Halil Şıvgın,Halil Şıvgın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 a6e11b96-4611-4a45-9473-bf82b10551be,Halil Şıvgın,Halil Şıvgın,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,17,,,,male
-818f2530-afec-4a9f-9b28-c0dbc80b8fee,Halis Soylu,Halis Soylu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+a6e11b96-4611-4a45-9473-bf82b10551be,Halil Şıvgın,Halil Şıvgın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 818f2530-afec-4a9f-9b28-c0dbc80b8fee,Halis Soylu,Halis Soylu,,,,Halkçı Parti,HP,area/kars,Kars,Grand National Assembly,17,,,,
+818f2530-afec-4a9f-9b28-c0dbc80b8fee,Halis Soylu,Halis Soylu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1026b628-29fa-42f4-9c48-ea679da0fcbf,Halit Barış Can,Halit Barış Can,,,,Halkçı Parti,HP,area/sinop,Sinop,Grand National Assembly,17,,,,
 a3af99f6-c299-4674-95df-8ebfc8f6829c,Haluk Bayülken,Haluk Bayülken,,,,Milliyetçi Demokrasi Partisi,MDP,area/antalya,Antalya,Grand National Assembly,17,,,,male
-398217af-3266-454c-ae61-19361dd0a6ad,Hamdi Özsoy,Hamdi Özsoy,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 398217af-3266-454c-ae61-19361dd0a6ad,Hamdi Özsoy,Hamdi Özsoy,,,,Anavatan Partisi,ANAP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,17,,,,male
+398217af-3266-454c-ae61-19361dd0a6ad,Hamdi Özsoy,Hamdi Özsoy,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 a3838379-df2f-45cc-9c88-fa79417e0c25,Hamit Melek,Hamit Melek,,,,Anavatan Partisi,ANAP,area/hatay,Hatay,Grand National Assembly,17,,,,
-194ea5e2-ff98-43be-944b-ae9b75fbe3a1,Hasan Adnan Tutkun,Hasan Adnan Tutkun,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 194ea5e2-ff98-43be-944b-ae9b75fbe3a1,Hasan Adnan Tutkun,Hasan Adnan Tutkun,,,,Anavatan Partisi,ANAP,area/amasya,Amasya,Grand National Assembly,17,,,,
+194ea5e2-ff98-43be-944b-ae9b75fbe3a1,Hasan Adnan Tutkun,Hasan Adnan Tutkun,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 e7b8977b-02ef-485e-abea-d945d2d806b6,Hasan Altay,Hasan Altay,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 e7b8977b-02ef-485e-abea-d945d2d806b6,Hasan Altay,Hasan Altay,,,,Halkçı Parti,HP,area/samsun,Samsun,Grand National Assembly,17,,,,
 f022e3ed-cceb-491b-baa9-abf8a900de7b,Hasan Celal Güzel,Hasan Celal Güzel,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 f022e3ed-cceb-491b-baa9-abf8a900de7b,Hasan Celal Güzel,Hasan Celal Güzel,,,,Anavatan Partisi,ANAP,area/vahit_melih_halefoğlu,Vahit Melih Halefoğlu,Grand National Assembly,17,,,,male
 3d5507f4-58b7-4cbc-bf4a-c61dbeac8e82,Hasan Fecri Alpaslan,Hasan Fecri Alpaslan,,,,Anavatan Partisi,ANAP,area/ağrı,Ağrı,Grand National Assembly,17,,,,male
-5ca646bb-a523-48ca-9aa8-b9e745f707d5,Hasan Pertev Aşçıoğlu,Hasan Pertev Aşçıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,https://upload.wikimedia.org/wikipedia/commons/7/73/Pertev_Aşçıoğlu_TTK_Kömür_Ocaklarını_Ziyareti_Sırasında_1990.jpg,male
 5ca646bb-a523-48ca-9aa8-b9e745f707d5,Hasan Pertev Aşçıoğlu,Hasan Pertev Aşçıoğlu,,,,Anavatan Partisi,ANAP,area/zonguldak,Zonguldak,Grand National Assembly,17,,,https://upload.wikimedia.org/wikipedia/commons/7/73/Pertev_Aşçıoğlu_TTK_Kömür_Ocaklarını_Ziyareti_Sırasında_1990.jpg,male
+5ca646bb-a523-48ca-9aa8-b9e745f707d5,Hasan Pertev Aşçıoğlu,Hasan Pertev Aşçıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,https://upload.wikimedia.org/wikipedia/commons/7/73/Pertev_Aşçıoğlu_TTK_Kömür_Ocaklarını_Ziyareti_Sırasında_1990.jpg,male
 d3e738cd-4a9b-4646-a8ad-733a82b74adc,Hatay,Hatay,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 4c7918a8-1dec-48c1-aa6b-91493ee3ba95,Haydar Koyuncu,Haydar Koyuncu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 4c7918a8-1dec-48c1-aa6b-91493ee3ba95,Haydar Koyuncu,Haydar Koyuncu,,,,Milliyetçi Demokrasi Partisi,MDP,area/konya,Konya,Grand National Assembly,17,,,,
-9aa56e26-e721-45e6-9a07-b648085a742a,Haydar Özalp,Haydar Özalp,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 9aa56e26-e721-45e6-9a07-b648085a742a,Haydar Özalp,Haydar Özalp,,,,Anavatan Partisi,ANAP,area/niğde,Niğde,Grand National Assembly,17,,,,
+9aa56e26-e721-45e6-9a07-b648085a742a,Haydar Özalp,Haydar Özalp,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 a1a58efe-47ec-47e4-af67-6281da837fe1,Hayrettin Elmas,Hayrettin Elmas,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 a1a58efe-47ec-47e4-af67-6281da837fe1,Hayrettin Elmas,Hayrettin Elmas,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
-0ddd5d7a-2001-4b1e-a032-bc4db0b97d70,Hayrettin Ozansoy,Hayrettin Ozansoy,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 0ddd5d7a-2001-4b1e-a032-bc4db0b97d70,Hayrettin Ozansoy,Hayrettin Ozansoy,,,,Halkçı Parti,HP,area/diyarbakır,Diyarbakır,Grand National Assembly,17,,,,
+0ddd5d7a-2001-4b1e-a032-bc4db0b97d70,Hayrettin Ozansoy,Hayrettin Ozansoy,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 ab8b7827-483f-4d31-bc78-7135dc7ce1e6,Hayrullah Olca,Hayrullah Olca,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 ab8b7827-483f-4d31-bc78-7135dc7ce1e6,Hayrullah Olca,Hayrullah Olca,,,,Halkçı Parti,HP,area/İzmir,İzmir,Grand National Assembly,17,,,,
 734a35b5-14d1-4514-a4fd-bc4069865b9c,Hazım Kutay,Hazım Kutay,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
@@ -284,30 +284,30 @@ ab8b7827-483f-4d31-bc78-7135dc7ce1e6,Hayrullah Olca,Hayrullah Olca,,,,Halkçı P
 5709a074-1709-4b53-b5b7-a29972791180,Hikmet Biçentürk,Hikmet Biçentürk,,,,Anavatan Partisi,ANAP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,17,,,,
 7ebfb888-d6dd-401c-886f-72e9dda72a8b,Hilmi Biçer,Hilmi Biçer,,,,Halkçı Parti,HP,,,Grand National Assembly,17,,,,
 7ebfb888-d6dd-401c-886f-72e9dda72a8b,Hilmi Biçer,Hilmi Biçer,,,,Milliyetçi Demokrasi Partisi,MDP,area/sinop,Sinop,Grand National Assembly,17,,,,
-f4d476e8-9c0a-4216-992a-b04d3bb28972,Hilmi Nalbantoğlu,Hilmi Nalbantoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 f4d476e8-9c0a-4216-992a-b04d3bb28972,Hilmi Nalbantoğlu,Hilmi Nalbantoğlu,,,,Halkçı Parti,HP,area/erzurum,Erzurum,Grand National Assembly,17,,,,
-0179325e-e172-413f-a815-6e5f072732e4,Hüsamettin Cindoruk,Hüsamettin Cindoruk,,,,Doğru Yol Partisi,DYP,,,Grand National Assembly,17,,,,male
+f4d476e8-9c0a-4216-992a-b04d3bb28972,Hilmi Nalbantoğlu,Hilmi Nalbantoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 0179325e-e172-413f-a815-6e5f072732e4,Hüsamettin Cindoruk,Hüsamettin Cindoruk,,,,Doğru Yol Partisi,DYP,area/Ümit_canuyar,Ümit Canuyar,Grand National Assembly,17,,,,male
+0179325e-e172-413f-a815-6e5f072732e4,Hüsamettin Cindoruk,Hüsamettin Cindoruk,,,,Doğru Yol Partisi,DYP,,,Grand National Assembly,17,,,,male
 e683fc72-c290-4b92-80b9-7898f68ef90e,Hüseyin Avni Güler,Hüseyin Avni Güler,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 e683fc72-c290-4b92-80b9-7898f68ef90e,Hüseyin Avni Güler,Hüseyin Avni Güler,,,,Halkçı Parti,HP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
-b7e7faa5-6145-4e1b-be72-131253eea0a9,Hüseyin Avni Sağesen,Hüseyin Avni Sağesen,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 b7e7faa5-6145-4e1b-be72-131253eea0a9,Hüseyin Avni Sağesen,Hüseyin Avni Sağesen,,,,Halkçı Parti,HP,area/ordu,Ordu,Grand National Assembly,17,,,,
-1b79f0e2-9389-40c3-b1e3-3249ac2d08b2,Hüseyin Aydemir,Hüseyin Aydemir,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+b7e7faa5-6145-4e1b-be72-131253eea0a9,Hüseyin Avni Sağesen,Hüseyin Avni Sağesen,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1b79f0e2-9389-40c3-b1e3-3249ac2d08b2,Hüseyin Aydemir,Hüseyin Aydemir,,,,Halkçı Parti,HP,area/İzmir,İzmir,Grand National Assembly,17,,,,male
+1b79f0e2-9389-40c3-b1e3-3249ac2d08b2,Hüseyin Aydemir,Hüseyin Aydemir,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 1b31275f-4f47-4232-a9a4-024d7cced71a,Hüseyin Aydın Arvasi,Hüseyin Aydın Arvasi,,,,Anavatan Partisi,ANAP,area/van,Van,Grand National Assembly,17,,,,male
 30837363-b8e5-4b31-b205-d19557bcf5df,Hüseyin Barlas Doğu,Hüseyin Barlas Doğu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-453dc3d5-5ce1-44d0-9c41-4e99a764040b,Hüseyin Cahit Aral,Hüseyin Cahit Aral,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,17,,,,
-85cc1dd7-6357-4e46-b363-b9d3114b4c1f,Hüseyin Mükerrem Hiç,Hüseyin Mükerrem Hiç,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+453dc3d5-5ce1-44d0-9c41-4e99a764040b,Hüseyin Cahit Aral,Hüseyin Cahit Aral,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,17,,,,male
 85cc1dd7-6357-4e46-b363-b9d3114b4c1f,Hüseyin Mükerrem Hiç,Hüseyin Mükerrem Hiç,,,,Milliyetçi Demokrasi Partisi,MDP,area/yozgat,Yozgat,Grand National Assembly,17,,,,male
+85cc1dd7-6357-4e46-b363-b9d3114b4c1f,Hüseyin Mükerrem Hiç,Hüseyin Mükerrem Hiç,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 7b75ccc4-86a4-4fb1-9c77-1440f1362121,Hüseyin Sabri Keskin,Hüseyin Sabri Keskin,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 7b75ccc4-86a4-4fb1-9c77-1440f1362121,Hüseyin Sabri Keskin,Hüseyin Sabri Keskin,,,,Milliyetçi Demokrasi Partisi,MDP,area/kastamonu,Kastamonu,Grand National Assembly,17,,,,male
-b1842688-0f1c-4db9-8e21-fb4b49cdd8ad,Hüseyin Şen,Hüseyin Şen,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 b1842688-0f1c-4db9-8e21-fb4b49cdd8ad,Hüseyin Şen,Hüseyin Şen,,,,Anavatan Partisi,ANAP,area/artvin,Artvin,Grand National Assembly,17,,,,
+b1842688-0f1c-4db9-8e21-fb4b49cdd8ad,Hüseyin Şen,Hüseyin Şen,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 ff685d9b-cd8c-45a2-81de-1fb5f4873868,Hüsnü Doğan,Hüsnü Doğan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 ff685d9b-cd8c-45a2-81de-1fb5f4873868,Hüsnü Doğan,Hüsnü Doğan,,,,Anavatan Partisi,ANAP,area/vahit_melih_halefoğlu,Vahit Melih Halefoğlu,Grand National Assembly,17,,,,
 9ada753f-60e6-4b55-93c6-6081483bef29,Isparta,Isparta,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-a2f27230-91b1-41cc-b764-1fb11dbba6f2,Işılay Saygın,Işılay Saygın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,female
 a2f27230-91b1-41cc-b764-1fb11dbba6f2,Işılay Saygın,Işılay Saygın,,,,Milliyetçi Demokrasi Partisi,MDP,area/İzmir,İzmir,Grand National Assembly,17,,,,female
+a2f27230-91b1-41cc-b764-1fb11dbba6f2,Işılay Saygın,Işılay Saygın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,female
 a1108163-1a48-42a4-bc73-a28efffaca50,Kadir Demir,Kadir Demir,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 a1108163-1a48-42a4-bc73-a28efffaca50,Kadir Demir,Kadir Demir,,,,Anavatan Partisi,ANAP,area/konya,Konya,Grand National Assembly,17,,,,
 7249df83-68c1-4ea4-acc0-0fc9d55873d1,Kadir Narin,Kadir Narin,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
@@ -315,24 +315,24 @@ a1108163-1a48-42a4-bc73-a28efffaca50,Kadir Demir,Kadir Demir,,,,Anavatan Partisi
 e7fdafcb-a71b-4923-8f29-b6866749c0a8,Kadri Altay,Kadri Altay,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 e7fdafcb-a71b-4923-8f29-b6866749c0a8,Kadri Altay,Kadri Altay,,,,Milliyetçi Demokrasi Partisi,MDP,area/antalya,Antalya,Grand National Assembly,17,,,,male
 d94e3913-c1cf-4fb5-a0d3-1ea81d127adc,Kahramanmaraş,Kahramanmaraş,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-05293fdf-8c8e-4818-a32a-b62a8dade8b3,Kamil Tuğrul Coşkunoğlu,Kamil Tuğrul Coşkunoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 05293fdf-8c8e-4818-a32a-b62a8dade8b3,Kamil Tuğrul Coşkunoğlu,Kamil Tuğrul Coşkunoğlu,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,17,,,,male
-64e5b7a1-a528-4e0d-a330-d97bb62d2a64,Kamran Karaman,Kamran Karaman,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+05293fdf-8c8e-4818-a32a-b62a8dade8b3,Kamil Tuğrul Coşkunoğlu,Kamil Tuğrul Coşkunoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 64e5b7a1-a528-4e0d-a330-d97bb62d2a64,Kamran Karaman,Kamran Karaman,,,,Anavatan Partisi,ANAP,area/hatay,Hatay,Grand National Assembly,17,,,,male
-b9a2da8f-c106-4280-b461-8c3d2a3240da,Kamran İnan,Kamran İnan,,,,Milliyetçi Demokrasi Partisi,MDP,,,Grand National Assembly,17,,,,male
+64e5b7a1-a528-4e0d-a330-d97bb62d2a64,Kamran Karaman,Kamran Karaman,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 b9a2da8f-c106-4280-b461-8c3d2a3240da,Kamran İnan,Kamran İnan,,,,Milliyetçi Demokrasi Partisi,MDP,area/bitlis,Bitlis,Grand National Assembly,17,,,,male
+b9a2da8f-c106-4280-b461-8c3d2a3240da,Kamran İnan,Kamran İnan,,,,Milliyetçi Demokrasi Partisi,MDP,,,Grand National Assembly,17,,,,male
 7f855f1d-6510-4ab6-bcc3-2a86f09dc239,Kars,Kars,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 da1412a1-e7b2-4d7e-b152-5410c22d2da4,Kastamonu,Kastamonu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 eba3ba1c-e233-4446-a8a8-b2dd4cd845df,Kaya Erdem,Kaya Erdem,,,,Anavatan Partisi,ANAP,area/İzmir,İzmir,Grand National Assembly,17,,,,male
 8b67d1bd-fd50-4f77-9c27-5bdba9a6a8af,Kayseri,Kayseri,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 70c6260d-2e7a-400f-bdd4-6f914589f347,Kazım Oksay,Kazım Oksay,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 70c6260d-2e7a-400f-bdd4-6f914589f347,Kazım Oksay,Kazım Oksay,,,,Anavatan Partisi,ANAP,area/bolu,Bolu,Grand National Assembly,17,,,,
-d0d133f1-504e-411c-a2ae-de4081474a42,Kazım İpek,Kazım İpek,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 d0d133f1-504e-411c-a2ae-de4081474a42,Kazım İpek,Kazım İpek,,,,Milliyetçi Demokrasi Partisi,MDP,area/amasya,Amasya,Grand National Assembly,17,,,,
+d0d133f1-504e-411c-a2ae-de4081474a42,Kazım İpek,Kazım İpek,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 4c2644ab-3b48-420a-aa5a-7f8fa5977cb3,Kemal Or,Kemal Or,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 4c2644ab-3b48-420a-aa5a-7f8fa5977cb3,Kemal Or,Kemal Or,,,,Anavatan Partisi,ANAP,area/konya,Konya,Grand National Assembly,17,,,,
-54d72db0-6d57-4e0c-aa7f-f0fe955adaa4,Kemal Özer,Kemal Özer,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 54d72db0-6d57-4e0c-aa7f-f0fe955adaa4,Kemal Özer,Kemal Özer,,,,Halkçı Parti,HP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,male
+54d72db0-6d57-4e0c-aa7f-f0fe955adaa4,Kemal Özer,Kemal Özer,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 eed108d5-7c71-42fd-812d-e441aabc31d8,Kemal İğrek,Kemal İğrek,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 eed108d5-7c71-42fd-812d-e441aabc31d8,Kemal İğrek,Kemal İğrek,,,,Anavatan Partisi,ANAP,area/bursa,Bursa,Grand National Assembly,17,,,,
 9a4b4553-b875-42ec-83bf-3886fc88912b,Kenan Nuri Nehrozoğlu,Kenan Nuri Nehrozoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
@@ -349,44 +349,44 @@ aa60ac75-913c-4770-a489-b29fe2123cb5,Kırklareli,Kırklareli,,,,Anavatan Partisi
 22abfee8-6ef1-4345-8d2e-c01d53fa14e3,Leyla Yeniay Köseoğlu,Leyla Yeniay Köseoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,female
 22abfee8-6ef1-4345-8d2e-c01d53fa14e3,Leyla Yeniay Köseoğlu,Leyla Yeniay Köseoğlu,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,female
 4ec6f695-cdf1-4970-b3c9-b656d598190c,Lezgin Önal,Lezgin Önal,,,,Halkçı Parti,HP,area/hakkâri,Hakkâri,Grand National Assembly,17,,,,
-3ac3d331-863c-46cc-968b-fe024e3ef500,Lütfullah Kayalar,Lütfullah Kayalar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 3ac3d331-863c-46cc-968b-fe024e3ef500,Lütfullah Kayalar,Lütfullah Kayalar,,,,Anavatan Partisi,ANAP,area/yozgat,Yozgat,Grand National Assembly,17,,,,male
+3ac3d331-863c-46cc-968b-fe024e3ef500,Lütfullah Kayalar,Lütfullah Kayalar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 a07b4d95-108e-4167-8a06-a304e32b4b8c,Mahmut Akkılıç,Mahmut Akkılıç,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 a07b4d95-108e-4167-8a06-a304e32b4b8c,Mahmut Akkılıç,Mahmut Akkılıç,,,,Halkçı Parti,HP,area/İzmir,İzmir,Grand National Assembly,17,,,,male
 a9d32f96-7151-4e69-ad98-dc06e31f8b8a,Mahmut Altunakar,Mahmut Altunakar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 a9d32f96-7151-4e69-ad98-dc06e31f8b8a,Mahmut Altunakar,Mahmut Altunakar,,,,Milliyetçi Demokrasi Partisi,MDP,area/diyarbakır,Diyarbakır,Grand National Assembly,17,,,,
-d3cc4256-20a6-415e-a082-5ac5a238d371,Mahmut Karabulut,Mahmut Karabulut,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 d3cc4256-20a6-415e-a082-5ac5a238d371,Mahmut Karabulut,Mahmut Karabulut,,,,Anavatan Partisi,ANAP,area/sivas,Sivas,Grand National Assembly,17,,,,male
-1a203ba1-1ccb-4a3a-9fa9-d635db73ceaf,Mahmut Oltan Sungurlu,Mahmut Oltan Sungurlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+d3cc4256-20a6-415e-a082-5ac5a238d371,Mahmut Karabulut,Mahmut Karabulut,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 1a203ba1-1ccb-4a3a-9fa9-d635db73ceaf,Mahmut Oltan Sungurlu,Mahmut Oltan Sungurlu,,,,Anavatan Partisi,ANAP,area/gümüşhane,Gümüşhane,Grand National Assembly,17,,,,male
+1a203ba1-1ccb-4a3a-9fa9-d635db73ceaf,Mahmut Oltan Sungurlu,Mahmut Oltan Sungurlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 05050876-c56b-4bc4-af0a-a12841b523d6,Mahmut Orhon,Mahmut Orhon,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 05050876-c56b-4bc4-af0a-a12841b523d6,Mahmut Orhon,Mahmut Orhon,,,,Anavatan Partisi,ANAP,area/yozgat,Yozgat,Grand National Assembly,17,,,,
-62acaaf7-5c6f-48b9-9efd-c98db4495f4c,Mahmut Sönmez,Mahmut Sönmez,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 62acaaf7-5c6f-48b9-9efd-c98db4495f4c,Mahmut Sönmez,Mahmut Sönmez,,,,Anavatan Partisi,ANAP,area/vahit_melih_halefoğlu,Vahit Melih Halefoğlu,Grand National Assembly,17,,,,
+62acaaf7-5c6f-48b9-9efd-c98db4495f4c,Mahmut Sönmez,Mahmut Sönmez,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 f03356cf-6aaf-4699-a403-b5071f0724a2,Malatya,Malatya,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 8ec9080b-6f6d-4e24-99b6-3c6cd61a9773,Manisa,Manisa,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 8ec9080b-6f6d-4e24-99b6-3c6cd61a9773,Manisa,Manisa,,,,Doğru Yol Partisi,DYP,area/Ümit_canuyar,Ümit Canuyar,Grand National Assembly,17,,,,
 42dbc733-14c4-4dfd-9f74-fe61c9e77b30,Mardin,Mardin,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 648283bf-44fd-4d5f-bbd7-a0a0567d0c67,Mehmet Abdurrezak Ceylan,Mehmet Abdurrezak Ceylan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 648283bf-44fd-4d5f-bbd7-a0a0567d0c67,Mehmet Abdurrezak Ceylan,Mehmet Abdurrezak Ceylan,,,,Milliyetçi Demokrasi Partisi,MDP,area/siirt,Siirt,Grand National Assembly,17,,,,male
-a433ae65-b44b-464f-8133-733b05a458c2,Mehmet Ali Doğuşlu,Mehmet Ali Doğuşlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 a433ae65-b44b-464f-8133-733b05a458c2,Mehmet Ali Doğuşlu,Mehmet Ali Doğuşlu,,,,Anavatan Partisi,ANAP,area/bingöl,Bingöl,Grand National Assembly,17,,,,male
+a433ae65-b44b-464f-8133-733b05a458c2,Mehmet Ali Doğuşlu,Mehmet Ali Doğuşlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 ec17bb64-f40a-4ad3-9fc7-eb65cc42ce7e,Mehmet Arif Atalay,Mehmet Arif Atalay,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 ec17bb64-f40a-4ad3-9fc7-eb65cc42ce7e,Mehmet Arif Atalay,Mehmet Arif Atalay,,,,Milliyetçi Demokrasi Partisi,MDP,area/adıyaman,Adıyaman,Grand National Assembly,17,,,,male
-62ae678f-c9e3-4719-9c7f-8defb7aad392,Mehmet Aydın,Mehmet Aydın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-62ae678f-c9e3-4719-9c7f-8defb7aad392,Mehmet Aydın,Mehmet Aydın,,,,Anavatan Partisi,ANAP,area/samsun,Samsun,Grand National Assembly,17,,,,
-c731e893-d632-4d70-81ea-7f52b0d96649,Mehmet Azizoğlu,Mehmet Azizoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+62ae678f-c9e3-4719-9c7f-8defb7aad392,Mehmet Aydın,Mehmet Aydın,,,,Anavatan Partisi,ANAP,area/samsun,Samsun,Grand National Assembly,17,,,,male
+62ae678f-c9e3-4719-9c7f-8defb7aad392,Mehmet Aydın,Mehmet Aydın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 c731e893-d632-4d70-81ea-7f52b0d96649,Mehmet Azizoğlu,Mehmet Azizoğlu,,,,Halkçı Parti,HP,area/bursa,Bursa,Grand National Assembly,17,,,,
-571df665-4d26-47ec-8c5c-0914f8298786,Mehmet Besim Göçer,Mehmet Besim Göçer,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+c731e893-d632-4d70-81ea-7f52b0d96649,Mehmet Azizoğlu,Mehmet Azizoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 571df665-4d26-47ec-8c5c-0914f8298786,Mehmet Besim Göçer,Mehmet Besim Göçer,,,,Halkçı Parti,HP,area/Çorum,Çorum,Grand National Assembly,17,,,,
-646247d8-016d-408f-8c9b-0271705f427d,Mehmet Budak,Mehmet Budak,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+571df665-4d26-47ec-8c5c-0914f8298786,Mehmet Besim Göçer,Mehmet Besim Göçer,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 646247d8-016d-408f-8c9b-0271705f427d,Mehmet Budak,Mehmet Budak,,,,Anavatan Partisi,ANAP,area/kırşehir,Kırşehir,Grand National Assembly,17,,,,
+646247d8-016d-408f-8c9b-0271705f427d,Mehmet Budak,Mehmet Budak,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 60aa9168-cbc1-4c7b-ab1d-b60a64f2604c,Mehmet Deliceoğlu,Mehmet Deliceoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 60aa9168-cbc1-4c7b-ab1d-b60a64f2604c,Mehmet Deliceoğlu,Mehmet Deliceoğlu,,,,Anavatan Partisi,ANAP,area/adıyaman,Adıyaman,Grand National Assembly,17,,,,
-2fba1a25-f08d-4dad-bdcd-d312fec8a654,Mehmet Erdal Durukan,Mehmet Erdal Durukan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 2fba1a25-f08d-4dad-bdcd-d312fec8a654,Mehmet Erdal Durukan,Mehmet Erdal Durukan,,,,Milliyetçi Demokrasi Partisi,MDP,area/adana,Adana,Grand National Assembly,17,,,,male
-578c876f-233d-4b94-9b75-2c808c865db6,Mehmet Fenni İslimyeli,Mehmet Fenni İslimyeli,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+2fba1a25-f08d-4dad-bdcd-d312fec8a654,Mehmet Erdal Durukan,Mehmet Erdal Durukan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 578c876f-233d-4b94-9b75-2c808c865db6,Mehmet Fenni İslimyeli,Mehmet Fenni İslimyeli,,,,Milliyetçi Demokrasi Partisi,MDP,area/balıkesir,Balıkesir,Grand National Assembly,17,,,,
+578c876f-233d-4b94-9b75-2c808c865db6,Mehmet Fenni İslimyeli,Mehmet Fenni İslimyeli,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 a7a39c61-ed84-4b3b-a0c2-b1a640a0eea4,Mehmet Gürbüz Şakranlı,Mehmet Gürbüz Şakranlı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 a7a39c61-ed84-4b3b-a0c2-b1a640a0eea4,Mehmet Gürbüz Şakranlı,Mehmet Gürbüz Şakranlı,,,,Anavatan Partisi,ANAP,area/manisa,Manisa,Grand National Assembly,17,,,,
 44e7b0f8-6036-4f93-8efa-d039bcea5aca,Mehmet Hayri Osmanlıoğlu,Mehmet Hayri Osmanlıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
@@ -399,8 +399,8 @@ bfc4bcc5-34f9-45fd-ab25-e15b03263285,Mehmet Kemal Gökçora,Mehmet Kemal Gökço
 bfc4bcc5-34f9-45fd-ab25-e15b03263285,Mehmet Kemal Gökçora,Mehmet Kemal Gökçora,,,,Halkçı Parti,HP,area/bursa,Bursa,Grand National Assembly,17,,,,
 34ab09c5-8fe2-4f39-9cb5-d3d2c75a09db,Mehmet Kocabaş,Mehmet Kocabaş,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 34ab09c5-8fe2-4f39-9cb5-d3d2c75a09db,Mehmet Kocabaş,Mehmet Kocabaş,,,,Milliyetçi Demokrasi Partisi,MDP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,17,,,,
-ac509c72-bf8c-4a76-9b85-5d3c6497b663,Mehmet Memduh Gökçen,Mehmet Memduh Gökçen,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 ac509c72-bf8c-4a76-9b85-5d3c6497b663,Mehmet Memduh Gökçen,Mehmet Memduh Gökçen,,,,Anavatan Partisi,ANAP,area/bursa,Bursa,Grand National Assembly,17,,,,
+ac509c72-bf8c-4a76-9b85-5d3c6497b663,Mehmet Memduh Gökçen,Mehmet Memduh Gökçen,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 41dc517c-0ace-4605-a365-af5e951e4452,Mehmet Muhlis Arıkan,Mehmet Muhlis Arıkan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 41dc517c-0ace-4605-a365-af5e951e4452,Mehmet Muhlis Arıkan,Mehmet Muhlis Arıkan,,,,Anavatan Partisi,ANAP,area/samsun,Samsun,Grand National Assembly,17,,,,
 c0378642-5294-486e-a0cb-545939de368b,Mehmet Mükerrem Taşçıoğlu,Mehmet Mükerrem Taşçıoğlu,,,,Anavatan Partisi,ANAP,area/sivas,Sivas,Grand National Assembly,17,,,,
@@ -408,41 +408,41 @@ c0378642-5294-486e-a0cb-545939de368b,Mehmet Mükerrem Taşçıoğlu,Mehmet Müke
 77ac0743-7eff-4173-8bf8-285b24d0beb2,Mehmet Necat Eldem,Mehmet Necat Eldem,,,,Anavatan Partisi,ANAP,area/mardin,Mardin,Grand National Assembly,17,,,,male
 d1d0248d-a0f5-4d8a-a630-825e3ee6a4a6,Mehmet Nuri Üzel,Mehmet Nuri Üzel,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 d1d0248d-a0f5-4d8a-a630-825e3ee6a4a6,Mehmet Nuri Üzel,Mehmet Nuri Üzel,,,,Halkçı Parti,HP,area/eskişehir,Eskişehir,Grand National Assembly,17,,,,
-773546a2-d049-4fe2-8ec3-1ebb45145478,Mehmet Onur,Mehmet Onur,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 773546a2-d049-4fe2-8ec3-1ebb45145478,Mehmet Onur,Mehmet Onur,,,,Anavatan Partisi,ANAP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,17,,,,
-1d76a886-195e-46c3-bbb4-0feb58ff558c,Mehmet Rüştü Şardağ,Mehmet Rüştü Şardağ,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+773546a2-d049-4fe2-8ec3-1ebb45145478,Mehmet Onur,Mehmet Onur,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1d76a886-195e-46c3-bbb4-0feb58ff558c,Mehmet Rüştü Şardağ,Mehmet Rüştü Şardağ,,,,Halkçı Parti,HP,area/İzmir,İzmir,Grand National Assembly,17,,,,
+1d76a886-195e-46c3-bbb4-0feb58ff558c,Mehmet Rüştü Şardağ,Mehmet Rüştü Şardağ,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 6dbd5918-b176-4437-8a0a-1773fa4b4548,Mehmet Sait Erol,Mehmet Sait Erol,,,,Halkçı Parti,HP,,,Grand National Assembly,17,,,,
 6dbd5918-b176-4437-8a0a-1773fa4b4548,Mehmet Sait Erol,Mehmet Sait Erol,,,,Halkçı Parti,HP,area/hakkâri,Hakkâri,Grand National Assembly,17,,,,
 f0cdb999-67a8-4ff5-a41f-3e4c6961dc64,Mehmet Sağdıç,Mehmet Sağdıç,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 f0cdb999-67a8-4ff5-a41f-3e4c6961dc64,Mehmet Sağdıç,Mehmet Sağdıç,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,17,,,,male
-fd63d429-5010-4acd-bf6d-eaa34a82d0d2,Mehmet Sedat Turan,Mehmet Sedat Turan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 fd63d429-5010-4acd-bf6d-eaa34a82d0d2,Mehmet Sedat Turan,Mehmet Sedat Turan,,,,Milliyetçi Demokrasi Partisi,MDP,area/kayseri,Kayseri,Grand National Assembly,17,,,,
-47bee7b4-ba62-4b32-9db8-5539a7427a68,Mehmet Seyfi Oktay,Mehmet Seyfi Oktay,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
-47bee7b4-ba62-4b32-9db8-5539a7427a68,Mehmet Seyfi Oktay,Mehmet Seyfi Oktay,,,,Halkçı Parti,HP,area/ankara,Ankara,Grand National Assembly,17,,,,male
-3315ca2a-6c72-409c-9f95-5107f7caa170,Mehmet Sezai Pekuslu,Mehmet Sezai Pekuslu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+fd63d429-5010-4acd-bf6d-eaa34a82d0d2,Mehmet Sedat Turan,Mehmet Sedat Turan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+47bee7b4-ba62-4b32-9db8-5539a7427a68,Mehmet Seyfi Oktay,Mehmet Seyfi Oktay,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+47bee7b4-ba62-4b32-9db8-5539a7427a68,Mehmet Seyfi Oktay,Mehmet Seyfi Oktay,,,,Halkçı Parti,HP,area/ankara,Ankara,Grand National Assembly,17,,,,
 3315ca2a-6c72-409c-9f95-5107f7caa170,Mehmet Sezai Pekuslu,Mehmet Sezai Pekuslu,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,17,,,,male
+3315ca2a-6c72-409c-9f95-5107f7caa170,Mehmet Sezai Pekuslu,Mehmet Sezai Pekuslu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 2de96462-c3d5-4ee0-a7a9-adebe7f8dc26,Mehmet Timur Çınar,Mehmet Timur Çınar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 2de96462-c3d5-4ee0-a7a9-adebe7f8dc26,Mehmet Timur Çınar,Mehmet Timur Çınar,,,,Anavatan Partisi,ANAP,area/manisa,Manisa,Grand National Assembly,17,,,,
 241c329e-a1c9-41d5-b939-51da7dcf48f3,Mehmet Topaç,Mehmet Topaç,,,,Anavatan Partisi,ANAP,area/uşak,Uşak,Grand National Assembly,17,,,,male
 1f55217a-97fa-4103-822b-de9f34d64954,Mehmet Turan Bayazıt,Mehmet Turan Bayazıt,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 1f55217a-97fa-4103-822b-de9f34d64954,Mehmet Turan Bayazıt,Mehmet Turan Bayazıt,,,,Halkçı Parti,HP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,17,,,,male
-3cc107af-044c-41a7-b8d5-4fcbd5e5e338,Mehmet Umur Akarca,Mehmet Umur Akarca,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 3cc107af-044c-41a7-b8d5-4fcbd5e5e338,Mehmet Umur Akarca,Mehmet Umur Akarca,,,,Anavatan Partisi,ANAP,area/muğla,Muğla,Grand National Assembly,17,,,,
+3cc107af-044c-41a7-b8d5-4fcbd5e5e338,Mehmet Umur Akarca,Mehmet Umur Akarca,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 0f3842ac-4bb4-4468-8452-36c5285129e8,Mehmet Vehbi Dinçerler,Mehmet Vehbi Dinçerler,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-651e525c-4ed1-43cf-a172-4576863f8fd4,Mehmet Yaşar,Mehmet Yaşar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 651e525c-4ed1-43cf-a172-4576863f8fd4,Mehmet Yaşar,Mehmet Yaşar,,,,Milliyetçi Demokrasi Partisi,MDP,area/ağrı,Ağrı,Grand National Assembly,17,,,,
+651e525c-4ed1-43cf-a172-4576863f8fd4,Mehmet Yaşar,Mehmet Yaşar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 3c9703d2-4cec-45f0-ab5e-0ca8d0bbc228,Mehmet Zeki Uzun,Mehmet Zeki Uzun,,,,Anavatan Partisi,ANAP,area/tokat,Tokat,Grand National Assembly,17,,,,
 25fd0c20-98ad-4bfa-8f8a-c44e65036273,Mehmet Özalp,Mehmet Özalp,,,,Anavatan Partisi,ANAP,area/aydın,Aydın,Grand National Assembly,17,,,,male
 219e05e1-9a01-4633-930e-38c5cafb390e,Mehmet Özdemir,Mehmet Özdemir,,,,Anavatan Partisi,ANAP,area/elazığ,Elazığ,Grand National Assembly,17,,,,male
-1c960bab-a7ce-487e-8a1d-e9d16dd66e05,Mehmet Üner,Mehmet Üner,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1c960bab-a7ce-487e-8a1d-e9d16dd66e05,Mehmet Üner,Mehmet Üner,,,,Halkçı Parti,HP,area/kayseri,Kayseri,Grand National Assembly,17,,,,
+1c960bab-a7ce-487e-8a1d-e9d16dd66e05,Mehmet Üner,Mehmet Üner,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 da3de9ca-6e62-4de0-a402-482b4938d243,Mekin Sarıoğlu,Mekin Sarıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 da3de9ca-6e62-4de0-a402-482b4938d243,Mekin Sarıoğlu,Mekin Sarıoğlu,,,,Anavatan Partisi,ANAP,area/manisa,Manisa,Grand National Assembly,17,,,,
-38d56a04-e779-4d49-b180-c2e5db4870d8,Metin Ataman,Metin Ataman,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 38d56a04-e779-4d49-b180-c2e5db4870d8,Metin Ataman,Metin Ataman,,,,Anavatan Partisi,ANAP,area/isparta,Isparta,Grand National Assembly,17,,,,
-fa0a3bfd-2175-4c8c-bd65-33e53ffa4201,Metin Balıbey,Metin Balıbey,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+38d56a04-e779-4d49-b180-c2e5db4870d8,Metin Ataman,Metin Ataman,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 fa0a3bfd-2175-4c8c-bd65-33e53ffa4201,Metin Balıbey,Metin Balıbey,,,,Anavatan Partisi,ANAP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,17,,,,male
+fa0a3bfd-2175-4c8c-bd65-33e53ffa4201,Metin Balıbey,Metin Balıbey,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 83ede58f-e2e1-4c7e-9436-73740c197501,Metin Emiroğlu,Metin Emiroğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 83ede58f-e2e1-4c7e-9436-73740c197501,Metin Emiroğlu,Metin Emiroğlu,,,,Anavatan Partisi,ANAP,area/malatya,Malatya,Grand National Assembly,17,,,,male
 f6e36681-0740-460d-ad70-4a87deb690c0,Metin Gürdere,Metin Gürdere,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
@@ -450,40 +450,40 @@ f6e36681-0740-460d-ad70-4a87deb690c0,Metin Gürdere,Metin Gürdere,,,,Anavatan P
 cd324f1c-87c0-4059-9c13-d82685d65096,Metin Yaman,Metin Yaman,,,,Anavatan Partisi,ANAP,area/erzincan,Erzincan,Grand National Assembly,17,,,,male
 ebc8235d-b454-411b-93c4-cc43bc4fef5c,Metin Üstünel,Metin Üstünel,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 ebc8235d-b454-411b-93c4-cc43bc4fef5c,Metin Üstünel,Metin Üstünel,,,,Halkçı Parti,HP,area/adana,Adana,Grand National Assembly,17,,,,
-1f5fd935-165d-4ca1-af55-79aeb6834edd,Mirza Kurşunluoğlu,Mirza Kurşunluoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1f5fd935-165d-4ca1-af55-79aeb6834edd,Mirza Kurşunluoğlu,Mirza Kurşunluoğlu,,,,Anavatan Partisi,ANAP,area/van,Van,Grand National Assembly,17,,,,
-c80e9282-8132-4a45-af41-3904f536c918,Mucip Ataklı,Mucip Ataklı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+1f5fd935-165d-4ca1-af55-79aeb6834edd,Mirza Kurşunluoğlu,Mirza Kurşunluoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 c80e9282-8132-4a45-af41-3904f536c918,Mucip Ataklı,Mucip Ataklı,,,,Halkçı Parti,HP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
-dc2b577b-0795-4be8-839b-0be9e854024b,Muhittin Yıldırım,Muhittin Yıldırım,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+c80e9282-8132-4a45-af41-3904f536c918,Mucip Ataklı,Mucip Ataklı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 dc2b577b-0795-4be8-839b-0be9e854024b,Muhittin Yıldırım,Muhittin Yıldırım,,,,Halkçı Parti,HP,area/edirne,Edirne,Grand National Assembly,17,,,,
-8dc2bc75-376c-4a69-abc6-87c3417289fd,Muhteşem Vasıf Yücel,Muhteşem Vasıf Yücel,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+dc2b577b-0795-4be8-839b-0be9e854024b,Muhittin Yıldırım,Muhittin Yıldırım,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 8dc2bc75-376c-4a69-abc6-87c3417289fd,Muhteşem Vasıf Yücel,Muhteşem Vasıf Yücel,,,,Halkçı Parti,HP,area/zonguldak,Zonguldak,Grand National Assembly,17,,,,
+8dc2bc75-376c-4a69-abc6-87c3417289fd,Muhteşem Vasıf Yücel,Muhteşem Vasıf Yücel,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 a382535e-274a-4232-8773-83100cf741ff,Murat Sökmenoğlu,Murat Sökmenoğlu,,,,Milliyetçi Demokrasi Partisi,MDP,area/hatay,Hatay,Grand National Assembly,17,,,,male
-c2d09c7d-34fb-4e46-920f-81d8071f0c6c,Musa Ateş,Musa Ateş,,,,Halkçı Parti,HP,,,Grand National Assembly,17,,,,
 c2d09c7d-34fb-4e46-920f-81d8071f0c6c,Musa Ateş,Musa Ateş,,,,Halkçı Parti,HP,area/tunceli,Tunceli,Grand National Assembly,17,,,,
-82cac3e6-f6be-4e7f-a67f-d4a1a43c9e1c,Musa Öğün,Musa Öğün,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+c2d09c7d-34fb-4e46-920f-81d8071f0c6c,Musa Ateş,Musa Ateş,,,,Halkçı Parti,HP,,,Grand National Assembly,17,,,,
 82cac3e6-f6be-4e7f-a67f-d4a1a43c9e1c,Musa Öğün,Musa Öğün,,,,Milliyetçi Demokrasi Partisi,MDP,area/kars,Kars,Grand National Assembly,17,,,,
+82cac3e6-f6be-4e7f-a67f-d4a1a43c9e1c,Musa Öğün,Musa Öğün,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 94851dd9-b4be-465e-b97f-076609cc27c9,Mustafa Balcılar,Mustafa Balcılar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 94851dd9-b4be-465e-b97f-076609cc27c9,Mustafa Balcılar,Mustafa Balcılar,,,,Anavatan Partisi,ANAP,area/eskişehir,Eskişehir,Grand National Assembly,17,,,,male
-eed7a63d-d0bb-40ca-8f8f-bf0b6fe691b0,Mustafa Batgün,Mustafa Batgün,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 eed7a63d-d0bb-40ca-8f8f-bf0b6fe691b0,Mustafa Batgün,Mustafa Batgün,,,,Anavatan Partisi,ANAP,area/kocaeli,Kocaeli,Grand National Assembly,17,,,,
-aeb51bf1-89d1-4cea-8fd5-a1deebea0d7e,Mustafa Demir,Mustafa Demir,,,,Anavatan Partisi,ANAP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,17,,,,
+eed7a63d-d0bb-40ca-8f8f-bf0b6fe691b0,Mustafa Batgün,Mustafa Batgün,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+aeb51bf1-89d1-4cea-8fd5-a1deebea0d7e,Mustafa Demir,Mustafa Demir,,,,Anavatan Partisi,ANAP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,17,,,,male
 c7d4675a-7cd2-40ae-b1fa-b3a011ff877f,Mustafa Ertuğrul Ünlü,Mustafa Ertuğrul Ünlü,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 c7d4675a-7cd2-40ae-b1fa-b3a011ff877f,Mustafa Ertuğrul Ünlü,Mustafa Ertuğrul Ünlü,,,,Anavatan Partisi,ANAP,area/bursa,Bursa,Grand National Assembly,17,,,,male
-f046a5d1-23db-4208-a8cc-6bb06757fa8f,Mustafa Kalemli,Mustafa Kalemli,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 f046a5d1-23db-4208-a8cc-6bb06757fa8f,Mustafa Kalemli,Mustafa Kalemli,,,,Anavatan Partisi,ANAP,area/kütahya,Kütahya,Grand National Assembly,17,,,,male
-0bb9e107-b5ed-4739-b642-e587be1f13ea,Mustafa Kani Bürke,Mustafa Kani Bürke,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+f046a5d1-23db-4208-a8cc-6bb06757fa8f,Mustafa Kalemli,Mustafa Kalemli,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 0bb9e107-b5ed-4739-b642-e587be1f13ea,Mustafa Kani Bürke,Mustafa Kani Bürke,,,,Halkçı Parti,HP,area/denizli,Denizli,Grand National Assembly,17,,,,
-56298f84-fa26-4d60-b2be-19fa4f2a49e7,Mustafa Kemal Palaoğlu,Mustafa Kemal Palaoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+0bb9e107-b5ed-4739-b642-e587be1f13ea,Mustafa Kani Bürke,Mustafa Kani Bürke,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 56298f84-fa26-4d60-b2be-19fa4f2a49e7,Mustafa Kemal Palaoğlu,Mustafa Kemal Palaoğlu,,,,Halkçı Parti,HP,area/sivas,Sivas,Grand National Assembly,17,,,,male
+56298f84-fa26-4d60-b2be-19fa4f2a49e7,Mustafa Kemal Palaoğlu,Mustafa Kemal Palaoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 68dde1d7-66cb-4114-9541-022f8ae85cab,Mustafa Kemal Togay,Mustafa Kemal Togay,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 68dde1d7-66cb-4114-9541-022f8ae85cab,Mustafa Kemal Togay,Mustafa Kemal Togay,,,,Anavatan Partisi,ANAP,area/isparta,Isparta,Grand National Assembly,17,,,,
 5567a098-c68a-4085-a1c6-d52a372894bb,Mustafa Kılıçaslan,Mustafa Kılıçaslan,,,,Anavatan Partisi,ANAP,area/sakarya,Sakarya,Grand National Assembly,17,,,,male
 64937202-2e65-454d-ae87-cd2ac2aaf9e0,Mustafa Murat Sökmenoğlu,Mustafa Murat Sökmenoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 54e9738e-8510-4b1e-b4cc-c4c3b1504633,Mustafa Rüştü Taşar,Mustafa Rüştü Taşar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 54e9738e-8510-4b1e-b4cc-c4c3b1504633,Mustafa Rüştü Taşar,Mustafa Rüştü Taşar,,,,Anavatan Partisi,ANAP,area/gaziantep,Gaziantep,Grand National Assembly,17,,,,male
-413a3a46-b2bd-40ee-9f14-68806c572f61,Mustafa Rıfkı Yaylalı,Mustafa Rıfkı Yaylalı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 413a3a46-b2bd-40ee-9f14-68806c572f61,Mustafa Rıfkı Yaylalı,Mustafa Rıfkı Yaylalı,,,,Anavatan Partisi,ANAP,area/erzurum,Erzurum,Grand National Assembly,17,,,,
+413a3a46-b2bd-40ee-9f14-68806c572f61,Mustafa Rıfkı Yaylalı,Mustafa Rıfkı Yaylalı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1a88679d-92ba-4563-9fc2-ba5ff895328e,Mustafa Sabri Güvenç,Mustafa Sabri Güvenç,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1a88679d-92ba-4563-9fc2-ba5ff895328e,Mustafa Sabri Güvenç,Mustafa Sabri Güvenç,,,,Anavatan Partisi,ANAP,area/niğde,Niğde,Grand National Assembly,17,,,,
 10387df1-b5ef-40de-b2a7-d122298a9248,Mustafa Tosun Çorapçıoğlu,Mustafa Tosun Çorapçıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
@@ -491,72 +491,72 @@ f046a5d1-23db-4208-a8cc-6bb06757fa8f,Mustafa Kalemli,Mustafa Kalemli,,,,Anavatan
 c6b91dbb-725e-4f30-9f6c-214cc1722b43,Mustafa Tınaz Titiz,Mustafa Tınaz Titiz,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 43d25158-3ff1-43fb-9f13-5b69438d3c82,Mustafa Uğur Ener,Mustafa Uğur Ener,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 43d25158-3ff1-43fb-9f13-5b69438d3c82,Mustafa Uğur Ener,Mustafa Uğur Ener,,,,Anavatan Partisi,ANAP,area/kütahya,Kütahya,Grand National Assembly,17,,,,
-393e361e-ae3b-4b77-b5e5-ca180e7003a3,Mustafa Çakaloğlu,Mustafa Çakaloğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 393e361e-ae3b-4b77-b5e5-ca180e7003a3,Mustafa Çakaloğlu,Mustafa Çakaloğlu,,,,Anavatan Partisi,ANAP,area/antalya,Antalya,Grand National Assembly,17,,,,
-e7df33f3-4919-417d-8a49-ea8ede7ca32a,Mustafa Çelebi,Mustafa Çelebi,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+393e361e-ae3b-4b77-b5e5-ca180e7003a3,Mustafa Çakaloğlu,Mustafa Çakaloğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 e7df33f3-4919-417d-8a49-ea8ede7ca32a,Mustafa Çelebi,Mustafa Çelebi,,,,Halkçı Parti,HP,area/hatay,Hatay,Grand National Assembly,17,,,,male
-9291258d-0071-4f07-a53e-e51ab8fd7eb8,Mustafa İzci,Mustafa İzci,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+e7df33f3-4919-417d-8a49-ea8ede7ca32a,Mustafa Çelebi,Mustafa Çelebi,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 9291258d-0071-4f07-a53e-e51ab8fd7eb8,Mustafa İzci,Mustafa İzci,,,,Milliyetçi Demokrasi Partisi,MDP,area/manisa,Manisa,Grand National Assembly,17,,,,
+9291258d-0071-4f07-a53e-e51ab8fd7eb8,Mustafa İzci,Mustafa İzci,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 8bd2a33a-50dc-4289-8131-01909f3b723c,Mustafa Şahin,Mustafa Şahin,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 8bd2a33a-50dc-4289-8131-01909f3b723c,Mustafa Şahin,Mustafa Şahin,,,,Anavatan Partisi,ANAP,area/kayseri,Kayseri,Grand National Assembly,17,,,,male
-1d1c63a2-2a16-488d-9fc7-bc100e7a716a,Muzaffer Arıcı,Muzaffer Arıcı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 1d1c63a2-2a16-488d-9fc7-bc100e7a716a,Muzaffer Arıcı,Muzaffer Arıcı,,,,Anavatan Partisi,ANAP,area/denizli,Denizli,Grand National Assembly,17,,,,male
+1d1c63a2-2a16-488d-9fc7-bc100e7a716a,Muzaffer Arıcı,Muzaffer Arıcı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 29d763c9-a211-4000-9c7d-abcd71c8d9b1,Muzaffer Yıldırım,Muzaffer Yıldırım,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 29d763c9-a211-4000-9c7d-abcd71c8d9b1,Muzaffer Yıldırım,Muzaffer Yıldırım,,,,Halkçı Parti,HP,area/kayseri,Kayseri,Grand National Assembly,17,,,,
-f2613a43-2bc7-4485-b505-817bff1c0ce6,Muzaffer İlhan,Muzaffer İlhan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 f2613a43-2bc7-4485-b505-817bff1c0ce6,Muzaffer İlhan,Muzaffer İlhan,,,,Milliyetçi Demokrasi Partisi,MDP,area/muğla,Muğla,Grand National Assembly,17,,,,male
+f2613a43-2bc7-4485-b505-817bff1c0ce6,Muzaffer İlhan,Muzaffer İlhan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 c61005de-a7ed-4cb6-a03f-56b1ec3c0716,Muğla,Muğla,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 af8d65fa-44e3-47ad-876e-1385ad19d62f,Muş,Muş,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-8729413d-7dbf-4fde-a6ca-4f8a8cfb7a5a,Mümtaz Güler,Mümtaz Güler,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 8729413d-7dbf-4fde-a6ca-4f8a8cfb7a5a,Mümtaz Güler,Mümtaz Güler,,,,Anavatan Partisi,ANAP,area/uşak,Uşak,Grand National Assembly,17,,,,
+8729413d-7dbf-4fde-a6ca-4f8a8cfb7a5a,Mümtaz Güler,Mümtaz Güler,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 8218f3e5-8970-476f-beac-252173062995,Mümtaz Özkök,Mümtaz Özkök,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 8218f3e5-8970-476f-beac-252173062995,Mümtaz Özkök,Mümtaz Özkök,,,,Anavatan Partisi,ANAP,area/sakarya,Sakarya,Grand National Assembly,17,,,,
 37527ce3-4ee3-4e75-a96e-8284f0838881,Münir Fuat Yazıcı,Münir Fuat Yazıcı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 37527ce3-4ee3-4e75-a96e-8284f0838881,Münir Fuat Yazıcı,Münir Fuat Yazıcı,,,,Anavatan Partisi,ANAP,area/manisa,Manisa,Grand National Assembly,17,,,,
-eab48b76-020c-406c-ac16-6f19a60060cc,Münir Sevinç,Münir Sevinç,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 eab48b76-020c-406c-ac16-6f19a60060cc,Münir Sevinç,Münir Sevinç,,,,Halkçı Parti,HP,area/eskişehir,Eskişehir,Grand National Assembly,17,,,,
+eab48b76-020c-406c-ac16-6f19a60060cc,Münir Sevinç,Münir Sevinç,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 06324fe4-704c-4ef6-a41b-9978fb3a345b,Nabi Poyraz,Nabi Poyraz,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 06324fe4-704c-4ef6-a41b-9978fb3a345b,Nabi Poyraz,Nabi Poyraz,,,,Anavatan Partisi,ANAP,area/ordu,Ordu,Grand National Assembly,17,,,,male
-c8c8587c-7f00-443d-a281-12b760833cba,Nabi Sabuncu,Nabi Sabuncu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 c8c8587c-7f00-443d-a281-12b760833cba,Nabi Sabuncu,Nabi Sabuncu,,,,Anavatan Partisi,ANAP,area/aydın,Aydın,Grand National Assembly,17,,,,
+c8c8587c-7f00-443d-a281-12b760833cba,Nabi Sabuncu,Nabi Sabuncu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 9e48c340-4c8f-4731-b6eb-4f4277c8c06f,Naci Taşel,Naci Taşel,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 9e48c340-4c8f-4731-b6eb-4f4277c8c06f,Naci Taşel,Naci Taşel,,,,Anavatan Partisi,ANAP,area/elazığ,Elazığ,Grand National Assembly,17,,,,
 ecaa8673-9a2b-4e15-a0c0-e8d049653629,Nadir Pazarbaşı,Nadir Pazarbaşı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 ecaa8673-9a2b-4e15-a0c0-e8d049653629,Nadir Pazarbaşı,Nadir Pazarbaşı,,,,Anavatan Partisi,ANAP,area/Çanakkale,Çanakkale,Grand National Assembly,17,,,,
-dd2607f3-59f0-4f60-99ea-28f88b8cbc69,Namık Kemal Şentürk,Namık Kemal Şentürk,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 dd2607f3-59f0-4f60-99ea-28f88b8cbc69,Namık Kemal Şentürk,Namık Kemal Şentürk,,,,Milliyetçi Demokrasi Partisi,MDP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
-7670346b-d8d3-44c5-8547-ebf7a42945bf,Nazmi Önder,Nazmi Önder,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+dd2607f3-59f0-4f60-99ea-28f88b8cbc69,Namık Kemal Şentürk,Namık Kemal Şentürk,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 7670346b-d8d3-44c5-8547-ebf7a42945bf,Nazmi Önder,Nazmi Önder,,,,Milliyetçi Demokrasi Partisi,MDP,area/muş,Muş,Grand National Assembly,17,,,,
-de45d3d1-c270-4703-b411-3963cb47350a,Necat Tunçsiper,Necat Tunçsiper,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+7670346b-d8d3-44c5-8547-ebf7a42945bf,Nazmi Önder,Nazmi Önder,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 de45d3d1-c270-4703-b411-3963cb47350a,Necat Tunçsiper,Necat Tunçsiper,,,,Anavatan Partisi,ANAP,area/balıkesir,Balıkesir,Grand National Assembly,17,,,,
-37901e90-c92b-45dd-87b4-8a8218856f30,Necdet Calp,Necdet Calp,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+de45d3d1-c270-4703-b411-3963cb47350a,Necat Tunçsiper,Necat Tunçsiper,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 37901e90-c92b-45dd-87b4-8a8218856f30,Necdet Calp,Necdet Calp,,,,Halkçı Parti,HP,area/ankara,Ankara,Grand National Assembly,17,,,,male
-7fd9c745-844b-4670-ac50-550510e5be76,Necip Oğuzhan Artukoğlu,Necip Oğuzhan Artukoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+37901e90-c92b-45dd-87b4-8a8218856f30,Necdet Calp,Necdet Calp,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 7fd9c745-844b-4670-ac50-550510e5be76,Necip Oğuzhan Artukoğlu,Necip Oğuzhan Artukoğlu,,,,Anavatan Partisi,ANAP,area/burdur,Burdur,Grand National Assembly,17,,,,
+7fd9c745-844b-4670-ac50-550510e5be76,Necip Oğuzhan Artukoğlu,Necip Oğuzhan Artukoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 ae8cc313-bca7-415d-9fb5-c1823b718632,Necmettin Karaduman,Necmettin Karaduman,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 ae8cc313-bca7-415d-9fb5-c1823b718632,Necmettin Karaduman,Necmettin Karaduman,,,,Anavatan Partisi,ANAP,area/trabzon,Trabzon,Grand National Assembly,17,,,,male
 a7a16eef-f68c-4021-991d-2abb061dae45,Nejat Abdullah Gülecek,Nejat Abdullah Gülecek,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 a7a16eef-f68c-4021-991d-2abb061dae45,Nejat Abdullah Gülecek,Nejat Abdullah Gülecek,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,17,,,,
-a9822125-1419-4aa2-a925-5d7c974f62da,Nejdet Naci Mimaroğlu,Nejdet Naci Mimaroğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 a9822125-1419-4aa2-a925-5d7c974f62da,Nejdet Naci Mimaroğlu,Nejdet Naci Mimaroğlu,,,,Milliyetçi Demokrasi Partisi,MDP,area/siirt,Siirt,Grand National Assembly,17,,,,
+a9822125-1419-4aa2-a925-5d7c974f62da,Nejdet Naci Mimaroğlu,Nejdet Naci Mimaroğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 996b4ba2-91aa-41ac-ae6d-4eeb2fe4a94e,Neriman Elgin,Neriman Elgin,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 996b4ba2-91aa-41ac-ae6d-4eeb2fe4a94e,Neriman Elgin,Neriman Elgin,,,,Halkçı Parti,HP,area/ankara,Ankara,Grand National Assembly,17,,,,
-f397db87-9494-4d4f-9725-f007d15f616e,Nevzat Bıyıklı,Nevzat Bıyıklı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 f397db87-9494-4d4f-9725-f007d15f616e,Nevzat Bıyıklı,Nevzat Bıyıklı,,,,Anavatan Partisi,ANAP,area/artvin,Artvin,Grand National Assembly,17,,,,
+f397db87-9494-4d4f-9725-f007d15f616e,Nevzat Bıyıklı,Nevzat Bıyıklı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 d8173b5e-f688-4876-a019-efc588e339d8,Nevzat Yağcı,Nevzat Yağcı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 d8173b5e-f688-4876-a019-efc588e339d8,Nevzat Yağcı,Nevzat Yağcı,,,,Anavatan Partisi,ANAP,area/elazığ,Elazığ,Grand National Assembly,17,,,,
 6c026ccd-2736-45ac-8d28-715a721cd936,Nevşehir,Nevşehir,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-2f5b3710-d911-4463-9bef-04b8e2a3e70b,Nihat Akpak,Nihat Akpak,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 2f5b3710-d911-4463-9bef-04b8e2a3e70b,Nihat Akpak,Nihat Akpak,,,,Anavatan Partisi,ANAP,area/sakarya,Sakarya,Grand National Assembly,17,,,,
+2f5b3710-d911-4463-9bef-04b8e2a3e70b,Nihat Akpak,Nihat Akpak,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 49ec7348-e7fe-44e1-b3be-d0f906d68fb7,Nihat Harmancı,Nihat Harmancı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 49ec7348-e7fe-44e1-b3be-d0f906d68fb7,Nihat Harmancı,Nihat Harmancı,,,,Anavatan Partisi,ANAP,area/konya,Konya,Grand National Assembly,17,,,,
 ec876d1a-8951-4588-8768-232a7aa78189,Nihat Türker,Nihat Türker,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 ec876d1a-8951-4588-8768-232a7aa78189,Nihat Türker,Nihat Türker,,,,Anavatan Partisi,ANAP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,17,,,,
 7ccfa033-689c-4ff0-8858-c4a9ce310e52,Niğde,Niğde,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-44a4e676-1ee5-43dd-92e4-a87aefb35521,Nuh Mehmet Kaşıkçı,Nuh Mehmet Kaşıkçı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 44a4e676-1ee5-43dd-92e4-a87aefb35521,Nuh Mehmet Kaşıkçı,Nuh Mehmet Kaşıkçı,,,,Anavatan Partisi,ANAP,area/kayseri,Kayseri,Grand National Assembly,17,,,,
-ce85a5b4-a289-46c3-9ddf-3fb8004edd4e,Nurettin Yağanoğlu,Nurettin Yağanoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+44a4e676-1ee5-43dd-92e4-a87aefb35521,Nuh Mehmet Kaşıkçı,Nuh Mehmet Kaşıkçı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 ce85a5b4-a289-46c3-9ddf-3fb8004edd4e,Nurettin Yağanoğlu,Nurettin Yağanoğlu,,,,Anavatan Partisi,ANAP,area/adana,Adana,Grand National Assembly,17,,,,male
+ce85a5b4-a289-46c3-9ddf-3fb8004edd4e,Nurettin Yağanoğlu,Nurettin Yağanoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 df7f8a6d-c007-4920-8f12-f8af036405d4,Nuri Korkmaz,Nuri Korkmaz,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 df7f8a6d-c007-4920-8f12-f8af036405d4,Nuri Korkmaz,Nuri Korkmaz,,,,Halkçı Parti,HP,area/adana,Adana,Grand National Assembly,17,,,,
 3bb2415e-ff73-4edd-89b1-3e08f196c623,Ogan Soysal,Ogan Soysal,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
@@ -574,67 +574,67 @@ d1dc874b-5540-4226-b8b3-c563f10706df,Ordu,Ordu,,,,Anavatan Partisi,ANAP,,,Grand 
 8be84e20-2ec7-4d2e-862f-a9ec4038d3e6,Osman Esgin Tipi,Osman Esgin Tipi,,,,Halkçı Parti,HP,area/aydın,Aydın,Grand National Assembly,17,,,,
 181c5ec3-e987-4daa-a126-bc015a6d8366,Osman Işık,Osman Işık,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 181c5ec3-e987-4daa-a126-bc015a6d8366,Osman Işık,Osman Işık,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,17,,,,
-6e0d9730-7c2d-4884-bbc2-bf5b24593baf,Osman Nuri Akyol,Osman Nuri Akyol,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 6e0d9730-7c2d-4884-bbc2-bf5b24593baf,Osman Nuri Akyol,Osman Nuri Akyol,,,,Anavatan Partisi,ANAP,area/kocaeli,Kocaeli,Grand National Assembly,17,,,,
-92a37840-6aa0-4e50-8c3c-041d79290f1f,Paşa Sarıoğlu,Paşa Sarıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+6e0d9730-7c2d-4884-bbc2-bf5b24593baf,Osman Nuri Akyol,Osman Nuri Akyol,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 92a37840-6aa0-4e50-8c3c-041d79290f1f,Paşa Sarıoğlu,Paşa Sarıoğlu,,,,Halkçı Parti,HP,area/ağrı,Ağrı,Grand National Assembly,17,,,,
+92a37840-6aa0-4e50-8c3c-041d79290f1f,Paşa Sarıoğlu,Paşa Sarıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 72db73f5-68b8-4429-b179-358301b799a1,Rafet İbrahimoğlu,Rafet İbrahimoğlu,,,,Milliyetçi Demokrasi Partisi,MDP,,,Grand National Assembly,17,,,,
 72db73f5-68b8-4429-b179-358301b799a1,Rafet İbrahimoğlu,Rafet İbrahimoğlu,,,,Milliyetçi Demokrasi Partisi,MDP,area/bitlis,Bitlis,Grand National Assembly,17,,,,
-8af419f9-f9c3-41a9-b7c8-5ca872f14adb,Recep Ercüment Konukman,Recep Ercüment Konukman,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 8af419f9-f9c3-41a9-b7c8-5ca872f14adb,Recep Ercüment Konukman,Recep Ercüment Konukman,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
+8af419f9-f9c3-41a9-b7c8-5ca872f14adb,Recep Ercüment Konukman,Recep Ercüment Konukman,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 8fbd0aee-c991-44da-9b11-299b65694861,Recep Kaya,Recep Kaya,,,,Anavatan Partisi,ANAP,area/bilecik,Bilecik,Grand National Assembly,17,,,,
-50a1cb0e-6deb-4a0c-9b73-4a1b83f076e2,Reşit Akif Ülker,Reşit Akif Ülker,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 50a1cb0e-6deb-4a0c-9b73-4a1b83f076e2,Reşit Akif Ülker,Reşit Akif Ülker,,,,Halkçı Parti,HP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
+50a1cb0e-6deb-4a0c-9b73-4a1b83f076e2,Reşit Akif Ülker,Reşit Akif Ülker,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 69684d72-56aa-487c-8e98-c9844e9036dc,Rize,Rize,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-778597a9-6e9d-4939-a17d-3cffc56921a9,Ruşan Işın,Ruşan Işın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 778597a9-6e9d-4939-a17d-3cffc56921a9,Ruşan Işın,Ruşan Işın,,,,Halkçı Parti,HP,area/sivas,Sivas,Grand National Assembly,17,,,,
+778597a9-6e9d-4939-a17d-3cffc56921a9,Ruşan Işın,Ruşan Işın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 c19a9b00-7634-4402-9111-a4d439609cd9,Rüştü Kazım Yücelen,Rüştü Kazım Yücelen,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 c19a9b00-7634-4402-9111-a4d439609cd9,Rüştü Kazım Yücelen,Rüştü Kazım Yücelen,,,,Anavatan Partisi,ANAP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,17,,,,male
-bfaeeb80-f488-4a28-89ce-43e24172cadf,Rıfat Bayazıt,Rıfat Bayazıt,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 bfaeeb80-f488-4a28-89ce-43e24172cadf,Rıfat Bayazıt,Rıfat Bayazıt,,,,Milliyetçi Demokrasi Partisi,MDP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,17,,,,
+bfaeeb80-f488-4a28-89ce-43e24172cadf,Rıfat Bayazıt,Rıfat Bayazıt,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 0f583540-4779-4fe5-9e88-4f1fb87dbae7,Rıza Tekin,Rıza Tekin,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 0f583540-4779-4fe5-9e88-4f1fb87dbae7,Rıza Tekin,Rıza Tekin,,,,Halkçı Parti,HP,area/siirt,Siirt,Grand National Assembly,17,,,,
 90734faa-939a-4460-a6dd-b76147b854ae,Rıza Öner Çakan,Rıza Öner Çakan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 90734faa-939a-4460-a6dd-b76147b854ae,Rıza Öner Çakan,Rıza Öner Çakan,,,,Halkçı Parti,HP,area/zonguldak,Zonguldak,Grand National Assembly,17,,,,
-7e014aae-7e62-44f0-865c-08c9ce98d312,Sabahattin Aras,Sabahattin Aras,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 7e014aae-7e62-44f0-865c-08c9ce98d312,Sabahattin Aras,Sabahattin Aras,,,,Anavatan Partisi,ANAP,area/erzurum,Erzurum,Grand National Assembly,17,,,,male
+7e014aae-7e62-44f0-865c-08c9ce98d312,Sabahattin Aras,Sabahattin Aras,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 c615b331-d9f4-470f-b6e6-c17a71c76a95,Sabahattin Eryurt,Sabahattin Eryurt,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 c615b331-d9f4-470f-b6e6-c17a71c76a95,Sabahattin Eryurt,Sabahattin Eryurt,,,,Milliyetçi Demokrasi Partisi,MDP,area/erzurum,Erzurum,Grand National Assembly,17,,,,
 881deb73-4943-40fa-929f-a65179a62192,Sabit Batumlu,Sabit Batumlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 881deb73-4943-40fa-929f-a65179a62192,Sabit Batumlu,Sabit Batumlu,,,,Halkçı Parti,HP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
-efa5efa6-379e-4ea6-8925-9a95c87f6779,Sabri Aras,Sabri Aras,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 efa5efa6-379e-4ea6-8925-9a95c87f6779,Sabri Aras,Sabri Aras,,,,Anavatan Partisi,ANAP,area/kars,Kars,Grand National Assembly,17,,,,male
-dcdd17ab-9e03-497e-9172-96cc4edb3fc8,Sabri Irmak,Sabri Irmak,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+efa5efa6-379e-4ea6-8925-9a95c87f6779,Sabri Aras,Sabri Aras,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 dcdd17ab-9e03-497e-9172-96cc4edb3fc8,Sabri Irmak,Sabri Irmak,,,,Halkçı Parti,HP,area/konya,Konya,Grand National Assembly,17,,,,
-2ddafa3b-4879-43af-8913-7eb7d3f9e7d4,Sadettin Ağacık,Sadettin Ağacık,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+dcdd17ab-9e03-497e-9172-96cc4edb3fc8,Sabri Irmak,Sabri Irmak,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 2ddafa3b-4879-43af-8913-7eb7d3f9e7d4,Sadettin Ağacık,Sadettin Ağacık,,,,Milliyetçi Demokrasi Partisi,MDP,area/kastamonu,Kastamonu,Grand National Assembly,17,,,,
+2ddafa3b-4879-43af-8913-7eb7d3f9e7d4,Sadettin Ağacık,Sadettin Ağacık,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 aee98653-59fa-4d5b-a2bd-034fe2e095c1,Safa Giray,Safa Giray,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,male
 0cef5e1f-fbeb-4e04-b32a-f3c24bc66938,Saffet Sakarya,Saffet Sakarya,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 0cef5e1f-fbeb-4e04-b32a-f3c24bc66938,Saffet Sakarya,Saffet Sakarya,,,,Anavatan Partisi,ANAP,area/Çankırı,Çankırı,Grand National Assembly,17,,,,
 31a74f2d-b4aa-44f2-8a1f-ee46ccd37dc8,Saffet Sert,Saffet Sert,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 31a74f2d-b4aa-44f2-8a1f-ee46ccd37dc8,Saffet Sert,Saffet Sert,,,,Anavatan Partisi,ANAP,area/konya,Konya,Grand National Assembly,17,,,,
 2248f52d-6396-4943-925f-fe29c4086a98,Saim Bülend Ulusu,Saim Bülend Ulusu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-4bc01e12-40fd-4700-bdd3-9083a7034c06,Sait Ekinci,Sait Ekinci,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 4bc01e12-40fd-4700-bdd3-9083a7034c06,Sait Ekinci,Sait Ekinci,,,,Anavatan Partisi,ANAP,area/vahit_melih_halefoğlu,Vahit Melih Halefoğlu,Grand National Assembly,17,,,,
+4bc01e12-40fd-4700-bdd3-9083a7034c06,Sait Ekinci,Sait Ekinci,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1bbb0f87-78c4-4e8d-a774-7e73d8b00280,Sakarya,Sakarya,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-11583ade-c6bb-41dc-8634-77b369393f46,Salih Alcan,Salih Alcan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 11583ade-c6bb-41dc-8634-77b369393f46,Salih Alcan,Salih Alcan,,,,Halkçı Parti,HP,area/tekirdağ,Tekirdağ,Grand National Assembly,17,,,,
-1a67afe8-8a03-40fa-89b0-7b683cb7e810,Salim Erel,Salim Erel,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+11583ade-c6bb-41dc-8634-77b369393f46,Salih Alcan,Salih Alcan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1a67afe8-8a03-40fa-89b0-7b683cb7e810,Salim Erel,Salim Erel,,,,Halkçı Parti,HP,area/konya,Konya,Grand National Assembly,17,,,,male
+1a67afe8-8a03-40fa-89b0-7b683cb7e810,Salim Erel,Salim Erel,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 155cebb2-63ec-4bd9-9d27-bd6701bf9e7f,Samsun,Samsun,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 aa2c071c-2111-408a-9f47-d6de3f3e5320,Selahattin Taflıoğlu,Selahattin Taflıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 aa2c071c-2111-408a-9f47-d6de3f3e5320,Selahattin Taflıoğlu,Selahattin Taflıoğlu,,,,Halkçı Parti,HP,area/yozgat,Yozgat,Grand National Assembly,17,,,,
 fc39bb00-86b1-4487-bd70-c33a603584e6,Selim Koçaker,Selim Koçaker,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 fc39bb00-86b1-4487-bd70-c33a603584e6,Selim Koçaker,Selim Koçaker,,,,Anavatan Partisi,ANAP,area/tokat,Tokat,Grand National Assembly,17,,,,
-bf08b94f-1e26-4f76-a9aa-4981b360f9c9,Selçuk Akıncı,Selçuk Akıncı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 bf08b94f-1e26-4f76-a9aa-4981b360f9c9,Selçuk Akıncı,Selçuk Akıncı,,,,Halkçı Parti,HP,area/tekirdağ,Tekirdağ,Grand National Assembly,17,,,,
-d427ea30-6038-4bf0-a3f8-b35eefb78026,Seyit Hüsamettin Konuksever,Seyit Hüsamettin Konuksever,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+bf08b94f-1e26-4f76-a9aa-4981b360f9c9,Selçuk Akıncı,Selçuk Akıncı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 d427ea30-6038-4bf0-a3f8-b35eefb78026,Seyit Hüsamettin Konuksever,Seyit Hüsamettin Konuksever,,,,Halkçı Parti,HP,area/edirne,Edirne,Grand National Assembly,17,,,,
+d427ea30-6038-4bf0-a3f8-b35eefb78026,Seyit Hüsamettin Konuksever,Seyit Hüsamettin Konuksever,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 48c73b72-28ab-4c5d-a8d3-f7adc5eb45c5,Seçkin Fırat,Seçkin Fırat,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 48c73b72-28ab-4c5d-a8d3-f7adc5eb45c5,Seçkin Fırat,Seçkin Fırat,,,,Anavatan Partisi,ANAP,area/bolu,Bolu,Grand National Assembly,17,,,,
 9ca78212-b132-4ac9-aec4-47473eb4c69a,Siirt,Siirt,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-cadaa6b7-989c-429d-8fd5-b1d9bf9415cc,Sinan Fevzi Fırat,Sinan Fevzi Fırat,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 cadaa6b7-989c-429d-8fd5-b1d9bf9415cc,Sinan Fevzi Fırat,Sinan Fevzi Fırat,,,,Milliyetçi Demokrasi Partisi,MDP,area/zonguldak,Zonguldak,Grand National Assembly,17,,,,male
+cadaa6b7-989c-429d-8fd5-b1d9bf9415cc,Sinan Fevzi Fırat,Sinan Fevzi Fırat,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 e8b65791-1b05-4ce4-9d73-b1f630a6539d,Sinop,Sinop,,,,Halkçı Parti,HP,,,Grand National Assembly,17,,,,
 b16b5a71-78f8-4e9d-94e4-9ecde287df1c,Sivas,Sivas,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 ca4dd506-27c0-4a4f-827f-f9963a162511,Sudi Türel,Sudi Türel,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
@@ -643,52 +643,52 @@ ca4dd506-27c0-4a4f-827f-f9963a162511,Sudi Türel,Sudi Türel,,,,Anavatan Partisi
 2574e958-2e6c-41d4-9915-9b9ed4ed8386,Suha Tanık,Suha Tanık,,,,Anavatan Partisi,ANAP,area/İzmir,İzmir,Grand National Assembly,17,,,,
 5407090f-e205-4355-95fa-134aab34563f,Sururi Baykal,Sururi Baykal,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 5407090f-e205-4355-95fa-134aab34563f,Sururi Baykal,Sururi Baykal,,,,Halkçı Parti,HP,area/ankara,Ankara,Grand National Assembly,17,,,,
-b9d05e68-7ae8-4338-a213-32c11fb5d01a,Süleyman Koyuncugil,Süleyman Koyuncugil,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 b9d05e68-7ae8-4338-a213-32c11fb5d01a,Süleyman Koyuncugil,Süleyman Koyuncugil,,,,Halkçı Parti,HP,area/gaziantep,Gaziantep,Grand National Assembly,17,,,,
+b9d05e68-7ae8-4338-a213-32c11fb5d01a,Süleyman Koyuncugil,Süleyman Koyuncugil,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 24a6b315-3dff-4c40-9de0-91a20786bb41,Süleyman Yağcıoğlu,Süleyman Yağcıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,https://upload.wikimedia.org/wikipedia/commons/2/25/Suleyman_Yagci1.jpg,male
 24a6b315-3dff-4c40-9de0-91a20786bb41,Süleyman Yağcıoğlu,Süleyman Yağcıoğlu,,,,Anavatan Partisi,ANAP,area/samsun,Samsun,Grand National Assembly,17,,,https://upload.wikimedia.org/wikipedia/commons/2/25/Suleyman_Yagci1.jpg,male
-78d335b5-de60-44e5-93fb-2d0eb1c8acc3,Süleyman Çelebi,Süleyman Çelebi,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-78d335b5-de60-44e5-93fb-2d0eb1c8acc3,Süleyman Çelebi,Süleyman Çelebi,,,,Milliyetçi Demokrasi Partisi,MDP,area/mardin,Mardin,Grand National Assembly,17,,,,
+78d335b5-de60-44e5-93fb-2d0eb1c8acc3,Süleyman Çelebi,Süleyman Çelebi,,,,Milliyetçi Demokrasi Partisi,MDP,area/mardin,Mardin,Grand National Assembly,17,,,,male
+78d335b5-de60-44e5-93fb-2d0eb1c8acc3,Süleyman Çelebi,Süleyman Çelebi,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 9f86b9c6-e495-45bd-9e82-56e03540d6fe,Sümer Oral,Sümer Oral,,,,Doğru Yol Partisi,DYP,,,Grand National Assembly,17,,,,
 9f86b9c6-e495-45bd-9e82-56e03540d6fe,Sümer Oral,Sümer Oral,,,,Doğru Yol Partisi,DYP,area/Ümit_canuyar,Ümit Canuyar,Grand National Assembly,17,,,,
-db2962d8-cac9-4c72-85b1-8fcad4b2b985,Talat Sargın,Talat Sargın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 db2962d8-cac9-4c72-85b1-8fcad4b2b985,Talat Sargın,Talat Sargın,,,,Anavatan Partisi,ANAP,area/tokat,Tokat,Grand National Assembly,17,,,,
+db2962d8-cac9-4c72-85b1-8fcad4b2b985,Talat Sargın,Talat Sargın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 857b2b07-e0f4-41ca-9af2-2ac85deee012,Talat Zengin,Talat Zengin,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 857b2b07-e0f4-41ca-9af2-2ac85deee012,Talat Zengin,Talat Zengin,,,,Anavatan Partisi,ANAP,area/malatya,Malatya,Grand National Assembly,17,,,,
 c23248c4-f6e5-4a26-a9f3-a4095728ca40,Tekirdağ,Tekirdağ,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-d461f115-b8c7-4b39-b7a3-c81834bc3c40,Tevfik Bilal,Tevfik Bilal,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 d461f115-b8c7-4b39-b7a3-c81834bc3c40,Tevfik Bilal,Tevfik Bilal,,,,Halkçı Parti,HP,area/hatay,Hatay,Grand National Assembly,17,,,,
+d461f115-b8c7-4b39-b7a3-c81834bc3c40,Tevfik Bilal,Tevfik Bilal,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 c1628285-8b30-4484-920b-9bf9fa8cefb3,Tevfik Güneş,Tevfik Güneş,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 c1628285-8b30-4484-920b-9bf9fa8cefb3,Tevfik Güneş,Tevfik Güneş,,,,Halkçı Parti,HP,area/kırşehir,Kırşehir,Grand National Assembly,17,,,,
-891d431e-17c5-41fd-ae19-1c3ebc9fee44,Togay Gemalmaz,Togay Gemalmaz,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 891d431e-17c5-41fd-ae19-1c3ebc9fee44,Togay Gemalmaz,Togay Gemalmaz,,,,Anavatan Partisi,ANAP,area/erzurum,Erzurum,Grand National Assembly,17,,,,
+891d431e-17c5-41fd-ae19-1c3ebc9fee44,Togay Gemalmaz,Togay Gemalmaz,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 9c7902e2-b64e-4fef-bb25-e72561c2172b,Tokat,Tokat,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 fa4762a4-ed33-4f04-9f05-f2298c7f2927,Trabzon,Trabzon,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 9eb353aa-4e91-44d4-b26b-6aa4a8b03a45,Tunceli,Tunceli,,,,Halkçı Parti,HP,,,Grand National Assembly,17,,,,
 b2bf712d-72bd-47dc-995d-f32d8398971a,Turgut Halit Kunter,Turgut Halit Kunter,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 b2bf712d-72bd-47dc-995d-f32d8398971a,Turgut Halit Kunter,Turgut Halit Kunter,,,,Milliyetçi Demokrasi Partisi,MDP,area/rize,Rize,Grand National Assembly,17,,,,
-2f1fa132-87a8-4234-9d26-40409e121f48,Turgut Sera Tirali,Turgut Sera Tirali,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 2f1fa132-87a8-4234-9d26-40409e121f48,Turgut Sera Tirali,Turgut Sera Tirali,,,,Milliyetçi Demokrasi Partisi,MDP,area/giresun,Giresun,Grand National Assembly,17,,,,
+2f1fa132-87a8-4234-9d26-40409e121f48,Turgut Sera Tirali,Turgut Sera Tirali,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 c2fc4e81-25be-42c7-9a38-86250555cf9a,Turgut Sunalp,Turgut Sunalp,,,,Milliyetçi Demokrasi Partisi,MDP,area/İzmir,İzmir,Grand National Assembly,17,,,,
-bcec1c30-138f-4192-90cd-7d91403d6262,Turgut Sözer,Turgut Sözer,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 bcec1c30-138f-4192-90cd-7d91403d6262,Turgut Sözer,Turgut Sözer,,,,Halkçı Parti,HP,area/sakarya,Sakarya,Grand National Assembly,17,,,,
-64d56452-1eda-4dba-9bac-799191d37ea4,Turgut Yaşar Gülez,Turgut Yaşar Gülez,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+bcec1c30-138f-4192-90cd-7d91403d6262,Turgut Sözer,Turgut Sözer,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 64d56452-1eda-4dba-9bac-799191d37ea4,Turgut Yaşar Gülez,Turgut Yaşar Gülez,,,,Milliyetçi Demokrasi Partisi,MDP,area/bolu,Bolu,Grand National Assembly,17,,,,
+64d56452-1eda-4dba-9bac-799191d37ea4,Turgut Yaşar Gülez,Turgut Yaşar Gülez,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 dbf83637-216e-4791-9039-9c5596865224,Turgut Özal,Turgut Özal,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,17,,,https://upload.wikimedia.org/wikipedia/commons/1/1b/Turgut_Özal_cropped.jpg,male
-6c1fd543-de96-48eb-80ae-9c2c9baa7ac3,Tülay Öney,Tülay Öney,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,female
 6c1fd543-de96-48eb-80ae-9c2c9baa7ac3,Tülay Öney,Tülay Öney,,,,Halkçı Parti,HP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,female
-3ce3d803-715b-42b4-8dbe-874305cd6cba,Türkan Turgut Arıkan,Türkan Turgut Arıkan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-3ce3d803-715b-42b4-8dbe-874305cd6cba,Türkan Turgut Arıkan,Türkan Turgut Arıkan,,,,Anavatan Partisi,ANAP,area/edirne,Edirne,Grand National Assembly,17,,,,
+6c1fd543-de96-48eb-80ae-9c2c9baa7ac3,Tülay Öney,Tülay Öney,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,female
+3ce3d803-715b-42b4-8dbe-874305cd6cba,Türkan Turgut Arıkan,Türkan Turgut Arıkan,,,,Anavatan Partisi,ANAP,area/edirne,Edirne,Grand National Assembly,17,,,,female
+3ce3d803-715b-42b4-8dbe-874305cd6cba,Türkan Turgut Arıkan,Türkan Turgut Arıkan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,female
 7bbbd2b7-7932-4e3c-8fbf-177c07c6f557,Tınaz Titiz,Tınaz Titiz,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
 6e354f77-ab0f-4ba0-9796-8647a519761b,Uşak,Uşak,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 5fd39e76-b6db-4db3-a58d-6d373f50b12c,Vahit Melih Halefoğlu,Vahit Melih Halefoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 66903749-2ba0-42ed-b327-0d6b45a13826,Van,Van,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-7858c91a-4976-404d-ae83-8e1e645837e8,Vecihi Akın,Vecihi Akın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 7858c91a-4976-404d-ae83-8e1e645837e8,Vecihi Akın,Vecihi Akın,,,,Milliyetçi Demokrasi Partisi,MDP,area/konya,Konya,Grand National Assembly,17,,,,
+7858c91a-4976-404d-ae83-8e1e645837e8,Vecihi Akın,Vecihi Akın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1af6c117-28ad-494f-93b4-7cdf1a48f51f,Vecihi Ataklı,Vecihi Ataklı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1af6c117-28ad-494f-93b4-7cdf1a48f51f,Vecihi Ataklı,Vecihi Ataklı,,,,Halkçı Parti,HP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,17,,,,
-d749b46f-db66-44d1-9c36-24522b6dbbef,Vehbi Batuman,Vehbi Batuman,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 d749b46f-db66-44d1-9c36-24522b6dbbef,Vehbi Batuman,Vehbi Batuman,,,,Halkçı Parti,HP,area/adana,Adana,Grand National Assembly,17,,,,
+d749b46f-db66-44d1-9c36-24522b6dbbef,Vehbi Batuman,Vehbi Batuman,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 58b16eda-e9e4-4896-831d-2691eb31125a,Vehbi Dinçerler,Vehbi Dinçerler,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
 de786917-5cc3-4857-82f3-ff21b064bf94,Veysel Atasoy,Veysel Atasoy,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 de786917-5cc3-4857-82f3-ff21b064bf94,Veysel Atasoy,Veysel Atasoy,,,,Anavatan Partisi,ANAP,area/zonguldak,Zonguldak,Grand National Assembly,17,,,,
@@ -696,49 +696,49 @@ fa53901e-4601-48a3-96f2-2b2321056850,Veysel Varol,Veysel Varol,,,,Anavatan Parti
 fa53901e-4601-48a3-96f2-2b2321056850,Veysel Varol,Veysel Varol,,,,Halkçı Parti,HP,area/erzincan,Erzincan,Grand National Assembly,17,,,,male
 627f379d-4dcd-4ec7-8385-eac5e0fdc3a5,Vural Arıkan,Vural Arıkan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 627f379d-4dcd-4ec7-8385-eac5e0fdc3a5,Vural Arıkan,Vural Arıkan,,,,Anavatan Partisi,ANAP,area/İzmir,İzmir,Grand National Assembly,17,,,,
-ee5f522f-4f18-428d-859c-2ae09ef6f54a,Yavuz Köymen,Yavuz Köymen,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 ee5f522f-4f18-428d-859c-2ae09ef6f54a,Yavuz Köymen,Yavuz Köymen,,,,Anavatan Partisi,ANAP,area/giresun,Giresun,Grand National Assembly,17,,,,
-2c89c1cb-3403-4b14-93ab-4c4d314976be,Yaşar Albayrak,Yaşar Albayrak,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+ee5f522f-4f18-428d-859c-2ae09ef6f54a,Yavuz Köymen,Yavuz Köymen,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 2c89c1cb-3403-4b14-93ab-4c4d314976be,Yaşar Albayrak,Yaşar Albayrak,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
+2c89c1cb-3403-4b14-93ab-4c4d314976be,Yaşar Albayrak,Yaşar Albayrak,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 e342ca86-bdcb-49da-9822-0868d304dfca,Yozgat,Yozgat,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 6de3ae6d-ebc1-4275-b733-c3f6bcfa14f7,Yusuf Demir,Yusuf Demir,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 6de3ae6d-ebc1-4275-b733-c3f6bcfa14f7,Yusuf Demir,Yusuf Demir,,,,Halkçı Parti,HP,area/uşak,Uşak,Grand National Assembly,17,,,,
-04639e9c-b372-4adf-9258-bfb6adea9349,Yusuf Salih Güngörmez,Yusuf Salih Güngörmez,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 04639e9c-b372-4adf-9258-bfb6adea9349,Yusuf Salih Güngörmez,Yusuf Salih Güngörmez,,,,Halkçı Parti,HP,area/kocaeli,Kocaeli,Grand National Assembly,17,,,,
+04639e9c-b372-4adf-9258-bfb6adea9349,Yusuf Salih Güngörmez,Yusuf Salih Güngörmez,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 f6082f9f-2b65-4614-87a3-2c28906d4384,Yusuf Ziya Kazancıoğlu,Yusuf Ziya Kazancıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 f6082f9f-2b65-4614-87a3-2c28906d4384,Yusuf Ziya Kazancıoğlu,Yusuf Ziya Kazancıoğlu,,,,Halkçı Parti,HP,area/trabzon,Trabzon,Grand National Assembly,17,,,,
 ca255c61-008b-42f9-bdd1-adb3697e786e,Yıldırım Akbulut,Yıldırım Akbulut,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,https://upload.wikimedia.org/wikipedia/commons/c/c1/Yildirim_Akbulut_(1988).jpg,male
 ca255c61-008b-42f9-bdd1-adb3697e786e,Yıldırım Akbulut,Yıldırım Akbulut,,,,Anavatan Partisi,ANAP,area/erzincan,Erzincan,Grand National Assembly,17,,,https://upload.wikimedia.org/wikipedia/commons/c/c1/Yildirim_Akbulut_(1988).jpg,male
 91d104cb-8519-4105-a3ff-14b20a994623,Yılmaz Altuğ,Yılmaz Altuğ,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 91d104cb-8519-4105-a3ff-14b20a994623,Yılmaz Altuğ,Yılmaz Altuğ,,,,Milliyetçi Demokrasi Partisi,MDP,area/sivas,Sivas,Grand National Assembly,17,,,,
-c4b9244b-875f-4293-b796-e6e084e00a27,Yılmaz Demir,Yılmaz Demir,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 c4b9244b-875f-4293-b796-e6e084e00a27,Yılmaz Demir,Yılmaz Demir,,,,Halkçı Parti,HP,area/bilecik,Bilecik,Grand National Assembly,17,,,,
+c4b9244b-875f-4293-b796-e6e084e00a27,Yılmaz Demir,Yılmaz Demir,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 bc30b4be-65fe-4a12-b1bc-2074af33d27b,Yılmaz Hocaoğlu,Yılmaz Hocaoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 bc30b4be-65fe-4a12-b1bc-2074af33d27b,Yılmaz Hocaoğlu,Yılmaz Hocaoğlu,,,,Milliyetçi Demokrasi Partisi,MDP,area/adana,Adana,Grand National Assembly,17,,,,
-d48f78b6-ce4f-4200-8b4e-75c8417519ac,Yılmaz İhsan Hastürk,Yılmaz İhsan Hastürk,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 d48f78b6-ce4f-4200-8b4e-75c8417519ac,Yılmaz İhsan Hastürk,Yılmaz İhsan Hastürk,,,,Halkçı Parti,HP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
-0930ba46-8975-4b0f-bcd5-d6894cd5bbd5,Zeki Yavuztürk,Zeki Yavuztürk,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+d48f78b6-ce4f-4200-8b4e-75c8417519ac,Yılmaz İhsan Hastürk,Yılmaz İhsan Hastürk,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 0930ba46-8975-4b0f-bcd5-d6894cd5bbd5,Zeki Yavuztürk,Zeki Yavuztürk,,,,Anavatan Partisi,ANAP,area/elazığ,Elazığ,Grand National Assembly,17,,,,
+0930ba46-8975-4b0f-bcd5-d6894cd5bbd5,Zeki Yavuztürk,Zeki Yavuztürk,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 b2bf72d5-1a5b-4108-a24c-3aa8d6e543bd,Ziya Ercan,Ziya Ercan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 b2bf72d5-1a5b-4108-a24c-3aa8d6e543bd,Ziya Ercan,Ziya Ercan,,,,Anavatan Partisi,ANAP,area/konya,Konya,Grand National Assembly,17,,,,
 a67b5c86-d20e-401f-84d3-9b43746adf12,Zonguldak,Zonguldak,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 5bd5ff2e-3fc2-4835-9094-037626aef2f5,Çanakkale,Çanakkale,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 c8858ef2-6fbc-4270-928f-a99f6976973a,Çankırı,Çankırı,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 41d582a9-c939-4a12-b4ad-739e50c86fbb,Çorum,Çorum,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-8cf41781-0d61-42d0-9b42-c4a716203f32,Ömer Ferruh İlter,Ömer Ferruh İlter,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 8cf41781-0d61-42d0-9b42-c4a716203f32,Ömer Ferruh İlter,Ömer Ferruh İlter,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
-1fa14744-808e-48cb-bb7b-7bd91f4e9a87,Ömer Kuşhan,Ömer Kuşhan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+8cf41781-0d61-42d0-9b42-c4a716203f32,Ömer Ferruh İlter,Ömer Ferruh İlter,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 1fa14744-808e-48cb-bb7b-7bd91f4e9a87,Ömer Kuşhan,Ömer Kuşhan,,,,Halkçı Parti,HP,area/kars,Kars,Grand National Assembly,17,,,,
-ed1248ae-74ca-4b3c-8712-c08497961ee5,Ömer Necati Cengiz,Ömer Necati Cengiz,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+1fa14744-808e-48cb-bb7b-7bd91f4e9a87,Ömer Kuşhan,Ömer Kuşhan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 ed1248ae-74ca-4b3c-8712-c08497961ee5,Ömer Necati Cengiz,Ömer Necati Cengiz,,,,Halkçı Parti,HP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,
+ed1248ae-74ca-4b3c-8712-c08497961ee5,Ömer Necati Cengiz,Ömer Necati Cengiz,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 0805fa91-9e2c-4c46-8dfb-a41f3e73279f,Özdemir Pehlivanoğlu,Özdemir Pehlivanoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 0805fa91-9e2c-4c46-8dfb-a41f3e73279f,Özdemir Pehlivanoğlu,Özdemir Pehlivanoğlu,,,,Anavatan Partisi,ANAP,area/İzmir,İzmir,Grand National Assembly,17,,,,
-0aea0a6f-1853-42c6-98c3-7fbf1c94bab8,Özer Gürbüz,Özer Gürbüz,,,,Halkçı Parti,HP,,,Grand National Assembly,17,,,,
 0aea0a6f-1853-42c6-98c3-7fbf1c94bab8,Özer Gürbüz,Özer Gürbüz,,,,Halkçı Parti,HP,area/sinop,Sinop,Grand National Assembly,17,,,,
-32c42cd0-e0d0-4307-a318-0450f286394e,Özgür Barutçu,Özgür Barutçu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+0aea0a6f-1853-42c6-98c3-7fbf1c94bab8,Özer Gürbüz,Özer Gürbüz,,,,Halkçı Parti,HP,,,Grand National Assembly,17,,,,
 32c42cd0-e0d0-4307-a318-0450f286394e,Özgür Barutçu,Özgür Barutçu,,,,Anavatan Partisi,ANAP,area/diyarbakır,Diyarbakır,Grand National Assembly,17,,,,
-344e2e7a-e359-42df-aa05-99da96108ee0,Ülkü Söylemezoğlu,Ülkü Söylemezoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+32c42cd0-e0d0-4307-a318-0450f286394e,Özgür Barutçu,Özgür Barutçu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 344e2e7a-e359-42df-aa05-99da96108ee0,Ülkü Söylemezoğlu,Ülkü Söylemezoğlu,,,,Milliyetçi Demokrasi Partisi,MDP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,17,,,,
+344e2e7a-e359-42df-aa05-99da96108ee0,Ülkü Söylemezoğlu,Ülkü Söylemezoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 2ecde1e2-039b-4af7-a219-daf82ac27adc,Ümit Canuyar,Ümit Canuyar,,,,Doğru Yol Partisi,DYP,,,Grand National Assembly,17,,,,
 a6b6777b-33d7-4ec4-818f-d066ce0dc45a,Ümit Haluk Bayülken,Ümit Haluk Bayülken,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 24e8ff9d-a212-4872-823e-f147c491b58f,Ünal Akkaya,Ünal Akkaya,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
@@ -747,18 +747,18 @@ a6b6777b-33d7-4ec4-818f-d066ce0dc45a,Ümit Haluk Bayülken,Ümit Haluk Bayülken
 0b360289-247f-4190-87ca-6e9333e141a9,Ünal Yaşar,Ünal Yaşar,,,,Anavatan Partisi,ANAP,area/gaziantep,Gaziantep,Grand National Assembly,17,,,,
 4d2b00a2-9ff9-4bb0-8739-362bef9460dd,İbrahim Aydoğan,İbrahim Aydoğan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 4d2b00a2-9ff9-4bb0-8739-362bef9460dd,İbrahim Aydoğan,İbrahim Aydoğan,,,,Anavatan Partisi,ANAP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,17,,,,
-0d97e21a-b22f-4bef-9020-ec9cdd657583,İbrahim Cüneyt Canver,İbrahim Cüneyt Canver,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 0d97e21a-b22f-4bef-9020-ec9cdd657583,İbrahim Cüneyt Canver,İbrahim Cüneyt Canver,,,,Halkçı Parti,HP,area/adana,Adana,Grand National Assembly,17,,,,male
-945bc8be-e61e-49ea-b9bf-8599e6223abb,İbrahim Fevzi Yaman,İbrahim Fevzi Yaman,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+0d97e21a-b22f-4bef-9020-ec9cdd657583,İbrahim Cüneyt Canver,İbrahim Cüneyt Canver,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 945bc8be-e61e-49ea-b9bf-8599e6223abb,İbrahim Fevzi Yaman,İbrahim Fevzi Yaman,,,,Anavatan Partisi,ANAP,area/isparta,Isparta,Grand National Assembly,17,,,,
-d36b69cb-35df-4e70-a8b0-4c8841622a20,İbrahim Halil Ural,İbrahim Halil Ural,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
+945bc8be-e61e-49ea-b9bf-8599e6223abb,İbrahim Fevzi Yaman,İbrahim Fevzi Yaman,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 d36b69cb-35df-4e70-a8b0-4c8841622a20,İbrahim Halil Ural,İbrahim Halil Ural,,,,Halkçı Parti,HP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,male
-d36e5db2-3e8c-4df3-a4ee-9b32f0987358,İbrahim Tayyar,İbrahim Tayyar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+d36b69cb-35df-4e70-a8b0-4c8841622a20,İbrahim Halil Ural,İbrahim Halil Ural,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 d36e5db2-3e8c-4df3-a4ee-9b32f0987358,İbrahim Tayyar,İbrahim Tayyar,,,,Halkçı Parti,HP,area/samsun,Samsun,Grand National Assembly,17,,,,
+d36e5db2-3e8c-4df3-a4ee-9b32f0987358,İbrahim Tayyar,İbrahim Tayyar,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 cda815b6-d5b6-4935-af0e-80a1acbbceef,İbrahim Taşdemir,İbrahim Taşdemir,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 cda815b6-d5b6-4935-af0e-80a1acbbceef,İbrahim Taşdemir,İbrahim Taşdemir,,,,Halkçı Parti,HP,area/ağrı,Ağrı,Grand National Assembly,17,,,,
-d075f325-b8ca-4efa-bfee-2dd9391c35da,İbrahim Turan,İbrahim Turan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 d075f325-b8ca-4efa-bfee-2dd9391c35da,İbrahim Turan,İbrahim Turan,,,,Anavatan Partisi,ANAP,area/gümüşhane,Gümüşhane,Grand National Assembly,17,,,,male
+d075f325-b8ca-4efa-bfee-2dd9391c35da,İbrahim Turan,İbrahim Turan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 cffccc7b-7654-4b4d-8f78-a2f9b7c48537,İbrahim Özbıyık,İbrahim Özbıyık,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 cffccc7b-7654-4b4d-8f78-a2f9b7c48537,İbrahim Özbıyık,İbrahim Özbıyık,,,,Anavatan Partisi,ANAP,area/kayseri,Kayseri,Grand National Assembly,17,,,,
 29829de3-ad21-4e3a-a6e6-5f1cb2f7a080,İbrahim Özdemir,İbrahim Özdemir,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
@@ -767,18 +767,18 @@ cffccc7b-7654-4b4d-8f78-a2f9b7c48537,İbrahim Özbıyık,İbrahim Özbıyık,,,,
 0a15f8cf-499e-4a7e-9032-22ae3ed33e52,İdris Gürpınar,İdris Gürpınar,,,,Halkçı Parti,HP,area/muğla,Muğla,Grand National Assembly,17,,,,
 51a66122-728c-4eaf-9e9c-23e57242efee,İhsan Gürbüz,İhsan Gürbüz,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 51a66122-728c-4eaf-9e9c-23e57242efee,İhsan Gürbüz,İhsan Gürbüz,,,,Halkçı Parti,HP,area/hatay,Hatay,Grand National Assembly,17,,,,
-1ccdf1d4-bb53-401d-8a7b-b82045db8ee7,İhsan Nazmi Tombuş,İhsan Nazmi Tombuş,,,,Anavatan Partisi,ANAP,area/Çorum,Çorum,Grand National Assembly,17,,,,
+1ccdf1d4-bb53-401d-8a7b-b82045db8ee7,İhsan Nazmi Tombuş,İhsan Nazmi Tombuş,,,,Anavatan Partisi,ANAP,area/Çorum,Çorum,Grand National Assembly,17,,,,male
 3d21ecc1-44e8-411c-882a-944bbe1cac5d,İhsan Nuri Topkaya,İhsan Nuri Topkaya,,,,Anavatan Partisi,ANAP,area/ordu,Ordu,Grand National Assembly,17,,,,
 eab7855b-80a1-4e3c-8dd6-85339b4d6c7c,İlhan Aküzüm,İlhan Aküzüm,,,,Anavatan Partisi,ANAP,area/kars,Kars,Grand National Assembly,17,,,,
 46874c82-b084-42d4-a933-207dc0b505c5,İlhan Aras,İlhan Aras,,,,Anavatan Partisi,ANAP,area/erzurum,Erzurum,Grand National Assembly,17,,,,
-9c8ceb43-2b77-4ae1-a287-070074172f2c,İlhan Aşkın,İlhan Aşkın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 9c8ceb43-2b77-4ae1-a287-070074172f2c,İlhan Aşkın,İlhan Aşkın,,,,Anavatan Partisi,ANAP,area/bursa,Bursa,Grand National Assembly,17,,,,
-3fcbf297-c6b9-48df-a7a5-f59938ce271d,İlhan Dinçel,İlhan Dinçel,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+9c8ceb43-2b77-4ae1-a287-070074172f2c,İlhan Aşkın,İlhan Aşkın,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 3fcbf297-c6b9-48df-a7a5-f59938ce271d,İlhan Dinçel,İlhan Dinçel,,,,Halkçı Parti,HP,area/malatya,Malatya,Grand National Assembly,17,,,,
-8a103e9e-1561-49e2-9ca7-ff04397beef6,İlker Tuncay,İlker Tuncay,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+3fcbf297-c6b9-48df-a7a5-f59938ce271d,İlhan Dinçel,İlhan Dinçel,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 8a103e9e-1561-49e2-9ca7-ff04397beef6,İlker Tuncay,İlker Tuncay,,,,Anavatan Partisi,ANAP,area/Çankırı,Çankırı,Grand National Assembly,17,,,,
-ef49ea54-826e-4820-bcd9-173f080d2a6f,İlyas Aktaş,İlyas Aktaş,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+8a103e9e-1561-49e2-9ca7-ff04397beef6,İlker Tuncay,İlker Tuncay,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 ef49ea54-826e-4820-bcd9-173f080d2a6f,İlyas Aktaş,İlyas Aktaş,,,,Anavatan Partisi,ANAP,area/samsun,Samsun,Grand National Assembly,17,,,,
+ef49ea54-826e-4820-bcd9-173f080d2a6f,İlyas Aktaş,İlyas Aktaş,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 dffd7c1c-f8b7-4316-99f3-fbcc6aec427d,İmren Aykut,İmren Aykut,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,female
 dffd7c1c-f8b7-4316-99f3-fbcc6aec427d,İmren Aykut,İmren Aykut,,,,Milliyetçi Demokrasi Partisi,MDP,area/İstanbul,İstanbul,Grand National Assembly,17,,,,female
 af1a3403-42a9-4e27-8f13-db240848759c,İsa Vardal,İsa Vardal,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
@@ -787,12 +787,12 @@ af1a3403-42a9-4e27-8f13-db240848759c,İsa Vardal,İsa Vardal,,,,Halkçı Parti,H
 00f6d5ea-101e-49e9-807e-f9f014287f1d,İskender Cenap Ege,İskender Cenap Ege,,,,Milliyetçi Demokrasi Partisi,MDP,area/aydın,Aydın,Grand National Assembly,17,,,,
 c1ae1a62-df7c-4831-bbc0-4fa431a54b6b,İsmail Dayı,İsmail Dayı,,,,Anavatan Partisi,ANAP,area/balıkesir,Balıkesir,Grand National Assembly,17,,,,male
 835d9619-9e3f-4502-8959-3712af5d8418,İsmail Safa Giray,İsmail Safa Giray,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-4cb4d4e6-6084-46a4-83a8-63c1cd07493b,İsmail Saruhan,İsmail Saruhan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 4cb4d4e6-6084-46a4-83a8-63c1cd07493b,İsmail Saruhan,İsmail Saruhan,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,17,,,,
+4cb4d4e6-6084-46a4-83a8-63c1cd07493b,İsmail Saruhan,İsmail Saruhan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 336c802f-e6ec-4aa3-8ebe-f6afb41f84ab,İsmail Özdağlar,İsmail Özdağlar,,,,Anavatan Partisi,ANAP,area/manisa,Manisa,Grand National Assembly,17,,,,male
 058cd55a-f7c3-4b26-be35-6741d127256f,İsmail Üğdül,İsmail Üğdül,,,,Anavatan Partisi,ANAP,area/edirne,Edirne,Grand National Assembly,17,,,,male
-07d19092-2c5e-4219-8802-00a6bc77d024,İsmail Şengün,İsmail Şengün,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 07d19092-2c5e-4219-8802-00a6bc77d024,İsmail Şengün,İsmail Şengün,,,,Milliyetçi Demokrasi Partisi,MDP,area/denizli,Denizli,Grand National Assembly,17,,,,male
+07d19092-2c5e-4219-8802-00a6bc77d024,İsmail Şengün,İsmail Şengün,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,male
 5fb6a7f6-ee3b-4f42-8f9f-60031868c0bf,İsmet Ergül,İsmet Ergül,,,,Anavatan Partisi,ANAP,area/kırşehir,Kırşehir,Grand National Assembly,17,,,,male
 d66d2deb-7bcd-4171-a137-fe674ef3ea42,İsmet Kaya Erdem,İsmet Kaya Erdem,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 7ca3b99e-0c88-48ce-9a1c-808e15d20312,İsmet Oktay,İsmet Oktay,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
@@ -801,23 +801,23 @@ bc4e6462-ce90-4f45-8731-ffca154b83de,İsmet Tavgaç,İsmet Tavgaç,,,,Anavatan P
 bc4e6462-ce90-4f45-8731-ffca154b83de,İsmet Tavgaç,İsmet Tavgaç,,,,Milliyetçi Demokrasi Partisi,MDP,area/bursa,Bursa,Grand National Assembly,17,,,,
 7dc379b6-ac65-49c7-aa81-e60998f037cd,İsmet Özarslan,İsmet Özarslan,,,,Anavatan Partisi,ANAP,area/amasya,Amasya,Grand National Assembly,17,,,,
 e65aed09-08fb-4851-8000-8a4913599a00,İstanbul,İstanbul,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-05eec717-2112-48ea-9b2f-c1ca85c19921,İzmir,İzmir,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 05eec717-2112-48ea-9b2f-c1ca85c19921,İzmir,İzmir,,,,Sosyaldemokrat Halkçı Parti,SHP,area/erdal_İnönü,Erdal İnönü,Grand National Assembly,17,,,,
+05eec717-2112-48ea-9b2f-c1ca85c19921,İzmir,İzmir,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 266c2916-5997-4f7e-bf16-4644da41c2e8,İçel (Mersin),İçel (Mersin),,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-4675c8d8-2397-40fa-83a3-deeebe01c1d1,Şaban Küçükoğlu,Şaban Küçükoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 4675c8d8-2397-40fa-83a3-deeebe01c1d1,Şaban Küçükoğlu,Şaban Küçükoğlu,,,,Anavatan Partisi,ANAP,area/kastamonu,Kastamonu,Grand National Assembly,17,,,,
+4675c8d8-2397-40fa-83a3-deeebe01c1d1,Şaban Küçükoğlu,Şaban Küçükoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 91c62c21-084a-4a8f-9580-cce7bfe207ec,Şanlıurfa,Şanlıurfa,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
-caa372dd-3e57-4af8-80fc-b4b8a22ba4b8,Şen İsmet Turhangil,Şen İsmet Turhangil,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 caa372dd-3e57-4af8-80fc-b4b8a22ba4b8,Şen İsmet Turhangil,Şen İsmet Turhangil,,,,Halkçı Parti,HP,area/manisa,Manisa,Grand National Assembly,17,,,,
-c0b86238-7445-4e59-b23c-a81a593c9520,Şerafettin Toktaş,Şerafettin Toktaş,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+caa372dd-3e57-4af8-80fc-b4b8a22ba4b8,Şen İsmet Turhangil,Şen İsmet Turhangil,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 c0b86238-7445-4e59-b23c-a81a593c9520,Şerafettin Toktaş,Şerafettin Toktaş,,,,Anavatan Partisi,ANAP,area/balıkesir,Balıkesir,Grand National Assembly,17,,,,
-a7481488-9172-4117-abe2-f9082824fc22,Şevki Taştan,Şevki Taştan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+c0b86238-7445-4e59-b23c-a81a593c9520,Şerafettin Toktaş,Şerafettin Toktaş,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 a7481488-9172-4117-abe2-f9082824fc22,Şevki Taştan,Şevki Taştan,,,,Halkçı Parti,HP,area/sivas,Sivas,Grand National Assembly,17,,,,
+a7481488-9172-4117-abe2-f9082824fc22,Şevki Taştan,Şevki Taştan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 80903493-b267-4387-b82c-cf8c778540b8,Şeyhmus Bahçeci,Şeyhmus Bahçeci,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 80903493-b267-4387-b82c-cf8c778540b8,Şeyhmus Bahçeci,Şeyhmus Bahçeci,,,,Halkçı Parti,HP,area/diyarbakır,Diyarbakır,Grand National Assembly,17,,,,
-b07415c3-5f20-4255-8455-66365976e070,Şükrü Babacan,Şükrü Babacan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 b07415c3-5f20-4255-8455-66365976e070,Şükrü Babacan,Şükrü Babacan,,,,Halkçı Parti,HP,area/kırklareli,Kırklareli,Grand National Assembly,17,,,,
-4ae2eec9-ec44-40b4-ba08-4057fdd66689,Şükrü Yürür,Şükrü Yürür,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+b07415c3-5f20-4255-8455-66365976e070,Şükrü Babacan,Şükrü Babacan,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 4ae2eec9-ec44-40b4-ba08-4057fdd66689,Şükrü Yürür,Şükrü Yürür,,,,Anavatan Partisi,ANAP,area/ordu,Ordu,Grand National Assembly,17,,,,
-b8b50bce-ac45-4c31-be2e-eb8ea1ab9235,Şükrü Yüzbaşıoğlu,Şükrü Yüzbaşıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
+4ae2eec9-ec44-40b4-ba08-4057fdd66689,Şükrü Yürür,Şükrü Yürür,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,
 b8b50bce-ac45-4c31-be2e-eb8ea1ab9235,Şükrü Yüzbaşıoğlu,Şükrü Yüzbaşıoğlu,,,,Halkçı Parti,HP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,17,,,,
+b8b50bce-ac45-4c31-be2e-eb8ea1ab9235,Şükrü Yüzbaşıoğlu,Şükrü Yüzbaşıoğlu,,,,Anavatan Partisi,ANAP,,,Grand National Assembly,17,,,,

--- a/data/Turkey/Assembly/term-18.csv
+++ b/data/Turkey/Assembly/term-18.csv
@@ -23,7 +23,7 @@ e3b8df62-2ac0-4d95-b69b-bd55fb1d024b,Adnan Ekmen,Adnan Ekmen,,,,Sosyaldemokrat H
 9fb6bce8-1ae2-4932-b329-0c5dcbd04b92,Adnan Keskin,Adnan Keskin,,,,Sosyaldemokrat Halkçı Parti,SHP,area/denizli,Denizli,Grand National Assembly,18,,,,male
 f478a30f-f752-425b-ae6c-7ba4b2a66ef5,Adnan Yıldız,Adnan Yıldız,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,18,,,,male
 56714277-e08a-49ff-b132-d79c723ff264,Ahmet Akgün Albayrak,Ahmet Akgün Albayrak,,,,Anavatan Partisi,ANAP,area/adana,Adana,Grand National Assembly,18,,,,male
-d5222db3-3e77-4dcf-89a9-ba72642a1301,Ahmet Altıntaş,Ahmet Altıntaş,,,,Anavatan Partisi,ANAP,area/muğla,Muğla,Grand National Assembly,18,,,,
+d5222db3-3e77-4dcf-89a9-ba72642a1301,Ahmet Altıntaş,Ahmet Altıntaş,,,,Anavatan Partisi,ANAP,area/muğla,Muğla,Grand National Assembly,18,,,,male
 5aac43df-5095-4736-8664-a2d1967a27fa,Ahmet Avcı,Ahmet Avcı,,,,Anavatan Partisi,ANAP,area/uşak,Uşak,Grand National Assembly,18,,,,
 b2c4f61e-37ed-4723-8a59-0a94689303a0,Ahmet Edip Uğur,Ahmet Edip Uğur,,,,Anavatan Partisi,ANAP,area/balıkesir,Balıkesir,Grand National Assembly,18,,,,male
 d40f3d0b-a87f-49b4-ba53-e0aabab342e8,Ahmet Ersin,Ahmet Ersin,,,,Sosyaldemokrat Halkçı Parti,SHP,area/İzmir,İzmir,Grand National Assembly,18,,,,
@@ -32,7 +32,7 @@ bf81cf44-0fed-40d7-8f90-42b5a785bce2,Ahmet Fehmi Işıklar,Ahmet Fehmi Işıklar
 aef676b6-da4e-4f7e-a7af-2ef601f7506e,Ahmet Karaevli,Ahmet Karaevli,,,,Anavatan Partisi,ANAP,area/tekirdağ,Tekirdağ,Grand National Assembly,18,,,,male
 c3e50a8e-53db-4d3e-bb2c-4612e20ee501,Ahmet Kurtcebe Alptemoçin,Ahmet Kurtcebe Alptemoçin,,,,Anavatan Partisi,ANAP,area/bursa,Bursa,Grand National Assembly,18,,,,male
 82087cb5-1825-4a78-9db0-90d1781f501c,Ahmet Küçükel,Ahmet Küçükel,,,,Doğru Yol Partisi,DYP,area/elazığ,Elazığ,Grand National Assembly,18,,,,
-303d56c9-65c3-4b05-bc87-3f1425406a89,Ahmet Mesut Yılmaz,Ahmet Mesut Yılmaz,,,,Anavatan Partisi,ANAP,area/rize,Rize,Grand National Assembly,18,,,,
+303d56c9-65c3-4b05-bc87-3f1425406a89,Ahmet Mesut Yılmaz,Ahmet Mesut Yılmaz,,,,Anavatan Partisi,ANAP,area/rize,Rize,Grand National Assembly,18,,,,male
 dcdedc06-a5d8-4d49-90fd-3539dbef6faa,Ahmet Neidim,Ahmet Neidim,,,,Doğru Yol Partisi,DYP,area/sakarya,Sakarya,Grand National Assembly,18,,,,male
 816916d5-0c86-4a2d-90ba-83744b2d3c18,Ahmet Türk,Ahmet Türk,,,,Sosyaldemokrat Halkçı Parti,SHP,area/mardin,Mardin,Grand National Assembly,18,,,https://upload.wikimedia.org/wikipedia/commons/4/46/Ahmet_Türk.jpg,male
 d915c3cc-e63b-44db-8b49-2986901d59b8,Ahmet Uncu,Ahmet Uncu,,,,Doğru Yol Partisi,DYP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,18,,,,male
@@ -79,7 +79,7 @@ e119f33c-386b-436e-b054-284f0d632f73,Aziz Bülent Öncel,Aziz Bülent Öncel,,,,
 936996cb-8231-425d-b943-532e6c7bfde2,Baki Durmaz,Baki Durmaz,,,,Doğru Yol Partisi,DYP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,18,,,,
 432901db-c64b-497d-abec-43f0c8b588a2,Bedrettin Doğancan Akyürek,Bedrettin Doğancan Akyürek,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,18,,,,
 4bd8865e-7bb8-4022-b5b0-3504822f43c3,Behiç Sadi Abbasoğlu,Behiç Sadi Abbasoğlu,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,18,,,,
-da279d78-35c4-49fd-b2d9-d336c1c08184,Beytullah Mehmet Gazioğlu,Beytullah Mehmet Gazioğlu,,,,Doğru Yol Partisi,DYP,area/bursa,Bursa,Grand National Assembly,18,,,,
+da279d78-35c4-49fd-b2d9-d336c1c08184,Beytullah Mehmet Gazioğlu,Beytullah Mehmet Gazioğlu,,,,Doğru Yol Partisi,DYP,area/bursa,Bursa,Grand National Assembly,18,,,,male
 55dc314b-bc3d-42b5-b2bb-1b95e7cb3b75,Beşer Baydar,Beşer Baydar,,,,Sosyaldemokrat Halkçı Parti,SHP,area/ankara,Ankara,Grand National Assembly,18,,,,
 cf772e54-e42b-40a4-bb04-b7ae776b2fa7,Beşir Çelebioğlu,Beşir Çelebioğlu,,,,Anavatan Partisi,ANAP,area/mardin,Mardin,Grand National Assembly,18,,,,
 a1b4f7b4-50aa-465b-af68-ba69881f5713,Birgen Keleş,Birgen Keleş,,,,Sosyaldemokrat Halkçı Parti,SHP,area/İzmir,İzmir,Grand National Assembly,18,,,,female
@@ -101,12 +101,12 @@ abe19024-a773-46d4-949c-d109126b7361,Cemil Çiçek,Cemil Çiçek,,,,Anavatan Par
 60eaf8a0-c9bd-46d7-858c-81d1760928b0,Cumhur Keskin,Cumhur Keskin,,,,Sosyaldemokrat Halkçı Parti,SHP,area/hakkâri,Hakkâri,Grand National Assembly,18,,,,
 64644586-aaec-42b2-8a12-ca82928feeda,Deniz Baykal,Deniz Baykal,,,,Sosyaldemokrat Halkçı Parti,SHP,area/antalya,Antalya,Grand National Assembly,18,,,https://upload.wikimedia.org/wikipedia/commons/5/58/Deniz_Baykal_TBMM.jpg,male
 e47d06ae-4c22-4a1c-a076-27b7089251b3,Doğan Baran,Doğan Baran,,,,Doğru Yol Partisi,DYP,area/niğde,Niğde,Grand National Assembly,18,,,,
-8d75f83a-982a-45f4-aebf-a7316a52f7f5,Durmuş Fikri Sağlar,Durmuş Fikri Sağlar,,,,Sosyaldemokrat Halkçı Parti,SHP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,18,,,,
+8d75f83a-982a-45f4-aebf-a7316a52f7f5,Durmuş Fikri Sağlar,Durmuş Fikri Sağlar,,,,Sosyaldemokrat Halkçı Parti,SHP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,18,,,,male
 004c0bc1-234a-4d4d-a456-c5a9331e2141,Ekin Dikmen,Ekin Dikmen,,,,Sosyaldemokrat Halkçı Parti,SHP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,18,,,,
 b59b7a78-7f7d-4305-bcc6-0d3dc1cc7411,Ekrem Kangal,Ekrem Kangal,,,,Sosyaldemokrat Halkçı Parti,SHP,area/sivas,Sivas,Grand National Assembly,18,,,,
 ca0d992d-fd09-4fd2-9589-3233dd531721,Ekrem Pakdemirli,Ekrem Pakdemirli,,,,Anavatan Partisi,ANAP,area/manisa,Manisa,Grand National Assembly,18,,,,
 73598272-9ee3-4eee-8561-761c44eb106a,Enis Tütüncü,Enis Tütüncü,,,,Sosyaldemokrat Halkçı Parti,SHP,area/tekirdağ,Tekirdağ,Grand National Assembly,18,,,,male
-ac30230d-d2be-4785-9138-8d726b973be9,Ercan Vuralhan,Ercan Vuralhan,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,18,,,,
+ac30230d-d2be-4785-9138-8d726b973be9,Ercan Vuralhan,Ercan Vuralhan,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,18,,,,male
 48c7fb12-59e0-4dc7-ae05-62aa3d4719cf,Erdal Kalkan,Erdal Kalkan,,,,Sosyaldemokrat Halkçı Parti,SHP,area/edirne,Edirne,Grand National Assembly,18,,,,
 c7056767-7947-414b-b5b6-e4a229795a12,Erdal İnönü,Erdal İnönü,,,,Sosyaldemokrat Halkçı Parti,SHP,area/İzmir,İzmir,Grand National Assembly,18,,,,male
 1cc20a3d-fad0-4dec-bd0c-3b5f78cb8d71,Erkan Kemaloğlu,Erkan Kemaloğlu,,,,Anavatan Partisi,ANAP,area/muş,Muş,Grand National Assembly,18,,,,
@@ -166,7 +166,7 @@ a1a58efe-47ec-47e4-af67-6281da837fe1,Hayrettin Elmas,Hayrettin Elmas,,,,Anavatan
 9fc67833-af6e-4e18-b339-1cf81759b001,Hüsamettin Örüç,Hüsamettin Örüç,,,,Anavatan Partisi,ANAP,area/bursa,Bursa,Grand National Assembly,18,,,,male
 1b31275f-4f47-4232-a9a4-024d7cced71a,Hüseyin Aydın Arvasi,Hüseyin Aydın Arvasi,,,,Anavatan Partisi,ANAP,area/van,Van,Grand National Assembly,18,,,,male
 30837363-b8e5-4b31-b205-d19557bcf5df,Hüseyin Barlas Doğu,Hüseyin Barlas Doğu,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,18,,,,
-453dc3d5-5ce1-44d0-9c41-4e99a764040b,Hüseyin Cahit Aral,Hüseyin Cahit Aral,,,,Anavatan Partisi,ANAP,area/elazığ,Elazığ,Grand National Assembly,18,,,,
+453dc3d5-5ce1-44d0-9c41-4e99a764040b,Hüseyin Cahit Aral,Hüseyin Cahit Aral,,,,Anavatan Partisi,ANAP,area/elazığ,Elazığ,Grand National Assembly,18,,,,male
 f749be66-e301-492f-ad62-9ce8890794dd,Hüseyin Cahit Erdemir,Hüseyin Cahit Erdemir,,,,Doğru Yol Partisi,DYP,area/kütahya,Kütahya,Grand National Assembly,18,,,,
 7b75ccc4-86a4-4fb1-9c77-1440f1362121,Hüseyin Sabri Keskin,Hüseyin Sabri Keskin,,,,Anavatan Partisi,ANAP,area/kastamonu,Kastamonu,Grand National Assembly,18,,,,male
 affaca79-b2dc-4da2-849b-886fc64222cb,Hüseyin Özalp,Hüseyin Özalp,,,,Doğru Yol Partisi,DYP,area/samsun,Samsun,Grand National Assembly,18,,,,male
@@ -193,7 +193,7 @@ b2cdfa12-ad45-4bd4-a1d3-951b2a5f3508,Kemal Akkaya,Kemal Akkaya,,,,Anavatan Parti
 311aa936-27cc-4ef0-b2e7-05654e152d07,Kudbettin Hamidi,Kudbettin Hamidi,,,,Anavatan Partisi,ANAP,area/siirt,Siirt,Grand National Assembly,18,,,,
 adc91d77-acaa-411d-8e45-3cdab18f58de,Kudret Bölükoğlu,Kudret Bölükoğlu,,,,Anavatan Partisi,ANAP,area/balıkesir,Balıkesir,Grand National Assembly,18,,,,
 4dc35dfe-0b34-4198-bca9-7ff1a1a1ecc4,Köksal Toptan,Köksal Toptan,,,,Doğru Yol Partisi,DYP,area/zonguldak,Zonguldak,Grand National Assembly,18,,,,male
-70e3dbe5-d5dd-435b-92c9-7c95bbe67325,Kıvılcım Kemal Anadol,Kıvılcım Kemal Anadol,,,,Sosyaldemokrat Halkçı Parti,SHP,area/İzmir,İzmir,Grand National Assembly,18,,,,
+70e3dbe5-d5dd-435b-92c9-7c95bbe67325,Kıvılcım Kemal Anadol,Kıvılcım Kemal Anadol,,,,Sosyaldemokrat Halkçı Parti,SHP,area/İzmir,İzmir,Grand National Assembly,18,,,,male
 ec212003-a6d4-4544-8ffc-2ff41ba34e05,Latif Sakıcı,Latif Sakıcı,,,,Doğru Yol Partisi,DYP,area/muğla,Muğla,Grand National Assembly,18,,,,
 6ceffdca-85d4-4143-90c1-55620c88e8e0,Ledin Barlas,Ledin Barlas,,,,Anavatan Partisi,ANAP,area/adana,Adana,Grand National Assembly,18,,,,
 22abfee8-6ef1-4345-8d2e-c01d53fa14e3,Leyla Yeniay Köseoğlu,Leyla Yeniay Köseoğlu,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,18,,,,female
@@ -213,11 +213,11 @@ cd787b08-d545-4531-9ef5-b67dc58cd8ac,Mahmut Öztürk,Mahmut Öztürk,,,,Doğru Y
 a433ae65-b44b-464f-8133-733b05a458c2,Mehmet Ali Doğuşlu,Mehmet Ali Doğuşlu,,,,Anavatan Partisi,ANAP,area/bingöl,Bingöl,Grand National Assembly,18,,,,male
 4ddb3ef6-1094-490a-b6ae-19b6d4a14f45,Mehmet Ali Eren,Mehmet Ali Eren,,,,Sosyaldemokrat Halkçı Parti,SHP,area/İstanbul,İstanbul,Grand National Assembly,18,,,,
 1f681429-f350-4aea-9565-bd267cca685c,Mehmet Ali Karadeniz,Mehmet Ali Karadeniz,,,,Anavatan Partisi,ANAP,area/giresun,Giresun,Grand National Assembly,18,,,,
-62ae678f-c9e3-4719-9c7f-8defb7aad392,Mehmet Aydın,Mehmet Aydın,,,,Anavatan Partisi,ANAP,area/samsun,Samsun,Grand National Assembly,18,,,,
+62ae678f-c9e3-4719-9c7f-8defb7aad392,Mehmet Aydın,Mehmet Aydın,,,,Anavatan Partisi,ANAP,area/samsun,Samsun,Grand National Assembly,18,,,,male
 2a28495f-01c2-4445-9b5b-c4376782f3be,Mehmet Bülent Çaparoğlu,Mehmet Bülent Çaparoğlu,,,,Anavatan Partisi,ANAP,area/malatya,Malatya,Grand National Assembly,18,,,,
 2bd9249d-8cc3-49bf-afdd-6b1f907346df,Mehmet Can,Mehmet Can,,,,Sosyaldemokrat Halkçı Parti,SHP,area/adana,Adana,Grand National Assembly,18,,,,male
 2389360b-5bcd-4355-875d-11dc020eb099,Mehmet Cavit Kavak,Mehmet Cavit Kavak,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,18,,,,male
-f4283185-b9fc-40ba-92c9-a2321b2f29eb,Mehmet Cevdet Selvi,Mehmet Cevdet Selvi,,,,Sosyaldemokrat Halkçı Parti,SHP,area/eskişehir,Eskişehir,Grand National Assembly,18,,,,male
+f4283185-b9fc-40ba-92c9-a2321b2f29eb,Mehmet Cevdet Selvi,Mehmet Cevdet Selvi,,,,Sosyaldemokrat Halkçı Parti,SHP,area/eskişehir,Eskişehir,Grand National Assembly,18,,,,
 60aa9168-cbc1-4c7b-ab1d-b60a64f2604c,Mehmet Deliceoğlu,Mehmet Deliceoğlu,,,,Anavatan Partisi,ANAP,area/adıyaman,Adıyaman,Grand National Assembly,18,,,,
 2697f0d3-53a0-4740-a994-3c2a311ab845,Mehmet Dönen,Mehmet Dönen,,,,Sosyaldemokrat Halkçı Parti,SHP,area/hatay,Hatay,Grand National Assembly,18,,,,male
 6296d7ac-9e81-4fa0-a0e2-0a5d5b470311,Mehmet Emin Seydagil,Mehmet Emin Seydagil,,,,Anavatan Partisi,ANAP,area/muş,Muş,Grand National Assembly,18,,,,male
@@ -239,7 +239,7 @@ c0378642-5294-486e-a0cb-545939de368b,Mehmet Mükerrem Taşçıoğlu,Mehmet Müke
 41334095-ccb4-4573-859b-87e0b58a3fce,Mehmet Pürdeloğlu,Mehmet Pürdeloğlu,,,,Anavatan Partisi,ANAP,area/hatay,Hatay,Grand National Assembly,18,,,,
 1a70240e-0e4a-45f5-8d71-6934c567a8ab,Mehmet Rauf Ertekin,Mehmet Rauf Ertekin,,,,Anavatan Partisi,ANAP,area/kütahya,Kütahya,Grand National Assembly,18,,,,
 f0cdb999-67a8-4ff5-a41f-3e4c6961dc64,Mehmet Sağdıç,Mehmet Sağdıç,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,18,,,,male
-1c7b61da-fdc1-41ab-9966-f813a6423626,Mehmet Selahattin Kılıç,Mehmet Selahattin Kılıç,,,,Doğru Yol Partisi,DYP,area/adana,Adana,Grand National Assembly,18,,,,male
+1c7b61da-fdc1-41ab-9966-f813a6423626,Mehmet Selahattin Kılıç,Mehmet Selahattin Kılıç,,,,Doğru Yol Partisi,DYP,area/adana,Adana,Grand National Assembly,18,,,,
 bdb7410e-7d72-4f19-8239-c65c3c0b35ed,Mehmet Seven,Mehmet Seven,,,,Anavatan Partisi,ANAP,area/bilecik,Bilecik,Grand National Assembly,18,,,,male
 3315ca2a-6c72-409c-9f95-5107f7caa170,Mehmet Sezai Pekuslu,Mehmet Sezai Pekuslu,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,18,,,,male
 bf5f0718-0e81-4043-9963-b9ab6d42d70f,Mehmet Tahir Köse,Mehmet Tahir Köse,,,,Sosyaldemokrat Halkçı Parti,SHP,area/amasya,Amasya,Grand National Assembly,18,,,,
@@ -272,7 +272,7 @@ a84eb3c1-b88a-401d-9655-a1e6e0d52a5e,Muslih Görentaş,Muslih Görentaş,,,,Anav
 94851dd9-b4be-465e-b97f-076609cc27c9,Mustafa Balcılar,Mustafa Balcılar,,,,Anavatan Partisi,ANAP,area/eskişehir,Eskişehir,Grand National Assembly,18,,,,male
 848f3058-4c9a-4696-884b-af4391561905,Mustafa Bozkurt,Mustafa Bozkurt,,,,Anavatan Partisi,ANAP,area/aydın,Aydın,Grand National Assembly,18,,,,
 956b8c03-7b12-465b-999a-75d7e18337f0,Mustafa Cumhur Ersümer,Mustafa Cumhur Ersümer,,,,Anavatan Partisi,ANAP,area/Çanakkale,Çanakkale,Grand National Assembly,18,,,,
-aeb51bf1-89d1-4cea-8fd5-a1deebea0d7e,Mustafa Demir,Mustafa Demir,,,,Anavatan Partisi,ANAP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,18,,,,
+aeb51bf1-89d1-4cea-8fd5-a1deebea0d7e,Mustafa Demir,Mustafa Demir,,,,Anavatan Partisi,ANAP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,18,,,,male
 28e39137-a3e6-46be-b36c-63691b235075,Mustafa Dinek,Mustafa Dinek,,,,Anavatan Partisi,ANAP,area/konya,Konya,Grand National Assembly,18,,,,
 f638414d-f3ff-4b6f-81f3-cda4d14874d2,Mustafa Erdoğan Yetenç,Mustafa Erdoğan Yetenç,,,,Sosyaldemokrat Halkçı Parti,SHP,area/manisa,Manisa,Grand National Assembly,18,,,,male
 c7d4675a-7cd2-40ae-b1fa-b3a011ff877f,Mustafa Ertuğrul Ünlü,Mustafa Ertuğrul Ünlü,,,,Anavatan Partisi,ANAP,area/bursa,Bursa,Grand National Assembly,18,,,,male
@@ -355,7 +355,7 @@ f2f12aa8-645f-4ff4-87a6-d0e9dba04b1f,Selahattin Mumcuoğlu,Selahattin Mumcuoğlu
 48c73b72-28ab-4c5d-a8d3-f7adc5eb45c5,Seçkin Fırat,Seçkin Fırat,,,,Anavatan Partisi,ANAP,area/bolu,Bolu,Grand National Assembly,18,,,,
 1e9bf7b2-b988-4df0-bdd9-40f2d2cd6370,Sudi Neş’e Türel,Sudi Neş’e Türel,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,18,,,,
 3c495593-df52-4b97-bdb1-87e7c32f38b8,Süleyman Demirel,Süleyman Demirel,,,,Doğru Yol Partisi,DYP,area/isparta,Isparta,Grand National Assembly,18,,,https://upload.wikimedia.org/wikipedia/commons/1/17/Suleyman_Demirel_1998.jpg,male
-78d335b5-de60-44e5-93fb-2d0eb1c8acc3,Süleyman Çelebi,Süleyman Çelebi,,,,Doğru Yol Partisi,DYP,area/mardin,Mardin,Grand National Assembly,18,,,,
+78d335b5-de60-44e5-93fb-2d0eb1c8acc3,Süleyman Çelebi,Süleyman Çelebi,,,,Doğru Yol Partisi,DYP,area/mardin,Mardin,Grand National Assembly,18,,,,male
 6fc4479e-f8ee-485f-a2f4-c470382f5aa1,Süleyman Şükrü Zeybek,Süleyman Şükrü Zeybek,,,,Anavatan Partisi,ANAP,area/muğla,Muğla,Grand National Assembly,18,,,,
 9f86b9c6-e495-45bd-9e82-56e03540d6fe,Sümer Oral,Sümer Oral,,,,Doğru Yol Partisi,DYP,area/manisa,Manisa,Grand National Assembly,18,,,,
 db2962d8-cac9-4c72-85b1-8fcad4b2b985,Talat Sargın,Talat Sargın,,,,Anavatan Partisi,ANAP,area/tokat,Tokat,Grand National Assembly,18,,,,
@@ -371,7 +371,7 @@ ce9011e5-5090-4221-a361-b4dcc8437c2d,Tufan Doğu,Tufan Doğu,,,,Sosyaldemokrat H
 64d56452-1eda-4dba-9bac-799191d37ea4,Turgut Yaşar Gülez,Turgut Yaşar Gülez,,,,Doğru Yol Partisi,DYP,area/bolu,Bolu,Grand National Assembly,18,,,,
 dbf83637-216e-4791-9039-9c5596865224,Turgut Özal,Turgut Özal,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,18,,,https://upload.wikimedia.org/wikipedia/commons/1/1b/Turgut_Özal_cropped.jpg,male
 ee8de983-5560-4168-8107-3843635668dd,Turhan Hırfanoğlu,Turhan Hırfanoğlu,,,,Sosyaldemokrat Halkçı Parti,SHP,area/hatay,Hatay,Grand National Assembly,18,,,,
-ac582dea-3664-4264-9318-b8962a6e10a4,Türkan Akyol,Türkan Akyol,,,,Sosyaldemokrat Halkçı Parti,SHP,area/İzmir,İzmir,Grand National Assembly,18,,,,
+ac582dea-3664-4264-9318-b8962a6e10a4,Türkan Akyol,Türkan Akyol,,,,Sosyaldemokrat Halkçı Parti,SHP,area/İzmir,İzmir,Grand National Assembly,18,,,,female
 aef83790-aeba-4509-9410-c46faafe8e34,Vedat Altun,Vedat Altun,,,,Sosyaldemokrat Halkçı Parti,SHP,area/kars,Kars,Grand National Assembly,18,,,,
 b9cb25c7-2d50-48a5-9eb1-55e0bea240db,Vefa Tanır,Vefa Tanır,,,,Doğru Yol Partisi,DYP,area/konya,Konya,Grand National Assembly,18,,,,
 81c2972e-95ee-490a-83e4-cdc5c4371a4c,Veli Aksoy,Veli Aksoy,,,,Sosyaldemokrat Halkçı Parti,SHP,area/İzmir,İzmir,Grand National Assembly,18,,,,

--- a/data/Turkey/Assembly/term-19.csv
+++ b/data/Turkey/Assembly/term-19.csv
@@ -5,7 +5,7 @@ f783e418-0afd-468a-bc43-9ed84ade6eb5,Abdullah Aykon Doğan,Abdullah Aykon Doğan
 51704345-f3a1-4eae-912a-85a06bd14622,Abdullah Gül,Abdullah Gül,,cbabdullahgul,,Refah Partisi,RP,area/kayseri,Kayseri,Grand National Assembly,19,,,https://upload.wikimedia.org/wikipedia/commons/9/91/Abdullah_Gül_2011-06-07.jpg,male
 1c52a659-abbe-4041-a0c8-4949fbb13751,Abdullah Kınalı,Abdullah Kınalı,,,,Doğru Yol Partisi,DYP,area/hatay,Hatay,Grand National Assembly,19,,,,
 5e7680ec-0ef3-4701-9f59-66be503528ef,Abdullah Ulutürk,Abdullah Ulutürk,,,,Doğru Yol Partisi,DYP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,19,,,,male
-bfcfd01a-8d36-4851-b246-1f44af926a25,Abdullatif Şener,Abdullatif Şener,,,,Refah Partisi,RP,area/sivas,Sivas,Grand National Assembly,19,,,,
+bfcfd01a-8d36-4851-b246-1f44af926a25,Abdullatif Şener,Abdullatif Şener,,,,Refah Partisi,RP,area/sivas,Sivas,Grand National Assembly,19,,,https://upload.wikimedia.org/wikipedia/commons/b/b9/Abdullatif_Sener-edited.jpg,male
 2a77bd51-87ba-4287-ad2d-dd110e6dae15,Abdurrahman Ünlü,Abdurrahman Ünlü,,,,Doğru Yol Partisi,DYP,area/kırıkkale,Kırıkkale,Grand National Assembly,19,,,,
 72419937-c3a9-4d2c-aeca-37ba5803bd63,Abdurrezak Yavuz,Abdurrezak Yavuz,,,,Doğru Yol Partisi,DYP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,19,,,,
 514d6688-9d10-40cd-a52c-04cf013d5c7b,Abdülbaki Ataç,Abdülbaki Ataç,,,,Doğru Yol Partisi,DYP,area/balıkesir,Balıkesir,Grand National Assembly,19,,,,
@@ -27,10 +27,10 @@ ea829c54-abc5-4e1b-8440-8fb18f65be28,Ahmet Derin,Ahmet Derin,,,,Refah Partisi,RP
 af601dec-cf50-42fa-b261-6ffd33d6e6e7,Ahmet Dökülmez,Ahmet Dökülmez,,,,Refah Partisi,RP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,19,,,,male
 bf81cf44-0fed-40d7-8f90-42b5a785bce2,Ahmet Fehmi Işıklar,Ahmet Fehmi Işıklar,,,,Sosyaldemokrat Halkçı Parti,SHP,area/diyarbakır,Diyarbakır,Grand National Assembly,19,,,,male
 63c586fa-4c5c-4e76-a02b-3c3e4e92f6f7,Ahmet Feyzi İnceöz,Ahmet Feyzi İnceöz,,,,Refah Partisi,RP,area/tokat,Tokat,Grand National Assembly,19,,,,
-89f96507-7cd4-4442-8aa9-9f059775f8a4,Ahmet Hamdi Üçpınarlar,Ahmet Hamdi Üçpınarlar,,,,Doğru Yol Partisi,DYP,area/Çanakkale,Çanakkale,Grand National Assembly,19,,,,
+89f96507-7cd4-4442-8aa9-9f059775f8a4,Ahmet Hamdi Üçpınarlar,Ahmet Hamdi Üçpınarlar,,,,Doğru Yol Partisi,DYP,area/Çanakkale,Çanakkale,Grand National Assembly,19,,,,male
 2e287779-2279-4ea8-9e2e-3dae8d750a4e,Ahmet Kabil,Ahmet Kabil,,,,Anavatan Partisi,ANAP,area/rize,Rize,Grand National Assembly,19,,,,male
 82087cb5-1825-4a78-9db0-90d1781f501c,Ahmet Küçükel,Ahmet Küçükel,,,,Doğru Yol Partisi,DYP,area/elazığ,Elazığ,Grand National Assembly,19,,,,
-303d56c9-65c3-4b05-bc87-3f1425406a89,Ahmet Mesut Yılmaz,Ahmet Mesut Yılmaz,,,,Anavatan Partisi,ANAP,area/rize,Rize,Grand National Assembly,19,,,,
+303d56c9-65c3-4b05-bc87-3f1425406a89,Ahmet Mesut Yılmaz,Ahmet Mesut Yılmaz,,,,Anavatan Partisi,ANAP,area/rize,Rize,Grand National Assembly,19,,,,male
 dcdedc06-a5d8-4d49-90fd-3539dbef6faa,Ahmet Neidim,Ahmet Neidim,,,,Doğru Yol Partisi,DYP,area/sakarya,Sakarya,Grand National Assembly,19,,,,male
 abda1513-498e-426d-a0c5-029b6c2001a1,Ahmet Remzi Hatip,Ahmet Remzi Hatip,,,,Refah Partisi,RP,area/konya,Konya,Grand National Assembly,19,,,,male
 bfcc1089-420b-478e-930c-020ebd0eb18f,Ahmet Sayın,Ahmet Sayın,,,,Doğru Yol Partisi,DYP,area/burdur,Burdur,Grand National Assembly,19,,,,
@@ -77,7 +77,7 @@ c30eca58-8be7-454c-ba16-749a0becff89,Bahattin Elçi,Bahattin Elçi,,,,Refah Part
 432901db-c64b-497d-abec-43f0c8b588a2,Bedrettin Doğancan Akyürek,Bedrettin Doğancan Akyürek,,,,Doğru Yol Partisi,DYP,area/İstanbul,İstanbul,Grand National Assembly,19,,,,
 0680d06e-d5ed-4237-8b68-ae43bbb51d9b,Bekir Sami Daçe,Bekir Sami Daçe,,,,Doğru Yol Partisi,DYP,area/adana,Adana,Grand National Assembly,19,,,,
 11d7c03d-2032-41ab-ad4b-0ea873665d8f,Bestami Teke,Bestami Teke,,,,Doğru Yol Partisi,DYP,area/hatay,Hatay,Grand National Assembly,19,,,,
-da279d78-35c4-49fd-b2d9-d336c1c08184,Beytullah Mehmet Gazioğlu,Beytullah Mehmet Gazioğlu,,,,Doğru Yol Partisi,DYP,area/bursa,Bursa,Grand National Assembly,19,,,,
+da279d78-35c4-49fd-b2d9-d336c1c08184,Beytullah Mehmet Gazioğlu,Beytullah Mehmet Gazioğlu,,,,Doğru Yol Partisi,DYP,area/bursa,Bursa,Grand National Assembly,19,,,,male
 6957a1c3-4ba5-4230-9078-cd34e97d46c0,Bilal Güngör,Bilal Güngör,,,,Doğru Yol Partisi,DYP,area/ankara,Ankara,Grand National Assembly,19,,,,male
 a28257c8-017a-484f-ae3b-999c4af631c6,Burhan Kara,Burhan Kara,,,,Anavatan Partisi,ANAP,area/giresun,Giresun,Grand National Assembly,19,,,,male
 6a5cfa74-acfb-4123-a0ac-4caa18d366d5,Bülent Akarcalı,Bülent Akarcalı,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,19,,,,male
@@ -98,11 +98,11 @@ f7bc5cb7-5d01-48a1-875c-186cc018599e,Cemil Erhan,Cemil Erhan,,,,Doğru Yol Parti
 34ff561d-9c82-4ed2-87c6-e0ed68248ddd,Cengiz Üretmen,Cengiz Üretmen,,,,Doğru Yol Partisi,DYP,area/manisa,Manisa,Grand National Assembly,19,,,,
 4baeae11-2b1a-4cf4-ba61-8dc628831b5a,Cevat Ayhan,Cevat Ayhan,,,,Refah Partisi,RP,area/sakarya,Sakarya,Grand National Assembly,19,,,,
 dc27aee0-09e0-400c-abdd-829c79f73cc5,Coşkun Gökalp,Coşkun Gökalp,,,,Sosyaldemokrat Halkçı Parti,SHP,area/kırşehir,Kırşehir,Grand National Assembly,19,,,,
-d084b4f5-9de7-4a63-ba7f-fe94c46b1aa6,Coşkun Kırca,Coşkun Kırca,,,,Doğru Yol Partisi,DYP,area/İstanbul,İstanbul,Grand National Assembly,19,,,,male
+d084b4f5-9de7-4a63-ba7f-fe94c46b1aa6,Coşkun Kırca,Coşkun Kırca,,,,Doğru Yol Partisi,DYP,area/İstanbul,İstanbul,Grand National Assembly,19,,,,
 64644586-aaec-42b2-8a12-ca82928feeda,Deniz Baykal,Deniz Baykal,,,,Sosyaldemokrat Halkçı Parti,SHP,area/antalya,Antalya,Grand National Assembly,19,,,https://upload.wikimedia.org/wikipedia/commons/5/58/Deniz_Baykal_TBMM.jpg,male
 e47d06ae-4c22-4a1c-a076-27b7089251b3,Doğan Baran,Doğan Baran,,,,Doğru Yol Partisi,DYP,area/niğde,Niğde,Grand National Assembly,19,,,,
-8d75f83a-982a-45f4-aebf-a7316a52f7f5,Durmuş Fikri Sağlar,Durmuş Fikri Sağlar,,,,Sosyaldemokrat Halkçı Parti,SHP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,19,,,,
-35bd5b58-cff0-4a67-b57b-f73f8720ab5f,Edip Safder Gaydalı,Edip Safder Gaydalı,,,,Anavatan Partisi,ANAP,area/bitlis,Bitlis,Grand National Assembly,19,,,,
+8d75f83a-982a-45f4-aebf-a7316a52f7f5,Durmuş Fikri Sağlar,Durmuş Fikri Sağlar,,,,Sosyaldemokrat Halkçı Parti,SHP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,19,,,,male
+35bd5b58-cff0-4a67-b57b-f73f8720ab5f,Edip Safder Gaydalı,Edip Safder Gaydalı,,,,Anavatan Partisi,ANAP,area/bitlis,Bitlis,Grand National Assembly,19,,,,male
 e7759e7d-22e9-435d-87d2-c1c3096cb9f9,Ekrem Ceyhun,Ekrem Ceyhun,,,,Doğru Yol Partisi,DYP,area/balıkesir,Balıkesir,Grand National Assembly,19,,,,
 ca0d992d-fd09-4fd2-9589-3233dd531721,Ekrem Pakdemirli,Ekrem Pakdemirli,,,,Anavatan Partisi,ANAP,area/manisa,Manisa,Grand National Assembly,19,,,,
 b97db525-d575-40f2-bacf-e1f77e5fad68,Elaattin Elmas,Elaattin Elmas,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,19,,,,
@@ -115,7 +115,7 @@ c7056767-7947-414b-b5b6-e4a229795a12,Erdal İnönü,Erdal İnönü,,,,Sosyaldemo
 869bd4b3-be02-48ea-9261-ab332a12d61b,Ergun Özdemir,Ergun Özdemir,,,,Doğru Yol Partisi,DYP,area/giresun,Giresun,Grand National Assembly,19,,,,
 d8708567-40ac-4e71-929a-fd04d0ed76f0,Erkut Şenbaş,Erkut Şenbaş,,,,Doğru Yol Partisi,DYP,area/İzmir,İzmir,Grand National Assembly,19,,,,
 4f778828-8712-4b38-945e-ec243359cd2b,Erman Şahin,Erman Şahin,,,,Sosyaldemokrat Halkçı Parti,SHP,area/muğla,Muğla,Grand National Assembly,19,,,,
-e13c2fa9-0977-4450-b3b5-50a3759c5a47,Ersin Faralyalı,Ersin Faralyalı,,,,Doğru Yol Partisi,DYP,area/İzmir,İzmir,Grand National Assembly,19,,,,
+e13c2fa9-0977-4450-b3b5-50a3759c5a47,Ersin Faralyalı,Ersin Faralyalı,,,,Doğru Yol Partisi,DYP,area/İzmir,İzmir,Grand National Assembly,19,,,,male
 12e7bc0c-522c-4726-9f92-f2a78a05f6b8,Ersin Taranoğlu,Ersin Taranoğlu,,,,Anavatan Partisi,ANAP,area/sakarya,Sakarya,Grand National Assembly,19,,,,
 5e6604fb-6236-406d-b6bd-58a65ce4d3a4,Ertekin Durutürk,Ertekin Durutürk,,,,Doğru Yol Partisi,DYP,area/isparta,Isparta,Grand National Assembly,19,,,,
 029f2db0-5b94-479c-9215-e3ccb4ef8d84,Esat Bütün,Esat Bütün,,,,Refah Partisi,RP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,19,,,,male
@@ -135,7 +135,7 @@ d9dbb524-9a7b-491f-8bdb-ce28add2bcee,Feridun Pehlivan,Feridun Pehlivan,,,,Anavat
 c8cc7ac1-4cfc-423a-a033-0f72f3b24cd2,Fethi Akkoç,Fethi Akkoç,,,,Doğru Yol Partisi,DYP,area/bursa,Bursa,Grand National Assembly,19,,,,
 d24af3c6-d8f4-4d50-b827-4681ae7ce11d,Fethiye Özver,Fethiye Özver,,,,Doğru Yol Partisi,DYP,area/tekirdağ,Tekirdağ,Grand National Assembly,19,,,,
 2ce88e5d-77ec-4e9f-8664-865eaff4c1a8,Fethullah Erbaş,Fethullah Erbaş,,,,Refah Partisi,RP,area/van,Van,Grand National Assembly,19,,,,
-99e2ce3b-78ee-4434-9727-f64e2b750890,Fevzi İşbaşaran,Fevzi İşbaşaran,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,19,,,,
+99e2ce3b-78ee-4434-9727-f64e2b750890,Fevzi İşbaşaran,Fevzi İşbaşaran,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,19,,,,male
 5f9cb4cb-ba56-4e06-96de-414dcb82f5a9,Fuat Çay,Fuat Çay,,,,Sosyaldemokrat Halkçı Parti,SHP,area/hatay,Hatay,Grand National Assembly,19,,,,male
 dda47016-4353-49f0-810c-bc717483a193,Gaffar Yakın,Gaffar Yakın,,,,Anavatan Partisi,ANAP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,19,,,,
 b34ca4d5-0a81-4b8b-b519-03502c733bb2,Gazi Barut,Gazi Barut,,,,Anavatan Partisi,ANAP,area/malatya,Malatya,Grand National Assembly,19,,,,
@@ -214,7 +214,7 @@ cd787b08-d545-4531-9ef5-b67dc58cd8ac,Mahmut Öztürk,Mahmut Öztürk,,,,Doğru Y
 9322ba82-eb7e-4a95-9d6d-cd745c28bc5e,Mehmet Adnan Ekmen,Mehmet Adnan Ekmen,,,,Sosyaldemokrat Halkçı Parti,SHP,area/batman,Batman,Grand National Assembly,19,,,,
 9e953f51-e0a6-441f-9b94-c2d932a47aad,Mehmet Ali Yavuz,Mehmet Ali Yavuz,,,,Doğru Yol Partisi,DYP,area/konya,Konya,Grand National Assembly,19,,,,male
 c750ea0c-a1b9-4532-ac1e-49990426c7c9,Mehmet Ali Yılmaz,Mehmet Ali Yılmaz,,,,Doğru Yol Partisi,DYP,area/trabzon,Trabzon,Grand National Assembly,19,,,,male
-d152982c-9713-4c42-87e1-a8e29bbbdf3e,Mehmet Alp,Mehmet Alp,,,,Sosyaldemokrat Halkçı Parti,SHP,area/kars,Kars,Grand National Assembly,19,,,,
+d152982c-9713-4c42-87e1-a8e29bbbdf3e,Mehmet Alp,Mehmet Alp,,,,Sosyaldemokrat Halkçı Parti,SHP,area/kars,Kars,Grand National Assembly,19,,,,male
 d4586d2e-e980-4d6f-90ee-3d3669da003a,Mehmet Bahattin Yücel,Mehmet Bahattin Yücel,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,19,,,,
 dc136ae3-5930-49cc-8b56-47e9f005bde3,Mehmet Batallı,Mehmet Batallı,,,,Doğru Yol Partisi,DYP,area/gaziantep,Gaziantep,Grand National Assembly,19,,,,male
 646247d8-016d-408f-8c9b-0271705f427d,Mehmet Budak,Mehmet Budak,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,19,,,,
@@ -238,11 +238,11 @@ ccf2e954-f5da-4730-8aa7-fcaa291838bc,Mehmet Köstepen,Mehmet Köstepen,,,,Doğru
 1a70240e-0e4a-45f5-8d71-6934c567a8ab,Mehmet Rauf Ertekin,Mehmet Rauf Ertekin,,,,Anavatan Partisi,ANAP,area/kütahya,Kütahya,Grand National Assembly,19,,,,
 f0524a9e-ab63-4844-a3ea-be3ff79b8671,Mehmet Sabri Güner,Mehmet Sabri Güner,,,,Doğru Yol Partisi,DYP,area/kars,Kars,Grand National Assembly,19,,,,male
 f0cdb999-67a8-4ff5-a41f-3e4c6961dc64,Mehmet Sağdıç,Mehmet Sağdıç,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,19,,,,male
-1c7b61da-fdc1-41ab-9966-f813a6423626,Mehmet Selahattin Kılıç,Mehmet Selahattin Kılıç,,,,Doğru Yol Partisi,DYP,area/adana,Adana,Grand National Assembly,19,,,,male
-bf35c68a-f6b1-43ce-9316-8bde4cbb5a06,Mehmet Selim Ensarioğlu,Mehmet Selim Ensarioğlu,,,,Doğru Yol Partisi,DYP,area/diyarbakır,Diyarbakır,Grand National Assembly,19,,,,
+1c7b61da-fdc1-41ab-9966-f813a6423626,Mehmet Selahattin Kılıç,Mehmet Selahattin Kılıç,,,,Doğru Yol Partisi,DYP,area/adana,Adana,Grand National Assembly,19,,,,
+bf35c68a-f6b1-43ce-9316-8bde4cbb5a06,Mehmet Selim Ensarioğlu,Mehmet Selim Ensarioğlu,,,,Doğru Yol Partisi,DYP,area/diyarbakır,Diyarbakır,Grand National Assembly,19,,,,male
 bdb7410e-7d72-4f19-8239-c65c3c0b35ed,Mehmet Seven,Mehmet Seven,,,,Anavatan Partisi,ANAP,area/bilecik,Bilecik,Grand National Assembly,19,,,,male
 7cf37c40-8ca2-4fb0-bdf8-f8f590406c7a,Mehmet Sevigen,Mehmet Sevigen,,,,Demokratik Sol Parti,DSP,area/İstanbul,İstanbul,Grand National Assembly,19,,,,male
-47bee7b4-ba62-4b32-9db8-5539a7427a68,Mehmet Seyfi Oktay,Mehmet Seyfi Oktay,,,,Sosyaldemokrat Halkçı Parti,SHP,area/ankara,Ankara,Grand National Assembly,19,,,,male
+47bee7b4-ba62-4b32-9db8-5539a7427a68,Mehmet Seyfi Oktay,Mehmet Seyfi Oktay,,,,Sosyaldemokrat Halkçı Parti,SHP,area/ankara,Ankara,Grand National Assembly,19,,,,
 7fa312fb-1ddf-417e-8fa2-7486c571e173,Mehmet Sincar,Mehmet Sincar,,,,Sosyaldemokrat Halkçı Parti,SHP,area/mardin,Mardin,Grand National Assembly,19,,,,male
 bf5f0718-0e81-4043-9963-b9ab6d42d70f,Mehmet Tahir Köse,Mehmet Tahir Köse,,,,Sosyaldemokrat Halkçı Parti,SHP,area/amasya,Amasya,Grand National Assembly,19,,,,
 0f3842ac-4bb4-4468-8452-36c5285129e8,Mehmet Vehbi Dinçerler,Mehmet Vehbi Dinçerler,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,19,,,,
@@ -317,11 +317,11 @@ bfacf4d7-56cf-4f5c-9d85-c568d50700dd,Nevşat Özer,Nevşat Özer,,,,Anavatan Par
 6f366f5d-06b0-4fc7-906c-9f955aa3da34,Oktay Öztürk,Oktay Öztürk,,,,Milliyetçi Çalışma Partisi,MÇP,area/erzurum,Erzurum,Grand National Assembly,19,,,,
 e4013e45-3c77-4018-9778-182b7cf1e34e,Onur Kumbaracıbaşı,Onur Kumbaracıbaşı,,,,Sosyaldemokrat Halkçı Parti,SHP,area/hatay,Hatay,Grand National Assembly,19,,,,male
 a712cb2b-2081-4e36-84a3-aa6682d411b1,Orhan Doğan,Orhan Doğan,,,,Sosyaldemokrat Halkçı Parti,SHP,area/Şırnak,Şırnak,Grand National Assembly,19,,,,male
-799c2096-6781-46f7-be38-370aeab751d7,Orhan Kilercioğlu,Orhan Kilercioğlu,,,,Doğru Yol Partisi,DYP,area/ankara,Ankara,Grand National Assembly,19,,,,
+799c2096-6781-46f7-be38-370aeab751d7,Orhan Kilercioğlu,Orhan Kilercioğlu,,,,Doğru Yol Partisi,DYP,area/ankara,Ankara,Grand National Assembly,19,,,,male
 cbc22626-a9ff-4ffb-8d32-472f0a9721eb,Orhan Şendağ,Orhan Şendağ,,,,Doğru Yol Partisi,DYP,area/adana,Adana,Grand National Assembly,19,,,,male
 07eb5bf4-e396-4dca-950f-8173c416b663,Osman Ceylan,Osman Ceylan,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,19,,,,
 a332e7be-88c4-4af0-b6bd-b8717a84e36f,Osman Develioğlu,Osman Develioğlu,,,,Refah Partisi,RP,area/kayseri,Kayseri,Grand National Assembly,19,,,,
-273004ea-d2e1-4ed2-8b51-595639b7849b,Osman Mümtaz Soysal,Osman Mümtaz Soysal,,,,Sosyaldemokrat Halkçı Parti,SHP,area/ankara,Ankara,Grand National Assembly,19,,,,
+273004ea-d2e1-4ed2-8b51-595639b7849b,Osman Mümtaz Soysal,Osman Mümtaz Soysal,,,,Sosyaldemokrat Halkçı Parti,SHP,area/ankara,Ankara,Grand National Assembly,19,,,,male
 72c8120f-34d1-4b3a-8277-b9701abed868,Osman Seyfi,Osman Seyfi,,,,Doğru Yol Partisi,DYP,area/nevşehir,Nevşehir,Grand National Assembly,19,,,,
 d23660a8-a2c6-4452-87c8-7fc47ea6588e,Osman Özbek,Osman Özbek,,,,Doğru Yol Partisi,DYP,area/konya,Konya,Grand National Assembly,19,,,,male
 faa4bb12-d625-4f59-a8f7-b5a5b08fafdf,Oğuzhan Asiltürk,Oğuzhan Asiltürk,,,,Refah Partisi,RP,area/malatya,Malatya,Grand National Assembly,19,,,,
@@ -346,7 +346,7 @@ f0140c12-cc3a-40eb-b664-5e99ce191f7d,Salih Kapusuz,Salih Kapusuz,,,,Refah Partis
 13e6d0d2-ce0a-47dd-8b08-1c178dbfea9b,Salih Sümer,Salih Sümer,,,,Sosyaldemokrat Halkçı Parti,SHP,area/diyarbakır,Diyarbakır,Grand National Assembly,19,,,,male
 d79a429f-5eaf-4607-8422-5c1603a820d9,Salman Kaya,Salman Kaya,,,,Sosyaldemokrat Halkçı Parti,SHP,area/ankara,Ankara,Grand National Assembly,19,,,,
 78e8f7ee-4643-4536-a0f1-e9d88483cf0f,Sami Sözat,Sami Sözat,,,,Doğru Yol Partisi,DYP,area/balıkesir,Balıkesir,Grand National Assembly,19,,,,
-96ede054-2b11-4a60-ba8d-5d6a7f05e588,Sedat Edip Bucak,Sedat Edip Bucak,,,,Doğru Yol Partisi,DYP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,19,,,,
+96ede054-2b11-4a60-ba8d-5d6a7f05e588,Sedat Edip Bucak,Sedat Edip Bucak,,,,Doğru Yol Partisi,DYP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,19,,,,male
 91d317a2-3308-4546-b9e4-7176a669d81d,Sedat Yurtdaş,Sedat Yurtdaş,,,,Sosyaldemokrat Halkçı Parti,SHP,area/diyarbakır,Diyarbakır,Grand National Assembly,19,,,,
 4718b67b-1ee1-4646-abe2-8f9f7e88e63a,Selahattin Karademir,Selahattin Karademir,,,,Doğru Yol Partisi,DYP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,19,,,,
 d12b5773-25e2-49b1-a3f9-5cb71a71fc98,Selim Sadak,Selim Sadak,,,,Sosyaldemokrat Halkçı Parti,SHP,area/Şırnak,Şırnak,Grand National Assembly,19,,,,male
@@ -412,8 +412,8 @@ c870a674-ba5a-40d2-a450-035ec8c05d29,Ülkü Gökalp Güney,Ülkü Gökalp Güney
 b2b08b18-c517-4489-aee7-7858f5730189,İbrahim Gürsoy,İbrahim Gürsoy,,,,Sosyaldemokrat Halkçı Parti,SHP,area/İstanbul,İstanbul,Grand National Assembly,19,,,,
 dc981566-b7fb-45e5-95c8-3ffbaef3fcf3,İbrahim Halil Çelik,İbrahim Halil Çelik,,,,Refah Partisi,RP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,19,,,,male
 6ba0b280-7c1c-450b-a197-2798330ca77c,İbrahim Kumaş,İbrahim Kumaş,,,,Refah Partisi,RP,area/tokat,Tokat,Grand National Assembly,19,,,,
-bbc9864e-0ece-4845-8930-349209acd700,İbrahim Melih Gökçek,İbrahim Melih Gökçek,,,,Refah Partisi,RP,area/ankara,Ankara,Grand National Assembly,19,,,,
-d8c94f59-fd91-4df8-bb3a-5a2d248ecbae,İbrahim Nami Çağan,İbrahim Nami Çağan,,,,Demokratik Sol Parti,DSP,area/İstanbul,İstanbul,Grand National Assembly,19,,,,male
+bbc9864e-0ece-4845-8930-349209acd700,İbrahim Melih Gökçek,İbrahim Melih Gökçek,,,,Refah Partisi,RP,area/ankara,Ankara,Grand National Assembly,19,,,,male
+d8c94f59-fd91-4df8-bb3a-5a2d248ecbae,İbrahim Nami Çağan,İbrahim Nami Çağan,,,,Demokratik Sol Parti,DSP,area/İstanbul,İstanbul,Grand National Assembly,19,,,,
 f1497120-7d7e-4376-bd02-44e0085af01f,İbrahim Tez,İbrahim Tez,,,,Sosyaldemokrat Halkçı Parti,SHP,area/ankara,Ankara,Grand National Assembly,19,,,,male
 f73269e5-9f49-4a09-ad58-475f141d0262,İbrahim Yaşar Dedelek,İbrahim Yaşar Dedelek,,,,Doğru Yol Partisi,DYP,area/eskişehir,Eskişehir,Grand National Assembly,19,,,,male
 29829de3-ad21-4e3a-a6e6-5f1cb2f7a080,İbrahim Özdemir,İbrahim Özdemir,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,19,,,,male
@@ -427,7 +427,7 @@ dffd7c1c-f8b7-4316-99f3-fbcc6aec427d,İmren Aykut,İmren Aykut,,,,Anavatan Parti
 5b887956-b89e-4368-813b-1842df1a05a2,İrfan Gürpınar,İrfan Gürpınar,,,,Sosyaldemokrat Halkçı Parti,SHP,area/kırklareli,Kırklareli,Grand National Assembly,19,,,,
 0a9fcf2f-903c-4ebb-bc29-61aa2392cb92,İrfan Köksalan,İrfan Köksalan,,,,Doğru Yol Partisi,DYP,area/ankara,Ankara,Grand National Assembly,19,,,,
 411bca39-a9c6-4372-ba42-d838a283c98e,İrfettin Akar,İrfettin Akar,,,,Doğru Yol Partisi,DYP,area/muğla,Muğla,Grand National Assembly,19,,,,
-36d3eb30-2aba-4bad-8041-9d744f255e09,İsmail Amasyalı,İsmail Amasyalı,,,,Doğru Yol Partisi,DYP,area/kocaeli,Kocaeli,Grand National Assembly,19,,,,
+36d3eb30-2aba-4bad-8041-9d744f255e09,İsmail Amasyalı,İsmail Amasyalı,,,,Doğru Yol Partisi,DYP,area/kocaeli,Kocaeli,Grand National Assembly,19,,,,male
 07d1070f-9bd2-44a2-add9-01c6f365788b,İsmail Cem,İsmail Cem,,,,Sosyaldemokrat Halkçı Parti,SHP,area/İstanbul,İstanbul,Grand National Assembly,19,,,,male
 b3dea5ac-7681-4dda-9276-f58023430c99,İsmail Coşar,İsmail Coşar,,,,Refah Partisi,RP,area/Çankırı,Çankırı,Grand National Assembly,19,,,,
 7e2b5da4-f351-4c6e-abf9-efbbee778b68,İsmail Kalkandelen,İsmail Kalkandelen,,,,Doğru Yol Partisi,DYP,area/kocaeli,Kocaeli,Grand National Assembly,19,,,,

--- a/data/Turkey/Assembly/term-2.csv
+++ b/data/Turkey/Assembly/term-2.csv
@@ -6,7 +6,7 @@ eef17fa5-19e0-414e-909f-d06c93abbf81,Abdullah Okyay,Abdullah Okyay,,,,Cumhuriyet
 e3b73d96-c1d1-4a5d-8d6a-b934bdaf8328,Abdurrahman Şeref,Abdurrahman Şeref,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,2,,,,male
 a889fbf8-7561-4bfd-bbfe-74cff08796d2,Abdurrahman Şeref Uluğ,Abdurrahman Şeref Uluğ,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbekir,Diyarbekir,Grand National Assembly,2,,,,
 28200a47-ef24-423c-9820-0f27fb353028,Abdülgani Ensari,Abdülgani Ensari,,,,Cumhuriyet Halk Partisi,CHP,area/mardin,Mardin,Grand National Assembly,2,,,,
-73bb95f9-84ca-4c76-a779-ec5a3052c806,Abdülhak Adnan Adıvar,Abdülhak Adnan Adıvar,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/1/16/Adnan_Bey.jpg,male
+73bb95f9-84ca-4c76-a779-ec5a3052c806,Abdülhak Adnan Adıvar,Abdülhak Adnan Adıvar,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,2,,,,
 1820c040-668c-4fbd-8d31-0d278d3a71e2,Abdülhak Fırat,Abdülhak Fırat,,,,Cumhuriyet Halk Partisi,CHP,area/erzincan,Erzincan,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/5/54/Abdülhak_Bey_(Fırat).jpg,
 4e9cda07-5fd8-4dec-acb9-19c5517906ba,Abdülkadir Emirmahmutoğlu,Abdülkadir Emirmahmutoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,2,,,,
 827f3f08-bace-411f-bbc2-a0b64f09e89d,Abdürrahman Rahmi Katoğlu,Abdürrahman Rahmi Katoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,2,,,,
@@ -19,8 +19,8 @@ f92cf29d-b46e-4f85-bec6-0397b0d8f634,Abidin Bey,Abidin Bey,,,,Cumhuriyet Halk Pa
 02732b7e-a415-4a2b-8eed-bbc3bdf62fe4,Ahmet Esat Uras,Ahmet Esat Uras,,,,Cumhuriyet Halk Partisi,CHP,area/amasya,Amasya,Grand National Assembly,2,,,,male
 a47f8375-81fa-4115-bbc5-da3e185f4f0c,Ahmet Faik Günday,Ahmet Faik Günday,,,,Cumhuriyet Halk Partisi,CHP,area/ordu,Ordu,Grand National Assembly,2,,,,male
 87201005-3186-4b76-b0c9-5ad9181755b8,Ahmet Ferit Tek,Ahmet Ferit Tek,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/8/8b/Ahmet_Ferit_Bey_Tek.jpg,male
-222a2464-7586-4687-a098-62c9b83764d1,Ahmet Fuat Bulca,Ahmet Fuat Bulca,,,,Cumhuriyet Halk Partisi,CHP,area/rize,Rize,Grand National Assembly,2,,,,
-c41bb37f-3fb4-4377-94a2-ef4cd191191b,Ahmet Hamdi Aksoy,Ahmet Hamdi Aksoy,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,2,,,,
+222a2464-7586-4687-a098-62c9b83764d1,Ahmet Fuat Bulca,Ahmet Fuat Bulca,,,,Cumhuriyet Halk Partisi,CHP,area/rize,Rize,Grand National Assembly,2,,,,male
+c41bb37f-3fb4-4377-94a2-ef4cd191191b,Ahmet Hamdi Aksoy,Ahmet Hamdi Aksoy,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,2,,,,male
 b42abf8f-e05d-44a1-9914-1cbb04551b9d,Ahmet Hamdi Altıok,Ahmet Hamdi Altıok,,,,Cumhuriyet Halk Partisi,CHP,area/bozok_(yozgat),Bozok (Yozgat),Grand National Assembly,2,,,,male
 ff674f1b-5daa-4e02-a2d6-7d78554daddc,Ahmet Hamdi Denizmen,Ahmet Hamdi Denizmen,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/1/16/A._Hamdi_Denizmen.jpg,male
 bafa1d09-3239-4553-b38b-6f50eede6ed7,Ahmet Hamdi Yalman,Ahmet Hamdi Yalman,,,,Cumhuriyet Halk Partisi,CHP,area/ordu,Ordu,Grand National Assembly,2,,,,male
@@ -40,7 +40,7 @@ a534a8c8-44fa-4267-9c71-65c8dbc01ff4,Ahmet İffet Mercimekoğlu,Ahmet İffet Mer
 2024739a-c4ee-4bdc-9875-fdf9462d9d4b,Ahmet Şükrü Bey,Ahmet Şükrü Bey,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,2,,,,male
 45a18db8-01b4-43ef-8889-9a22a58ba63b,Ahmet Şükrü Kulualp,Ahmet Şükrü Kulualp,,,,Cumhuriyet Halk Partisi,CHP,area/dersim_(tunceli),Dersim (Tunceli),Grand National Assembly,2,,,,male
 f6e38a77-3b31-4633-a6c4-0ff002e542dc,Ali Cenani,Ali Cenani,,,,Cumhuriyet Halk Partisi,CHP,area/gaziantep,Gaziantep,Grand National Assembly,2,,,,
-3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44,Ali Fethi Okyar,Ali Fethi Okyar,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,2,,,,
+3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44,Ali Fethi Okyar,Ali Fethi Okyar,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/9/99/Ali_Fethi_Okyar.jpg,male
 82f66062-5e0a-45b0-af46-9cdd6bddab64,Ali Fuat Bucak,Ali Fuat Bucak,,,,Cumhuriyet Halk Partisi,CHP,area/urfa,Urfa,Grand National Assembly,2,,,,
 7da075c8-1f09-40b1-a9f4-957caa15a55e,Ali Fuat Cebesoy,Ali Fuat Cebesoy,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/0/09/Ali_Fuat_Pasha.jpg,male
 7881040a-5770-413d-9417-1a11689d9ed8,Ali Galip Yenen,Ali Galip Yenen,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,2,,,,male
@@ -73,14 +73,14 @@ f279251b-c449-41d6-92a5-10bbc26b846e,Binbaşızade Rıza Bey,Binbaşızade Rıza
 bc4363b7-f1d7-441f-a81a-c701bfeeae87,Cavit Ekin,Cavit Ekin,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbekir,Diyarbekir,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/5/54/Abdulkadir_Cavit_Bey_Ekin.jpg,male
 645f1b5c-b03a-4c64-a2d7-e7f253fd72a9,Cavit Paşa,Cavit Paşa,,,,Cumhuriyet Halk Partisi,CHP,area/canik_(samsun),Canik (Samsun),Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/6/6d/Djavid_Pasha.jpg,
 cc0de41b-90b6-4447-8e4d-09d127edd7e3,Celal Nuri İleri,Celal Nuri İleri,,,,Cumhuriyet Halk Partisi,CHP,area/gelibolu,Gelibolu,Grand National Assembly,2,,,,
-98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/9/9b/Celal_bayar.jpg,male
+98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,2,,,,
 9d95d988-0207-42d7-8215-5f2f19fc7c12,Cemal Hüsnü Taray,Cemal Hüsnü Taray,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,2,,,,male
 cef6dbcf-01c2-4d0b-8973-a7e6db9c9227,Cevat Abbas Gürer,Cevat Abbas Gürer,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/d/d9/Cevat_Abbas_Gürer.jpg,male
 786755e3-4aa1-4fbe-add3-bcbfeff27759,Cevdet Barlas,Cevdet Barlas,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,2,,,,
 a8388bc8-b37d-4e61-8e1f-69a0f5a9c364,Cudi Paşa,Cudi Paşa,,,,Cumhuriyet Halk Partisi,CHP,area/siverek,Siverek,Grand National Assembly,2,,,,
 6c7ef0fa-110e-45d1-a4ae-57f760329e82,Derviş Ural,Derviş Ural,,,,Cumhuriyet Halk Partisi,CHP,area/mardin,Mardin,Grand National Assembly,2,,,,
 da7a1891-05c4-42b6-9237-80b0c9ba3192,Ebubekir Hâzım Tepeyran,Ebubekir Hâzım Tepeyran,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/b/be/Ebubekir_Hazim_Bey.jpg,male
-2f649ab8-dbee-4ccb-87bd-ebf23f3b8a09,Edip Servet Tör,Edip Servet Tör,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/e/ed/Edip_Servet_Tör.jpg,male
+2f649ab8-dbee-4ccb-87bd-ebf23f3b8a09,Edip Servet Tör,Edip Servet Tör,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,2,,,,
 eaf81a09-59c1-4be9-8b16-e62953a6d316,Ekrem Rize,Ekrem Rize,,,,Cumhuriyet Halk Partisi,CHP,area/rize,Rize,Grand National Assembly,2,,,,male
 d254bd36-ee72-4d6b-ad8e-0b9a1507516b,Emin Cemal Suda,Emin Cemal Suda,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,2,,,,male
 8cd8c9bb-149d-4f10-ac94-33fcf2a621c7,Emin Sazak,Emin Sazak,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,2,,,,male
@@ -108,7 +108,7 @@ ee10e749-a615-49a6-8cf8-c6a9f4937458,Hafız İbrahim Demiralay,Hafız İbrahim D
 b85e88b1-46aa-4822-ac9d-a4774a50fdf8,Hakkı Ungan,Hakkı Ungan,,,,Cumhuriyet Halk Partisi,CHP,area/van,Van,Grand National Assembly,2,,,,male
 0804038f-1757-447e-85ca-509c8a4788c3,Halet Sağıroğlu,Halet Sağıroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/4/49/Halet_Bey_Sağıroğlu.jpg,male
 45d21b8d-ec42-410d-9432-346ac916653b,Halil Fahri Gürmen,Halil Fahri Gürmen,,,,Cumhuriyet Halk Partisi,CHP,area/siverek,Siverek,Grand National Assembly,2,,,,
-2e825a8d-4b7b-40e7-8266-37b4eb8c6743,Halil Hulki Ayrım,Halil Hulki Ayrım,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,2,,,,
+2e825a8d-4b7b-40e7-8266-37b4eb8c6743,Halil Hulki Ayrım,Halil Hulki Ayrım,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,2,,,,male
 db78d6a3-2803-4896-a438-a49d925eee3f,Halil Işık,Halil Işık,,,,Cumhuriyet Halk Partisi,CHP,area/ertuğrul_(bilecik),Ertuğrul (Bilecik),Grand National Assembly,2,,,,male
 b099beb8-8683-4589-a9da-769ec98c5c4a,Halil Sıtkı Kumru,Halil Sıtkı Kumru,,,,Cumhuriyet Halk Partisi,CHP,area/ordu,Ordu,Grand National Assembly,2,,,,male
 c9428e1e-97d1-4e60-8b13-18b54ca841d6,Halil Türkmen,Halil Türkmen,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,2,,,,male
@@ -133,7 +133,7 @@ a405e7ea-e904-4709-824c-9db14c6873bd,Hilmi Oytaç,Hilmi Oytaç,,,,Cumhuriyet Hal
 6a876b7f-9f26-4152-9560-cc7a06aa68c1,Hüseyin Ferit Törümküney,Hüseyin Ferit Törümküney,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,2,,,,male
 e5ccb9b4-6fcf-4d11-bde8-54e73c1fee40,Hüseyin Gökçelik,Hüseyin Gökçelik,,,,Cumhuriyet Halk Partisi,CHP,area/elaziz_(elazığ),Elaziz (Elazığ),Grand National Assembly,2,,,,male
 df5d46c7-fce5-487f-8323-198732f202a1,Hüseyin Hüsnü Özdamar,Hüseyin Hüsnü Özdamar,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/e/e7/Hussein_Husnu_Efendi.jpg,male
-c897a10b-39ef-4ea8-a585-ddfe834a92a0,Hüseyin Rauf Orbay,Hüseyin Rauf Orbay,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,2,,,,
+c897a10b-39ef-4ea8-a585-ddfe834a92a0,Hüseyin Rauf Orbay,Hüseyin Rauf Orbay,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,2,,,,male
 7a4c9167-4df7-49e9-a309-e57c7f0e960b,Hüseyin Rıfkı Bey,Hüseyin Rıfkı Bey,,,,Cumhuriyet Halk Partisi,CHP,area/edirne,Edirne,Grand National Assembly,2,,,,
 e5e0cda6-5a2d-4075-a100-681d1014cfd2,Hüseyin Vasıf Çınar,Hüseyin Vasıf Çınar,,,,Cumhuriyet Halk Partisi,CHP,area/saruhan_(manisa),Saruhan (Manisa),Grand National Assembly,2,,,,male
 f5ba38c8-456b-4ef4-9b53-f396d489efdb,Hüseyin Çelikbaş,Hüseyin Çelikbaş,,,,Cumhuriyet Halk Partisi,CHP,area/burdur,Burdur,Grand National Assembly,2,,,,male
@@ -155,7 +155,7 @@ dc3cc573-341b-4e22-961f-156425d68f8f,Mahmut Nedim Soydan,Mahmut Nedim Soydan,,,,
 0335f481-3838-430e-803c-d81a968e04c5,Mazhar Germen,Mazhar Germen,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,2,,,,
 07afbe2f-6cde-477d-acd4-25164c417aeb,Mazhar Müfit Kansu,Mazhar Müfit Kansu,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,2,,,,
 fecc8f3e-3ac8-4a2b-86b9-02048b8cc1e8,Mehmed Refik Kakmacı,Mehmed Refik Kakmacı,,,,Cumhuriyet Halk Partisi,CHP,area/kırşehir,Kırşehir,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/5/52/Refik_İsmail_Bey.jpg,male
-a692e94f-ddd3-408c-96af-92442c254b1f,Mehmet Arif Bey,Mehmet Arif Bey,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,2,,,,
+a692e94f-ddd3-408c-96af-92442c254b1f,Mehmet Arif Bey,Mehmet Arif Bey,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/0/02/Mehmed_Arif_Bey.jpg,male
 3c724c86-f1b6-4caf-b4e0-74875983468c,Mehmet Avni Doğan,Mehmet Avni Doğan,,,,Cumhuriyet Halk Partisi,CHP,area/bozok_(yozgat),Bozok (Yozgat),Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/3/30/Mehmet_Avni_Bey_Doğan.jpg,male
 ae9dac62-570e-401b-9fa7-cfc5419ad486,Mehmet Cazım Duru,Mehmet Cazım Duru,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,2,,,,
 d0d6895e-8404-4d1c-96b4-1ef5e18b1746,Mehmet Cemil Uybadın,Mehmet Cemil Uybadın,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,2,,,,
@@ -167,7 +167,7 @@ d9f6798e-d69e-4adb-9fa9-e90d5389e9be,Mehmet Emin Yurdakul,Mehmet Emin Yurdakul,,
 774155e8-cc13-45c8-9761-0957ba65ba4b,Mehmet Esat İleri,Mehmet Esat İleri,,,,Cumhuriyet Halk Partisi,CHP,area/menteşe_(muğla),Menteşe (Muğla),Grand National Assembly,2,,,,male
 a1c3115a-8545-4bd9-9271-712b2959606a,Mehmet Halis Tarıkahya,Mehmet Halis Tarıkahya,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/d/d0/Halis_Turgut_Bey.jpg,male
 3db7011e-7d92-4d56-a215-5c482ae65d0d,Mehmet Hamdi Arpağ,Mehmet Hamdi Arpağ,,,,Cumhuriyet Halk Partisi,CHP,area/erzincan,Erzincan,Grand National Assembly,2,,,,male
-f4bdf57f-104d-472e-a5da-769df2ecc757,Mehmet Kusun,Mehmet Kusun,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,2,,,,
+f4bdf57f-104d-472e-a5da-769df2ecc757,Mehmet Kusun,Mehmet Kusun,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,2,,,,male
 645883ca-3934-4c2e-bf92-f055699ffa9b,Mehmet Mithat Alan,Mehmet Mithat Alan,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,2,,,,male
 2230fc16-1d77-4607-970e-c60a63f47205,Mehmet Mühto,Mehmet Mühto,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,2,,,,male
 8e985396-14d1-4f8a-96ec-e96816837736,Mehmet Münir Çağıl,Mehmet Münir Çağıl,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,2,,,,male
@@ -183,13 +183,13 @@ ab64fd49-b4e7-4bf9-9fdc-a107b29e561b,Mehmet Neşet Özercan,Mehmet Neşet Özerc
 65dff33c-7fa8-49ed-af9e-981f08a8e309,Mehmet Nuhoğlu,Mehmet Nuhoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,2,,,,male
 77d6cce7-218b-404d-becb-2253fceb79a8,Mehmet Nurettin Akkın,Mehmet Nurettin Akkın,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,2,,,,male
 eeed3bcd-d4e8-4a09-857e-da1d08db3650,Mehmet Nuri Budak,Mehmet Nuri Budak,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbekir,Diyarbekir,Grand National Assembly,2,,,,
-4fb43215-aa33-4a48-9438-beedc5cfa945,Mehmet Nuri Conker,Mehmet Nuri Conker,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,2,,,,
+4fb43215-aa33-4a48-9438-beedc5cfa945,Mehmet Nuri Conker,Mehmet Nuri Conker,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,2,,,,male
 e43b1a93-2ef6-48ac-973d-5267e711aae9,Mehmet Ragıp Akça,Mehmet Ragıp Akça,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,2,,,,male
 ce024cab-178f-44bd-9c21-b02fdc316808,Mehmet Rahmi Eyüboğlu,Mehmet Rahmi Eyüboğlu,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,2,,,,male
 6e25500b-0521-4c9f-bba8-73177448db92,Mehmet Recai Baykal,Mehmet Recai Baykal,,,,Cumhuriyet Halk Partisi,CHP,area/ordu,Ordu,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/0/08/Recai_Bey_Baykal.jpg,male
 00a27340-6a1b-4795-8e2a-dbd4b0ec16c4,Mehmet Refet Ülgen,Mehmet Refet Ülgen,,,,Cumhuriyet Halk Partisi,CHP,area/urfa,Urfa,Grand National Assembly,2,,,,
 a54bd42b-ad62-4600-a0b3-45ab93881f2a,Mehmet Rıza Dinçay,Mehmet Rıza Dinçay,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,2,,,,male
-5862b388-6f4a-426b-ace7-1369cd044307,Mehmet Sabit Sağıroğlu,Mehmet Sabit Sağıroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/erzincan,Erzincan,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/6/63/Sabit_Bey_Sağıroğlu.jpg,male
+5862b388-6f4a-426b-ace7-1369cd044307,Mehmet Sabit Sağıroğlu,Mehmet Sabit Sağıroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/erzincan,Erzincan,Grand National Assembly,2,,,,
 a5571160-118c-44fb-a194-961031f78deb,Mehmet Sabri Toprak,Mehmet Sabri Toprak,,,,Cumhuriyet Halk Partisi,CHP,area/saruhan_(manisa),Saruhan (Manisa),Grand National Assembly,2,,,,male
 f7aa4ca6-d8dc-429b-9c38-ee7b71d5d15e,Mehmet Tahsin Hüdayioğlu,Mehmet Tahsin Hüdayioğlu,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,2,,,,male
 5308c5d8-5537-4def-bb08-e1bfab80aa8f,Mehmet Vehbi Bolak,Mehmet Vehbi Bolak,,,,Cumhuriyet Halk Partisi,CHP,area/karesi_(balıkesir),Karesi (Balıkesir),Grand National Assembly,2,,,,male
@@ -212,11 +212,11 @@ db5792b5-ed7f-467a-91ec-a0d11eb0883a,Mustafa Fevzi Sarhan,Mustafa Fevzi Sarhan,,
 f847a2e2-2e57-4681-ad8d-066fc517868d,Mustafa Feyzi Karaağaç,Mustafa Feyzi Karaağaç,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,2,,,,male
 d2ba9c59-8b2f-4e4c-b2db-3300994d21e0,Mustafa Hilmi Çayırlıoğlu,Mustafa Hilmi Çayırlıoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,2,,,,male
 fe61a430-358a-4eb4-8074-fe9512abd074,Mustafa Kamil Dursun,Mustafa Kamil Dursun,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,2,,,,male
-b0713117-c1a3-4ae4-afba-5928c8ba4331,Mustafa Kemal Atatürk,Mustafa Kemal Atatürk,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/c/cc/MustafaKemalAtaturk_crop.jpg,male
+b0713117-c1a3-4ae4-afba-5928c8ba4331,Mustafa Kemal Atatürk,Mustafa Kemal Atatürk,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,2,,,,
 588c0508-bdfa-45c2-986e-c428ee8d97f2,Mustafa Kerem,Mustafa Kerem,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,2,,,,male
 416ce349-1b6a-4620-ac9d-de41edafa2ab,Mustafa Necati Uğural,Mustafa Necati Uğural,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,2,,,,male
 54f96e04-0c2f-43c6-aec5-cd2f0eb960c1,Mustafa Rahmi Köken,Mustafa Rahmi Köken,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,2,,,,male
-29609f07-f6a1-4554-95b3-213a85e2148f,Mustafa Sabri Süsoy,Mustafa Sabri Süsoy,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,2,,,,
+29609f07-f6a1-4554-95b3-213a85e2148f,Mustafa Sabri Süsoy,Mustafa Sabri Süsoy,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/6/6b/Mustafa_Vasfi_Bey_Süsoy.jpg,male
 2a4248ce-3651-4824-953a-fd193f947275,Mustafa Solmaz,Mustafa Solmaz,,,,Cumhuriyet Halk Partisi,CHP,area/elaziz_(elazığ),Elaziz (Elazığ),Grand National Assembly,2,,,,male
 530919e5-2a29-4344-8722-cc17a8f91ffb,Mustafa Ulusan,Mustafa Ulusan,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,2,,,,male
 b4ffdee5-203e-49be-bf4c-be58b4db40a4,Mustafa Şeref Özkan,Mustafa Şeref Özkan,,,,Cumhuriyet Halk Partisi,CHP,area/burdur,Burdur,Grand National Assembly,2,,,,male
@@ -252,11 +252,11 @@ f669c61b-05bf-4ebb-bc4d-c496e21c5bab,Refik Saydam,Refik Saydam,,,,Cumhuriyet Hal
 0100f7f7-51a9-4766-9c70-ae90131d1398,Saffet Arıkan,Saffet Arıkan,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,2,,,,male
 90ba9146-41f7-40e6-8634-b83a906d636e,Saffet Kemalettin Yetkin,Saffet Kemalettin Yetkin,,,,Cumhuriyet Halk Partisi,CHP,area/urfa,Urfa,Grand National Assembly,2,,,,
 bb21f4a9-20c8-493f-bef6-5823efd82af4,Saim Uzel,Saim Uzel,,,,Cumhuriyet Halk Partisi,CHP,area/saruhan_(manisa),Saruhan (Manisa),Grand National Assembly,2,,,,
-70672dee-818c-49a5-84f1-227b49753518,Sakallı Nurettin,Sakallı Nurettin,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,2,,,,
+70672dee-818c-49a5-84f1-227b49753518,Sakallı Nurettin,Sakallı Nurettin,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/b/b9/Sakalli_Nureddin_Pasha.jpg,male
 8868c010-fb05-4abc-9f8c-c88ddfe51fd8,Salih Bozok,Salih Bozok,,,,Cumhuriyet Halk Partisi,CHP,area/bozok_(yozgat),Bozok (Yozgat),Grand National Assembly,2,,,,male
 a8f4968d-97dd-4540-978b-b8f7d637a1a5,Samih Yalnızgil,Samih Yalnızgil,,,,Cumhuriyet Halk Partisi,CHP,area/biga,Biga,Grand National Assembly,2,,,,
 77a2c798-b827-4b31-8083-e2c2893138a3,Seyfi Aydın,Seyfi Aydın,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,2,,,,
-20501cea-0077-46af-a493-5fbb9a97e778,Seyit Bey,Seyit Bey,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,2,,,,
+20501cea-0077-46af-a493-5fbb9a97e778,Seyit Bey,Seyit Bey,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/6/60/Seyit_Bey.jpg,male
 8b04bd41-5230-4cc0-9235-2ae72707c00b,Sofrasur Asizade Resul Bey,Sofrasur Asizade Resul Bey,,,,Cumhuriyet Halk Partisi,CHP,area/bitlis,Bitlis,Grand National Assembly,2,,,,
 87d75493-c518-4558-bf11-27d62b20353e,Süleyman Karakaya,Süleyman Karakaya,,,,Cumhuriyet Halk Partisi,CHP,area/elaziz_(elazığ),Elaziz (Elazığ),Grand National Assembly,2,,,,male
 c3dc0e4c-d84f-463b-9915-a637964deebc,Süleyman Necmi Selmen,Süleyman Necmi Selmen,,,,Cumhuriyet Halk Partisi,CHP,area/canik_(samsun),Canik (Samsun),Grand National Assembly,2,,,,male
@@ -279,7 +279,7 @@ b3d8ba2a-4799-4918-8c7a-9c5f0d6ee17e,Veysel Rıza Zarbun,Veysel Rıza Zarbun,,,,
 fdd92963-1e3a-4a88-aac6-5ebf8cd3d453,Yahya Kemal Beyatlı,Yahya Kemal Beyatlı,,,,Cumhuriyet Halk Partisi,CHP,area/urfa,Urfa,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/f/f4/Yahya_Kemal_Bey.jpg,male
 95f285e7-32e4-4fb0-bbc2-0e8497dffb82,Yakup Kadri Karaosmanoğlu,Yakup Kadri Karaosmanoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/mardin,Mardin,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/5/5e/Yakup_Kadri_Karaosmanoğlu.jpg,male
 23852149-e92f-46f9-b592-fa4075b2687e,Yunus Nadi Abalıoğlu,Yunus Nadi Abalıoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/menteşe_(muğla),Menteşe (Muğla),Grand National Assembly,2,,,,male
-c999f612-40a2-4233-91c4-1e64472f8ac2,Yusuf Akçora,Yusuf Akçora,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,2,,,,
+c999f612-40a2-4233-91c4-1e64472f8ac2,Yusuf Akçora,Yusuf Akçora,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/9/92/Yusuf_akcura.jpg,male
 f9d793a6-3dcb-4bf2-9b64-a9066d19932c,Yusuf Başkaya,Yusuf Başkaya,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,2,,,,male
 e382f965-bc25-42d6-be02-475f53c2a69e,Yusuf Kemal Tengirşenk,Yusuf Kemal Tengirşenk,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,2,,,,male
 c79d78b5-e33f-4496-82fe-1d9c8178ef59,Yusuf Ziya Başara,Yusuf Ziya Başara,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,2,,,,male
@@ -306,7 +306,7 @@ d3866b31-a12a-4673-8499-8090b21d7376,İhsan Hamit Tiğrel,İhsan Hamit Tiğrel,,
 03ceb289-7357-4d48-91aa-c579a66a65c2,İhsan Sökmen,İhsan Sökmen,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,2,,,,male
 30407a46-db45-481d-a328-c86d9962558a,İlyas Sami Muş,İlyas Sami Muş,,,,Cumhuriyet Halk Partisi,CHP,area/muş,Muş,Grand National Assembly,2,,,,
 2f138b29-b5c9-4ad2-8ae8-828ef661e3a4,İsmail Canbulat,İsmail Canbulat,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,2,,,,male
-b2ee4381-f5fe-48a0-a1e6-492fe3be14aa,İsmail Cevat Çobanlı,İsmail Cevat Çobanlı,,,,Cumhuriyet Halk Partisi,CHP,area/elaziz_(elazığ),Elaziz (Elazığ),Grand National Assembly,2,,,,
+b2ee4381-f5fe-48a0-a1e6-492fe3be14aa,İsmail Cevat Çobanlı,İsmail Cevat Çobanlı,,,,Cumhuriyet Halk Partisi,CHP,area/elaziz_(elazığ),Elaziz (Elazığ),Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/4/42/Cevat_Pasha.jpg,male
 6b17a79c-c2d0-4ed0-8b71-421f33a44bc8,İsmail Hakkı Erel,İsmail Hakkı Erel,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,2,,,,male
 4e7f14c4-1192-4331-a56c-468cbc82cdc3,İsmail Kemal Alpsar,İsmail Kemal Alpsar,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,2,,,https://upload.wikimedia.org/wikipedia/commons/a/a7/İsmail_Kemal_Bey_(Alpsar).jpg,male
 0019a4f1-9038-4170-b9e6-492bcfa4581d,İsmail Sabuncu,İsmail Sabuncu,,,,Cumhuriyet Halk Partisi,CHP,area/karahisar-ı_Şarki_(Şebinkarahisar),Karahisar-ı Şarki (Şebinkarahisar),Grand National Assembly,2,,,,male

--- a/data/Turkey/Assembly/term-20.csv
+++ b/data/Turkey/Assembly/term-20.csv
@@ -17,7 +17,7 @@ e16fe9e0-2aa8-4cdf-897d-c6b18540c485,Abdullah Gencer,Abdullah Gencer,,,,Refah Pa
 514d6688-9d10-40cd-a52c-04cf013d5c7b,Abdülbaki Ataç,Abdülbaki Ataç,,,,Doğru Yol Partisi,DYP,area/balıkesir,Balıkesir,Grand National Assembly,20,,,,
 47bdba76-56b8-4b38-a5ce-a91056875041,Abdülkadir Aksu,Abdülkadir Aksu,,,,Anavatan Partisi,ANAP,area/diyarbakır,Diyarbakır,Grand National Assembly,20,,,,male
 b4efcf77-a669-4397-b926-be83fdb6bc75,Abdülkadir Cenkçiler,Abdülkadir Cenkçiler,,,,Doğru Yol Partisi,DYP,area/bursa,Bursa,Grand National Assembly,20,,,,male
-ffdc2272-5e10-4851-b200-911ec1354d8e,Abdüllatif Şener,Abdüllatif Şener,,,,Refah Partisi,RP,area/sivas,Sivas,Grand National Assembly,20,,,https://upload.wikimedia.org/wikipedia/commons/b/b9/Abdullatif_Sener-edited.jpg,male
+ffdc2272-5e10-4851-b200-911ec1354d8e,Abdüllatif Şener,Abdüllatif Şener,,,,Refah Partisi,RP,area/sivas,Sivas,Grand National Assembly,20,,,,
 8bbbdcce-7624-4301-b421-b6cd0e7ab9ff,Adem Yıldız,Adem Yıldız,,,,Anavatan Partisi,ANAP,area/samsun,Samsun,Grand National Assembly,20,,,,
 2a306490-8436-412a-9b1c-79bdb63a7628,Adil Aşırım,Adil Aşırım,,,,Demokratik Sol Parti,DSP,area/iğdır,Iğdır,Grand National Assembly,20,,,,male
 9fb6bce8-1ae2-4932-b329-0c5dcbd04b92,Adnan Keskin,Adnan Keskin,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,20,,,,male
@@ -33,11 +33,11 @@ af601dec-cf50-42fa-b261-6ffd33d6e6e7,Ahmet Dökülmez,Ahmet Dökülmez,,,,Refah 
 1e10846e-d33f-4367-ad1a-4313a97e2427,Ahmet Esat Kıratlıoğlu,Ahmet Esat Kıratlıoğlu,,,,Doğru Yol Partisi,DYP,area/nevşehir,Nevşehir,Grand National Assembly,20,,,,
 63c586fa-4c5c-4e76-a02b-3c3e4e92f6f7,Ahmet Feyzi İnceöz,Ahmet Feyzi İnceöz,,,,Refah Partisi,RP,area/tokat,Tokat,Grand National Assembly,20,,,,
 1db41ede-6f52-4aae-9b25-b57142eb132d,Ahmet Güryüz Ketenci,Ahmet Güryüz Ketenci,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,20,,,,
-89f96507-7cd4-4442-8aa9-9f059775f8a4,Ahmet Hamdi Üçpınarlar,Ahmet Hamdi Üçpınarlar,,,,Doğru Yol Partisi,DYP,area/Çanakkale,Çanakkale,Grand National Assembly,20,,,,
+89f96507-7cd4-4442-8aa9-9f059775f8a4,Ahmet Hamdi Üçpınarlar,Ahmet Hamdi Üçpınarlar,,,,Doğru Yol Partisi,DYP,area/Çanakkale,Çanakkale,Grand National Assembly,20,,,,male
 2e287779-2279-4ea8-9e2e-3dae8d750a4e,Ahmet Kabil,Ahmet Kabil,,,,Anavatan Partisi,ANAP,area/ordu,Ordu,Grand National Assembly,20,,,,male
 fea611f9-9ff1-4794-b292-cadccae3b41c,Ahmet Karavar,Ahmet Karavar,,,,Refah Partisi,RP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,20,,,,
 d6bd540e-722f-41a8-83ea-e06b49e5053a,Ahmet Küçük,Ahmet Küçük,,,,Cumhuriyet Halk Partisi,CHP,area/Çanakkale,Çanakkale,Grand National Assembly,20,,,,male
-303d56c9-65c3-4b05-bc87-3f1425406a89,Ahmet Mesut Yılmaz,Ahmet Mesut Yılmaz,,,,Anavatan Partisi,ANAP,area/ordu,Ordu,Grand National Assembly,20,,,,
+303d56c9-65c3-4b05-bc87-3f1425406a89,Ahmet Mesut Yılmaz,Ahmet Mesut Yılmaz,,,,Anavatan Partisi,ANAP,area/ordu,Ordu,Grand National Assembly,20,,,,male
 dcdedc06-a5d8-4d49-90fd-3539dbef6faa,Ahmet Neidim,Ahmet Neidim,,,,Anavatan Partisi,ANAP,area/sakarya,Sakarya,Grand National Assembly,20,,,,male
 3921d1d0-780e-49e7-8d39-1c9b91c1e10b,Ahmet Nurettin Aydın,Ahmet Nurettin Aydın,,,,Refah Partisi,RP,area/samsun,Samsun,Grand National Assembly,20,,,,male
 41e63376-c776-47a2-87bb-d6d6fecbbec0,Ahmet Piriştina,Ahmet Piriştina,,,,Demokratik Sol Parti,DSP,area/İzmir,İzmir,Grand National Assembly,20,,,,male
@@ -103,7 +103,7 @@ a28257c8-017a-484f-ae3b-999c4af631c6,Burhan Kara,Burhan Kara,,,,Anavatan Partisi
 741e71ba-8649-4fe6-bb14-b131e10aea6f,Bülent Arınç,Bülent Arınç,,,,Refah Partisi,RP,area/manisa,Manisa,Grand National Assembly,20,,,https://upload.wikimedia.org/wikipedia/commons/3/3f/Bulent_Arinc.jpg,male
 77784419-d51e-4f5d-9630-a2dc13d67354,Bülent Atasayan,Bülent Atasayan,,,,Anavatan Partisi,ANAP,area/kocaeli,Kocaeli,Grand National Assembly,20,,,,
 c25b1f9d-9104-455b-9bc0-d9492cb16111,Bülent Ecevit,Bülent Ecevit,,,,Demokratik Sol Parti,DSP,area/İstanbul,İstanbul,Grand National Assembly,20,,,https://upload.wikimedia.org/wikipedia/commons/f/ff/Bülent_Ecevit-Davos_2000_cropped.jpg,male
-3d267c5d-d4a3-46e5-8f67-0aedccc14693,Bülent Tanla,Bülent Tanla,,,,Demokratik Sol Parti,DSP,area/İstanbul,İstanbul,Grand National Assembly,20,,,,
+3d267c5d-d4a3-46e5-8f67-0aedccc14693,Bülent Tanla,Bülent Tanla,,,,Demokratik Sol Parti,DSP,area/İstanbul,İstanbul,Grand National Assembly,20,,,,male
 ad698f06-82c0-4b0f-8aad-2cf5f1d8b97b,Cafer Güneş,Cafer Güneş,,,,Refah Partisi,RP,area/kırşehir,Kırşehir,Grand National Assembly,20,,,,
 7a1c2ac3-2f66-407f-a749-d268a9597906,Cafer Tufan Yazıcıoğlu,Cafer Tufan Yazıcıoğlu,,,,Demokratik Sol Parti,DSP,area/bartın,Bartın,Grand National Assembly,20,,,,
 ba96368b-e24c-4ee7-8690-d2b566fca3c8,Cavit Çağlar,Cavit Çağlar,,,,Doğru Yol Partisi,DYP,area/bursa,Bursa,Grand National Assembly,20,,,,male
@@ -120,13 +120,13 @@ abe19024-a773-46d4-949c-d109126b7361,Cemil Çiçek,Cemil Çiçek,,,,Anavatan Par
 4baeae11-2b1a-4cf4-ba61-8dc628831b5a,Cevat Ayhan,Cevat Ayhan,,,,Refah Partisi,RP,area/sakarya,Sakarya,Grand National Assembly,20,,,,
 184f9366-4b91-4916-a510-622ef1a4b8b8,Cevdet Akçalı,Cevdet Akçalı,,,,Refah Partisi,RP,area/adana,Adana,Grand National Assembly,20,,,,male
 b08042f8-182e-4521-918b-804235c7e5b2,Cevdet Aydın,Cevdet Aydın,,,,Doğru Yol Partisi,DYP,area/yalova,Yalova,Grand National Assembly,20,,,,
-8a37ad16-1842-43a4-ae37-fbe8b71d42c6,Cevdet Selvi,Cevdet Selvi,,,,Demokratik Sol Parti,DSP,area/İstanbul,İstanbul,Grand National Assembly,20,,,,
+8a37ad16-1842-43a4-ae37-fbe8b71d42c6,Cevdet Selvi,Cevdet Selvi,,,,Demokratik Sol Parti,DSP,area/İstanbul,İstanbul,Grand National Assembly,20,,,,male
 b504eaa9-4361-4542-9cfe-efb5d8934510,Demir Berberoğlu,Demir Berberoğlu,,,,Doğru Yol Partisi,DYP,area/eskişehir,Eskişehir,Grand National Assembly,20,,,,
 64644586-aaec-42b2-8a12-ca82928feeda,Deniz Baykal,Deniz Baykal,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,20,,,https://upload.wikimedia.org/wikipedia/commons/5/58/Deniz_Baykal_TBMM.jpg,male
 e47d06ae-4c22-4a1c-a076-27b7089251b3,Doğan Baran,Doğan Baran,,,,Doğru Yol Partisi,DYP,area/niğde,Niğde,Grand National Assembly,20,,,,
 190d339e-bf16-4ac6-b521-a827a4d3b10b,Doğan Güreş,Doğan Güreş,,,,Doğru Yol Partisi,DYP,area/kilis,Kilis,Grand National Assembly,20,,,,male
-8d75f83a-982a-45f4-aebf-a7316a52f7f5,Durmuş Fikri Sağlar,Durmuş Fikri Sağlar,,,,Cumhuriyet Halk Partisi,CHP,area/mersin,Mersin,Grand National Assembly,20,,,,
-35bd5b58-cff0-4a67-b57b-f73f8720ab5f,Edip Safder Gaydalı,Edip Safder Gaydalı,,,,Doğru Yol Partisi,DYP,area/bitlis,Bitlis,Grand National Assembly,20,,,,
+8d75f83a-982a-45f4-aebf-a7316a52f7f5,Durmuş Fikri Sağlar,Durmuş Fikri Sağlar,,,,Cumhuriyet Halk Partisi,CHP,area/mersin,Mersin,Grand National Assembly,20,,,,male
+35bd5b58-cff0-4a67-b57b-f73f8720ab5f,Edip Safder Gaydalı,Edip Safder Gaydalı,,,,Doğru Yol Partisi,DYP,area/bitlis,Bitlis,Grand National Assembly,20,,,,male
 668feb4a-73b2-4098-9a44-9d114d1c23c7,Ekrem Erdem,Ekrem Erdem,,,,Refah Partisi,RP,area/İstanbul,İstanbul,Grand National Assembly,20,,,,
 ca0d992d-fd09-4fd2-9589-3233dd531721,Ekrem Pakdemirli,Ekrem Pakdemirli,,,,Anavatan Partisi,ANAP,area/manisa,Manisa,Grand National Assembly,20,,,,
 1e7f445d-53ad-41ea-b416-c8f0996e6b55,Emin Karaa,Emin Karaa,,,,Demokratik Sol Parti,DSP,area/kütahya,Kütahya,Grand National Assembly,20,,,,male
@@ -267,19 +267,19 @@ b5dfe1ae-0184-4b4c-9fe8-05b7f806270e,Mehmet Fuat Fırat,Mehmet Fuat Fırat,,,,Re
 9ee5e614-7315-41d9-83b2-8d84d19a2bc2,Mehmet Gölhan,Mehmet Gölhan,,,,Doğru Yol Partisi,DYP,area/ankara,Ankara,Grand National Assembly,20,,,,male
 1cac2246-ec02-4152-8cd0-fef03abb8180,Mehmet Gözlükaya,Mehmet Gözlükaya,,,,Doğru Yol Partisi,DYP,area/denizli,Denizli,Grand National Assembly,20,,,,male
 4e4b4fdc-275d-408d-917c-72c0fe6effa4,Mehmet Halit Dağlı,Mehmet Halit Dağlı,,,,Doğru Yol Partisi,DYP,area/adana,Adana,Grand National Assembly,20,,,,
-1a2f06e6-f419-490e-ae2d-520222842a95,Mehmet Kemal Ağar,Mehmet Kemal Ağar,,,,Doğru Yol Partisi,DYP,area/elazığ,Elazığ,Grand National Assembly,20,,,,
+1a2f06e6-f419-490e-ae2d-520222842a95,Mehmet Kemal Ağar,Mehmet Kemal Ağar,,,,Doğru Yol Partisi,DYP,area/elazığ,Elazığ,Grand National Assembly,20,,,,male
 b36afa76-d8f7-40d5-9bcb-c1f4a0f33b9f,Mehmet Keçeciler,Mehmet Keçeciler,,,,Anavatan Partisi,ANAP,area/konya,Konya,Grand National Assembly,20,,,,male
 a4ef5540-a70e-4083-8ae7-e72bf11fd3f4,Mehmet Korkmaz,Mehmet Korkmaz,,,,Demokratik Türkiye Partisi,DTP,area/kütahya,Kütahya,Grand National Assembly,20,,,,
 ccf2e954-f5da-4730-8aa7-fcaa291838bc,Mehmet Köstepen,Mehmet Köstepen,,,,Doğru Yol Partisi,DYP,area/İzmir,İzmir,Grand National Assembly,20,,,,male
 6b0042c2-b599-421e-8de6-da3e711c5b07,Mehmet Moğultay,Mehmet Moğultay,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,20,,,,male
 add873e6-fd60-4ee4-8b42-b4f1c5b14006,Mehmet Necati Çetinkaya,Mehmet Necati Çetinkaya,,,,Doğru Yol Partisi,DYP,area/konya,Konya,Grand National Assembly,20,,,,male
-01b10bd7-2ba2-4d1f-b797-4952863baff5,Mehmet Recai Kutan,Mehmet Recai Kutan,,,,Refah Partisi,RP,area/malatya,Malatya,Grand National Assembly,20,,,,
+01b10bd7-2ba2-4d1f-b797-4952863baff5,Mehmet Recai Kutan,Mehmet Recai Kutan,,,,Refah Partisi,RP,area/malatya,Malatya,Grand National Assembly,20,,,https://upload.wikimedia.org/wikipedia/commons/d/d9/Recai_Kutan_2009_crop.jpg,male
 f0524a9e-ab63-4844-a3ea-be3ff79b8671,Mehmet Sabri Güner,Mehmet Sabri Güner,,,,Doğru Yol Partisi,DYP,area/kars,Kars,Grand National Assembly,20,,,,male
 3e603ddf-e1e6-4ba4-b7ae-094fa2eaa9ac,Mehmet Salih Katırcıoğlu,Mehmet Salih Katırcıoğlu,,,,Refah Partisi,RP,area/niğde,Niğde,Grand National Assembly,20,,,,
 e66af0ef-590d-4104-86e6-bd3cbd0f8d48,Mehmet Salih Yıldırım,Mehmet Salih Yıldırım,,,,Anavatan Partisi,ANAP,area/Şırnak,Şırnak,Grand National Assembly,20,,,,male
 f0cdb999-67a8-4ff5-a41f-3e4c6961dc64,Mehmet Sağdıç,Mehmet Sağdıç,,,,Anavatan Partisi,ANAP,area/ankara,Ankara,Grand National Assembly,20,,,,male
 c8f11a41-0297-4d7c-a7fe-4c37cdf7f6fd,Mehmet Sağlam,Mehmet Sağlam,,,,Doğru Yol Partisi,DYP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,20,,,,male
-bf35c68a-f6b1-43ce-9316-8bde4cbb5a06,Mehmet Selim Ensarioğlu,Mehmet Selim Ensarioğlu,,,,Doğru Yol Partisi,DYP,area/diyarbakır,Diyarbakır,Grand National Assembly,20,,,,
+bf35c68a-f6b1-43ce-9316-8bde4cbb5a06,Mehmet Selim Ensarioğlu,Mehmet Selim Ensarioğlu,,,,Doğru Yol Partisi,DYP,area/diyarbakır,Diyarbakır,Grand National Assembly,20,,,,male
 7cf37c40-8ca2-4fb0-bdf8-f8f590406c7a,Mehmet Sevigen,Mehmet Sevigen,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,20,,,,male
 e8c5b596-d745-44c7-a8ac-817fd85fe17f,Mehmet Sılay,Mehmet Sılay,,,,Refah Partisi,RP,area/hatay,Hatay,Grand National Assembly,20,,,,male
 05291fa1-285b-41c6-ad82-ca46a8c20b40,Mehmet Tatar,Mehmet Tatar,,,,Doğru Yol Partisi,DYP,area/Şırnak,Şırnak,Grand National Assembly,20,,,,male
@@ -296,7 +296,7 @@ f6e36681-0740-460d-ad70-4a87deb690c0,Metin Gürdere,Metin Gürdere,,,,Anavatan P
 f61440bd-8ec4-417d-8116-e1a5faafa10d,Metin Işık,Metin Işık,,,,Refah Partisi,RP,area/İstanbul,İstanbul,Grand National Assembly,20,,,,male
 cbd738d8-a280-4d87-b476-a7fd16c0f177,Metin Perli,Metin Perli,,,,Refah Partisi,RP,area/kütahya,Kütahya,Grand National Assembly,20,,,,
 dadba235-a48e-492e-8700-48633fb44040,Metin Öney,Metin Öney,,,,Anavatan Partisi,ANAP,area/İzmir,İzmir,Grand National Assembly,20,,,,male
-64062a77-60a7-41fd-aa4f-4a46d0a1ae7e,Metin Şahin,Metin Şahin,,,,Demokratik Sol Parti,DSP,area/antalya,Antalya,Grand National Assembly,20,,,,
+64062a77-60a7-41fd-aa4f-4a46d0a1ae7e,Metin Şahin,Metin Şahin,,,,Demokratik Sol Parti,DSP,area/antalya,Antalya,Grand National Assembly,20,,,,male
 a7b6ef42-32e5-4009-bcab-1b14081a3522,Mikail Korkmaz,Mikail Korkmaz,,,,Refah Partisi,RP,area/kırıkkale,Kırıkkale,Grand National Assembly,20,,,,
 58ca6f4a-1373-4170-8d21-ee22a2fb0161,Miraç Akdoğan,Miraç Akdoğan,,,,Anavatan Partisi,ANAP,area/malatya,Malatya,Grand National Assembly,20,,,,
 71c519b1-612f-4ad9-9708-473dbda3de3e,Muhammet Polat,Muhammet Polat,,,,Refah Partisi,RP,area/aydın,Aydın,Grand National Assembly,20,,,,
@@ -341,13 +341,13 @@ ed5ce3a4-00af-46bb-95b9-532a1af87538,Mustafa İstemihan Talay,Mustafa İstemihan
 b96a9b99-8fbc-41c1-a265-4f0c8b0a1313,Muzaffer Arslan,Muzaffer Arslan,,,,Anavatan Partisi,ANAP,area/diyarbakır,Diyarbakır,Grand National Assembly,20,,,,
 d363485b-2940-4977-924e-5fc6aa417c8c,Muzaffer Arıkan,Muzaffer Arıkan,,,,Doğru Yol Partisi,DYP,area/mardin,Mardin,Grand National Assembly,20,,,,
 4cf939a8-3d16-4e56-8435-d98059e47f27,Müjdat Koç,Müjdat Koç,,,,Demokratik Sol Parti,DSP,area/ordu,Ordu,Grand National Assembly,20,,,,
-b818f8d3-c869-4224-90e5-6b15554eb23b,Mümtaz Soysal,Mümtaz Soysal,,,,Demokratik Sol Parti,DSP,area/zonguldak,Zonguldak,Grand National Assembly,20,,,,male
+b818f8d3-c869-4224-90e5-6b15554eb23b,Mümtaz Soysal,Mümtaz Soysal,,,,Demokratik Sol Parti,DSP,area/zonguldak,Zonguldak,Grand National Assembly,20,,,,
 06324fe4-704c-4ef6-a41b-9978fb3a345b,Nabi Poyraz,Nabi Poyraz,,,,Anavatan Partisi,ANAP,area/ordu,Ordu,Grand National Assembly,20,,,,male
 ff067b9d-ae95-4524-aa58-4976f0a669f6,Naci Terzi,Naci Terzi,,,,Refah Partisi,RP,area/erzincan,Erzincan,Grand National Assembly,20,,,,
 8a116fae-99da-4495-9d39-4dc7f0946311,Nafiz Kurt,Nafiz Kurt,,,,Doğru Yol Partisi,DYP,area/samsun,Samsun,Grand National Assembly,20,,,,
 99457c11-8d91-4962-8929-a256866f56c3,Nahit Menteşe,Nahit Menteşe,,,,Doğru Yol Partisi,DYP,area/aydın,Aydın,Grand National Assembly,20,,,,male
 6fb96a52-dd66-4a6c-a024-9a6197b710fd,Naim Geylani,Naim Geylani,,,,Anavatan Partisi,ANAP,area/hakkâri,Hakkâri,Grand National Assembly,20,,,,
-5647f7d4-688e-4a0c-a90d-067299330465,Nami Çağan,Nami Çağan,,,,Demokratik Sol Parti,DSP,area/İstanbul,İstanbul,Grand National Assembly,20,,,,
+5647f7d4-688e-4a0c-a90d-067299330465,Nami Çağan,Nami Çağan,,,,Demokratik Sol Parti,DSP,area/İstanbul,İstanbul,Grand National Assembly,20,,,,male
 1d0f9841-ff81-4966-bc20-8183ce336b3c,Namık Kemal Zeybek,Namık Kemal Zeybek,,,,Doğru Yol Partisi,DYP,area/İstanbul,İstanbul,Grand National Assembly,20,,,,male
 2f205f08-fd59-47db-9891-c68b0156c5b9,Necati Albay,Necati Albay,,,,Demokratik Sol Parti,DSP,area/eskişehir,Eskişehir,Grand National Assembly,20,,,,male
 41162910-44ec-46c6-838f-afbf43f9637b,Necati Güllülü,Necati Güllülü,,,,Anavatan Partisi,ANAP,area/erzurum,Erzurum,Grand National Assembly,20,,,,male
@@ -411,10 +411,10 @@ f0140c12-cc3a-40eb-b664-5e99ce191f7d,Salih Kapusuz,Salih Kapusuz,,,,Refah Partis
 13e6d0d2-ce0a-47dd-8b08-1c178dbfea9b,Salih Sümer,Salih Sümer,,,,Doğru Yol Partisi,DYP,area/diyarbakır,Diyarbakır,Grand National Assembly,20,,,,male
 6ba8ebf2-10c4-43e7-a02d-3388edbb193f,Sami Küçükbaşkan,Sami Küçükbaşkan,,,,Anavatan Partisi,ANAP,area/antalya,Antalya,Grand National Assembly,20,,,,
 b810bf5c-6a76-40de-a99d-0aba0731c8f1,Sebğatullah Seydaoğlu,Sebğatullah Seydaoğlu,,,,Anavatan Partisi,ANAP,area/diyarbakır,Diyarbakır,Grand National Assembly,20,,,,
-bb75fba4-df5e-4ce1-afb3-4257a6bc4ecc,Sedat Aloğlu,Sedat Aloğlu,,,,Doğru Yol Partisi,DYP,area/İstanbul,İstanbul,Grand National Assembly,20,,,,
-96ede054-2b11-4a60-ba8d-5d6a7f05e588,Sedat Edip Bucak,Sedat Edip Bucak,,,,Doğru Yol Partisi,DYP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,20,,,,
+bb75fba4-df5e-4ce1-afb3-4257a6bc4ecc,Sedat Aloğlu,Sedat Aloğlu,,,,Doğru Yol Partisi,DYP,area/İstanbul,İstanbul,Grand National Assembly,20,,,,male
+96ede054-2b11-4a60-ba8d-5d6a7f05e588,Sedat Edip Bucak,Sedat Edip Bucak,,,,Doğru Yol Partisi,DYP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,20,,,,male
 933b02c0-2d6f-42a7-bd12-db562cc25426,Sema Pişkinsüt,Sema Pişkinsüt,,,,Demokratik Sol Parti,DSP,area/aydın,Aydın,Grand National Assembly,20,,,,female
-40853043-aeb9-4a52-8527-879945833044,Seyfi Oktay,Seyfi Oktay,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,20,,,,
+40853043-aeb9-4a52-8527-879945833044,Seyfi Oktay,Seyfi Oktay,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,20,,,,male
 100747b9-b422-4492-97b0-fce005dc16a6,Seyit Eyyüpoğlu,Seyit Eyyüpoğlu,,,,Anavatan Partisi,ANAP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,20,,,,male
 51cfe7ac-05ca-43e9-8a60-c99cd0294adc,Seyyit Haşim Haşimi,Seyyit Haşim Haşimi,,,,Refah Partisi,RP,area/diyarbakır,Diyarbakır,Grand National Assembly,20,,,,
 2a4d0ed5-3022-4ce6-8a00-2bac4ad983b1,Suat Pamukçu,Suat Pamukçu,,,,Refah Partisi,RP,area/bayburt,Bayburt,Grand National Assembly,20,,,,
@@ -422,7 +422,7 @@ bb75fba4-df5e-4ce1-afb3-4257a6bc4ecc,Sedat Aloğlu,Sedat Aloğlu,,,,Doğru Yol P
 5ed81f1f-7ce4-4749-ad24-bd7c578c00da,Süleyman Arif Emre,Süleyman Arif Emre,,,,Refah Partisi,RP,area/İstanbul,İstanbul,Grand National Assembly,20,,,,male
 fc085f1e-1a52-4b93-9845-d04e6adf519d,Süleyman Hatinoğlu,Süleyman Hatinoğlu,,,,Anavatan Partisi,ANAP,area/artvin,Artvin,Grand National Assembly,20,,,,male
 bdd30e49-d991-4cd9-8a9c-2da0daf02ff5,Süleyman Metin Kalkan,Süleyman Metin Kalkan,,,,Refah Partisi,RP,area/hatay,Hatay,Grand National Assembly,20,,,,
-78d335b5-de60-44e5-93fb-2d0eb1c8acc3,Süleyman Çelebi,Süleyman Çelebi,,,,Anavatan Partisi,ANAP,area/mardin,Mardin,Grand National Assembly,20,,,,
+78d335b5-de60-44e5-93fb-2d0eb1c8acc3,Süleyman Çelebi,Süleyman Çelebi,,,,Anavatan Partisi,ANAP,area/mardin,Mardin,Grand National Assembly,20,,,,male
 9f86b9c6-e495-45bd-9e82-56e03540d6fe,Sümer Oral,Sümer Oral,,,,Anavatan Partisi,ANAP,area/manisa,Manisa,Grand National Assembly,20,,,,
 4e2837dc-ebc0-48fd-9fab-ee1cc90ae2cc,Sıddık Altay,Sıddık Altay,,,,Refah Partisi,RP,area/ağrı,Ağrı,Grand National Assembly,20,,,,
 ba32cbe0-7167-42f4-9639-f628d0b984fb,Sıtkı Cengil,Sıtkı Cengil,,,,Refah Partisi,RP,area/adana,Adana,Grand National Assembly,20,,,,

--- a/data/Turkey/Assembly/term-21.csv
+++ b/data/Turkey/Assembly/term-21.csv
@@ -10,7 +10,7 @@ e48e5e76-3f17-4607-8bc9-493221bd4668,Abdullah Veli Seyda,Abdullah Veli Seyda,,,,
 739c720c-9c36-446e-9198-1ba498881b59,Abdurrahman Küçük,Abdurrahman Küçük,,,,Milliyetçi Hareket Partisi,MHP,area/ankara,Ankara,Grand National Assembly,21,,,,
 a91b14a0-1849-471f-b699-01af15b88e06,Abdülkadir Akcan,Abdülkadir Akcan,,,,Milliyetçi Hareket Partisi,MHP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,21,,,,
 47bdba76-56b8-4b38-a5ce-a91056875041,Abdülkadir Aksu,Abdülkadir Aksu,,,,Fazilet Partisi,FP,area/İstanbul,İstanbul,Grand National Assembly,21,,,,male
-ffdc2272-5e10-4851-b200-911ec1354d8e,Abdüllatif Şener,Abdüllatif Şener,,,,Fazilet Partisi,FP,area/sivas,Sivas,Grand National Assembly,21,,,https://upload.wikimedia.org/wikipedia/commons/b/b9/Abdullatif_Sener-edited.jpg,male
+ffdc2272-5e10-4851-b200-911ec1354d8e,Abdüllatif Şener,Abdüllatif Şener,,,,Fazilet Partisi,FP,area/sivas,Sivas,Grand National Assembly,21,,,,
 511829b4-313e-4cb0-9744-1016df0281ea,Adanan Uçaş,Adanan Uçaş,,,,Milliyetçi Hareket Partisi,MHP,area/amasya,Amasya,Grand National Assembly,21,,,,
 8284a984-3b1f-4dc1-bbcd-4b71e75c4052,Adnan Fatin Özdemir,Adnan Fatin Özdemir,,,,Milliyetçi Hareket Partisi,MHP,area/adana,Adana,Grand National Assembly,21,,,,
 608f680c-cbf9-451a-8064-250ffbf3a6dc,Agah Oktay Güner,Agah Oktay Güner,,,,Anavatan Partisi,ANAP,area/balıkesir,Balıkesir,Grand National Assembly,21,,,,
@@ -24,7 +24,7 @@ ea829c54-abc5-4e1b-8440-8fb18f65be28,Ahmet Derin,Ahmet Derin,,,,Fazilet Partisi,
 2e287779-2279-4ea8-9e2e-3dae8d750a4e,Ahmet Kabil,Ahmet Kabil,,,,Anavatan Partisi,ANAP,area/rize,Rize,Grand National Assembly,21,,,,male
 fea611f9-9ff1-4794-b292-cadccae3b41c,Ahmet Karavar,Ahmet Karavar,,,,Fazilet Partisi,FP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,21,,,,
 926ecdf7-d4be-4062-9f0d-732803f97264,Ahmet Kenan Tanrıkulu,Ahmet Kenan Tanrıkulu,,,,Milliyetçi Hareket Partisi,MHP,area/İzmir,İzmir,Grand National Assembly,21,,,,male
-303d56c9-65c3-4b05-bc87-3f1425406a89,Ahmet Mesut Yılmaz,Ahmet Mesut Yılmaz,,,,Anavatan Partisi,ANAP,area/rize,Rize,Grand National Assembly,21,,,,
+303d56c9-65c3-4b05-bc87-3f1425406a89,Ahmet Mesut Yılmaz,Ahmet Mesut Yılmaz,,,,Anavatan Partisi,ANAP,area/rize,Rize,Grand National Assembly,21,,,,male
 3921d1d0-780e-49e7-8d39-1c9b91c1e10b,Ahmet Nurettin Aydın,Ahmet Nurettin Aydın,,,,Fazilet Partisi,FP,area/siirt,Siirt,Grand National Assembly,21,,,,male
 ac342395-e79a-413f-b204-260fb2f2ff42,Ahmet Sancar Sayın,Ahmet Sancar Sayın,,,,Demokratik Sol Parti,DSP,area/antalya,Antalya,Grand National Assembly,21,,,,
 d1bee377-9f58-42b0-a06b-f4dc34911248,Ahmet Sünnetçioğlu,Ahmet Sünnetçioğlu,,,,Fazilet Partisi,FP,area/bursa,Bursa,Grand National Assembly,21,,,,
@@ -70,7 +70,7 @@ b13608d2-0ee8-479b-a33c-9534a4f556b8,Ataullah Hamidi,Ataullah Hamidi,,,,Anavatan
 c77a670b-44b2-4664-9cf7-9629aae3a754,Atilla Mutman,Atilla Mutman,,,,Demokratik Sol Parti,DSP,area/İzmir,İzmir,Grand National Assembly,21,,,,
 8ea08de7-6d6f-4a0b-a0f8-9a6cc55b0479,Avni Akyol,Avni Akyol,,,,Anavatan Partisi,ANAP,area/bolu,Bolu,Grand National Assembly,21,,,,
 9e737a65-fabf-47bf-ade4-5783d21adcdc,Avni Doğan,Avni Doğan,,,,Fazilet Partisi,FP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,21,,,,
-d0e5894b-b8b2-4991-84bf-985391d26a63,Aydın Ağan Ayaydın,Aydın Ağan Ayaydın,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,21,,,,
+d0e5894b-b8b2-4991-84bf-985391d26a63,Aydın Ağan Ayaydın,Aydın Ağan Ayaydın,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,21,,,,male
 26c2abc4-cc09-4f27-9155-58f916b65418,Aydın Gökmen,Aydın Gökmen,,,,Milliyetçi Hareket Partisi,MHP,area/balıkesir,Balıkesir,Grand National Assembly,21,,,,
 2c5ccb5e-2451-4a21-93ff-32c4259a3e54,Aydın Menderes,Aydın Menderes,,,,Fazilet Partisi,FP,area/İstanbul,İstanbul,Grand National Assembly,21,,,,male
 2c543c00-d4ee-43ad-831d-34531b4924cf,Aydın Tümen,Aydın Tümen,,,,Demokratik Sol Parti,DSP,area/ankara,Ankara,Grand National Assembly,21,,,,male
@@ -78,7 +78,7 @@ d0e5894b-b8b2-4991-84bf-985391d26a63,Aydın Ağan Ayaydın,Aydın Ağan Ayaydın
 4cf9015a-5ffb-42c2-a701-2a6167344296,Ayhan Çevik,Ayhan Çevik,,,,Milliyetçi Hareket Partisi,MHP,area/van,Van,Grand National Assembly,21,,,,
 e7bfce37-6064-4eca-ba8b-c94e8a0549ab,Ayvaz Gökdemir,Ayvaz Gökdemir,,,,Doğru Yol Partisi,DYP,area/erzurum,Erzurum,Grand National Assembly,21,,,,male
 eda5b717-dbc3-4c62-a81c-1c4a02c659bb,Ayşe Gürocak,Ayşe Gürocak,,,,Demokratik Sol Parti,DSP,area/ankara,Ankara,Grand National Assembly,21,,,,
-e3593d74-d206-4fac-aee7-70bd478fca78,Ayşe Nazlı Ilıcak,Ayşe Nazlı Ilıcak,,,,Fazilet Partisi,FP,area/İstanbul,İstanbul,Grand National Assembly,21,,,,
+e3593d74-d206-4fac-aee7-70bd478fca78,Ayşe Nazlı Ilıcak,Ayşe Nazlı Ilıcak,,,,Fazilet Partisi,FP,area/İstanbul,İstanbul,Grand National Assembly,21,,,,female
 8f2ea96e-3fa0-48ba-97bc-ebbb5c121990,Azmi Ateş,Azmi Ateş,,,,Fazilet Partisi,FP,area/İstanbul,İstanbul,Grand National Assembly,21,,,,
 6093b146-f262-46ea-a0b1-9d33863e26bd,Bahri Sipahi,Bahri Sipahi,,,,Demokratik Sol Parti,DSP,area/İstanbul,İstanbul,Grand National Assembly,21,,,,
 579dccb5-2eb5-46b6-a68f-4128e265a888,Bahri Zengin,Bahri Zengin,,,,Fazilet Partisi,FP,area/İstanbul,İstanbul,Grand National Assembly,21,,,,
@@ -119,7 +119,7 @@ abe19024-a773-46d4-949c-d109126b7361,Cemil Çiçek,Cemil Çiçek,,,,Fazilet Part
 e0c3d800-3dc6-477f-8b78-18d8a8760bf6,Devlet Bahçeli,Devlet Bahçeli,,,,Milliyetçi Hareket Partisi,MHP,area/osmaniye,Osmaniye,Grand National Assembly,21,,,https://upload.wikimedia.org/wikipedia/commons/e/e9/Devlet_Bahçeli_TBMM.jpg,male
 e47d06ae-4c22-4a1c-a076-27b7089251b3,Doğan Baran,Doğan Baran,,,,Doğru Yol Partisi,DYP,area/niğde,Niğde,Grand National Assembly,21,,,,
 190d339e-bf16-4ac6-b521-a827a4d3b10b,Doğan Güreş,Doğan Güreş,,,,Doğru Yol Partisi,DYP,area/kilis,Kilis,Grand National Assembly,21,,,,male
-35bd5b58-cff0-4a67-b57b-f73f8720ab5f,Edip Safder Gaydalı,Edip Safder Gaydalı,,,,Anavatan Partisi,ANAP,area/bitlis,Bitlis,Grand National Assembly,21,,,,
+35bd5b58-cff0-4a67-b57b-f73f8720ab5f,Edip Safder Gaydalı,Edip Safder Gaydalı,,,,Anavatan Partisi,ANAP,area/bitlis,Bitlis,Grand National Assembly,21,,,,male
 3da95bbd-9910-40b0-bb14-f00cf610615a,Edip Özbaş,Edip Özbaş,,,,Milliyetçi Hareket Partisi,MHP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,21,,,,
 45efbf35-859e-4499-a34d-26602d7e8ea8,Edip Özgenç,Edip Özgenç,,,,Demokratik Sol Parti,DSP,area/mersin,Mersin,Grand National Assembly,21,,,,male
 e411b312-ec95-408c-8842-18bea798f36c,Ediz Hun,Ediz Hun,,,,Anavatan Partisi,ANAP,area/İstanbul,İstanbul,Grand National Assembly,21,,,,male
@@ -267,7 +267,7 @@ e823c117-3678-487b-bd87-5fe940af339b,Mehmet Güneş,Mehmet Güneş,,,,Anavatan P
 4e4b4fdc-275d-408d-917c-72c0fe6effa4,Mehmet Halit Dağlı,Mehmet Halit Dağlı,,,,Doğru Yol Partisi,DYP,area/adana,Adana,Grand National Assembly,21,,,,
 82d94bda-a56a-4390-abf8-9f9b8c258aa2,Mehmet Hanifi Tiryaki,Mehmet Hanifi Tiryaki,,,,Milliyetçi Hareket Partisi,MHP,area/gaziantep,Gaziantep,Grand National Assembly,21,,,,
 5204897a-ca1d-4e7a-83f3-b7e9811e340c,Mehmet Kaya,Mehmet Kaya,,,,Milliyetçi Hareket Partisi,MHP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,21,,,,
-1a2f06e6-f419-490e-ae2d-520222842a95,Mehmet Kemal Ağar,Mehmet Kemal Ağar,,,,Bağımsız,ind,area/elazığ,Elazığ,Grand National Assembly,21,,,,
+1a2f06e6-f419-490e-ae2d-520222842a95,Mehmet Kemal Ağar,Mehmet Kemal Ağar,,,,Bağımsız,ind,area/elazığ,Elazığ,Grand National Assembly,21,,,,male
 b36afa76-d8f7-40d5-9bcb-c1f4a0f33b9f,Mehmet Keçeciler,Mehmet Keçeciler,,,,Anavatan Partisi,ANAP,area/konya,Konya,Grand National Assembly,21,,,,male
 b6245fad-fd3f-4c44-977e-93b130c9a5b8,Mehmet Kocabatmaz,Mehmet Kocabatmaz,,,,Demokratik Sol Parti,DSP,area/denizli,Denizli,Grand National Assembly,21,,,,male
 2a04de4a-028c-46dc-87dc-fd0537e931b6,Mehmet Kundakcı,Mehmet Kundakcı,,,,Milliyetçi Hareket Partisi,MHP,area/osmaniye,Osmaniye,Grand National Assembly,21,,,,
@@ -277,12 +277,12 @@ b6245fad-fd3f-4c44-977e-93b130c9a5b8,Mehmet Kocabatmaz,Mehmet Kocabatmaz,,,,Demo
 add873e6-fd60-4ee4-8b42-b4f1c5b14006,Mehmet Necati Çetinkaya,Mehmet Necati Çetinkaya,,,,Doğru Yol Partisi,DYP,area/manisa,Manisa,Grand National Assembly,21,,,,male
 e71d1757-3e48-44b4-b336-628f8bf10b40,Mehmet Nuri Tarhan,Mehmet Nuri Tarhan,,,,Milliyetçi Hareket Partisi,MHP,area/hatay,Hatay,Grand National Assembly,21,,,,
 c7eb72a1-ef8e-49c9-8e5c-cac54fe2222e,Mehmet Pak,Mehmet Pak,,,,Milliyetçi Hareket Partisi,MHP,area/İstanbul,İstanbul,Grand National Assembly,21,,,,
-01b10bd7-2ba2-4d1f-b797-4952863baff5,Mehmet Recai Kutan,Mehmet Recai Kutan,,,,Fazilet Partisi,FP,area/malatya,Malatya,Grand National Assembly,21,,,,
+01b10bd7-2ba2-4d1f-b797-4952863baff5,Mehmet Recai Kutan,Mehmet Recai Kutan,,,,Fazilet Partisi,FP,area/malatya,Malatya,Grand National Assembly,21,,,https://upload.wikimedia.org/wikipedia/commons/d/d9/Recai_Kutan_2009_crop.jpg,male
 1f19b84f-a760-46fa-8c73-d3ce1d428108,Mehmet Sadri Yıldırım,Mehmet Sadri Yıldırım,,,,Doğru Yol Partisi,DYP,area/eskişehir,Eskişehir,Grand National Assembly,21,,,,
 430f19e0-5c8e-4b55-a4b3-34cf541c984c,Mehmet Sait Değer,Mehmet Sait Değer,,,,Doğru Yol Partisi,DYP,area/Şırnak,Şırnak,Grand National Assembly,21,,,,
 e66af0ef-590d-4104-86e6-bd3cbd0f8d48,Mehmet Salih Yıldırım,Mehmet Salih Yıldırım,,,,Anavatan Partisi,ANAP,area/Şırnak,Şırnak,Grand National Assembly,21,,,,male
 c8f11a41-0297-4d7c-a7fe-4c37cdf7f6fd,Mehmet Sağlam,Mehmet Sağlam,,,,Doğru Yol Partisi,DYP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,21,,,,male
-bf35c68a-f6b1-43ce-9316-8bde4cbb5a06,Mehmet Selim Ensarioğlu,Mehmet Selim Ensarioğlu,,,,Doğru Yol Partisi,DYP,area/diyarbakır,Diyarbakır,Grand National Assembly,21,,,,
+bf35c68a-f6b1-43ce-9316-8bde4cbb5a06,Mehmet Selim Ensarioğlu,Mehmet Selim Ensarioğlu,,,,Doğru Yol Partisi,DYP,area/diyarbakır,Diyarbakır,Grand National Assembly,21,,,,male
 eec6a00e-053a-4d14-92ce-28d4bfe44cb4,Mehmet Serdaroğlu,Mehmet Serdaroğlu,,,,Milliyetçi Hareket Partisi,MHP,area/kastamonu,Kastamonu,Grand National Assembly,21,,,,
 bf5f0718-0e81-4043-9963-b9ab6d42d70f,Mehmet Tahir Köse,Mehmet Tahir Köse,,,,Demokratik Sol Parti,DSP,area/İstanbul,İstanbul,Grand National Assembly,21,,,,
 5b691eea-8314-469b-b821-ded70307257a,Mehmet Telek,Mehmet Telek,,,,Milliyetçi Hareket Partisi,MHP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,21,,,,
@@ -290,7 +290,7 @@ dc9f0693-d0bb-4c1e-9cf9-88dc37f985e8,Mehmet Vecdi Gönül,Mehmet Vecdi Gönül,,
 ce32119d-43b4-4cf3-a145-828f845b890f,Mehmet Yalçınkaya,Mehmet Yalçınkaya,,,,Doğru Yol Partisi,DYP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,21,,,,
 15e32701-ef93-401a-9ef2-e93b34439055,Mehmet Yaşar Ünal,Mehmet Yaşar Ünal,,,,Demokratik Sol Parti,DSP,area/uşak,Uşak,Grand National Assembly,21,,,,
 c8d57e4c-b7b0-46ea-a5bc-c4516ec53f3e,Mehmet Zeki Okudan,Mehmet Zeki Okudan,,,,Fazilet Partisi,FP,area/antalya,Antalya,Grand National Assembly,21,,,,
-c1e74b88-9ea5-47ae-b2b9-e89d86863fcc,Mehmet Zeki Sezer,Mehmet Zeki Sezer,,,,Demokratik Sol Parti,DSP,area/ankara,Ankara,Grand National Assembly,21,,,,
+c1e74b88-9ea5-47ae-b2b9-e89d86863fcc,Mehmet Zeki Sezer,Mehmet Zeki Sezer,,,,Demokratik Sol Parti,DSP,area/ankara,Ankara,Grand National Assembly,21,,,https://upload.wikimedia.org/wikipedia/commons/0/0c/Zeki_Sezer-edited.jpg,male
 1f54705e-e001-487d-bb6a-02d43d9b54db,Mehmet Zeki Çelik,Mehmet Zeki Çelik,,,,Fazilet Partisi,FP,area/ankara,Ankara,Grand National Assembly,21,,,,
 b59cc037-ee74-4ddf-a7ce-9c54a5d9711e,Mehmet Çakar,Mehmet Çakar,,,,Anavatan Partisi,ANAP,area/samsun,Samsun,Grand National Assembly,21,,,,
 50bc65fa-f944-44ff-8ea4-b8d0c8d351f1,Mehmet Çiçek,Mehmet Çiçek,,,,Fazilet Partisi,FP,area/yozgat,Yozgat,Grand National Assembly,21,,,,male
@@ -306,7 +306,7 @@ b3167c88-c0ce-4355-afc0-07185498208c,Meral Akşener,Meral Akşener,,,,Doğru Yol
 b3f6e6f8-f396-486f-b385-2febdda0cb4f,Metin Ergun,Metin Ergun,,,,Milliyetçi Hareket Partisi,MHP,area/muğla,Muğla,Grand National Assembly,21,,,,
 730a0f6e-b151-4e37-aa93-120bcff05894,Metin Kocabaş,Metin Kocabaş,,,,Doğru Yol Partisi,DYP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,21,,,,
 ba4f4870-e09c-4080-9501-af17da3fe66e,Metin Musaoğlu,Metin Musaoğlu,,,,Doğru Yol Partisi,DYP,area/mardin,Mardin,Grand National Assembly,21,,,,male
-64062a77-60a7-41fd-aa4f-4a46d0a1ae7e,Metin Şahin,Metin Şahin,,,,Demokratik Sol Parti,DSP,area/antalya,Antalya,Grand National Assembly,21,,,,
+64062a77-60a7-41fd-aa4f-4a46d0a1ae7e,Metin Şahin,Metin Şahin,,,,Demokratik Sol Parti,DSP,area/antalya,Antalya,Grand National Assembly,21,,,,male
 a004cc19-8349-4e4e-a407-2b1bbdec951f,Mihrali Aksu,Mihrali Aksu,,,,Milliyetçi Hareket Partisi,MHP,area/erzincan,Erzincan,Grand National Assembly,21,,,,
 58ca6f4a-1373-4170-8d21-ee22a2fb0161,Miraç Akdoğan,Miraç Akdoğan,,,,Anavatan Partisi,ANAP,area/malatya,Malatya,Grand National Assembly,21,,,,
 0a7dd76d-28bc-444f-8db3-25ea7007907b,Muhammet Turhan İmamoğlu,Muhammet Turhan İmamoğlu,,,,Demokratik Sol Parti,DSP,area/kocaeli,Kocaeli,Grand National Assembly,21,,,,
@@ -341,7 +341,7 @@ b280aa87-ddf0-47f3-8544-dc6f7ec3cb7d,Mustafa Haykır,Mustafa Haykır,,,,Anavatan
 9144df3c-6ace-45d4-8642-a3935a7df593,Mustafa Sait Gönen,Mustafa Sait Gönen,,,,Milliyetçi Hareket Partisi,MHP,area/konya,Konya,Grand National Assembly,21,,,,
 04021be6-20bb-4fa0-b5e4-2204d5dcf733,Mustafa Verkaya,Mustafa Verkaya,,,,Milliyetçi Hareket Partisi,MHP,area/İstanbul,İstanbul,Grand National Assembly,21,,,,
 60384f61-cf79-43c3-8f18-f72df517939f,Mustafa Vural,Mustafa Vural,,,,Demokratik Sol Parti,DSP,area/antalya,Antalya,Grand National Assembly,21,,,,male
-5cf24c39-dca8-45b5-b418-2a338ef77c78,Mustafa Yaman,Mustafa Yaman,,,,Milliyetçi Hareket Partisi,MHP,area/giresun,Giresun,Grand National Assembly,21,,,,
+5cf24c39-dca8-45b5-b418-2a338ef77c78,Mustafa Yaman,Mustafa Yaman,,,,Milliyetçi Hareket Partisi,MHP,area/giresun,Giresun,Grand National Assembly,21,,,,male
 f307a244-7664-4ff3-b7d4-3ba7c8470261,Mustafa Yılmaz,Mustafa Yılmaz,,,,Demokratik Sol Parti,DSP,area/gaziantep,Gaziantep,Grand National Assembly,21,,,,male
 fceab11c-d5a0-4572-ae41-11b06f186982,Mustafa Zorlu,Mustafa Zorlu,,,,Milliyetçi Hareket Partisi,MHP,area/isparta,Isparta,Grand National Assembly,21,,,,
 7546cc92-eb32-404a-a159-9ce433d60ea1,Mustafa Örs,Mustafa Örs,,,,Doğru Yol Partisi,DYP,area/burdur,Burdur,Grand National Assembly,21,,,,
@@ -433,7 +433,7 @@ f0140c12-cc3a-40eb-b664-5e99ce191f7d,Salih Kapusuz,Salih Kapusuz,,,,Fazilet Part
 a3dde381-ce8a-451f-a946-a0d66044b5f6,Sebahat Vardar,Sebahat Vardar,,,,Demokratik Sol Parti,DSP,area/bilecik,Bilecik,Grand National Assembly,21,,,,
 7ab478c5-e89d-4e74-a9a0-08476e0b486e,Sebahattin Karakelle,Sebahattin Karakelle,,,,Doğru Yol Partisi,DYP,area/erzincan,Erzincan,Grand National Assembly,21,,,,
 b810bf5c-6a76-40de-a99d-0aba0731c8f1,Sebğatullah Seydaoğlu,Sebğatullah Seydaoğlu,,,,Anavatan Partisi,ANAP,area/diyarbakır,Diyarbakır,Grand National Assembly,21,,,,
-96ede054-2b11-4a60-ba8d-5d6a7f05e588,Sedat Edip Bucak,Sedat Edip Bucak,,,,Doğru Yol Partisi,DYP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,21,,,,
+96ede054-2b11-4a60-ba8d-5d6a7f05e588,Sedat Edip Bucak,Sedat Edip Bucak,,,,Doğru Yol Partisi,DYP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,21,,,,male
 06a4fe9f-fe9d-4a55-974f-5d6a7a05cf47,Sedat Çevik,Sedat Çevik,,,,Milliyetçi Hareket Partisi,MHP,area/ankara,Ankara,Grand National Assembly,21,,,,
 0b413494-a90c-4dab-8b52-9c3190a969bd,Sefer Ekşi,Sefer Ekşi,,,,Anavatan Partisi,ANAP,area/kocaeli,Kocaeli,Grand National Assembly,21,,,,
 66cce1b2-674b-4d24-9a9b-00f3b112e733,Sefer Koçak,Sefer Koçak,,,,Anavatan Partisi,ANAP,area/ordu,Ordu,Grand National Assembly,21,,,,
@@ -450,7 +450,7 @@ bdd30e49-d991-4cd9-8a9c-2da0daf02ff5,Süleyman Metin Kalkan,Süleyman Metin Kalk
 9318a62b-11f5-4973-bd89-7f492f7e24d2,Süleyman Servet Sazak,Süleyman Servet Sazak,,,,Milliyetçi Hareket Partisi,MHP,area/eskişehir,Eskişehir,Grand National Assembly,21,,,,male
 b2cf0fed-8f87-4a21-8a31-d32af719e9f9,Süleyman Turan Çirkin,Süleyman Turan Çirkin,,,,Milliyetçi Hareket Partisi,MHP,area/hatay,Hatay,Grand National Assembly,21,,,,
 63695e2d-c0f2-4544-ba67-2fea0866fca2,Süleyman Yağız,Süleyman Yağız,,,,Demokratik Sol Parti,DSP,area/İstanbul,İstanbul,Grand National Assembly,21,,,,
-78d335b5-de60-44e5-93fb-2d0eb1c8acc3,Süleyman Çelebi,Süleyman Çelebi,,,,Anavatan Partisi,ANAP,area/mardin,Mardin,Grand National Assembly,21,,,,
+78d335b5-de60-44e5-93fb-2d0eb1c8acc3,Süleyman Çelebi,Süleyman Çelebi,,,,Anavatan Partisi,ANAP,area/mardin,Mardin,Grand National Assembly,21,,,,male
 9f86b9c6-e495-45bd-9e82-56e03540d6fe,Sümer Oral,Sümer Oral,,,,Anavatan Partisi,ANAP,area/İzmir,İzmir,Grand National Assembly,21,,,,
 63fea29e-fcdc-41ad-b80b-6d48e22f5f5f,Sıtkı Turan,Sıtkı Turan,,,,Milliyetçi Hareket Partisi,MHP,area/Çanakkale,Çanakkale,Grand National Assembly,21,,,,
 f5ee4680-dec7-458f-bf3f-df478b3570bc,Tahsin Baysık,Tahsin Baysık,,,,Demokratik Sol Parti,DSP,area/zonguldak,Zonguldak,Grand National Assembly,21,,,,
@@ -509,7 +509,7 @@ ed2fec55-d8e1-4384-a63c-b7793ecd0cbc,Ömer İzgi,Ömer İzgi,,,,Milliyetçi Hare
 670a7cef-c238-4652-9663-043b893e3c4a,İbrahim Gürdal,İbrahim Gürdal,,,,Anavatan Partisi,ANAP,area/antalya,Antalya,Grand National Assembly,21,,,,male
 105f3a62-0c26-4a1f-9d5c-3000055ddf86,İbrahim Halil Oral,İbrahim Halil Oral,,,,Milliyetçi Hareket Partisi,MHP,area/bitlis,Bitlis,Grand National Assembly,21,,,,
 56a0a784-ee7d-441b-9eca-8af46ec1d7c6,İbrahim Konukoğlu,İbrahim Konukoğlu,,,,Doğru Yol Partisi,DYP,area/gaziantep,Gaziantep,Grand National Assembly,21,,,,
-d8c94f59-fd91-4df8-bb3a-5a2d248ecbae,İbrahim Nami Çağan,İbrahim Nami Çağan,,,,Demokratik Sol Parti,DSP,area/İstanbul,İstanbul,Grand National Assembly,21,,,,male
+d8c94f59-fd91-4df8-bb3a-5a2d248ecbae,İbrahim Nami Çağan,İbrahim Nami Çağan,,,,Demokratik Sol Parti,DSP,area/İstanbul,İstanbul,Grand National Assembly,21,,,,
 a04a04ab-bde8-4d31-a282-8c78d8f9aaab,İbrahim Yavuz Bildik,İbrahim Yavuz Bildik,,,,Demokratik Sol Parti,DSP,area/adana,Adana,Grand National Assembly,21,,,,male
 a0c38d8a-c6ee-4a0d-ad95-1506d71ff6c1,İbrahim Yazıcı,İbrahim Yazıcı,,,,Doğru Yol Partisi,DYP,area/muğla,Muğla,Grand National Assembly,21,,,,male
 f73269e5-9f49-4a09-ad58-475f141d0262,İbrahim Yaşar Dedelek,İbrahim Yaşar Dedelek,,,,Anavatan Partisi,ANAP,area/eskişehir,Eskişehir,Grand National Assembly,21,,,,male

--- a/data/Turkey/Assembly/term-22.csv
+++ b/data/Turkey/Assembly/term-22.csv
@@ -15,7 +15,7 @@ b39452ae-c9b0-4d7e-a473-c228919229df,Abdullah Çetinkaya,Abdullah Çetinkaya,,,,
 06fd03ba-2224-4981-98e5-7728433becdd,Abdurrezzak Erten,Abdurrezzak Erten,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,22,,,,
 47bdba76-56b8-4b38-a5ce-a91056875041,Abdülkadir Aksu,Abdülkadir Aksu,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,22,,,,male
 91665b2f-3335-4086-8802-c708bfdd907b,Abdülkadir Ateş,Abdülkadir Ateş,,,,Cumhuriyet Halk Partisi,CHP,area/gaziantep,Gaziantep,Grand National Assembly,22,,,,
-ffdc2272-5e10-4851-b200-911ec1354d8e,Abdüllatif Şener,Abdüllatif Şener,,,,Adalet ve Kalkınma Partisi,AKP,area/sivas,Sivas,Grand National Assembly,22,,,https://upload.wikimedia.org/wikipedia/commons/b/b9/Abdullatif_Sener-edited.jpg,male
+ffdc2272-5e10-4851-b200-911ec1354d8e,Abdüllatif Şener,Abdüllatif Şener,,,,Adalet ve Kalkınma Partisi,AKP,area/sivas,Sivas,Grand National Assembly,22,,,,
 bf1f8085-e71f-4557-912a-4947a7d05e79,Adem Baştürk,Adem Baştürk,,,,Adalet ve Kalkınma Partisi,AKP,area/kayseri,Kayseri,Grand National Assembly,22,,,,male
 9aea46ff-cbbb-425b-9b09-ee863d62e8bd,Adem Tatlı,Adem Tatlı,,,,Adalet ve Kalkınma Partisi,AKP,area/giresun,Giresun,Grand National Assembly,22,,,,
 89ca5868-ae89-406d-a8fc-372ea7a41068,Afif Demirkıran,Afif Demirkıran,,,,Adalet ve Kalkınma Partisi,AKP,area/batman,Batman,Grand National Assembly,22,,,,
@@ -45,7 +45,7 @@ d0c4b445-703c-4509-a445-346d7cbf8331,Ahmet Çağlayan,Ahmet Çağlayan,,,,Adalet
 1f6a8402-7f99-4b3d-b823-ce3b00d105b3,Alaattin Büyükkaya,Alaattin Büyükkaya,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,22,,,,
 49e07169-e180-422b-b294-106fd47ac7f3,Alaettin Güven,Alaettin Güven,,,,Adalet ve Kalkınma Partisi,AKP,area/kütahya,Kütahya,Grand National Assembly,22,,,,
 67f8c4d9-bd98-445a-95f9-cbaa9f71d817,Algan Hacaloğlu,Algan Hacaloğlu,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,22,,,,
-a3f17739-bbce-45bb-94bc-b97f6e008d0f,Ali Arslan,Ali Arslan,,,,Cumhuriyet Halk Partisi,CHP,area/muğla,Muğla,Grand National Assembly,22,,,,
+a3f17739-bbce-45bb-94bc-b97f6e008d0f,Ali Arslan,Ali Arslan,,,,Cumhuriyet Halk Partisi,CHP,area/muğla,Muğla,Grand National Assembly,22,,,,male
 bd95f5df-196a-4c61-945c-5ad3c4e411b5,Ali Ayağ,Ali Ayağ,,,,Adalet ve Kalkınma Partisi,AKP,area/edirne,Edirne,Grand National Assembly,22,,,,male
 aa4fb89f-66e8-4cc1-bfa8-bcb59cc16b62,Ali Aydın Dumanoğlu,Ali Aydın Dumanoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/trabzon,Trabzon,Grand National Assembly,22,,,,
 eaed0ce3-2496-4e6f-a57e-d6d9c8b96733,Ali Aydınlıoğlu,Ali Aydınlıoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/balıkesir,Balıkesir,Grand National Assembly,22,,,,
@@ -79,7 +79,7 @@ ed59fa42-4ad4-47fb-8d12-1dbc6a705fc8,Atilla Koç,Atilla Koç,,,,Adalet ve Kalkı
 9e737a65-fabf-47bf-ade4-5783d21adcdc,Avni Doğan,Avni Doğan,,,,Adalet ve Kalkınma Partisi,AKP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,22,,,,
 cea9e1b7-8673-434d-92c8-d6792833f2c9,Ayhan Sefer Üstün,Ayhan Sefer Üstün,,,,Adalet ve Kalkınma Partisi,AKP,area/sakarya,Sakarya,Grand National Assembly,22,,,,
 af504fd3-dd73-4d43-b309-9ca2ea15b018,Ayhan Zeynep Tekin,Ayhan Zeynep Tekin,,,,Adalet ve Kalkınma Partisi,AKP,area/adana,Adana,Grand National Assembly,22,,,,
-7b913e34-7774-4b0a-bc94-cc29cdcb4c7c,Ayşe Gülsün Bilgehan,Ayşe Gülsün Bilgehan,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,22,,,,
+7b913e34-7774-4b0a-bc94-cc29cdcb4c7c,Ayşe Gülsün Bilgehan,Ayşe Gülsün Bilgehan,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,22,,,,female
 7bc3cfed-ee43-46f5-85db-718f94777912,Aziz Akgül,Aziz Akgül,,,,Adalet ve Kalkınma Partisi,AKP,area/diyarbakır,Diyarbakır,Grand National Assembly,22,,,,
 8f2ea96e-3fa0-48ba-97bc-ebbb5c121990,Azmi Ateş,Azmi Ateş,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,22,,,,
 f92c5bf9-e6c4-4be6-9b50-a8e7970e45ca,Bayram Özçelik,Bayram Özçelik,,,,Adalet ve Kalkınma Partisi,AKP,area/burdur,Burdur,Grand National Assembly,22,,,,
@@ -95,7 +95,7 @@ a1b4f7b4-50aa-465b-af68-ba69881f5713,Birgen Keleş,Birgen Keleş,,,,Cumhuriyet H
 741e71ba-8649-4fe6-bb14-b131e10aea6f,Bülent Arınç,Bülent Arınç,,,,Adalet ve Kalkınma Partisi,AKP,area/manisa,Manisa,Grand National Assembly,22,,,https://upload.wikimedia.org/wikipedia/commons/3/3f/Bulent_Arinc.jpg,male
 33ac5dc1-cc6a-4c8d-aa6f-cdf1cb7f0b03,Bülent Baratalı,Bülent Baratalı,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,22,,,,
 19f7af80-9198-449e-b567-e91ffd1290ca,Bülent Gedikli,Bülent Gedikli,,,,Adalet ve Kalkınma Partisi,AKP,area/ankara,Ankara,Grand National Assembly,22,,,,male
-86af147e-7f57-47ba-bb13-ec839afab851,Bülent Hasan Tanla,Bülent Hasan Tanla,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,22,,,,male
+86af147e-7f57-47ba-bb13-ec839afab851,Bülent Hasan Tanla,Bülent Hasan Tanla,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,22,,,,
 3baec5cc-36d0-4f87-943c-ddbb36aa31e7,Cahit Can,Cahit Can,,,,Adalet ve Kalkınma Partisi,AKP,area/sinop,Sinop,Grand National Assembly,22,,,,male
 99d4c975-1966-42c8-bfb1-b0b721c85aa7,Cavit Torun,Cavit Torun,,,,Adalet ve Kalkınma Partisi,AKP,area/diyarbakır,Diyarbakır,Grand National Assembly,22,,,,
 460a3ebb-0a1e-4ad5-b9a4-c5514baee6d3,Cemal Kaya,Cemal Kaya,,,,Adalet ve Kalkınma Partisi,AKP,area/ağrı,Ağrı,Grand National Assembly,22,,,,male
@@ -104,13 +104,13 @@ a1b4f7b4-50aa-465b-af68-ba69881f5713,Birgen Keleş,Birgen Keleş,,,,Cumhuriyet H
 abe19024-a773-46d4-949c-d109126b7361,Cemil Çiçek,Cemil Çiçek,,,,Adalet ve Kalkınma Partisi,AKP,area/ankara,Ankara,Grand National Assembly,22,,,https://upload.wikimedia.org/wikipedia/commons/3/3c/Cemil_Cicek.jpg,male
 1775ea31-cc72-4136-9326-28ee6e6e09c8,Cengiz Kaptanoğlu,Cengiz Kaptanoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,22,,,,
 d396df95-7c64-4326-b8c7-bd9eb2088a52,Cevdet Erdöl,Cevdet Erdöl,,,,Adalet ve Kalkınma Partisi,AKP,area/trabzon,Trabzon,Grand National Assembly,22,,,,
-3d4d5cad-d3d1-4a71-82d3-19f0038045da,Cânân Aritman,Cânân Aritman,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,22,,,,
+3d4d5cad-d3d1-4a71-82d3-19f0038045da,Cânân Aritman,Cânân Aritman,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,22,,,,female
 44c41905-4953-4739-974e-8918311757b1,Cüneyit Karabıyık,Cüneyit Karabıyık,,,,Adalet ve Kalkınma Partisi,AKP,area/van,Van,Grand National Assembly,22,,,,
 7b1c53f9-357a-4d61-9cc1-2e348b032154,Dengir Mir Mehmet Fırat,Dengir Mir Mehmet Fırat,,,,Adalet ve Kalkınma Partisi,AKP,area/mersin,Mersin,Grand National Assembly,22,,,,male
 64644586-aaec-42b2-8a12-ca82928feeda,Deniz Baykal,Deniz Baykal,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,22,,,https://upload.wikimedia.org/wikipedia/commons/5/58/Deniz_Baykal_TBMM.jpg,male
 7a4118d0-f518-4f7d-9b77-43d5635a379b,Durdu Mehmet Kastal,Durdu Mehmet Kastal,,,,Adalet ve Kalkınma Partisi,AKP,area/osmaniye,Osmaniye,Grand National Assembly,22,,,,
 b65485a8-a994-4dce-869b-c2990c98c76f,Dursun Akdemir,Dursun Akdemir,,,,Adalet ve Kalkınma Partisi,AKP,area/iğdır,Iğdır,Grand National Assembly,22,,,,
-35bd5b58-cff0-4a67-b57b-f73f8720ab5f,Edip Safder Gaydalı,Edip Safder Gaydalı,,,,Adalet ve Kalkınma Partisi,AKP,area/bitlis,Bitlis,Grand National Assembly,22,,,,
+35bd5b58-cff0-4a67-b57b-f73f8720ab5f,Edip Safder Gaydalı,Edip Safder Gaydalı,,,,Adalet ve Kalkınma Partisi,AKP,area/bitlis,Bitlis,Grand National Assembly,22,,,,male
 c0a6638b-57e9-4820-b77e-2b1aa6880e3b,Egemen Bağış,Egemen Bağış,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,22,,,https://upload.wikimedia.org/wikipedia/commons/6/64/Egemen_Bagis_2006.jpg,male
 668feb4a-73b2-4098-9a44-9d114d1c23c7,Ekrem Erdem,Ekrem Erdem,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,22,,,,
 b6147f08-1cb6-41bc-8e8a-84515f837c41,Emin Koç,Emin Koç,,,,Cumhuriyet Halk Partisi,CHP,area/yozgat,Yozgat,Grand National Assembly,22,,,,
@@ -141,7 +141,7 @@ a572fbe9-43a4-465f-8223-3b8d34837173,Fahrettin Poyraz,Fahrettin Poyraz,,,,Adalet
 e568cd0c-ef85-4107-bfcc-7bf71524ad0e,Fahri Çakır,Fahri Çakır,,,,Adalet ve Kalkınma Partisi,AKP,area/düzce,Düzce,Grand National Assembly,22,,,,
 308a7df8-7a4f-4bd6-a6ff-9c63d88fd667,Faruk Anbarcıoğlu,Faruk Anbarcıoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/bursa,Bursa,Grand National Assembly,22,,,,
 4444e84f-9761-4112-9676-29d72c2a3065,Faruk Koca,Faruk Koca,,,,Adalet ve Kalkınma Partisi,AKP,area/ankara,Ankara,Grand National Assembly,22,,,,
-15267a5a-bc66-447b-b532-542713f88d6f,Faruk Nafız Özak,Faruk Nafız Özak,,,,Adalet ve Kalkınma Partisi,AKP,area/trabzon,Trabzon,Grand National Assembly,22,,,,male
+15267a5a-bc66-447b-b532-542713f88d6f,Faruk Nafız Özak,Faruk Nafız Özak,,,,Adalet ve Kalkınma Partisi,AKP,area/trabzon,Trabzon,Grand National Assembly,22,,,,
 be45c5c7-bae9-48eb-b335-22cf4572e890,Faruk Çelik,Faruk Çelik,,,,Adalet ve Kalkınma Partisi,AKP,area/bursa,Bursa,Grand National Assembly,22,,,https://upload.wikimedia.org/wikipedia/commons/e/e1/Faruk-Çelik-2009.jpg,male
 ded23c69-91de-45c5-bd7c-a875702d9ced,Fatih Arıkan,Fatih Arıkan,,,,Adalet ve Kalkınma Partisi,AKP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,22,,,,
 36b92f61-6eb1-4a16-9d00-ce23b8712e53,Fatma Seniha Nükhet Hotar,Fatma Seniha Nükhet Hotar,,,,Adalet ve Kalkınma Partisi,AKP,area/İzmir,İzmir,Grand National Assembly,22,,,,
@@ -184,7 +184,7 @@ b592ecd8-d3d1-4ab9-90a7-2e1918c3e4eb,Halil Tiryaki,Halil Tiryaki,,,,Cumhuriyet H
 87110a19-66e1-4c02-bd67-0a0a997cdbba,Halil Ünlütepe,Halil Ünlütepe,,,,Cumhuriyet Halk Partisi,CHP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,22,,,,male
 91580128-36b8-4c58-a881-ecdd7923c515,Halil Ürün,Halil Ürün,,,,Adalet ve Kalkınma Partisi,AKP,area/konya,Konya,Grand National Assembly,22,,,,male
 111c6912-f734-4aba-9355-0197b0d4fe63,Halil İbrahim Yılmaz,Halil İbrahim Yılmaz,,,,Adalet ve Kalkınma Partisi,AKP,area/kütahya,Kütahya,Grand National Assembly,22,,,,
-093e58e0-a421-46a7-89b0-7e24491b9613,Haluk Koç,Haluk Koç,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,22,,,,male
+093e58e0-a421-46a7-89b0-7e24491b9613,Haluk Koç,Haluk Koç,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,22,,,,
 e7ba745b-1463-447b-a62b-1a86e6cdd0b3,Haluk İpek,Haluk İpek,,,,Adalet ve Kalkınma Partisi,AKP,area/ankara,Ankara,Grand National Assembly,22,,,,male
 97ad00cd-180d-4b1a-977a-91f62e22eac9,Hamit Taşcı,Hamit Taşcı,,,,Adalet ve Kalkınma Partisi,AKP,area/ordu,Ordu,Grand National Assembly,22,,,,
 4686fa0c-be65-442c-ba28-ce93b2d71e4e,Hamza Albayrak,Hamza Albayrak,,,,Adalet ve Kalkınma Partisi,AKP,area/amasya,Amasya,Grand National Assembly,22,,,,
@@ -225,7 +225,7 @@ f20e438c-a260-4971-b8c8-fcab9ac84071,Kemal Unakıtan,Kemal Unakıtan,,,,Adalet v
 abdf280a-b058-46f6-8fcb-3a0c7f97f23c,Kerim Özkul,Kerim Özkul,,,,Adalet ve Kalkınma Partisi,AKP,area/konya,Konya,Grand National Assembly,22,,,,
 4dc35dfe-0b34-4198-bca9-7ff1a1a1ecc4,Köksal Toptan,Köksal Toptan,,,,Adalet ve Kalkınma Partisi,AKP,area/zonguldak,Zonguldak,Grand National Assembly,22,,,,male
 a0bfc970-9a14-4c2e-ade7-88b2be79768a,Kürşad Tüzmen,Kürşad Tüzmen,,,,Adalet ve Kalkınma Partisi,AKP,area/gaziantep,Gaziantep,Grand National Assembly,22,,,,male
-70e3dbe5-d5dd-435b-92c9-7c95bbe67325,Kıvılcım Kemal Anadol,Kıvılcım Kemal Anadol,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,22,,,,
+70e3dbe5-d5dd-435b-92c9-7c95bbe67325,Kıvılcım Kemal Anadol,Kıvılcım Kemal Anadol,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,22,,,,male
 de8adc71-aa83-4177-bc8a-9edd10f0484b,Lokman Ayva,Lokman Ayva,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,22,,,,male
 95ffa4d0-e2ca-4874-9829-be0922f988df,M. İhsan Arslan,M. İhsan Arslan,,,,Adalet ve Kalkınma Partisi,AKP,area/diyarbakır,Diyarbakır,Grand National Assembly,22,,,,
 fbd90005-5aa3-4ca0-83f3-437ef15dc3b1,Mahfuz Güler,Mahfuz Güler,,,,Adalet ve Kalkınma Partisi,AKP,area/bingöl,Bingöl,Grand National Assembly,22,,,,
@@ -238,20 +238,20 @@ e6f18e16-e80d-4431-a4cc-ff1385353585,Mahmut Göksu,Mahmut Göksu,,,,Adalet ve Ka
 e0e4cbad-08b6-411d-89cb-4c1cc69f6d8a,Mahmut Yıldız,Mahmut Yıldız,,,,Cumhuriyet Halk Partisi,CHP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,22,,,,
 14a5f275-a920-4075-a6ef-01e7613186fe,Maliki Ejder Arvas,Maliki Ejder Arvas,,,,Adalet ve Kalkınma Partisi,AKP,area/van,Van,Grand National Assembly,22,,,,
 30df5cd8-88e0-43c2-9c64-434dd1fd1177,Medeni Yılmaz,Medeni Yılmaz,,,,Adalet ve Kalkınma Partisi,AKP,area/muş,Muş,Grand National Assembly,22,,,,
-835f265a-0529-4b66-b8d2-93499bda9967,Mehmet Akif Hamzaçebi,Mehmet Akif Hamzaçebi,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,22,,,,
+835f265a-0529-4b66-b8d2-93499bda9967,Mehmet Akif Hamzaçebi,Mehmet Akif Hamzaçebi,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,22,,,https://upload.wikimedia.org/wikipedia/commons/0/09/Akif_Hamzaçebi.jpg,male
 ff02dd93-c29d-42b0-a4ce-16bce5cd71b6,Mehmet Ali Arıkan,Mehmet Ali Arıkan,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,22,,,,male
 f0fe173b-4767-4fba-8d1b-63913f86dc3a,Mehmet Ali Bulut,Mehmet Ali Bulut,,,,Adalet ve Kalkınma Partisi,AKP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,22,,,,
 7ae414f3-a5e4-4c85-86f2-453bea34e08d,Mehmet Ali Özpolat,Mehmet Ali Özpolat,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,22,,,,
 07db8d85-b95b-49a4-9db7-6c89481ca0b2,Mehmet Ali Şahin,Mehmet Ali Şahin,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,22,,,https://upload.wikimedia.org/wikipedia/commons/4/48/Mehmet_Ali_Sahin.jpg,male
-2f9fa196-adea-495d-af40-4fc28975728f,Mehmet Alp,Mehmet Alp,,,,Adalet ve Kalkınma Partisi,AKP,area/burdur,Burdur,Grand National Assembly,22,,,,
+2f9fa196-adea-495d-af40-4fc28975728f,Mehmet Alp,Mehmet Alp,,,,Adalet ve Kalkınma Partisi,AKP,area/burdur,Burdur,Grand National Assembly,22,,,,male
 64cce0ee-1ddb-4831-ab82-d27c621fe882,Mehmet Altan Karapaşaoğlu,Mehmet Altan Karapaşaoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/bursa,Bursa,Grand National Assembly,22,,,,male
 e42ebf46-319e-48e9-b432-7bb159c81a43,Mehmet Asım Kulak,Mehmet Asım Kulak,,,,Adalet ve Kalkınma Partisi,AKP,area/bartın,Bartın,Grand National Assembly,22,,,,
 d2b33f22-67a1-4868-827b-d63771cdafc6,Mehmet Atilla Maraş,Mehmet Atilla Maraş,,,,Adalet ve Kalkınma Partisi,AKP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,22,,,,male
-c043eaa2-9492-422e-9ca1-deea7cc55e48,Mehmet Aydın,Mehmet Aydın,,,,Adalet ve Kalkınma Partisi,AKP,area/İzmir,İzmir,Grand National Assembly,22,,,,
+c043eaa2-9492-422e-9ca1-deea7cc55e48,Mehmet Aydın,Mehmet Aydın,,,,Adalet ve Kalkınma Partisi,AKP,area/İzmir,İzmir,Grand National Assembly,22,,,,male
 3689753e-fb9c-45ca-b93c-ccb7fb183e3b,Mehmet Beyazıt Denizolgun,Mehmet Beyazıt Denizolgun,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,22,,,,
 a891c2fe-7b97-444c-bd82-36893fcb4d4e,Mehmet Beşir Hamidi,Mehmet Beşir Hamidi,,,,Adalet ve Kalkınma Partisi,AKP,area/mardin,Mardin,Grand National Assembly,22,,,,
 17af8160-7486-424a-ab53-58a02e945ccc,Mehmet Boztaş,Mehmet Boztaş,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,22,,,,
-f4283185-b9fc-40ba-92c9-a2321b2f29eb,Mehmet Cevdet Selvi,Mehmet Cevdet Selvi,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,22,,,,male
+f4283185-b9fc-40ba-92c9-a2321b2f29eb,Mehmet Cevdet Selvi,Mehmet Cevdet Selvi,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,22,,,,
 5413a9b9-3d19-45e2-8f41-4f5f80a9c1ad,Mehmet Ceylan,Mehmet Ceylan,,,,Adalet ve Kalkınma Partisi,AKP,area/karabük,Karabük,Grand National Assembly,22,,,,male
 b909d053-885b-449d-80cb-960298c4decc,Mehmet Daniş,Mehmet Daniş,,,,Adalet ve Kalkınma Partisi,AKP,area/Çanakkale,Çanakkale,Grand National Assembly,22,,,,male
 479ef277-428a-4af1-93cf-12f2e7a6fdbb,Mehmet Dülger,Mehmet Dülger,,,,Adalet ve Kalkınma Partisi,AKP,area/antalya,Antalya,Grand National Assembly,22,,,,male
@@ -264,16 +264,16 @@ ddf3eecb-0297-4521-a612-75a29dbf58a1,Mehmet Eraslan,Mehmet Eraslan,,,,Adalet ve 
 457a62aa-2e66-453b-b7b1-46130161b5d1,Mehmet Faruk Bayrak,Mehmet Faruk Bayrak,,,,Adalet ve Kalkınma Partisi,AKP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,22,,,,
 2dcbfb3a-e68b-46d2-8963-f6975cf9930a,Mehmet Fehmi Uyanık,Mehmet Fehmi Uyanık,,,,Adalet ve Kalkınma Partisi,AKP,area/diyarbakır,Diyarbakır,Grand National Assembly,22,,,,
 07fdb9ae-c8ad-47a1-972a-8580d891bf37,Mehmet Güner,Mehmet Güner,,,,Adalet ve Kalkınma Partisi,AKP,area/bolu,Bolu,Grand National Assembly,22,,,,
-d2b4d521-55b5-468e-80e8-b0ed9ddd15b1,Mehmet Hilmi Güler,Mehmet Hilmi Güler,,,,Adalet ve Kalkınma Partisi,AKP,area/ordu,Ordu,Grand National Assembly,22,,,,
+d2b4d521-55b5-468e-80e8-b0ed9ddd15b1,Mehmet Hilmi Güler,Mehmet Hilmi Güler,,,,Adalet ve Kalkınma Partisi,AKP,area/ordu,Ordu,Grand National Assembly,22,,,,male
 e8c109c8-9d21-4845-97b9-8ffdc55ccc61,Mehmet Işık,Mehmet Işık,,,,Cumhuriyet Halk Partisi,CHP,area/giresun,Giresun,Grand National Assembly,22,,,,
 64bf23c6-7a2a-4664-b1b5-a1546c6317b1,Mehmet Kartal,Mehmet Kartal,,,,Adalet ve Kalkınma Partisi,AKP,area/van,Van,Grand National Assembly,22,,,,male
-1a2f06e6-f419-490e-ae2d-520222842a95,Mehmet Kemal Ağar,Mehmet Kemal Ağar,,,,Bağımsız,ind,area/elazığ,Elazığ,Grand National Assembly,22,,,,
+1a2f06e6-f419-490e-ae2d-520222842a95,Mehmet Kemal Ağar,Mehmet Kemal Ağar,,,,Bağımsız,ind,area/elazığ,Elazığ,Grand National Assembly,22,,,,male
 e02d089c-969e-43a1-b95a-a6dc2001b2c9,Mehmet Kerim Yıldız,Mehmet Kerim Yıldız,,,,Adalet ve Kalkınma Partisi,AKP,area/ağrı,Ağrı,Grand National Assembly,22,,,,male
-50b6b532-aca4-44bb-b58d-ca557401a584,Mehmet Kesimoğlu,Mehmet Kesimoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/kırklareli,Kırklareli,Grand National Assembly,22,,,,male
+50b6b532-aca4-44bb-b58d-ca557401a584,Mehmet Kesimoğlu,Mehmet Kesimoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/kırklareli,Kırklareli,Grand National Assembly,22,,,,
 d5de9db7-c4e2-4f9a-9b00-97fff5d288a2,Mehmet Kurt,Mehmet Kurt,,,,Adalet ve Kalkınma Partisi,AKP,area/samsun,Samsun,Grand National Assembly,22,,,,
 659524fd-fca0-4200-ad14-ae5a73fdcf0d,Mehmet Küçükaşık,Mehmet Küçükaşık,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,22,,,,
 59569b77-9fc4-4828-8d11-6fee26beaaa4,Mehmet Kılıç,Mehmet Kılıç,,,,Adalet ve Kalkınma Partisi,AKP,area/konya,Konya,Grand National Assembly,22,,,,male
-aea2f99a-3d32-4a85-9138-9bb4964c7aac,Mehmet Mehdi Eker,Mehmet Mehdi Eker,,,,Adalet ve Kalkınma Partisi,AKP,area/diyarbakır,Diyarbakır,Grand National Assembly,22,,,,
+aea2f99a-3d32-4a85-9138-9bb4964c7aac,Mehmet Mehdi Eker,Mehmet Mehdi Eker,,,,Adalet ve Kalkınma Partisi,AKP,area/diyarbakır,Diyarbakır,Grand National Assembly,22,,,https://upload.wikimedia.org/wikipedia/commons/a/a4/Mehdi_Eker.jpg,male
 a29b612f-c6d7-48d8-ae41-a3444dbe9def,Mehmet Melik Özmen,Mehmet Melik Özmen,,,,Adalet ve Kalkınma Partisi,AKP,area/ağrı,Ağrı,Grand National Assembly,22,,,,male
 c8272438-e974-49c4-b2da-4bddf80ac88a,Mehmet Mesut Özakcan,Mehmet Mesut Özakcan,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,22,,,,
 b1436c57-f28a-47cc-a9ba-82e248f69a17,Mehmet Mustafa Açıkalın,Mehmet Mustafa Açıkalın,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,22,,,,
@@ -344,8 +344,8 @@ f638414d-f3ff-4b6f-81f3-cda4d14874d2,Mustafa Erdoğan Yetenç,Mustafa Erdoğan Y
 c4d2f7fd-a25a-4643-a964-e51f5d29195a,Mustafa Gazalcı,Mustafa Gazalcı,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,22,,,,male
 d350774d-7a1d-4940-a4b3-f5a9c64b0b20,Mustafa Ilıcalı,Mustafa Ilıcalı,,,,Adalet ve Kalkınma Partisi,AKP,area/erzurum,Erzurum,Grand National Assembly,22,,,,male
 e9f5d840-19f9-4e3e-ab11-0da082292be2,Mustafa Nuri Akbulut,Mustafa Nuri Akbulut,,,,Adalet ve Kalkınma Partisi,AKP,area/erzurum,Erzurum,Grand National Assembly,22,,,,
-e3a5d1e8-36d0-41c7-b3e8-6c6d7ac6c5ef,Mustafa Said Yazıcıoğlu,Mustafa Said Yazıcıoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/ankara,Ankara,Grand National Assembly,22,,,,
-4639a57e-99ca-49b2-958f-cee4484e0f4a,Mustafa Sayar,Mustafa Sayar,,,,Cumhuriyet Halk Partisi,CHP,area/amasya,Amasya,Grand National Assembly,22,,,,
+e3a5d1e8-36d0-41c7-b3e8-6c6d7ac6c5ef,Mustafa Said Yazıcıoğlu,Mustafa Said Yazıcıoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/ankara,Ankara,Grand National Assembly,22,,,,male
+4639a57e-99ca-49b2-958f-cee4484e0f4a,Mustafa Sayar,Mustafa Sayar,,,,Cumhuriyet Halk Partisi,CHP,area/amasya,Amasya,Grand National Assembly,22,,,,male
 676de05d-c841-43d9-9943-9f8b22298509,Mustafa Tuna,Mustafa Tuna,,,,Adalet ve Kalkınma Partisi,AKP,area/ankara,Ankara,Grand National Assembly,22,,,,
 f307a244-7664-4ff3-b7d4-3ba7c8470261,Mustafa Yılmaz,Mustafa Yılmaz,,,,Cumhuriyet Halk Partisi,CHP,area/gaziantep,Gaziantep,Grand National Assembly,22,,,,male
 bf9b9b11-6528-4136-bffd-642118d66987,Mustafa Zeydan,Mustafa Zeydan,,,,Adalet ve Kalkınma Partisi,AKP,area/hakkâri,Hakkâri,Grand National Assembly,22,,,,male
@@ -383,7 +383,7 @@ fdcff6d8-8365-4868-a919-896bf36be2bf,Nurettin Canikli,Nurettin Canikli,,,,Adalet
 4d8306b0-3400-405a-94e8-b15a8a250efa,Nurettin Sözen,Nurettin Sözen,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,22,,,,male
 8683d750-bb66-4840-8577-91b87867e719,Nuri Çilingir,Nuri Çilingir,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,22,,,,
 27c03766-22c6-43b7-92cd-11385b35545b,Nusret Bayraktar,Nusret Bayraktar,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,22,,,,
-a8cb4f61-456c-4a07-96f3-78ce139374bb,Onur Başaran Öymen,Onur Başaran Öymen,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,22,,,,
+a8cb4f61-456c-4a07-96f3-78ce139374bb,Onur Başaran Öymen,Onur Başaran Öymen,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,22,,,,male
 16c81498-06f3-4876-99da-fe99e9d3b16d,Orhan Eraslan,Orhan Eraslan,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,22,,,,
 8c7ca376-2d39-4684-a596-132a223e7580,Orhan Erdem,Orhan Erdem,,,,Adalet ve Kalkınma Partisi,AKP,area/konya,Konya,Grand National Assembly,22,,,,male
 0adf5d4c-f18b-455f-a28c-9933f425505f,Orhan Seyfi Terzibaşıoğlu,Orhan Seyfi Terzibaşıoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/muğla,Muğla,Grand National Assembly,22,,,,male
@@ -500,7 +500,7 @@ b3b37a6b-a6a8-4633-8452-08f3a56b9c46,Zülfü Demirbağ,Zülfü Demirbağ,,,,Adal
 70f4c419-a09f-4e3a-ac06-b10151032c1f,Zülfükar İzol,Zülfükar İzol,,,,Adalet ve Kalkınma Partisi,AKP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,22,,,,
 406f3423-d33b-4118-86af-08f7228e9333,Ömer Abuşoğlu,Ömer Abuşoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/gaziantep,Gaziantep,Grand National Assembly,22,,,,male
 304c6874-c5db-4a02-b08d-e87e1266c4e7,Ömer Kulaksız,Ömer Kulaksız,,,,Adalet ve Kalkınma Partisi,AKP,area/sivas,Sivas,Grand National Assembly,22,,,,
-66c29288-d499-44a8-8bb5-e66ed24f4716,Ömer Zülfü Livaneli,Ömer Zülfü Livaneli,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,22,,,,
+66c29288-d499-44a8-8bb5-e66ed24f4716,Ömer Zülfü Livaneli,Ömer Zülfü Livaneli,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,22,,,https://upload.wikimedia.org/wikipedia/commons/7/78/Livaneli.jpg,male
 38cb391f-bb87-4295-b121-47179b8c1d58,Ömer Çelik,Ömer Çelik,,,,Adalet ve Kalkınma Partisi,AKP,area/adana,Adana,Grand National Assembly,22,,,https://upload.wikimedia.org/wikipedia/commons/c/ce/Ömer_Çelik_cropped.jpg,male
 c537b387-e41f-4072-8db1-8324464928a5,Ömer Özyılmaz,Ömer Özyılmaz,,,,Adalet ve Kalkınma Partisi,AKP,area/erzurum,Erzurum,Grand National Assembly,22,,,,
 653f1bae-6974-4b0c-89fc-34934b0ac6fb,Ömer İnan,Ömer İnan,,,,Adalet ve Kalkınma Partisi,AKP,area/mersin,Mersin,Grand National Assembly,22,,,,

--- a/data/Turkey/Assembly/term-23.csv
+++ b/data/Turkey/Assembly/term-23.csv
@@ -34,7 +34,7 @@ d40f3d0b-a87f-49b4-ba53-e0aabab342e8,Ahmet Ersin,Ahmet Ersin,,,,Cumhuriyet Halk 
 926ecdf7-d4be-4062-9f0d-732803f97264,Ahmet Kenan Tanrıkulu,Ahmet Kenan Tanrıkulu,,,,Milliyetçi Hareket Partisi,MHP,area/İzmir_(ii),İzmir (II),Grand National Assembly,23,,,,male
 cd393adb-374b-4c35-bae5-4c4f9835a922,Ahmet Koca,Ahmet Koca,,,,Adalet ve Kalkınma Partisi,AKP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,23,,,,
 d6bd540e-722f-41a8-83ea-e06b49e5053a,Ahmet Küçük,Ahmet Küçük,,,,Cumhuriyet Halk Partisi,CHP,area/Çanakkale,Çanakkale,Grand National Assembly,23,,,,male
-303d56c9-65c3-4b05-bc87-3f1425406a89,Ahmet Mesut Yılmaz,Ahmet Mesut Yılmaz,,,,Bağımsız,ind,area/rize,Rize,Grand National Assembly,23,,,,
+303d56c9-65c3-4b05-bc87-3f1425406a89,Ahmet Mesut Yılmaz,Ahmet Mesut Yılmaz,,,,Bağımsız,ind,area/rize,Rize,Grand National Assembly,23,,,,male
 437223a9-c0a8-480b-a3fd-bfacb5a2a2da,Ahmet Orhan,Ahmet Orhan,,,,Milliyetçi Hareket Partisi,MHP,area/manisa,Manisa,Grand National Assembly,23,,,,
 9ed20685-415e-46df-a0e2-3a363fa93763,Ahmet Tan,Ahmet Tan,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,23,,,,male
 816916d5-0c86-4a2d-90ba-83744b2d3c18,Ahmet Türk,Ahmet Türk,,,,Bağımsız,ind,area/mardin,Mardin,Grand National Assembly,23,,,https://upload.wikimedia.org/wikipedia/commons/4/46/Ahmet_Türk.jpg,male
@@ -49,7 +49,7 @@ d8c8e8b3-cc82-437d-9f60-b981289feb8f,Akın Birdal,Akın Birdal,,,,Bağımsız,in
 1f6a8402-7f99-4b3d-b823-ce3b00d105b3,Alaattin Büyükkaya,Alaattin Büyükkaya,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(ii),İstanbul (II),Grand National Assembly,23,,,,
 19515bb5-2bf8-4d57-91f4-cd154c982db6,Alev Dedegil,Alev Dedegil,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(iii),İstanbul (III),Grand National Assembly,23,,,,female
 67f8c4d9-bd98-445a-95f9-cbaa9f71d817,Algan Hacaloğlu,Algan Hacaloğlu,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,23,,,,
-a3f17739-bbce-45bb-94bc-b97f6e008d0f,Ali Arslan,Ali Arslan,,,,Cumhuriyet Halk Partisi,CHP,area/muğla,Muğla,Grand National Assembly,23,,,,
+a3f17739-bbce-45bb-94bc-b97f6e008d0f,Ali Arslan,Ali Arslan,,,,Cumhuriyet Halk Partisi,CHP,area/muğla,Muğla,Grand National Assembly,23,,,,male
 1f627461-0944-41d3-a886-a2395424d062,Ali Babacan,Ali Babacan,,,,Adalet ve Kalkınma Partisi,AKP,area/ankara_(i),Ankara (I),Grand National Assembly,23,,,https://upload.wikimedia.org/wikipedia/commons/a/a2/Ali_Babacan_-_World_Economic_Forum_on_the_Middle_East_2008_retouched.jpg,male
 a1c5eefb-bd09-47ee-b6ec-1449fdb1d131,Ali Er,Ali Er,,,,Adalet ve Kalkınma Partisi,AKP,area/mersin,Mersin,Grand National Assembly,23,,,,
 5ff92e8e-3fde-43ee-8e88-7f9f8c1ec6be,Ali Güner,Ali Güner,,,,Adalet ve Kalkınma Partisi,AKP,area/iğdır,Iğdır,Grand National Assembly,23,,,,
@@ -156,7 +156,7 @@ a572fbe9-43a4-465f-8223-3b8d34837173,Fahrettin Poyraz,Fahrettin Poyraz,,,,Adalet
 81cf59d8-6294-4a3a-9ff2-1a8e41fa60ab,Faik Öztrak,Faik Öztrak,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,23,,,,male
 36b170ab-616d-4e90-8d7c-8b2135443491,Faruk Bal,Faruk Bal,,,,Milliyetçi Hareket Partisi,MHP,area/konya,Konya,Grand National Assembly,23,,,,male
 4444e84f-9761-4112-9676-29d72c2a3065,Faruk Koca,Faruk Koca,,,,Adalet ve Kalkınma Partisi,AKP,area/ankara_(i),Ankara (I),Grand National Assembly,23,,,,
-15267a5a-bc66-447b-b532-542713f88d6f,Faruk Nafız Özak,Faruk Nafız Özak,,,,Adalet ve Kalkınma Partisi,AKP,area/trabzon,Trabzon,Grand National Assembly,23,,,,male
+15267a5a-bc66-447b-b532-542713f88d6f,Faruk Nafız Özak,Faruk Nafız Özak,,,,Adalet ve Kalkınma Partisi,AKP,area/trabzon,Trabzon,Grand National Assembly,23,,,,
 60d5b234-d259-4955-8675-e7c5fcbf1a79,Faruk Septioğlu,Faruk Septioğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/elazığ,Elazığ,Grand National Assembly,23,,,,male
 be45c5c7-bae9-48eb-b335-22cf4572e890,Faruk Çelik,Faruk Çelik,,,,Adalet ve Kalkınma Partisi,AKP,area/bursa,Bursa,Grand National Assembly,23,,,https://upload.wikimedia.org/wikipedia/commons/e/e1/Faruk-Çelik-2009.jpg,male
 ded23c69-91de-45c5-bd7c-a875702d9ced,Fatih Arıkan,Fatih Arıkan,,,,Adalet ve Kalkınma Partisi,AKP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,23,,,,
@@ -165,7 +165,7 @@ e533aac7-3289-4b6e-966e-9520a5e17d14,Fatih Atay,Fatih Atay,,,,Cumhuriyet Halk Pa
 0df41789-9ee5-4eeb-bd59-14592377e59a,Fatih Öztürk,Fatih Öztürk,,,,Adalet ve Kalkınma Partisi,AKP,area/samsun,Samsun,Grand National Assembly,23,,,,male
 69a2d05e-d59c-40dc-88c7-8b95770e019b,Fatma Kotan,Fatma Kotan,,,,Adalet ve Kalkınma Partisi,AKP,area/ağrı,Ağrı,Grand National Assembly,23,,,,
 823a8bad-8c89-4dc3-8d90-fc80489812b6,Fatma Kurtulan,Fatma Kurtulan,,,,Bağımsız,ind,area/van,Van,Grand National Assembly,23,,,,female
-893db21d-fdef-44c1-af07-8c17e0d7bbf7,Fatma Nur Serter,Fatma Nur Serter,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,23,,,,
+893db21d-fdef-44c1-af07-8c17e0d7bbf7,Fatma Nur Serter,Fatma Nur Serter,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,23,,,,female
 36b92f61-6eb1-4a16-9d00-ce23b8712e53,Fatma Seniha Nükhet Hotar,Fatma Seniha Nükhet Hotar,,,,Adalet ve Kalkınma Partisi,AKP,area/İzmir_(i),İzmir (I),Grand National Assembly,23,,,,
 5d2b9e09-8832-461e-9000-9f92d96ff099,Fatma Şahin,Fatma Şahin,,,,Adalet ve Kalkınma Partisi,AKP,area/gaziantep,Gaziantep,Grand National Assembly,23,,,"https://upload.wikimedia.org/wikipedia/commons/4/48/Fatma_Sahin_-_World_Economic_Forum_on_the_Middle_East,_North_Africa_and_Eurasia_2012.jpg",female
 8bf3546e-9b7d-4af2-a040-555c5e96219a,Fatoş Gürkan,Fatoş Gürkan,,,,Adalet ve Kalkınma Partisi,AKP,area/adana,Adana,Grand National Assembly,23,,,,female
@@ -177,7 +177,7 @@ f849f248-1631-4b02-a2ec-42a49f99f072,Fehmi Murat Sönmez,Fehmi Murat Sönmez,,,,
 7a331e02-04f1-4f95-b3f6-0ae2a7e87dbe,Fetani Battal,Fetani Battal,,,,Adalet ve Kalkınma Partisi,AKP,area/bayburt,Bayburt,Grand National Assembly,23,,,,
 ad6f8250-f1c5-497b-85fd-7628753d57e7,Fevzi Topuz,Fevzi Topuz,,,,Cumhuriyet Halk Partisi,CHP,area/muğla,Muğla,Grand National Assembly,23,,,,
 3190a5da-046d-43b9-8bad-c9b7c6f49a10,Fevzi Şanverdi,Fevzi Şanverdi,,,,Adalet ve Kalkınma Partisi,AKP,area/hatay,Hatay,Grand National Assembly,23,,,,
-5809b956-c77a-4afe-9814-69c1a50cbbe2,Feyzi İşbaşaran,Feyzi İşbaşaran,,,,Adalet ve Kalkınma Partisi,AKP,area/elazığ,Elazığ,Grand National Assembly,23,,,,male
+5809b956-c77a-4afe-9814-69c1a50cbbe2,Feyzi İşbaşaran,Feyzi İşbaşaran,,,,Adalet ve Kalkınma Partisi,AKP,area/elazığ,Elazığ,Grand National Assembly,23,,,,
 5f43f175-2108-413c-9c76-d4a0e913c6e7,Feyzullah Kıyıklık,Feyzullah Kıyıklık,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(iii),İstanbul (III),Grand National Assembly,23,,,,
 d876144a-c64a-45da-b0ac-d87a290e1b3f,Fikri Işık,Fikri Işık,,,,Adalet ve Kalkınma Partisi,AKP,area/kocaeli,Kocaeli,Grand National Assembly,23,,,,male
 329609eb-52a9-4c82-8dd6-74a4d29ce1a4,Fuat Bol,Fuat Bol,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(iii),İstanbul (III),Grand National Assembly,23,,,,
@@ -198,7 +198,7 @@ e0c57f5c-576f-4986-83f8-889c574d3b75,Hakkı Suha Okay,Hakkı Suha Okay,,,,Cumhur
 51cdfef9-2047-4633-beda-20f6bbc48ef4,Halide İncekara,Halide İncekara,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(iii),İstanbul (III),Grand National Assembly,23,,,,female
 b507d923-0db5-40f5-9c62-4c103d774ef4,Halil Aydoğan,Halil Aydoğan,,,,Adalet ve Kalkınma Partisi,AKP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,23,,,,
 87110a19-66e1-4c02-bd67-0a0a997cdbba,Halil Ünlütepe,Halil Ünlütepe,,,,Cumhuriyet Halk Partisi,CHP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,23,,,,male
-093e58e0-a421-46a7-89b0-7e24491b9613,Haluk Koç,Haluk Koç,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,23,,,,male
+093e58e0-a421-46a7-89b0-7e24491b9613,Haluk Koç,Haluk Koç,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,23,,,,
 dd05785e-e1d7-4b2c-9a57-200da1ff85c4,Haluk Özdalga,Haluk Özdalga,,,,Adalet ve Kalkınma Partisi,AKP,area/ankara_(i),Ankara (I),Grand National Assembly,23,,,,male
 e7ba745b-1463-447b-a62b-1a86e6cdd0b3,Haluk İpek,Haluk İpek,,,,Adalet ve Kalkınma Partisi,AKP,area/ankara_(ii),Ankara (II),Grand National Assembly,23,,,,male
 027301e4-d9b9-4060-bf44-404818f79ce7,Hamit Geylani,Hamit Geylani,,,,Bağımsız,ind,area/hakkâri,Hakkâri,Grand National Assembly,23,,,,male
@@ -256,7 +256,7 @@ abe0959d-2139-4d59-b396-20e2401bf36b,Kutbettin Arzu,Kutbettin Arzu,,,,Adalet ve 
 4dc35dfe-0b34-4198-bca9-7ff1a1a1ecc4,Köksal Toptan,Köksal Toptan,,,,Adalet ve Kalkınma Partisi,AKP,area/zonguldak,Zonguldak,Grand National Assembly,23,,,,male
 a0bfc970-9a14-4c2e-ade7-88b2be79768a,Kürşad Tüzmen,Kürşad Tüzmen,,,,Adalet ve Kalkınma Partisi,AKP,area/mersin,Mersin,Grand National Assembly,23,,,,male
 08b21ccb-790c-43c5-9e56-f2283c302fb8,Kürşat Atılgan,Kürşat Atılgan,,,,Milliyetçi Hareket Partisi,MHP,area/adana,Adana,Grand National Assembly,23,,,,male
-70e3dbe5-d5dd-435b-92c9-7c95bbe67325,Kıvılcım Kemal Anadol,Kıvılcım Kemal Anadol,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir_(ii),İzmir (II),Grand National Assembly,23,,,,
+70e3dbe5-d5dd-435b-92c9-7c95bbe67325,Kıvılcım Kemal Anadol,Kıvılcım Kemal Anadol,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir_(ii),İzmir (II),Grand National Assembly,23,,,,male
 de8adc71-aa83-4177-bc8a-9edd10f0484b,Lokman Ayva,Lokman Ayva,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(iii),İstanbul (III),Grand National Assembly,23,,,,male
 00110218-2555-47b2-a2b8-a4ae16c75ef2,Lütfi Elvan,Lütfi Elvan,,,,Adalet ve Kalkınma Partisi,AKP,area/karaman,Karaman,Grand National Assembly,23,,,https://upload.wikimedia.org/wikipedia/commons/1/10/Lütfi_Elvan_(cropped).jpg,male
 b383888d-b697-46ca-964f-f8f9986eb825,Lütfi Çırakoğlu,Lütfi Çırakoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/rize,Rize,Grand National Assembly,23,,,,male
@@ -266,17 +266,17 @@ e6e23fa1-54b9-4de6-ad57-fbcc1275b6b3,Mahmut Dede,Mahmut Dede,,,,Adalet ve Kalkı
 cf99a330-4407-4986-b663-110e7bb04ea8,Mahmut Mücahit Fındıklı,Mahmut Mücahit Fındıklı,,,,Adalet ve Kalkınma Partisi,AKP,area/malatya,Malatya,Grand National Assembly,23,,,,
 fcb8a5b0-7e2e-410b-92de-03a6952711fb,Malik Ecder Özdemir,Malik Ecder Özdemir,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,23,,,,
 30df5cd8-88e0-43c2-9c64-434dd1fd1177,Medeni Yılmaz,Medeni Yılmaz,,,,Adalet ve Kalkınma Partisi,AKP,area/muş,Muş,Grand National Assembly,23,,,,
-835f265a-0529-4b66-b8d2-93499bda9967,Mehmet Akif Hamzaçebi,Mehmet Akif Hamzaçebi,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,23,,,,
+835f265a-0529-4b66-b8d2-93499bda9967,Mehmet Akif Hamzaçebi,Mehmet Akif Hamzaçebi,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,23,,,https://upload.wikimedia.org/wikipedia/commons/0/09/Akif_Hamzaçebi.jpg,male
 0854fb09-e86e-4d7b-86eb-2208d71e2b17,Mehmet Akif Paksoy,Mehmet Akif Paksoy,,,,Milliyetçi Hareket Partisi,MHP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,23,,,,
 7058b701-7390-4d28-875e-761370d360ab,Mehmet Ali Susam,Mehmet Ali Susam,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir_(ii),İzmir (II),Grand National Assembly,23,,,,
 7ae414f3-a5e4-4c85-86f2-453bea34e08d,Mehmet Ali Özpolat,Mehmet Ali Özpolat,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(iii),İstanbul (III),Grand National Assembly,23,,,,
 07db8d85-b95b-49a4-9db7-6c89481ca0b2,Mehmet Ali Şahin,Mehmet Ali Şahin,,,,Adalet ve Kalkınma Partisi,AKP,area/antalya,Antalya,Grand National Assembly,23,,,https://upload.wikimedia.org/wikipedia/commons/4/48/Mehmet_Ali_Sahin.jpg,male
-2f9fa196-adea-495d-af40-4fc28975728f,Mehmet Alp,Mehmet Alp,,,,Adalet ve Kalkınma Partisi,AKP,area/burdur,Burdur,Grand National Assembly,23,,,,
+2f9fa196-adea-495d-af40-4fc28975728f,Mehmet Alp,Mehmet Alp,,,,Adalet ve Kalkınma Partisi,AKP,area/burdur,Burdur,Grand National Assembly,23,,,,male
 64cce0ee-1ddb-4831-ab82-d27c621fe882,Mehmet Altan Karapaşaoğlu,Mehmet Altan Karapaşaoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/bursa,Bursa,Grand National Assembly,23,,,,male
 94960c7e-aa4f-4719-a549-54051f69dcdb,Mehmet Aydın,Mehmet Aydın,,,,Adalet ve Kalkınma Partisi,AKP,area/İzmir_(i),İzmir (I),Grand National Assembly,23,,,,
 3689753e-fb9c-45ca-b93c-ccb7fb183e3b,Mehmet Beyazıt Denizolgun,Mehmet Beyazıt Denizolgun,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,23,,,,
 acb993bb-299a-402a-9047-e5240a84feb6,Mehmet Cemal Öztaylan,Mehmet Cemal Öztaylan,,,,Adalet ve Kalkınma Partisi,AKP,area/balıkesir,Balıkesir,Grand National Assembly,23,,,,male
-f4283185-b9fc-40ba-92c9-a2321b2f29eb,Mehmet Cevdet Selvi,Mehmet Cevdet Selvi,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,23,,,,male
+f4283185-b9fc-40ba-92c9-a2321b2f29eb,Mehmet Cevdet Selvi,Mehmet Cevdet Selvi,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,23,,,,
 5413a9b9-3d19-45e2-8f41-4f5f80a9c1ad,Mehmet Ceylan,Mehmet Ceylan,,,,Adalet ve Kalkınma Partisi,AKP,area/karabük,Karabük,Grand National Assembly,23,,,,male
 8d18a191-5296-4b6f-9030-afb28cf0d6d9,Mehmet Cihat Özönder,Mehmet Cihat Özönder,,,,Milliyetçi Hareket Partisi,MHP,area/İstanbul_(iii),İstanbul (III),Grand National Assembly,23,,,,male
 b909d053-885b-449d-80cb-960298c4decc,Mehmet Daniş,Mehmet Daniş,,,,Adalet ve Kalkınma Partisi,AKP,area/Çanakkale,Çanakkale,Grand National Assembly,23,,,,male
@@ -291,8 +291,8 @@ e11ea33d-3061-486b-851b-8368005d9ca7,Mehmet Erdoğan,Mehmet Erdoğan,,,,Adalet v
 4f1d9d55-22be-4883-9d78-ccbfe1fa38c9,Mehmet Günal,Mehmet Günal,,,,Milliyetçi Hareket Partisi,MHP,area/antalya,Antalya,Grand National Assembly,23,,,,male
 bcebe11d-db2b-4133-bed1-59e61bcf97d5,Mehmet Halit Demir,Mehmet Halit Demir,,,,Adalet ve Kalkınma Partisi,AKP,area/mardin,Mardin,Grand National Assembly,23,,,,
 970a8fc4-e6c9-4294-82e2-225d49823c5b,Mehmet Hanifi Alır,Mehmet Hanifi Alır,,,,Adalet ve Kalkınma Partisi,AKP,area/ağrı,Ağrı,Grand National Assembly,23,,,,male
-d2b4d521-55b5-468e-80e8-b0ed9ddd15b1,Mehmet Hilmi Güler,Mehmet Hilmi Güler,,,,Adalet ve Kalkınma Partisi,AKP,area/ordu,Ordu,Grand National Assembly,23,,,,
-aea2f99a-3d32-4a85-9138-9bb4964c7aac,Mehmet Mehdi Eker,Mehmet Mehdi Eker,,,,Adalet ve Kalkınma Partisi,AKP,area/diyarbakır,Diyarbakır,Grand National Assembly,23,,,,
+d2b4d521-55b5-468e-80e8-b0ed9ddd15b1,Mehmet Hilmi Güler,Mehmet Hilmi Güler,,,,Adalet ve Kalkınma Partisi,AKP,area/ordu,Ordu,Grand National Assembly,23,,,,male
+aea2f99a-3d32-4a85-9138-9bb4964c7aac,Mehmet Mehdi Eker,Mehmet Mehdi Eker,,,,Adalet ve Kalkınma Partisi,AKP,area/diyarbakır,Diyarbakır,Grand National Assembly,23,,,https://upload.wikimedia.org/wikipedia/commons/a/a4/Mehdi_Eker.jpg,male
 b1436c57-f28a-47cc-a9ba-82e248f69a17,Mehmet Mustafa Açıkalın,Mehmet Mustafa Açıkalın,,,,Adalet ve Kalkınma Partisi,AKP,area/sivas,Sivas,Grand National Assembly,23,,,,
 df1d069a-e900-4fc8-8d8c-c76ec5d80901,Mehmet Müezzinoğlu,Mehmet Müezzinoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(iii),İstanbul (III),Grand National Assembly,23,,,,male
 add873e6-fd60-4ee4-8b42-b4f1c5b14006,Mehmet Necati Çetinkaya,Mehmet Necati Çetinkaya,,,,Adalet ve Kalkınma Partisi,AKP,area/elazığ,Elazığ,Grand National Assembly,23,,,,male
@@ -309,7 +309,7 @@ ab2095f3-725a-421d-a4f5-1e42828cd693,Mehmet Sekmen,Mehmet Sekmen,,,,Adalet ve Ka
 eec6a00e-053a-4d14-92ce-28d4bfe44cb4,Mehmet Serdaroğlu,Mehmet Serdaroğlu,,,,Milliyetçi Hareket Partisi,MHP,area/kastamonu,Kastamonu,Grand National Assembly,23,,,,
 7cf37c40-8ca2-4fb0-bdf8-f8f590406c7a,Mehmet Sevigen,Mehmet Sevigen,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(ii),İstanbul (II),Grand National Assembly,23,,,,male
 87f2dc96-ab09-4c3a-bcb8-6c4337ececde,Mehmet Tunçak,Mehmet Tunçak,,,,Adalet ve Kalkınma Partisi,AKP,area/bursa,Bursa,Grand National Assembly,23,,,,male
-d8d7f6e0-5832-4f7d-801e-bf29c4f6de16,Mehmet Ufuk Uras,Mehmet Ufuk Uras,,,,Bağımsız,ind,area/İstanbul_(i),İstanbul (I),Grand National Assembly,23,,,,
+d8d7f6e0-5832-4f7d-801e-bf29c4f6de16,Mehmet Ufuk Uras,Mehmet Ufuk Uras,,,,Bağımsız,ind,area/İstanbul_(i),İstanbul (I),Grand National Assembly,23,,,,male
 dc9f0693-d0bb-4c1e-9cf9-88dc37f985e8,Mehmet Vecdi Gönül,Mehmet Vecdi Gönül,,,,Adalet ve Kalkınma Partisi,AKP,area/İzmir_(ii),İzmir (II),Grand National Assembly,23,,,,
 4fa8fd31-4989-431b-bade-b5f52c99fbbd,Mehmet Yaşar Öztürk,Mehmet Yaşar Öztürk,,,,Adalet ve Kalkınma Partisi,AKP,area/yozgat,Yozgat,Grand National Assembly,23,,,,male
 76430ff2-6f7c-4153-a2b5-c8c886e90fa7,Mehmet Yüksel,Mehmet Yüksel,,,,Adalet ve Kalkınma Partisi,AKP,area/denizli,Denizli,Grand National Assembly,23,,,,male
@@ -336,7 +336,7 @@ b9c604cc-d4e3-4a2b-b0cf-b5bf64055ed1,Mevlüt Akgün,Mevlüt Akgün,,,,Adalet ve 
 ecd5e64b-436b-4737-b905-9981f57ed489,Mikail Arslan,Mikail Arslan,,,,Adalet ve Kalkınma Partisi,AKP,area/kırşehir,Kırşehir,Grand National Assembly,23,,,,
 8dcb1447-5414-40cb-804d-befdd3fa0e10,Mithat Ekici,Mithat Ekici,,,,Adalet ve Kalkınma Partisi,AKP,area/denizli,Denizli,Grand National Assembly,23,,,,
 3c8ecf66-c9f6-4713-b539-304b78d4b861,Mithat Melen,Mithat Melen,,,,Milliyetçi Hareket Partisi,MHP,area/İstanbul_(ii),İstanbul (II),Grand National Assembly,23,,,,male
-5402ad3e-f5ee-4ecb-bbc5-c24e5b71ff31,Muhammed Rıza Yalçınkaya,Muhammed Rıza Yalçınkaya,,,,Cumhuriyet Halk Partisi,CHP,area/bartın,Bartın,Grand National Assembly,23,,,,male
+5402ad3e-f5ee-4ecb-bbc5-c24e5b71ff31,Muhammed Rıza Yalçınkaya,Muhammed Rıza Yalçınkaya,,,,Cumhuriyet Halk Partisi,CHP,area/bartın,Bartın,Grand National Assembly,23,,,,
 9cfd18ff-2361-4740-9d17-01e10c7018ac,Muharrem Candan,Muharrem Candan,,,,Adalet ve Kalkınma Partisi,AKP,area/konya,Konya,Grand National Assembly,23,,,,
 0f8dedcc-7801-49c8-b629-6fa26e50c017,Muharrem Selamoğlu,Muharrem Selamoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/niğde,Niğde,Grand National Assembly,23,,,,
 9b0895da-9137-4ca0-bbe5-2847a9ca4ae2,Muharrem Varlı,Muharrem Varlı,,,,Milliyetçi Hareket Partisi,MHP,area/adana,Adana,Grand National Assembly,23,,,,male
@@ -359,11 +359,11 @@ f638414d-f3ff-4b6f-81f3-cda4d14874d2,Mustafa Erdoğan Yetenç,Mustafa Erdoğan Y
 0021cf04-06fd-4b43-8177-21113da5c4c3,Mustafa Kalaycı,Mustafa Kalaycı,,,,Milliyetçi Hareket Partisi,MHP,area/konya,Konya,Grand National Assembly,23,,,,male
 7f83a04e-74bf-4692-a6a8-d98cf35be8eb,Mustafa Kemal Cengiz,Mustafa Kemal Cengiz,,,,Milliyetçi Hareket Partisi,MHP,area/Çanakkale,Çanakkale,Grand National Assembly,23,,,,
 94744e2a-5669-4792-af92-c0a51b78b2b3,Mustafa Kuş,Mustafa Kuş,,,,Adalet ve Kalkınma Partisi,AKP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,23,,,,male
-e3a5d1e8-36d0-41c7-b3e8-6c6d7ac6c5ef,Mustafa Said Yazıcıoğlu,Mustafa Said Yazıcıoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/ankara_(ii),Ankara (II),Grand National Assembly,23,,,,
+e3a5d1e8-36d0-41c7-b3e8-6c6d7ac6c5ef,Mustafa Said Yazıcıoğlu,Mustafa Said Yazıcıoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/ankara_(ii),Ankara (II),Grand National Assembly,23,,,,male
 60384f61-cf79-43c3-8f18-f72df517939f,Mustafa Vural,Mustafa Vural,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,23,,,,male
 91e175cb-456e-45ea-8aad-a6bf1aeb4316,Mustafa Çetin,Mustafa Çetin,,,,Adalet ve Kalkınma Partisi,AKP,area/uşak,Uşak,Grand National Assembly,23,,,,male
 6a4d44ba-f9a3-4d80-a2a1-7a0b1fba50b8,Mustafa Özbayrak,Mustafa Özbayrak,,,,Adalet ve Kalkınma Partisi,AKP,area/kırıkkale,Kırıkkale,Grand National Assembly,23,,,,
-744f3ba6-0bbb-4d18-a02c-82835ffe8fac,Mustafa Öztürk,Mustafa Öztürk,,,,Adalet ve Kalkınma Partisi,AKP,area/hatay,Hatay,Grand National Assembly,23,,,,
+744f3ba6-0bbb-4d18-a02c-82835ffe8fac,Mustafa Öztürk,Mustafa Öztürk,,,,Adalet ve Kalkınma Partisi,AKP,area/hatay,Hatay,Grand National Assembly,23,,,,male
 848f04b0-9d6e-43be-94d9-e7d9ef59a5a0,Mustafa Özyürek,Mustafa Özyürek,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(ii),İstanbul (II),Grand National Assembly,23,,,,male
 eac46dcc-cb10-4246-92fe-7c11c6371bde,Mustafa Ünal,Mustafa Ünal,,,,Adalet ve Kalkınma Partisi,AKP,area/karabük,Karabük,Grand National Assembly,23,,,,male
 9069606b-921c-436c-bdc2-8d69073332d8,Mustafa Şükrü Elekdağ,Mustafa Şükrü Elekdağ,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(iii),İstanbul (III),Grand National Assembly,23,,,,male
@@ -390,7 +390,7 @@ fdcff6d8-8365-4868-a919-896bf36be2bf,Nurettin Canikli,Nurettin Canikli,,,,Adalet
 58352665-73c7-4e20-947c-526e19e57e5c,Nuri Uslu,Nuri Uslu,,,,Adalet ve Kalkınma Partisi,AKP,area/uşak,Uşak,Grand National Assembly,23,,,,
 27c03766-22c6-43b7-92cd-11385b35545b,Nusret Bayraktar,Nusret Bayraktar,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,23,,,,
 0848e1fc-16bc-443f-a8b8-2aff2e46a1cd,Oktay Vural,Oktay Vural,,,,Milliyetçi Hareket Partisi,MHP,area/İzmir_(i),İzmir (I),Grand National Assembly,23,,,https://upload.wikimedia.org/wikipedia/commons/5/5f/Oktay_Vural_cropped.jpg,male
-a8cb4f61-456c-4a07-96f3-78ce139374bb,Onur Başaran Öymen,Onur Başaran Öymen,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,23,,,,
+a8cb4f61-456c-4a07-96f3-78ce139374bb,Onur Başaran Öymen,Onur Başaran Öymen,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,23,,,,male
 8c7ca376-2d39-4684-a596-132a223e7580,Orhan Erdem,Orhan Erdem,,,,Adalet ve Kalkınma Partisi,AKP,area/konya,Konya,Grand National Assembly,23,,,,male
 4b042883-f3d0-48bd-83ba-cc49377059b4,Orhan Karasayar,Orhan Karasayar,,,,Adalet ve Kalkınma Partisi,AKP,area/hatay,Hatay,Grand National Assembly,23,,,,
 d04cb27d-35da-47e9-96c7-d1002d9ad23b,Orhan Ziya Diren,Orhan Ziya Diren,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,23,,,,
@@ -400,7 +400,7 @@ b1b92ea7-e502-456c-9500-a3e65e8b774c,Osman Coşkun,Osman Coşkun,,,,Adalet ve Ka
 ec752d4d-9bb0-4a0f-950c-c4db0be58159,Osman Demir,Osman Demir,,,,Adalet ve Kalkınma Partisi,AKP,area/tokat,Tokat,Grand National Assembly,23,,,,
 e59155af-51b6-4ddc-9c82-01170879ee22,Osman Durmuş,Osman Durmuş,,,,Milliyetçi Hareket Partisi,MHP,area/kırıkkale,Kırıkkale,Grand National Assembly,23,,,,male
 3bdd8b18-1bb3-46fb-b0b3-94b1a6d48380,Osman Ertuğrul,Osman Ertuğrul,,,,Milliyetçi Hareket Partisi,MHP,area/aksaray,Aksaray,Grand National Assembly,23,,,,male
-4d51ab1c-4124-4df7-9280-054e6b7c0e0b,Osman Gazi Yağmurdereli,Osman Gazi Yağmurdereli,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(ii),İstanbul (II),Grand National Assembly,23,,,,
+4d51ab1c-4124-4df7-9280-054e6b7c0e0b,Osman Gazi Yağmurdereli,Osman Gazi Yağmurdereli,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(ii),İstanbul (II),Grand National Assembly,23,,,,male
 1d404fb7-b5bb-4012-b5fd-abb65a6f22b7,Osman Kaptan,Osman Kaptan,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,23,,,,male
 9a2bb49c-91a9-4183-9864-d327f493db0e,Osman Kılıç,Osman Kılıç,,,,Adalet ve Kalkınma Partisi,AKP,area/sivas,Sivas,Grand National Assembly,23,,,,
 c56b180b-6819-4c95-9583-d0f70b4ebc04,Osman Pepe,Osman Pepe,,,,Adalet ve Kalkınma Partisi,AKP,area/kocaeli,Kocaeli,Grand National Assembly,23,,,,male
@@ -458,7 +458,7 @@ d6c9ae86-dd09-4912-9611-0b7db3560a9e,Süleyman Latif Yunusoğlu,Süleyman Latif 
 0cb1dde7-2cb2-4e9d-bfb2-0246e422f915,Süleyman Nevzat Korkmaz,Süleyman Nevzat Korkmaz,,,,Milliyetçi Hareket Partisi,MHP,area/isparta,Isparta,Grand National Assembly,23,,,,male
 b2cf0fed-8f87-4a21-8a31-d32af719e9f9,Süleyman Turan Çirkin,Süleyman Turan Çirkin,,,,Milliyetçi Hareket Partisi,MHP,area/hatay,Hatay,Grand National Assembly,23,,,,
 63695e2d-c0f2-4544-ba67-2fea0866fca2,Süleyman Yağız,Süleyman Yağız,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(ii),İstanbul (II),Grand National Assembly,23,,,,
-78d335b5-de60-44e5-93fb-2d0eb1c8acc3,Süleyman Çelebi,Süleyman Çelebi,,,,Adalet ve Kalkınma Partisi,AKP,area/mardin,Mardin,Grand National Assembly,23,,,,
+78d335b5-de60-44e5-93fb-2d0eb1c8acc3,Süleyman Çelebi,Süleyman Çelebi,,,,Adalet ve Kalkınma Partisi,AKP,area/mardin,Mardin,Grand National Assembly,23,,,,male
 f154e843-71ac-46bd-b512-453a0de2bd04,Süreyya Sadi Bilgiç,Süreyya Sadi Bilgiç,,,,Adalet ve Kalkınma Partisi,AKP,area/isparta,Isparta,Grand National Assembly,23,,,,male
 5554a445-af3a-4a7e-9abf-2a9245790abc,Sırrı Sakık,Sırrı Sakık,,,,Bağımsız,ind,area/muş,Muş,Grand National Assembly,23,,,https://upload.wikimedia.org/wikipedia/commons/7/7c/Sırrı_Sakık.jpg,male
 3774bab9-5600-406b-ad97-d2b7e71610a4,Tacidar Seyhan,Tacidar Seyhan,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,23,,,,

--- a/data/Turkey/Assembly/term-24.csv
+++ b/data/Turkey/Assembly/term-24.csv
@@ -22,7 +22,7 @@ efe6688a-5d06-482d-ae3c-c922c730fec0,Ahmet Duran Bulut,Ahmet Duran Bulut,,,,Mill
 b2c4f61e-37ed-4723-8a59-0a94689303a0,Ahmet Edip Uğur,Ahmet Edip Uğur,,,,Adalet ve Kalkınma Partisi,AKP,area/balıkesir,Balıkesir,Grand National Assembly,24,,,,male
 c83e7e1d-674a-4234-831d-88e44d23a68f,Ahmet Erdal Feralan,Ahmet Erdal Feralan,,,,Adalet ve Kalkınma Partisi,AKP,area/nevşehir,Nevşehir,Grand National Assembly,24,,,,male
 fec0a883-4f7c-4509-bb84-3e94e20291b5,Ahmet Haldun Ertürk,Ahmet Haldun Ertürk,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(ii),İstanbul (II),Grand National Assembly,24,,,,
-ce4e553c-3391-440f-b5ff-19e985f7665d,Ahmet Haluk Koç,Ahmet Haluk Koç,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,24,,,,
+ce4e553c-3391-440f-b5ff-19e985f7665d,Ahmet Haluk Koç,Ahmet Haluk Koç,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,24,,,,male
 926ecdf7-d4be-4062-9f0d-732803f97264,Ahmet Kenan Tanrıkulu,Ahmet Kenan Tanrıkulu,,,,Milliyetçi Hareket Partisi,MHP,area/İzmir_(ii),İzmir (II),Grand National Assembly,24,,,,male
 ea4878e0-467f-4c56-84ef-c95e61fece7b,Ahmet Kutalmış Türkeş,Ahmet Kutalmış Türkeş,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(ii),İstanbul (II),Grand National Assembly,24,,,,male
 82d0a36e-b49a-4372-b3c4-ed4a83a21def,Ahmet Salih Dal,Ahmet Salih Dal,,,,Adalet ve Kalkınma Partisi,AKP,area/kilis,Kilis,Grand National Assembly,24,,,,
@@ -64,7 +64,7 @@ c9b19f25-bbff-4a2f-bdc2-40ac1b7871e0,Altan Tan,Altan Tan,,,,Bağımsız,ind,area
 f4f93782-6f36-469a-81f2-12d6e665ad42,Atila Kaya,Atila Kaya,,,,Milliyetçi Hareket Partisi,MHP,area/İstanbul_(iii),İstanbul (III),Grand National Assembly,24,,,,male
 e69c224c-fbcd-4fc7-8712-d7a93121a033,Atilla Kart,Atilla Kart,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,24,,,,
 ab2cc3e6-9a47-4d86-9023-d1b5f8c5239d,Avni Erdemir,Avni Erdemir,,,,Adalet ve Kalkınma Partisi,AKP,area/amasya,Amasya,Grand National Assembly,24,,,,
-d0e5894b-b8b2-4991-84bf-985391d26a63,Aydın Ağan Ayaydın,Aydın Ağan Ayaydın,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(ii),İstanbul (II),Grand National Assembly,24,,,,
+d0e5894b-b8b2-4991-84bf-985391d26a63,Aydın Ağan Ayaydın,Aydın Ağan Ayaydın,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(ii),İstanbul (II),Grand National Assembly,24,,,,male
 1461ccd3-c7ba-4149-baea-a654ba05931f,Aydın Bıyıklıoğlu,Aydın Bıyıklıoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/trabzon,Trabzon,Grand National Assembly,24,,,,
 fa4659d7-e2b1-477c-9710-4eba005c388f,Aydın Özcan,Aydın Özcan,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir_(i),İzmir (I),Grand National Assembly,24,,,,
 12285e89-7aa5-4ec1-8144-67b77d393f16,Aydın Şengül,Aydın Şengül,,,,Adalet ve Kalkınma Partisi,AKP,area/İzmir_(ii),İzmir (II),Grand National Assembly,24,,,,
@@ -77,10 +77,10 @@ d1fdbceb-29b3-4baf-aa7b-6a686056077d,Aylin Nazlıaka,Aylin Nazlıaka,,,,Cumhuriy
 58da65a2-b90e-4cea-a414-fdb5e7f401be,Aytun Çıray,Aytun Çıray,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir_(ii),İzmir (II),Grand National Assembly,24,,,,
 c7cd9c82-e20b-42cf-af34-6bcebc350384,Aytuğ Atıcı,Aytuğ Atıcı,,,,Cumhuriyet Halk Partisi,CHP,area/mersin,Mersin,Grand National Assembly,24,,,,
 f310e47e-b82a-4c55-9294-7e59e4e3a978,Ayşe Eser Danışoğlu,Ayşe Eser Danışoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,24,,,,
-7b913e34-7774-4b0a-bc94-cc29cdcb4c7c,Ayşe Gülsün Bilgehan,Ayşe Gülsün Bilgehan,,,,Cumhuriyet Halk Partisi,CHP,area/ankara_(ii),Ankara (II),Grand National Assembly,24,,,,
+7b913e34-7774-4b0a-bc94-cc29cdcb4c7c,Ayşe Gülsün Bilgehan,Ayşe Gülsün Bilgehan,,,,Cumhuriyet Halk Partisi,CHP,area/ankara_(ii),Ankara (II),Grand National Assembly,24,,,,female
 a0b4696f-b059-41d7-9206-838ed084bd8e,Ayşe Nur Bahçekapılı,Ayşe Nur Bahçekapılı,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(ii),İstanbul (II),Grand National Assembly,24,,,,female
 a6b2aa9c-bbd7-4e07-9043-50ceb9a7985f,Ayşe Türkmenoğlu,Ayşe Türkmenoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/konya,Konya,Grand National Assembly,24,,,,
-18253297-802d-4ef2-8dee-58a2e4c7be28,Ayşenur Külahlıoğlu İslam,Ayşenur Külahlıoğlu İslam,,,,Adalet ve Kalkınma Partisi,AKP,area/sakarya,Sakarya,Grand National Assembly,24,,,,
+18253297-802d-4ef2-8dee-58a2e4c7be28,Ayşenur Külahlıoğlu İslam,Ayşenur Külahlıoğlu İslam,,,,Adalet ve Kalkınma Partisi,AKP,area/sakarya,Sakarya,Grand National Assembly,24,,,,female
 40c4b708-cbfe-4ff3-84e5-1948466edd07,Bahattin Şeker,Bahattin Şeker,,,,Milliyetçi Hareket Partisi,MHP,area/bilecik,Bilecik,Grand National Assembly,24,,,,
 f92c5bf9-e6c4-4be6-9b50-a8e7970e45ca,Bayram Özçelik,Bayram Özçelik,,,,Adalet ve Kalkınma Partisi,AKP,area/burdur,Burdur,Grand National Assembly,24,,,,
 56223bca-49b9-41b7-9853-59406db6055c,Bedrettin Yıldırım,Bedrettin Yıldırım,,,,Adalet ve Kalkınma Partisi,AKP,area/bursa,Bursa,Grand National Assembly,24,,,,
@@ -161,14 +161,14 @@ a839de0e-7d31-483b-92f7-c4b94148462f,Faik Tunay,Faik Tunay,,,,Cumhuriyet Halk Pa
 81cf59d8-6294-4a3a-9ff2-1a8e41fa60ab,Faik Öztrak,Faik Öztrak,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,24,,,,male
 36b170ab-616d-4e90-8d7c-8b2135443491,Faruk Bal,Faruk Bal,,,,Milliyetçi Hareket Partisi,MHP,area/konya,Konya,Grand National Assembly,24,,,,male
 38ee4d47-e769-421a-b2a7-5ac98822c617,Faruk Işık,Faruk Işık,,,,Adalet ve Kalkınma Partisi,AKP,area/muş,Muş,Grand National Assembly,24,,,,
-146e65d1-5dff-4dd9-b08a-c27b858b749f,Faruk Nafiz Özak,Faruk Nafiz Özak,,,,Adalet ve Kalkınma Partisi,AKP,area/trabzon,Trabzon,Grand National Assembly,24,,,,
+146e65d1-5dff-4dd9-b08a-c27b858b749f,Faruk Nafiz Özak,Faruk Nafiz Özak,,,,Adalet ve Kalkınma Partisi,AKP,area/trabzon,Trabzon,Grand National Assembly,24,,,,male
 60d5b234-d259-4955-8675-e7c5fcbf1a79,Faruk Septioğlu,Faruk Septioğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/elazığ,Elazığ,Grand National Assembly,24,,,,male
 be45c5c7-bae9-48eb-b335-22cf4572e890,Faruk Çelik,Faruk Çelik,,,,Adalet ve Kalkınma Partisi,AKP,area/urfa,Urfa,Grand National Assembly,24,,,https://upload.wikimedia.org/wikipedia/commons/e/e1/Faruk-Çelik-2009.jpg,male
 5a210e5e-33d6-4a1e-9d7b-fd8e646e971b,Fatih Çiftci,Fatih Çiftci,,,,Adalet ve Kalkınma Partisi,AKP,area/van,Van,Grand National Assembly,24,,,,
 94fba3fd-1612-4539-b78f-0d110a336fd7,Fatih Şahin,Fatih Şahin,,,,Adalet ve Kalkınma Partisi,AKP,area/ankara_(i),Ankara (I),Grand National Assembly,24,,,,male
 b53c3927-6928-462c-b1d1-f197742ad49e,Fatihhan Ünal,Fatihhan Ünal,,,,Adalet ve Kalkınma Partisi,AKP,area/ordu,Ordu,Grand National Assembly,24,,,,
-893db21d-fdef-44c1-af07-8c17e0d7bbf7,Fatma Nur Serter,Fatma Nur Serter,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,24,,,,
-c2fed048-ac33-41f3-8e0e-9beac8b82631,Fatma Salman Kotan,Fatma Salman Kotan,,,,Adalet ve Kalkınma Partisi,AKP,area/ağrı,Ağrı,Grand National Assembly,24,,,,
+893db21d-fdef-44c1-af07-8c17e0d7bbf7,Fatma Nur Serter,Fatma Nur Serter,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,24,,,,female
+c2fed048-ac33-41f3-8e0e-9beac8b82631,Fatma Salman Kotan,Fatma Salman Kotan,,,,Adalet ve Kalkınma Partisi,AKP,area/ağrı,Ağrı,Grand National Assembly,24,,,,female
 5d2b9e09-8832-461e-9000-9f92d96ff099,Fatma Şahin,Fatma Şahin,,,,Adalet ve Kalkınma Partisi,AKP,area/gaziantep,Gaziantep,Grand National Assembly,24,,,"https://upload.wikimedia.org/wikipedia/commons/4/48/Fatma_Sahin_-_World_Economic_Forum_on_the_Middle_East,_North_Africa_and_Eurasia_2012.jpg",female
 8bf3546e-9b7d-4af2-a040-555c5e96219a,Fatoş Gürkan,Fatoş Gürkan,,,,Adalet ve Kalkınma Partisi,AKP,area/adana,Adana,Grand National Assembly,24,,,,female
 be77af6c-ea0c-46e2-9dd9-e845f3890061,Faysal Sarıyıldız,Faysal Sarıyıldız,,,,Bağımsız,ind,area/Şırnak,Şırnak,Grand National Assembly,24,,,,
@@ -252,7 +252,7 @@ e886dbe4-c3e4-49f6-a008-1f95802dac70,Mahmut Kaçar,Mahmut Kaçar,,,,Adalet ve Ka
 cf99a330-4407-4986-b663-110e7bb04ea8,Mahmut Mücahit Fındıklı,Mahmut Mücahit Fındıklı,,,,Adalet ve Kalkınma Partisi,AKP,area/malatya,Malatya,Grand National Assembly,24,,,,
 2ded6f00-263b-44a4-a9c4-94d6f02e531b,Mahmut Tanal,Mahmut Tanal,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,24,,,,
 fcb8a5b0-7e2e-410b-92de-03a6952711fb,Malik Ecder Özdemir,Malik Ecder Özdemir,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,24,,,,
-835f265a-0529-4b66-b8d2-93499bda9967,Mehmet Akif Hamzaçebi,Mehmet Akif Hamzaçebi,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,24,,,,
+835f265a-0529-4b66-b8d2-93499bda9967,Mehmet Akif Hamzaçebi,Mehmet Akif Hamzaçebi,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,24,,,https://upload.wikimedia.org/wikipedia/commons/0/09/Akif_Hamzaçebi.jpg,male
 ce3576bc-4fca-4fec-a975-2a57a163c6fc,Mehmet Akyürek,Mehmet Akyürek,,,,Adalet ve Kalkınma Partisi,AKP,area/urfa,Urfa,Grand National Assembly,24,,,,
 8598c938-45f0-4b7a-b043-79c67f9890c3,Mehmet Ali Ediboğlu,Mehmet Ali Ediboğlu,,,,Cumhuriyet Halk Partisi,CHP,area/hatay,Hatay,Grand National Assembly,24,,,,
 f4eb4653-73fa-45f0-8503-def0073725a4,Mehmet Ali Okur,Mehmet Ali Okur,,,,Adalet ve Kalkınma Partisi,AKP,area/kocaeli,Kocaeli,Grand National Assembly,24,,,,
@@ -276,7 +276,7 @@ c3b14316-0652-4249-abd8-016cad62b75f,Mehmet Geldi,Mehmet Geldi,,,,Adalet ve Kalk
 5e38e66c-b7d6-4316-b822-337e241f083e,Mehmet Hilal Kaplan,Mehmet Hilal Kaplan,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,24,,,,
 0989df97-0aa0-4546-b231-b3bd42b6c0f3,Mehmet Kasım Gülpınar,Mehmet Kasım Gülpınar,,,,Adalet ve Kalkınma Partisi,AKP,area/urfa,Urfa,Grand National Assembly,24,,,,
 e02d089c-969e-43a1-b95a-a6dc2001b2c9,Mehmet Kerim Yıldız,Mehmet Kerim Yıldız,,,,Adalet ve Kalkınma Partisi,AKP,area/ağrı,Ağrı,Grand National Assembly,24,,,,male
-aea2f99a-3d32-4a85-9138-9bb4964c7aac,Mehmet Mehdi Eker,Mehmet Mehdi Eker,,,,Adalet ve Kalkınma Partisi,AKP,area/diyarbakır,Diyarbakır,Grand National Assembly,24,,,,
+aea2f99a-3d32-4a85-9138-9bb4964c7aac,Mehmet Mehdi Eker,Mehmet Mehdi Eker,,,,Adalet ve Kalkınma Partisi,AKP,area/diyarbakır,Diyarbakır,Grand National Assembly,24,,,https://upload.wikimedia.org/wikipedia/commons/a/a4/Mehdi_Eker.jpg,male
 e2b6f571-3eae-4aff-ab4c-029411bc7743,Mehmet Metiner,Mehmet Metiner,,,,Adalet ve Kalkınma Partisi,AKP,area/adıyaman,Adıyaman,Grand National Assembly,24,,,,male
 8c8193f6-e42e-4708-9431-14108511233d,Mehmet Muş,Mehmet Muş,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(iii),İstanbul (III),Grand National Assembly,24,,,,
 df1d069a-e900-4fc8-8d8c-c76ec5d80901,Mehmet Müezzinoğlu,Mehmet Müezzinoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/edirne,Edirne,Grand National Assembly,24,,,,male
@@ -284,7 +284,7 @@ add873e6-fd60-4ee4-8b42-b4f1c5b14006,Mehmet Necati Çetinkaya,Mehmet Necati Çet
 72791094-761b-4dbb-b46b-88adeabf6ebc,Mehmet Sarı,Mehmet Sarı,,,,Adalet ve Kalkınma Partisi,AKP,area/gaziantep,Gaziantep,Grand National Assembly,24,,,,male
 252c3541-58f1-4d93-9177-f3cc32fe0f99,Mehmet Sayım Tekelioğlu,Mehmet Sayım Tekelioğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/İzmir_(i),İzmir (I),Grand National Assembly,24,,,,
 c8f11a41-0297-4d7c-a7fe-4c37cdf7f6fd,Mehmet Sağlam,Mehmet Sağlam,,,,Adalet ve Kalkınma Partisi,AKP,area/kahramanmaraş,Kahramanmaraş,Grand National Assembly,24,,,,male
-342f6036-28ad-4bcd-8cfe-380046791321,Mehmet Siyam Kesimoğlu,Mehmet Siyam Kesimoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/kırklareli,Kırklareli,Grand National Assembly,24,,,,
+342f6036-28ad-4bcd-8cfe-380046791321,Mehmet Siyam Kesimoğlu,Mehmet Siyam Kesimoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/kırklareli,Kırklareli,Grand National Assembly,24,,,,male
 4ca02272-47a7-44dd-b20f-e1c406dd871a,Mehmet Süleyman Hamzaoğulları,Mehmet Süleyman Hamzaoğulları,,,,Adalet ve Kalkınma Partisi,AKP,area/diyarbakır,Diyarbakır,Grand National Assembly,24,,,,
 76430ff2-6f7c-4153-a2b5-c8c886e90fa7,Mehmet Yüksel,Mehmet Yüksel,,,,Adalet ve Kalkınma Partisi,AKP,area/denizli,Denizli,Grand National Assembly,24,,,,male
 d7f5cc4f-1224-4cd9-893b-65e6ab26252d,Mehmet Zafer Çağlayan,Mehmet Zafer Çağlayan,,,,Adalet ve Kalkınma Partisi,AKP,area/mersin,Mersin,Grand National Assembly,24,,,"https://upload.wikimedia.org/wikipedia/commons/f/f5/Mehmet_Zafer_Caglayan_-_World_Economic_Forum_on_the_Middle_East,_North_Africa_and_Eurasia_2012_crop.jpg",male
@@ -308,7 +308,7 @@ ea19408f-e916-403b-8263-2f72d881a0ef,Mevlüt Dudu,Mevlüt Dudu,,,,Cumhuriyet Hal
 2b10495c-c445-4c6a-8339-1b0a1325aca7,Mine Lök Beyaz,Mine Lök Beyaz,,,,Adalet ve Kalkınma Partisi,AKP,area/diyarbakır,Diyarbakır,Grand National Assembly,24,,,,
 1c0aa235-a226-4661-b40c-3eabd44b492e,Muammer Güler,Muammer Güler,,,,Adalet ve Kalkınma Partisi,AKP,area/mardin,Mardin,Grand National Assembly,24,,,,male
 4f21f429-939a-4df5-a2ca-ca681509b0c3,Muhammed Murtaza Yetiş,Muhammed Murtaza Yetiş,,,,Adalet ve Kalkınma Partisi,AKP,area/adıyaman,Adıyaman,Grand National Assembly,24,,,,male
-5402ad3e-f5ee-4ecb-bbc5-c24e5b71ff31,Muhammed Rıza Yalçınkaya,Muhammed Rıza Yalçınkaya,,,,Cumhuriyet Halk Partisi,CHP,area/bartın,Bartın,Grand National Assembly,24,,,,male
+5402ad3e-f5ee-4ecb-bbc5-c24e5b71ff31,Muhammed Rıza Yalçınkaya,Muhammed Rıza Yalçınkaya,,,,Cumhuriyet Halk Partisi,CHP,area/bartın,Bartın,Grand National Assembly,24,,,,
 0de2eba1-2f2c-478f-8fdc-dfd0bc8e1d9a,Muhammed Çetin,Muhammed Çetin,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,24,,,,
 89205b13-38bb-487b-8ccc-2c991015316e,Muhammet Bilal Macit,Muhammet Bilal Macit,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,24,,,,male
 1f6e0240-6a59-4fc7-b8a4-d9586eb40a66,Muharrem Işık,Muharrem Işık,,,,Cumhuriyet Halk Partisi,CHP,area/erzincan,Erzincan,Grand National Assembly,24,,,,
@@ -333,8 +333,8 @@ e7f1c8d4-7023-4156-a03d-1cc790ecea92,Mustafa Kabakcı,Mustafa Kabakcı,,,,Adalet
 0021cf04-06fd-4b43-8177-21113da5c4c3,Mustafa Kalaycı,Mustafa Kalaycı,,,,Milliyetçi Hareket Partisi,MHP,area/konya,Konya,Grand National Assembly,24,,,,male
 ae6bdc28-f322-41dd-8bf5-8e6c5138a8fa,Mustafa Kemal Şerbetçioğlu,Mustafa Kemal Şerbetçioğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/bursa,Bursa,Grand National Assembly,24,,,,
 c51bece2-6b08-46a6-9d2d-aebb20a9cce1,Mustafa Moroğlu,Mustafa Moroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir_(ii),İzmir (II),Grand National Assembly,24,,,,
-36df5bbc-0c97-4ac0-92b9-3eff4b0a0106,Mustafa Sezgin Tanrıkulu,Mustafa Sezgin Tanrıkulu,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(ii),İstanbul (II),Grand National Assembly,24,,,,
-7510e2e1-0c00-43e1-8bb6-eda6118c1d60,Mustafa Öztürk,Mustafa Öztürk,,,,Adalet ve Kalkınma Partisi,AKP,area/bursa,Bursa,Grand National Assembly,24,,,,
+36df5bbc-0c97-4ac0-92b9-3eff4b0a0106,Mustafa Sezgin Tanrıkulu,Mustafa Sezgin Tanrıkulu,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(ii),İstanbul (II),Grand National Assembly,24,,,,male
+7510e2e1-0c00-43e1-8bb6-eda6118c1d60,Mustafa Öztürk,Mustafa Öztürk,,,,Adalet ve Kalkınma Partisi,AKP,area/bursa,Bursa,Grand National Assembly,24,,,,male
 bc812f54-1419-404e-ab09-3c039431e742,Mustafa Şahin,Mustafa Şahin,,,,Adalet ve Kalkınma Partisi,AKP,area/malatya,Malatya,Grand National Assembly,24,,,,
 ec7c2bca-14d6-4b84-99a7-be069f12b0f5,Mustafa Şentop,Mustafa Şentop,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(iii),İstanbul (III),Grand National Assembly,24,,,,male
 e6ff4a50-a598-44b8-a5e2-bf1d01e7dbc6,Muzaffer Aslan,Muzaffer Aslan,,,,Adalet ve Kalkınma Partisi,AKP,area/kırşehir,Kırşehir,Grand National Assembly,24,,,,
@@ -374,10 +374,10 @@ fdcff6d8-8365-4868-a919-896bf36be2bf,Nurettin Canikli,Nurettin Canikli,,,,Adalet
 48c5c1a5-7dc8-4870-8e55-877417f49025,Osman Aydın,Osman Aydın,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,24,,,,male
 665beb65-e554-44d9-b1d2-53250976a10f,Osman Aşkın Bak,Osman Aşkın Bak,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(ii),İstanbul (II),Grand National Assembly,24,,,,
 b51c64c3-b677-496a-b064-48df14b8c5c5,Osman Boyraz,Osman Boyraz,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,24,,,,
-a17a618b-0ff6-456a-a05d-22a62b3aef02,Osman Faruk Loğoğlu,Osman Faruk Loğoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,24,,,,
+a17a618b-0ff6-456a-a05d-22a62b3aef02,Osman Faruk Loğoğlu,Osman Faruk Loğoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,24,,,,male
 e764c4c4-fcb3-42ba-b40a-1ec988af5b0a,Osman Kahveci,Osman Kahveci,,,,Adalet ve Kalkınma Partisi,AKP,area/karabük,Karabük,Grand National Assembly,24,,,,male
 1d404fb7-b5bb-4012-b5fd-abb65a6f22b7,Osman Kaptan,Osman Kaptan,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,24,,,,male
-23e9a0fb-98a2-4ec4-b267-a8f7fc241cf8,Osman Taney Korutürk,Osman Taney Korutürk,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,24,,,,
+23e9a0fb-98a2-4ec4-b267-a8f7fc241cf8,Osman Taney Korutürk,Osman Taney Korutürk,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul_(i),İstanbul (I),Grand National Assembly,24,,,,male
 798b6071-7977-4e44-b06c-ba132719f3e9,Osman Çakır,Osman Çakır,,,,Adalet ve Kalkınma Partisi,AKP,area/düzce,Düzce,Grand National Assembly,24,,,,
 b6d124d5-df85-48e8-8492-9224dea160a5,Osman Ören,Osman Ören,,,,Adalet ve Kalkınma Partisi,AKP,area/siirt,Siirt,Grand National Assembly,24,,,,
 cac8cf0c-7de4-41a9-ab0b-1af4e10e2bb7,Oya Eronat,Oya Eronat,,,,Adalet ve Kalkınma Partisi,AKP,area/diyarbakır,Diyarbakır,Grand National Assembly,24,,,,
@@ -489,7 +489,7 @@ c85a77a1-fce9-4aa5-99c4-b8f241424174,Zelkif Kazdal,Zelkif Kazdal,,,,Adalet ve Ka
 41cab79e-52a0-460d-8f27-bfc404e94b89,Zeyid Aslan,Zeyid Aslan,,,,Adalet ve Kalkınma Partisi,AKP,area/tokat,Tokat,Grand National Assembly,24,,,,
 5d35c122-37e8-4671-ab0b-6b37e32a88e7,Zeynep Karahan Uslu,Zeynep Karahan Uslu,,,,Adalet ve Kalkınma Partisi,AKP,area/urfa,Urfa,Grand National Assembly,24,,,,female
 8a81dc19-0430-48f8-a8b8-86d26fb0ff01,Ziver Özdemir,Ziver Özdemir,,,,Adalet ve Kalkınma Partisi,AKP,area/batman,Batman,Grand National Assembly,24,,,,
-f93c19f2-9461-47ef-bc25-b1d026fcb7f5,Zuhal Topçu,Zuhal Topçu,,,,Milliyetçi Hareket Partisi,MHP,area/ankara_(i),Ankara (I),Grand National Assembly,24,,,,
+f93c19f2-9461-47ef-bc25-b1d026fcb7f5,Zuhal Topçu,Zuhal Topçu,,,,Milliyetçi Hareket Partisi,MHP,area/ankara_(i),Ankara (I),Grand National Assembly,24,,,,female
 b3b37a6b-a6a8-4633-8452-08f3a56b9c46,Zülfü Demirbağ,Zülfü Demirbağ,,,,Adalet ve Kalkınma Partisi,AKP,area/elazığ,Elazığ,Grand National Assembly,24,,,,
 0a4c3fd4-fc58-4c24-a659-87f5d784c576,Çiğdem Münevver Ökten,Çiğdem Münevver Ökten,,,,Adalet ve Kalkınma Partisi,AKP,area/mersin,Mersin,Grand National Assembly,24,,,,
 ea57eace-4b34-45d5-bbf6-5794a935f153,Ömer Dinçer,Ömer Dinçer,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul_(iii),İstanbul (III),Grand National Assembly,24,,,,male

--- a/data/Turkey/Assembly/term-25.csv
+++ b/data/Turkey/Assembly/term-25.csv
@@ -23,10 +23,10 @@ c4c51167-517f-4fad-aaa5-c092311003a1,Adnan Şefik Çirkin,Adnan Şefik Çirkin,,
 751a6140-d9c1-4287-bff8-5ba899c0a359,Ahmet Doğan,Ahmet Doğan,,,,Adalet ve Kalkınma Partisi,AKP,area/kayseri,Kayseri,Grand National Assembly,25,,,,
 8ebff008-f373-46b8-84ae-47ec6fde05b0,Ahmet Eşref Fakıbaba,Ahmet Eşref Fakıbaba,,,,Adalet ve Kalkınma Partisi,AKP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,25,,,,male
 c2fe3533-b6e7-4f5a-8439-aea5631e7b61,Ahmet Gündoğdu,Ahmet Gündoğdu,,,,Adalet ve Kalkınma Partisi,AKP,area/ankara,Ankara,Grand National Assembly,25,,,,
-ce4e553c-3391-440f-b5ff-19e985f7665d,Ahmet Haluk Koç,Ahmet Haluk Koç,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,25,,,,
+ce4e553c-3391-440f-b5ff-19e985f7665d,Ahmet Haluk Koç,Ahmet Haluk Koç,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,25,,,,male
 926ecdf7-d4be-4062-9f0d-732803f97264,Ahmet Kenan Tanrıkulu,Ahmet Kenan Tanrıkulu,,,,Milliyetçi Hareket Partisi,MHP,area/İzmir,İzmir,Grand National Assembly,25,,,,male
 290739e3-49d4-4f75-aa68-36609fdb7ecf,Ahmet Selim Yurdakul,Ahmet Selim Yurdakul,,,,Milliyetçi Hareket Partisi,MHP,area/antalya,Antalya,Grand National Assembly,25,,,,
-61f10d69-18cc-47f5-b675-3d833a887cdc,Ahmet Tuncay Özkan,Ahmet Tuncay Özkan,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,25,,,,
+61f10d69-18cc-47f5-b675-3d833a887cdc,Ahmet Tuncay Özkan,Ahmet Tuncay Özkan,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,25,,,,male
 7bb1fe3b-4b98-4c21-9766-bb4925a202d1,Ahmet Yıldırım,Ahmet Yıldırım,,,,Halkların Demokratik Partisi,HDP,area/muş,Muş,Grand National Assembly,25,,,,
 6dab7f3a-d1f4-4e90-a73a-18981a2c4cf2,Ahmet İyimaya,Ahmet İyimaya,,,,Adalet ve Kalkınma Partisi,AKP,area/ankara,Ankara,Grand National Assembly,25,,,,male
 5a4b4310-2bde-41d5-95bc-45185cbfdfc2,Akif Çağatay Kılıç,Akif Çağatay Kılıç,,,,Adalet ve Kalkınma Partisi,AKP,area/samsun,Samsun,Grand National Assembly,25,,,"https://upload.wikimedia.org/wikipedia/commons/0/05/AkifÇağatayKılıç,_Minister_of_Youth_and_Sports_(May_2014).JPG",male
@@ -69,11 +69,11 @@ d1fdbceb-29b3-4baf-aa7b-6a686056077d,Aylin Nazlıaka,Aylin Nazlıaka,,,,Cumhuriy
 c7cd9c82-e20b-42cf-af34-6bcebc350384,Aytuğ Atıcı,Aytuğ Atıcı,,,,Cumhuriyet Halk Partisi,CHP,area/mersin,Mersin,Grand National Assembly,25,,,,
 2fb0051a-32b0-4a12-866a-fb01b5198040,Ayşe Acar Başaran,Ayşe Acar Başaran,,,,Halkların Demokratik Partisi,HDP,area/batman,Batman,Grand National Assembly,25,,,,
 e8b133ff-47da-4673-b0af-1d2ea0fd4355,Ayşe Doğan,Ayşe Doğan,,,,Adalet ve Kalkınma Partisi,AKP,area/tekirdağ,Tekirdağ,Grand National Assembly,25,,,,
-7b913e34-7774-4b0a-bc94-cc29cdcb4c7c,Ayşe Gülsün Bilgehan,Ayşe Gülsün Bilgehan,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,25,,,,
+7b913e34-7774-4b0a-bc94-cc29cdcb4c7c,Ayşe Gülsün Bilgehan,Ayşe Gülsün Bilgehan,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,25,,,,female
 5f8ea3fa-f6ce-45c1-82f1-327bc8ed2c8e,Ayşe Keşir,Ayşe Keşir,,,,Adalet ve Kalkınma Partisi,AKP,area/düzce,Düzce,Grand National Assembly,25,,,,
 a0b4696f-b059-41d7-9206-838ed084bd8e,Ayşe Nur Bahçekapılı,Ayşe Nur Bahçekapılı,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,25,,,,female
 cd494a2c-9070-467a-89d8-8691337d730e,Ayşe Sula Köseoğlu,Ayşe Sula Köseoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/trabzon,Trabzon,Grand National Assembly,25,,,,
-b93ff0e7-1d86-4793-97a1-b4989acbaa33,Ayşenur İslam,Ayşenur İslam,,,,Adalet ve Kalkınma Partisi,AKP,area/sakarya,Sakarya,Grand National Assembly,25,,,,female
+b93ff0e7-1d86-4793-97a1-b4989acbaa33,Ayşenur İslam,Ayşenur İslam,,,,Adalet ve Kalkınma Partisi,AKP,area/sakarya,Sakarya,Grand National Assembly,25,,,,
 e1472fe5-8ef3-4106-9e8d-6b0830362f1f,Aziz Babuşçu,Aziz Babuşçu,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,25,,,,
 5bac3d58-4558-4b84-a02d-c64e6521c7a5,Baki Şimşek,Baki Şimşek,,,,Milliyetçi Hareket Partisi,MHP,area/mersin,Mersin,Grand National Assembly,25,,,,
 6602dc75-7d42-4734-918d-ddd6334a843d,Barış Karadeniz,Barış Karadeniz,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,25,,,,
@@ -119,7 +119,7 @@ ab204988-4f94-4f88-a3fd-c55a456ee0b5,Didem Engin,Didem Engin,,,,Cumhuriyet Halk 
 bf9beec5-33c9-4ccd-9948-d05e97a91249,Dilek Öcalan,Dilek Öcalan,,,,Halkların Demokratik Partisi,HDP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,25,,,,
 526d9e52-72fa-41cd-b727-ab11b528e9e5,Dirayet Taşdemir,Dirayet Taşdemir,,,,Halkların Demokratik Partisi,HDP,area/ağrı,Ağrı,Grand National Assembly,25,,,,
 54846200-2900-4938-9aed-4b43869c2490,Durmuş Ali Sarıkaya,Durmuş Ali Sarıkaya,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,25,,,,
-8d75f83a-982a-45f4-aebf-a7316a52f7f5,Durmuş Fikri Sağlar,Durmuş Fikri Sağlar,,,,Cumhuriyet Halk Partisi,CHP,area/mersin,Mersin,Grand National Assembly,25,,,,
+8d75f83a-982a-45f4-aebf-a7316a52f7f5,Durmuş Fikri Sağlar,Durmuş Fikri Sağlar,,,,Cumhuriyet Halk Partisi,CHP,area/mersin,Mersin,Grand National Assembly,25,,,,male
 04ac6412-0071-42a0-9d28-786d47f09827,Durmuş Yalçın,Durmuş Yalçın,,,,Milliyetçi Hareket Partisi,MHP,area/karabük,Karabük,Grand National Assembly,25,,,,
 5d03c480-c7ff-4f75-8b70-ca3cf32a7a94,Durmuş Yılmaz,Durmuş Yılmaz,,,,Milliyetçi Hareket Partisi,MHP,area/uşak,Uşak,Grand National Assembly,25,,,,male
 8295839d-402f-4f0d-9348-6d57043b3724,Dursun Çiçek,Dursun Çiçek,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,25,,,,male
@@ -259,7 +259,7 @@ c08594e2-fb40-430c-bb4f-b076aa29cc09,Mahmut Sami Mallı,Mahmut Sami Mallı,,,,Ad
 b592531a-c9dc-4070-9fae-0a5106f36b10,Markar Eseyan,Markar Eseyan,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,25,,,,male
 4787d82d-05b0-4605-8283-d66cfea1a1c4,Mazhar Bağlı,Mazhar Bağlı,,,,Adalet ve Kalkınma Partisi,AKP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,25,,,,
 cd37ebe7-6109-497a-b83d-82d18ad16fce,Mazlum Nurlu,Mazlum Nurlu,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,25,,,,
-835f265a-0529-4b66-b8d2-93499bda9967,Mehmet Akif Hamzaçebi,Mehmet Akif Hamzaçebi,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,25,,,,
+835f265a-0529-4b66-b8d2-93499bda9967,Mehmet Akif Hamzaçebi,Mehmet Akif Hamzaçebi,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,25,,,https://upload.wikimedia.org/wikipedia/commons/0/09/Akif_Hamzaçebi.jpg,male
 99765200-967a-439f-b414-600ea03f094a,Mehmet Akif Yılmaz,Mehmet Akif Yılmaz,,,,Adalet ve Kalkınma Partisi,AKP,area/kocaeli,Kocaeli,Grand National Assembly,25,,,,
 00f3d2fe-5b92-475b-9a15-eabad6f1a509,Mehmet Ali Aslan,Mehmet Ali Aslan,,,,Halkların Demokratik Partisi,HDP,area/mardin,Mardin,Grand National Assembly,25,,,,
 c30c93ca-e9b9-4a68-996c-d5a8cfffd994,Mehmet Ali Pulcu,Mehmet Ali Pulcu,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,25,,,,
@@ -308,7 +308,7 @@ e0114e80-799f-45be-abd4-bad2bf81f57a,Mithat Sancar,Mithat Sancar,,,,Halkların D
 e957db51-d1a5-4f00-9e3f-6e62dbc7d48f,Mizgin Irgat,Mizgin Irgat,,,,Halkların Demokratik Partisi,HDP,area/bitlis,Bitlis,Grand National Assembly,25,,,,
 2747bfef-0870-40b5-b1b5-ce085036ca0d,Muhammet Balta,Muhammet Balta,,,,Adalet ve Kalkınma Partisi,AKP,area/trabzon,Trabzon,Grand National Assembly,25,,,,
 6c453c55-7a0d-427d-ae99-6023872732b3,Muhammet Emin Akbaşoğlu,Muhammet Emin Akbaşoğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/Çankırı,Çankırı,Grand National Assembly,25,,,,
-9f26af5f-3578-4801-a9e6-838db7e69c76,Muhammet Rıza Yalçınkaya,Muhammet Rıza Yalçınkaya,,,,Cumhuriyet Halk Partisi,CHP,area/bartın,Bartın,Grand National Assembly,25,,,,
+9f26af5f-3578-4801-a9e6-838db7e69c76,Muhammet Rıza Yalçınkaya,Muhammet Rıza Yalçınkaya,,,,Cumhuriyet Halk Partisi,CHP,area/bartın,Bartın,Grand National Assembly,25,,,,male
 d7e67604-e82a-4ba0-b768-502fb2df3fe6,Muhammet Uğur Kaleli,Muhammet Uğur Kaleli,,,,Adalet ve Kalkınma Partisi,AKP,area/konya,Konya,Grand National Assembly,25,,,,
 21643053-17ae-40ae-b2ef-5e8fff55c6d0,Muharrem Erkek,Muharrem Erkek,,,,Cumhuriyet Halk Partisi,CHP,area/Çanakkale,Çanakkale,Grand National Assembly,25,,,,
 9b0895da-9137-4ca0-bbe5-2847a9ca4ae2,Muharrem Varlı,Muharrem Varlı,,,,Milliyetçi Hareket Partisi,MHP,area/adana,Adana,Grand National Assembly,25,,,,male
@@ -337,12 +337,12 @@ a220440d-41a6-488b-b3e1-e170d6b3356f,Mustafa Köse,Mustafa Köse,,,,Adalet ve Ka
 4075c7c8-9062-4df9-9225-c4bd979453cc,Mustafa Mit,Mustafa Mit,,,,Milliyetçi Hareket Partisi,MHP,area/ankara,Ankara,Grand National Assembly,25,,,,
 c6fa857f-b328-409d-be44-e470c7ccd630,Mustafa Muhammet Gültak,Mustafa Muhammet Gültak,,,,Adalet ve Kalkınma Partisi,AKP,area/mersin,Mersin,Grand National Assembly,25,,,,
 9144df3c-6ace-45d4-8642-a3935a7df593,Mustafa Sait Gönen,Mustafa Sait Gönen,,,,Milliyetçi Hareket Partisi,MHP,area/konya,Konya,Grand National Assembly,25,,,,
-36df5bbc-0c97-4ac0-92b9-3eff4b0a0106,Mustafa Sezgin Tanrıkulu,Mustafa Sezgin Tanrıkulu,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,25,,,,
+36df5bbc-0c97-4ac0-92b9-3eff4b0a0106,Mustafa Sezgin Tanrıkulu,Mustafa Sezgin Tanrıkulu,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,25,,,,male
 d8466ceb-11d8-4e25-8fa4-bbedd636c378,Mustafa Tuncer,Mustafa Tuncer,,,,Cumhuriyet Halk Partisi,CHP,area/amasya,Amasya,Grand National Assembly,25,,,,
 95d8402e-61a5-4937-ac53-ba8e4f2eb319,Mustafa Yel,Mustafa Yel,,,,Adalet ve Kalkınma Partisi,AKP,area/tekirdağ,Tekirdağ,Grand National Assembly,25,,,,
 65beb0cc-469c-4ff7-a0ca-42184d3212c4,Mustafa Yeneroğlu,Mustafa Yeneroğlu,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,25,,,,
 9aed12a2-4ed8-4581-86ef-42bb95239911,Mustafa Yün,Mustafa Yün,,,,Milliyetçi Hareket Partisi,MHP,area/kilis,Kilis,Grand National Assembly,25,,,,
-d1c04c7e-1726-40ff-85e5-7fd7bc749f96,Mustafa İbrahim Turhan,Mustafa İbrahim Turhan,,,,Adalet ve Kalkınma Partisi,AKP,area/İzmir,İzmir,Grand National Assembly,25,,,,
+d1c04c7e-1726-40ff-85e5-7fd7bc749f96,Mustafa İbrahim Turhan,Mustafa İbrahim Turhan,,,,Adalet ve Kalkınma Partisi,AKP,area/İzmir,İzmir,Grand National Assembly,25,,,,male
 f6079dc8-c74e-49be-b17f-1b6789b041c4,Mustafa İsen,Mustafa İsen,,,,Adalet ve Kalkınma Partisi,AKP,area/sakarya,Sakarya,Grand National Assembly,25,,,,male
 bc812f54-1419-404e-ab09-3c039431e742,Mustafa Şahin,Mustafa Şahin,,,,Adalet ve Kalkınma Partisi,AKP,area/malatya,Malatya,Grand National Assembly,25,,,,
 ec7c2bca-14d6-4b84-99a7-be069f12b0f5,Mustafa Şentop,Mustafa Şentop,,,,Adalet ve Kalkınma Partisi,AKP,area/İstanbul,İstanbul,Grand National Assembly,25,,,,male
@@ -499,7 +499,7 @@ af1ebbda-6c79-456d-b3bc-83edf81adc38,Zeynep Altıok,Zeynep Altıok,,,,Cumhuriyet
 d3ec333c-f479-40ad-9ec9-441ac0937e80,Ziya Altunyaldız,Ziya Altunyaldız,,,,Adalet ve Kalkınma Partisi,AKP,area/konya,Konya,Grand National Assembly,25,,,,
 0b00e301-f9be-47a8-a6b0-abc05b7c3fa4,Ziya Pir,Ziya Pir,,,,Halkların Demokratik Partisi,HDP,area/diyarbakır,Diyarbakır,Grand National Assembly,25,,,,
 4fcfef49-3c37-4321-9a44-b805b4a8d1b4,Ziya Çalışkan,Ziya Çalışkan,,,,Halkların Demokratik Partisi,HDP,area/Şanlıurfa,Şanlıurfa,Grand National Assembly,25,,,,
-e9858714-9237-4298-ba45-bfb2fde2671c,Zühal Topcu,Zühal Topcu,,,,Milliyetçi Hareket Partisi,MHP,area/ankara,Ankara,Grand National Assembly,25,,,,female
+e9858714-9237-4298-ba45-bfb2fde2671c,Zühal Topcu,Zühal Topcu,,,,Milliyetçi Hareket Partisi,MHP,area/ankara,Ankara,Grand National Assembly,25,,,,
 8883688d-6e5a-45a2-a744-aa22a1cdb657,Zülfikar İnönü Tümer,Zülfikar İnönü Tümer,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,25,,,,
 14b5c944-cbcc-4882-adb7-e37250c73946,Çağlar Demirel,Çağlar Demirel,,,,Halkların Demokratik Partisi,HDP,area/diyarbakır,Diyarbakır,Grand National Assembly,25,,,,
 11f8072c-19be-4bd2-ba73-192baba0c91d,Çetin Arık,Çetin Arık,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,25,,,,

--- a/data/Turkey/Assembly/term-3.csv
+++ b/data/Turkey/Assembly/term-3.csv
@@ -13,8 +13,8 @@ db3bac76-5239-4a36-8de9-626801170c0a,Ahmet Cemal Tunca,Ahmet Cemal Tunca,,,,Cumh
 3fbde1de-c08f-4abf-9f1b-be9623898980,Ahmet Enver Özgen,Ahmet Enver Özgen,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,3,,,,
 02732b7e-a415-4a2b-8eed-bbc3bdf62fe4,Ahmet Esat Uras,Ahmet Esat Uras,,,,Cumhuriyet Halk Partisi,CHP,area/amasya,Amasya,Grand National Assembly,3,,,,male
 32089e16-b4e3-44b3-9689-23dca1057857,Ahmet Fikri Tüzer,Ahmet Fikri Tüzer,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,3,,,,male
-222a2464-7586-4687-a098-62c9b83764d1,Ahmet Fuat Bulca,Ahmet Fuat Bulca,,,,Cumhuriyet Halk Partisi,CHP,area/rize,Rize,Grand National Assembly,3,,,,
-c41bb37f-3fb4-4377-94a2-ef4cd191191b,Ahmet Hamdi Aksoy,Ahmet Hamdi Aksoy,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,3,,,,
+222a2464-7586-4687-a098-62c9b83764d1,Ahmet Fuat Bulca,Ahmet Fuat Bulca,,,,Cumhuriyet Halk Partisi,CHP,area/rize,Rize,Grand National Assembly,3,,,,male
+c41bb37f-3fb4-4377-94a2-ef4cd191191b,Ahmet Hamdi Aksoy,Ahmet Hamdi Aksoy,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,3,,,,male
 b42abf8f-e05d-44a1-9914-1cbb04551b9d,Ahmet Hamdi Altıok,Ahmet Hamdi Altıok,,,,Cumhuriyet Halk Partisi,CHP,area/yozgat,Yozgat,Grand National Assembly,3,,,,male
 ff674f1b-5daa-4e02-a2d6-7d78554daddc,Ahmet Hamdi Denizmen,Ahmet Hamdi Denizmen,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/1/16/A._Hamdi_Denizmen.jpg,male
 48234d32-3e97-4b9d-bb67-3ec0cb18ae48,Ahmet Hamdi Dikmen,Ahmet Hamdi Dikmen,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,3,,,,male
@@ -28,7 +28,7 @@ c738f4cd-8443-4b26-a71d-a435c4be9eef,Ahmet Mithat Kalabalık,Ahmet Mithat Kalaba
 29a99f5c-d70a-4058-b257-1bf0b3723c08,Ahmet Münir Erhan,Ahmet Münir Erhan,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,3,,,,male
 0d85a2a1-4913-4e4e-94c0-76c3c5961978,Ahmet Nurettin Berkol,Ahmet Nurettin Berkol,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,3,,,,male
 8bc8823d-dfd1-45cc-933b-db666bab0160,Ahmet Ragıp Özdemiroğlu,Ahmet Ragıp Özdemiroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,3,,,,male
-27ea2b6e-50a1-4bf1-9ad9-b822f82f432b,Ahmet Rasim Arık,Ahmet Rasim Arık,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,3,,,,
+27ea2b6e-50a1-4bf1-9ad9-b822f82f432b,Ahmet Rasim Arık,Ahmet Rasim Arık,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,3,,,,male
 af26b7d3-0e15-40df-b1b9-f4a252c03a5b,Ahmet Sadri Hattuza,Ahmet Sadri Hattuza,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,3,,,,male
 f74a1435-d7a1-4a94-a3d7-40dd4cf86655,Ahmet Saffet Ohkay,Ahmet Saffet Ohkay,,,,Cumhuriyet Halk Partisi,CHP,area/elaziz_(elazığ),Elaziz (Elazığ),Grand National Assembly,3,,,,male
 b1d14954-da1b-4038-b90d-cf92d3adeb91,Ahmet Saki Derin,Ahmet Saki Derin,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,3,,,,male
@@ -38,7 +38,7 @@ a5f36f60-e22b-4e94-aea6-49c5f86a2f1d,Ahmet Ziya Tonguç,Ahmet Ziya Tonguç,,,,Cu
 4a36bee9-a5af-409c-bdfa-7b824b8a988c,Akif Akyüz,Akif Akyüz,,,,Cumhuriyet Halk Partisi,CHP,area/rize,Rize,Grand National Assembly,3,,,,
 93bbbfa6-b695-4c9a-a847-c490c43cb097,Akif Öztürk,Akif Öztürk,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,3,,,,
 f6e38a77-3b31-4633-a6c4-0ff002e542dc,Ali Cenani,Ali Cenani,,,,Cumhuriyet Halk Partisi,CHP,area/gaziantep,Gaziantep,Grand National Assembly,3,,,,
-3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44,Ali Fethi Okyar,Ali Fethi Okyar,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,3,,,,
+3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44,Ali Fethi Okyar,Ali Fethi Okyar,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/9/99/Ali_Fethi_Okyar.jpg,male
 7881040a-5770-413d-9417-1a11689d9ed8,Ali Galip Yenen,Ali Galip Yenen,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,3,,,,male
 b91d21e9-7b84-4729-8e62-ac15de4cb101,Ali Haydar Yuluğ,Ali Haydar Yuluğ,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/e/ea/Haydar_Bey_Yuluğ.jpg,male
 9990a134-c9cc-44b7-bf26-69243bc4c0e8,Ali Haydar Çerçel,Ali Haydar Çerçel,,,,Cumhuriyet Halk Partisi,CHP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,3,,,,
@@ -71,8 +71,8 @@ e5187887-97bf-4789-8f26-1b51060ba948,Behiç Erkin,Behiç Erkin,,,,Cumhuriyet Hal
 c96605a0-82ff-4825-b4c4-b49c4de3e9e5,Bekir Lütfi Çiftçi,Bekir Lütfi Çiftçi,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,3,,,,
 78b04cfc-1ce3-4f41-b39d-247a18c40de6,Burhanettin Binzet,Burhanettin Binzet,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,3,,,,
 cc0de41b-90b6-4447-8e4d-09d127edd7e3,Celal Nuri İleri,Celal Nuri İleri,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,3,,,,
-7a59a813-b07b-452f-ba43-3813b85116e6,Celal Sahir Erozan,Celal Sahir Erozan,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,3,,,,
-98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/9/9b/Celal_bayar.jpg,male
+7a59a813-b07b-452f-ba43-3813b85116e6,Celal Sahir Erozan,Celal Sahir Erozan,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,3,,,,male
+98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,3,,,,
 fb8e2e98-0291-40fd-96d0-b0b5c56e107e,Cemal Dolunay,Cemal Dolunay,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,3,,,,male
 9d95d988-0207-42d7-8215-5f2f19fc7c12,Cemal Hüsnü Taray,Cemal Hüsnü Taray,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,3,,,,male
 98bf9358-8839-4568-a787-ff85f935edf8,Cemil Arıcan,Cemil Arıcan,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,3,,,,
@@ -106,7 +106,7 @@ ee10e749-a615-49a6-8cf8-c6a9f4937458,Hafız İbrahim Demiralay,Hafız İbrahim D
 963d547a-ebd9-4fc1-817e-527e22d28e35,Hakkı Tarık Us,Hakkı Tarık Us,,,,Cumhuriyet Halk Partisi,CHP,area/giresun,Giresun,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/6/61/Hakkı_Tarık_Us.jpg,male
 b85e88b1-46aa-4822-ac9d-a4774a50fdf8,Hakkı Ungan,Hakkı Ungan,,,,Cumhuriyet Halk Partisi,CHP,area/van,Van,Grand National Assembly,3,,,,male
 8ac114ac-8076-4888-9008-41e1c25dc9ee,Halil Boztepe,Halil Boztepe,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,3,,,,male
-2e825a8d-4b7b-40e7-8266-37b4eb8c6743,Halil Hulki Ayrım,Halil Hulki Ayrım,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,3,,,,
+2e825a8d-4b7b-40e7-8266-37b4eb8c6743,Halil Hulki Ayrım,Halil Hulki Ayrım,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,3,,,,male
 b099beb8-8683-4589-a9da-769ec98c5c4a,Halil Sıtkı Kumru,Halil Sıtkı Kumru,,,,Cumhuriyet Halk Partisi,CHP,area/ordu,Ordu,Grand National Assembly,3,,,,male
 c9428e1e-97d1-4e60-8b13-18b54ca841d6,Halil Türkmen,Halil Türkmen,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,3,,,,male
 ea6c57e9-736e-4f27-ad68-0b8d4464331b,Halil İbrahim Nakıpoğlu,Halil İbrahim Nakıpoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,3,,,,male
@@ -145,7 +145,7 @@ e5e0cda6-5a2d-4075-a100-681d1014cfd2,Hüseyin Vasıf Çınar,Hüseyin Vasıf Ç�
 e0dce5e0-7084-46ff-b7d2-607e5bc61ec9,Hüsnü Kortel,Hüsnü Kortel,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,3,,,,
 e0dba001-1b44-4502-ab67-b935431d7d4a,Kadri Ramazanoğlu,Kadri Ramazanoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,3,,,,
 3ed7d865-486c-4486-87af-6337d7ad3a71,Kazım Samanlı,Kazım Samanlı,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,3,,,,
-a4884bcd-8e0d-4c12-a532-a8804da6c9ed,Kazım Sevüktekin,Kazım Sevüktekin,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,3,,,,
+a4884bcd-8e0d-4c12-a532-a8804da6c9ed,Kazım Sevüktekin,Kazım Sevüktekin,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/c/c7/KSevuktekin.jpg,male
 58a2b8cb-4bd0-4a7e-9cf2-da3f8dee9bef,Kemal Gürol,Kemal Gürol,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,3,,,,male
 8c66e3d2-aa50-419e-8e3b-001aa510c4a8,Kemal Zaim Sunel,Kemal Zaim Sunel,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,3,,,,male
 363bb9a2-ba18-4e07-ad72-d9fffdb2a711,Kemalettin Olpak,Kemalettin Olpak,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,3,,,,
@@ -171,7 +171,7 @@ d9f6798e-d69e-4adb-9fa9-e90d5389e9be,Mehmet Emin Yurdakul,Mehmet Emin Yurdakul,,
 dd654097-28aa-4c37-8f22-d900268a8fdb,Mehmet Fazıl Tümtürk,Mehmet Fazıl Tümtürk,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,3,,,,male
 7ced9cba-d2b5-4d7d-a9bf-6e4d9f5b0ea0,Mehmet Hakkı Saydam,Mehmet Hakkı Saydam,,,,Cumhuriyet Halk Partisi,CHP,area/İçel_(silifke),İçel (Silifke),Grand National Assembly,3,,,,male
 f6f73dc8-7659-4088-bd93-62373413fa81,Mehmet Kani Karaosmanoğlu,Mehmet Kani Karaosmanoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,3,,,,male
-f4bdf57f-104d-472e-a5da-769df2ecc757,Mehmet Kusun,Mehmet Kusun,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,3,,,,
+f4bdf57f-104d-472e-a5da-769df2ecc757,Mehmet Kusun,Mehmet Kusun,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,3,,,,male
 645883ca-3934-4c2e-bf92-f055699ffa9b,Mehmet Mithat Alan,Mehmet Mithat Alan,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,3,,,,male
 2230fc16-1d77-4607-970e-c60a63f47205,Mehmet Mühto,Mehmet Mühto,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,3,,,,male
 8e985396-14d1-4f8a-96ec-e96816837736,Mehmet Münir Çağıl,Mehmet Münir Çağıl,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,3,,,,male
@@ -183,7 +183,7 @@ d0a373c4-df59-40f2-a5d9-8800b6df412c,Mehmet Nazif Sirel,Mehmet Nazif Sirel,,,,Cu
 ab64fd49-b4e7-4bf9-9fdc-a107b29e561b,Mehmet Neşet Özercan,Mehmet Neşet Özercan,,,,Cumhuriyet Halk Partisi,CHP,area/aksaray,Aksaray,Grand National Assembly,3,,,,male
 ad82837f-06e4-4cd4-8c84-4d741313f235,Mehmet Niyazi Erenli,Mehmet Niyazi Erenli,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,3,,,,
 77d6cce7-218b-404d-becb-2253fceb79a8,Mehmet Nurettin Akkın,Mehmet Nurettin Akkın,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,3,,,,male
-4fb43215-aa33-4a48-9438-beedc5cfa945,Mehmet Nuri Conker,Mehmet Nuri Conker,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,3,,,,
+4fb43215-aa33-4a48-9438-beedc5cfa945,Mehmet Nuri Conker,Mehmet Nuri Conker,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,3,,,,male
 8a33eecb-1bf2-423f-9288-74883105fb2c,Mehmet Nuri Tuna,Mehmet Nuri Tuna,,,,Cumhuriyet Halk Partisi,CHP,area/muğla,Muğla,Grand National Assembly,3,,,,male
 6c7494d3-66fa-408f-8ec3-2c4bc57e3426,Mehmet Nuri Ural,Mehmet Nuri Ural,,,,Cumhuriyet Halk Partisi,CHP,area/mardin,Mardin,Grand National Assembly,3,,,,male
 e43b1a93-2ef6-48ac-973d-5267e711aae9,Mehmet Ragıp Akça,Mehmet Ragıp Akça,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,3,,,,male
@@ -193,8 +193,8 @@ e43b1a93-2ef6-48ac-973d-5267e711aae9,Mehmet Ragıp Akça,Mehmet Ragıp Akça,,,,
 30e49e20-e720-4239-843e-700e11afc7a9,Mehmet Rifat Ünür,Mehmet Rifat Ünür,,,,Cumhuriyet Halk Partisi,CHP,area/Çankırı,Çankırı,Grand National Assembly,3,,,,male
 53c10b11-1b89-4113-a079-e2588d3185a5,Mehmet Rüştü Bekit,Mehmet Rüştü Bekit,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,3,,,,male
 a54bd42b-ad62-4600-a0b3-45ab93881f2a,Mehmet Rıza Dinçay,Mehmet Rıza Dinçay,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,3,,,,male
-a5571160-118c-44fb-a194-961031f78deb,Mehmet Sabri Toprak,Mehmet Sabri Toprak,,,,Cumhuriyet Halk Partisi,CHP,area/cebel-i_bereket_(osmaniye),Cebel-i Bereket (Osmaniye),Grand National Assembly,3,,,,male
 a5571160-118c-44fb-a194-961031f78deb,Mehmet Sabri Toprak,Mehmet Sabri Toprak,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,3,,,,male
+a5571160-118c-44fb-a194-961031f78deb,Mehmet Sabri Toprak,Mehmet Sabri Toprak,,,,Cumhuriyet Halk Partisi,CHP,area/cebel-i_bereket_(osmaniye),Cebel-i Bereket (Osmaniye),Grand National Assembly,3,,,,male
 f2341cad-3199-40d6-8e6f-f8e1ba90995b,Mehmet Sadık Deniz,Mehmet Sadık Deniz,,,,Cumhuriyet Halk Partisi,CHP,area/balıkesir,Balıkesir,Grand National Assembly,3,,,,male
 203d96fb-4cb5-4ae0-b7c8-d94d825e0825,Mehmet Tevfik Yücel,Mehmet Tevfik Yücel,,,,Cumhuriyet Halk Partisi,CHP,area/Şebinkarahisar,Şebinkarahisar,Grand National Assembly,3,,,,
 e27d5ac1-d336-4e16-a417-41ecee11ec72,Mehmet Yaşar Özey,Mehmet Yaşar Özey,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,3,,,,male
@@ -213,26 +213,26 @@ f31b354f-0f8b-42a8-8755-0ccfd2187051,Muhittin Çöteli,Muhittin Çöteli,,,,Cumh
 9e28acf9-e7bc-4e25-8842-3fd445fd9325,Musa Kazım Tunç,Musa Kazım Tunç,,,,Cumhuriyet Halk Partisi,CHP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,3,,,,male
 81747339-ad31-49a1-8c9d-7ee9997fa5f2,Mustafa Abdülhalik Renda,Mustafa Abdülhalik Renda,,,,Cumhuriyet Halk Partisi,CHP,area/Çankırı,Çankırı,Grand National Assembly,3,,,,male
 742a7bb8-c9b3-479a-aa37-60237f09ab8e,Mustafa Cantekin,Mustafa Cantekin,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,3,,,,male
-e9524a9b-7cba-4c05-aca0-ed88468b323e,Mustafa Edip Tör,Mustafa Edip Tör,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,3,,,,
+e9524a9b-7cba-4c05-aca0-ed88468b323e,Mustafa Edip Tör,Mustafa Edip Tör,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/e/ed/Edip_Servet_Tör.jpg,male
 3a934ecb-84fa-4722-978d-8f44c708065b,Mustafa Fehmi Gerçeker,Mustafa Fehmi Gerçeker,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/a/a2/Mustafa_Fehmi_Efendi_(Gerçeker).jpg,male
 8e455157-6de6-48f1-acf3-ba5cf13e4c1c,Mustafa Ferit Arsan,Mustafa Ferit Arsan,,,,Cumhuriyet Halk Partisi,CHP,area/gaziantep,Gaziantep,Grand National Assembly,3,,,,male
 db5792b5-ed7f-467a-91ec-a0d11eb0883a,Mustafa Fevzi Sarhan,Mustafa Fevzi Sarhan,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,3,,,,male
 fe61a430-358a-4eb4-8074-fe9512abd074,Mustafa Kamil Dursun,Mustafa Kamil Dursun,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,3,,,,male
-b0713117-c1a3-4ae4-afba-5928c8ba4331,Mustafa Kemal Atatürk,Mustafa Kemal Atatürk,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/c/cc/MustafaKemalAtaturk_crop.jpg,male
+b0713117-c1a3-4ae4-afba-5928c8ba4331,Mustafa Kemal Atatürk,Mustafa Kemal Atatürk,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,3,,,,
 416ce349-1b6a-4620-ac9d-de41edafa2ab,Mustafa Necati Uğural,Mustafa Necati Uğural,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,3,,,,male
 54f96e04-0c2f-43c6-aec5-cd2f0eb960c1,Mustafa Rahmi Köken,Mustafa Rahmi Köken,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,3,,,,male
 a37b4f30-1ecf-4ad9-a0cf-2a9854ee3d70,Mustafa Reşit Özsoy,Mustafa Reşit Özsoy,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,3,,,,male
-29609f07-f6a1-4554-95b3-213a85e2148f,Mustafa Sabri Süsoy,Mustafa Sabri Süsoy,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,3,,,,
+29609f07-f6a1-4554-95b3-213a85e2148f,Mustafa Sabri Süsoy,Mustafa Sabri Süsoy,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/6/6b/Mustafa_Vasfi_Bey_Süsoy.jpg,male
 2a4248ce-3651-4824-953a-fd193f947275,Mustafa Solmaz,Mustafa Solmaz,,,,Cumhuriyet Halk Partisi,CHP,area/elaziz_(elazığ),Elaziz (Elazığ),Grand National Assembly,3,,,,male
 530919e5-2a29-4344-8722-cc17a8f91ffb,Mustafa Ulusan,Mustafa Ulusan,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,3,,,,male
 b4ffdee5-203e-49be-bf4c-be58b4db40a4,Mustafa Şeref Özkan,Mustafa Şeref Özkan,,,,Cumhuriyet Halk Partisi,CHP,area/burdur,Burdur,Grand National Assembly,3,,,,male
 f5a3f437-5ccb-4198-bdf1-7eb10615add1,Münip Boya,Münip Boya,,,,Cumhuriyet Halk Partisi,CHP,area/van,Van,Grand National Assembly,3,,,,
-c6f10a6c-08e0-4e19-a0b5-ce4115e3456e,Naci Eldeniz,Naci Eldeniz,,,,Cumhuriyet Halk Partisi,CHP,area/cebel-i_bereket_(osmaniye),Cebel-i Bereket (Osmaniye),Grand National Assembly,3,,,,male
+c6f10a6c-08e0-4e19-a0b5-ce4115e3456e,Naci Eldeniz,Naci Eldeniz,,,,Cumhuriyet Halk Partisi,CHP,area/cebel-i_bereket_(osmaniye),Cebel-i Bereket (Osmaniye),Grand National Assembly,3,,,,
 c589fe5e-b215-4dbe-bea4-62d3a0a05d71,Nafi Atuf Kansu,Nafi Atuf Kansu,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,3,,,,
 2c73bae7-c30d-4854-8037-cd582bbcb69d,Nahit Kerven,Nahit Kerven,,,,Cumhuriyet Halk Partisi,CHP,area/kırklareli,Kırklareli,Grand National Assembly,3,,,,
 da8ab36a-6f9b-46bd-ae95-1655f283954f,Necip Ali Küçüka,Necip Ali Küçüka,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/6/63/Necip_Ali_Küçükağa.jpg,male
 2dfff97e-b657-4240-b87f-066e4e61f9e9,Necip Asım Yazıksız,Necip Asım Yazıksız,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/4/40/Necip_Asım_Bey_Yazıksız.jpg,
-a5980128-93fd-428f-9928-f03e76e10b82,Necmettin Sadık Sadak,Necmettin Sadık Sadak,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,3,,,,
+a5980128-93fd-428f-9928-f03e76e10b82,Necmettin Sadık Sadak,Necmettin Sadık Sadak,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/9/9e/Necmettin_Sadık_Bey.jpg,male
 eec968cf-333a-408b-913b-22064197d812,Nevzat Tandoğan,Nevzat Tandoğan,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/7/76/Abdullah_Nevzat_Bey_Tandoğan.jpg,male
 ded14e13-3dd7-465f-bcbf-6a87fa82fc28,Nusret Sadullah Ayaşlı,Nusret Sadullah Ayaşlı,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,3,,,,
 a720bc90-db3e-42de-b721-eb96a0df8389,Osman Erçin,Osman Erçin,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,3,,,,male
@@ -244,7 +244,7 @@ a720bc90-db3e-42de-b721-eb96a0df8389,Osman Erçin,Osman Erçin,,,,Cumhuriyet Hal
 aea8e1ed-3593-4016-b804-ace53d3321d0,Recep Peker,Recep Peker,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/e/ef/RECEP_PEKER.jpg,male
 32c4c15a-2ec6-4e4b-bc53-169c23a3fc31,Recep Zühtü Soyak,Recep Zühtü Soyak,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,3,,,,
 320561fc-f4ea-4e54-8e48-e610a4b8564d,Refet Topçuoğlu,Refet Topçuoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/urfa,Urfa,Grand National Assembly,3,,,,
-05f819e7-9d1b-4bd3-be24-9ef2fc9c3989,Refik Güran,Refik Güran,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,3,,,,
+05f819e7-9d1b-4bd3-be24-9ef2fc9c3989,Refik Güran,Refik Güran,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,3,,,,male
 a925e47e-f648-483a-a319-63b5395dc609,Refik Ilgaz,Refik Ilgaz,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,3,,,,
 d493f63d-29fd-47ea-86be-cfb81239c06c,Refik Koraltan,Refik Koraltan,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/7/7c/Bekir_Refik_Bey_Koraltan.jpg,male
 f669c61b-05bf-4ebb-bc4d-c496e21c5bab,Refik Saydam,Refik Saydam,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/3/3c/Refik_Saydam.jpg,male
@@ -285,7 +285,7 @@ dab79c7e-e965-4935-ae40-9c4422fa0968,Tevfik Rüştü Aras,Tevfik Rüştü Aras,,
 282cd480-4554-463d-8f9e-d1be8bd00e19,Yahya Galip Kargı,Yahya Galip Kargı,,,,Cumhuriyet Halk Partisi,CHP,area/kırşehir,Kırşehir,Grand National Assembly,3,,,,male
 95f285e7-32e4-4fb0-bbc2-0e8497dffb82,Yakup Kadri Karaosmanoğlu,Yakup Kadri Karaosmanoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/mardin,Mardin,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/5/5e/Yakup_Kadri_Karaosmanoğlu.jpg,male
 23852149-e92f-46f9-b592-fa4075b2687e,Yunus Nadi Abalıoğlu,Yunus Nadi Abalıoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/muğla,Muğla,Grand National Assembly,3,,,,male
-c999f612-40a2-4233-91c4-1e64472f8ac2,Yusuf Akçora,Yusuf Akçora,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,3,,,,
+c999f612-40a2-4233-91c4-1e64472f8ac2,Yusuf Akçora,Yusuf Akçora,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,3,,,https://upload.wikimedia.org/wikipedia/commons/9/92/Yusuf_akcura.jpg,male
 f9d793a6-3dcb-4bf2-9b64-a9066d19932c,Yusuf Başkaya,Yusuf Başkaya,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,3,,,,male
 2f098157-0467-4e1a-a0f7-86092436f995,Yusuf Behçet Gücer,Yusuf Behçet Gücer,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,3,,,,male
 e382f965-bc25-42d6-be02-475f53c2a69e,Yusuf Kemal Tengirşenk,Yusuf Kemal Tengirşenk,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,3,,,,male

--- a/data/Turkey/Assembly/term-4.csv
+++ b/data/Turkey/Assembly/term-4.csv
@@ -13,8 +13,8 @@ c0824aa8-ce8e-4f0d-8693-c733fe8244ed,Ahmet Cevat Emre,Ahmet Cevat Emre,,,,Cumhur
 7864da01-77e3-45c7-b386-38f480cead34,Ahmet Cevdet Taflıoğlu,Ahmet Cevdet Taflıoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/yozgat,Yozgat,Grand National Assembly,4,,,,
 02732b7e-a415-4a2b-8eed-bbc3bdf62fe4,Ahmet Esat Uras,Ahmet Esat Uras,,,,Cumhuriyet Halk Partisi,CHP,area/amasya,Amasya,Grand National Assembly,4,,,,male
 32089e16-b4e3-44b3-9689-23dca1057857,Ahmet Fikri Tüzer,Ahmet Fikri Tüzer,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,4,,,,male
-222a2464-7586-4687-a098-62c9b83764d1,Ahmet Fuat Bulca,Ahmet Fuat Bulca,,,,Cumhuriyet Halk Partisi,CHP,area/rize,Rize,Grand National Assembly,4,,,,
-c41bb37f-3fb4-4377-94a2-ef4cd191191b,Ahmet Hamdi Aksoy,Ahmet Hamdi Aksoy,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,4,,,,
+222a2464-7586-4687-a098-62c9b83764d1,Ahmet Fuat Bulca,Ahmet Fuat Bulca,,,,Cumhuriyet Halk Partisi,CHP,area/rize,Rize,Grand National Assembly,4,,,,male
+c41bb37f-3fb4-4377-94a2-ef4cd191191b,Ahmet Hamdi Aksoy,Ahmet Hamdi Aksoy,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,4,,,,male
 b42abf8f-e05d-44a1-9914-1cbb04551b9d,Ahmet Hamdi Altıok,Ahmet Hamdi Altıok,,,,Cumhuriyet Halk Partisi,CHP,area/yozgat,Yozgat,Grand National Assembly,4,,,,male
 ff674f1b-5daa-4e02-a2d6-7d78554daddc,Ahmet Hamdi Denizmen,Ahmet Hamdi Denizmen,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/1/16/A._Hamdi_Denizmen.jpg,male
 48234d32-3e97-4b9d-bb67-3ec0cb18ae48,Ahmet Hamdi Dikmen,Ahmet Hamdi Dikmen,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,4,,,,male
@@ -24,18 +24,18 @@ bafa1d09-3239-4553-b38b-6f50eede6ed7,Ahmet Hamdi Yalman,Ahmet Hamdi Yalman,,,,Cu
 806f9833-0698-40e2-9c83-54fed272074d,Ahmet Hamdi Ülkümen,Ahmet Hamdi Ülkümen,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,4,,,,male
 e8f27fc2-7416-4662-ab02-f5ce9b8d0494,Ahmet Hazım Börekçi,Ahmet Hazım Börekçi,,,,Cumhuriyet Halk Partisi,CHP,area/kırşehir,Kırşehir,Grand National Assembly,4,,,,male
 11dbb8d3-23ea-40a1-86d3-1925c7977ee3,Ahmet Hilmi Kalaç,Ahmet Hilmi Kalaç,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,4,,,,male
-52fe9f39-65d8-4a73-a5e3-747ce85e6c52,Ahmet Kemalettin Turan,Ahmet Kemalettin Turan,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,4,,,,
+52fe9f39-65d8-4a73-a5e3-747ce85e6c52,Ahmet Kemalettin Turan,Ahmet Kemalettin Turan,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,4,,,,male
 6edde5fe-a49f-4cec-924a-33a782474384,Ahmet Muhtar Mollaoğlu,Ahmet Muhtar Mollaoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,4,,,,male
 0c86647d-3e8b-4dc6-b005-249121fd131e,Ahmet Münir Akkaya,Ahmet Münir Akkaya,,,,Cumhuriyet Halk Partisi,CHP,area/giresun,Giresun,Grand National Assembly,4,,,,male
 8bc8823d-dfd1-45cc-933b-db666bab0160,Ahmet Ragıp Özdemiroğlu,Ahmet Ragıp Özdemiroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,4,,,,male
-27ea2b6e-50a1-4bf1-9ad9-b822f82f432b,Ahmet Rasim Arık,Ahmet Rasim Arık,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,4,,,,
+27ea2b6e-50a1-4bf1-9ad9-b822f82f432b,Ahmet Rasim Arık,Ahmet Rasim Arık,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,4,,,,male
 f74a1435-d7a1-4a94-a3d7-40dd4cf86655,Ahmet Saffet Ohkay,Ahmet Saffet Ohkay,,,,Cumhuriyet Halk Partisi,CHP,area/elazığ,Elazığ,Grand National Assembly,4,,,,male
 181faaf7-38d9-4bc8-a557-5b0830cfcb2a,Ahmet Sungur,Ahmet Sungur,,,,Cumhuriyet Halk Partisi,CHP,area/yozgat,Yozgat,Grand National Assembly,4,,,,male
 8ab30454-7f3e-4e85-9c3a-591e90686ed3,Ahmet Sungur,Ahmet Sungur,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,4,,,,
 bb9553fc-5bcd-4294-9761-d700cadd7ead,Ahmet Süreyya Örgeevren,Ahmet Süreyya Örgeevren,,,,Cumhuriyet Halk Partisi,CHP,area/aksaray,Aksaray,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/3/3f/Süreyya_Örgeevren.jpg,male
 e296e27a-0382-4a20-a7a7-d6b6fe07a9de,Ahmet Talat Onay,Ahmet Talat Onay,,,,Cumhuriyet Halk Partisi,CHP,area/Çankırı,Çankırı,Grand National Assembly,4,,,,male
 495e8a79-8794-4637-a820-bd76054efa22,Ahmet Tevfik Şatır,Ahmet Tevfik Şatır,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,4,,,,
-bef95561-bf86-4178-bc27-b13fa14eb227,Ahmet Uluçay,Ahmet Uluçay,,,,Cumhuriyet Halk Partisi,CHP,area/ordu,Ordu,Grand National Assembly,4,,,,
+bef95561-bf86-4178-bc27-b13fa14eb227,Ahmet Uluçay,Ahmet Uluçay,,,,Cumhuriyet Halk Partisi,CHP,area/ordu,Ordu,Grand National Assembly,4,,,,male
 e3e90e81-2ec2-4600-9f44-a2be052f2ad6,Ahmet Vasfi Şenözen,Ahmet Vasfi Şenözen,,,,Cumhuriyet Halk Partisi,CHP,area/balıkesir,Balıkesir,Grand National Assembly,4,,,,
 34b64782-8001-4149-aa25-53ff23157e31,Ahmet Özdemir,Ahmet Özdemir,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,4,,,,male
 7a03d191-2f51-431d-b420-bfb8dffd6622,Ahmet İhsan Tokgöz,Ahmet İhsan Tokgöz,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,4,,,,male
@@ -76,8 +76,8 @@ c3001f96-12f7-446b-864c-fa1fd84fb1b0,Aziz Samih İlter,Aziz Samih İlter,,,,Cumh
 c96605a0-82ff-4825-b4c4-b49c4de3e9e5,Bekir Lütfi Çiftçi,Bekir Lütfi Çiftçi,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,4,,,,
 b725b83e-2e7b-4a89-822e-24d0793a57bb,Cafer Sayılır,Cafer Sayılır,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,4,,,,male
 cc0de41b-90b6-4447-8e4d-09d127edd7e3,Celal Nuri İleri,Celal Nuri İleri,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,4,,,,
-7a59a813-b07b-452f-ba43-3813b85116e6,Celal Sahir Erozan,Celal Sahir Erozan,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,4,,,,
-98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/9/9b/Celal_bayar.jpg,male
+7a59a813-b07b-452f-ba43-3813b85116e6,Celal Sahir Erozan,Celal Sahir Erozan,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,4,,,,male
+98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,4,,,,
 0a9f2fc2-d556-4ec9-83a1-fc344423dec7,Cemal Akçin,Cemal Akçin,,,,Cumhuriyet Halk Partisi,CHP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,4,,,,male
 cef6dbcf-01c2-4d0b-8973-a7e6db9c9227,Cevat Abbas Gürer,Cevat Abbas Gürer,,,,Cumhuriyet Halk Partisi,CHP,area/bitlis,Bitlis,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/d/d9/Cevat_Abbas_Gürer.jpg,male
 c64e1c08-1625-47fd-a5e5-75e4d628faff,Emin Aslan Tokat,Emin Aslan Tokat,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,4,,,,male
@@ -85,7 +85,7 @@ d254bd36-ee72-4d6b-ad8e-0b9a1507516b,Emin Cemal Suda,Emin Cemal Suda,,,,Cumhuriy
 05714462-f621-4def-966c-75a2349ee482,Emin Fikri Eralp,Emin Fikri Eralp,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,4,,,,male
 0789dc9c-2797-4a6a-9867-b58119ebea39,Emin Gevecioğlu,Emin Gevecioğlu,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/f/fa/Emin_Bey_Geveci.jpg,male
 8cd8c9bb-149d-4f10-ac94-33fcf2a621c7,Emin Sazak,Emin Sazak,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,4,,,,male
-c8eab67a-fe54-44b3-8792-bccb4c6dc468,Enis Avni Akagündüz,Enis Avni Akagündüz,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,4,,,,
+c8eab67a-fe54-44b3-8792-bccb4c6dc468,Enis Avni Akagündüz,Enis Avni Akagündüz,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/c/cc/Enis_Avni_Bey_Akagündüz.jpg,male
 c44015f6-07e3-46ea-af0b-b7d04416758f,Enver Adakan,Enver Adakan,,,,Cumhuriyet Halk Partisi,CHP,area/balıkesir,Balıkesir,Grand National Assembly,4,,,,male
 1c61fdcd-e366-4e36-b164-0cb4933bf3e1,Esat Sagay,Esat Sagay,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,4,,,,male
 79bd137e-782e-40f0-8912-6a5bfa42c078,Esat Özoğuz,Esat Özoğuz,,,,Cumhuriyet Halk Partisi,CHP,area/rize,Rize,Grand National Assembly,4,,,,
@@ -110,7 +110,7 @@ b85e88b1-46aa-4822-ac9d-a4774a50fdf8,Hakkı Ungan,Hakkı Ungan,,,,Cumhuriyet Hal
 641e833c-4ca2-4039-a73f-c7a9f3a77288,Halil Benli,Halil Benli,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,4,,,,male
 8ac114ac-8076-4888-9008-41e1c25dc9ee,Halil Boztepe,Halil Boztepe,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,4,,,,male
 9014b727-3f57-4325-9747-43823dcd6988,Halil Ethem Eldem,Halil Ethem Eldem,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,4,,,,male
-2e825a8d-4b7b-40e7-8266-37b4eb8c6743,Halil Hulki Ayrım,Halil Hulki Ayrım,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,4,,,,
+2e825a8d-4b7b-40e7-8266-37b4eb8c6743,Halil Hulki Ayrım,Halil Hulki Ayrım,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,4,,,,male
 1df8d114-caed-4422-b594-c3c6e6e64a62,Halil Menteşe,Halil Menteşe,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,4,,,,male
 8e723128-dae4-4a14-9e0b-2c722c08a4c9,Halil Tekşen,Halil Tekşen,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,4,,,,
 c9428e1e-97d1-4e60-8b13-18b54ca841d6,Halil Türkmen,Halil Türkmen,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,4,,,,male
@@ -152,7 +152,7 @@ df5d46c7-fce5-487f-8323-198732f202a1,Hüseyin Hüsnü Özdamar,Hüseyin Hüsnü 
 8527bee3-f2ff-4a78-a9c5-4f4deb52b47f,Hüseyin Sırrı Bellioğlu,Hüseyin Sırrı Bellioğlu,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/7/70/Hüseyin_Sırrı_Bellioğlu.jpg,male
 e5e0cda6-5a2d-4075-a100-681d1014cfd2,Hüseyin Vasıf Çınar,Hüseyin Vasıf Çınar,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,4,,,,male
 3ed7d865-486c-4486-87af-6337d7ad3a71,Kazım Samanlı,Kazım Samanlı,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,4,,,,
-a4884bcd-8e0d-4c12-a532-a8804da6c9ed,Kazım Sevüktekin,Kazım Sevüktekin,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,4,,,,
+a4884bcd-8e0d-4c12-a532-a8804da6c9ed,Kazım Sevüktekin,Kazım Sevüktekin,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/c/c7/KSevuktekin.jpg,male
 8c66e3d2-aa50-419e-8e3b-001aa510c4a8,Kemal Zaim Sunel,Kemal Zaim Sunel,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,4,,,,male
 363bb9a2-ba18-4e07-ad72-d9fffdb2a711,Kemalettin Olpak,Kemalettin Olpak,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,4,,,,
 ff08a751-e06c-43bc-bd79-f86c8f5c7c11,Kâzım Özalp,Kâzım Özalp,,,,Cumhuriyet Halk Partisi,CHP,area/balıkesir,Balıkesir,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/5/57/Özalp.jpg,male
@@ -184,7 +184,7 @@ a2042120-25f4-4e79-8815-db1acf6fceac,Mehmet Naim Onat,Mehmet Naim Onat,,,,Cumhur
 6272c4f6-895a-413c-af49-c2a8cd003414,Mehmet Naki Yücekök,Mehmet Naki Yücekök,,,,Cumhuriyet Halk Partisi,CHP,area/muş,Muş,Grand National Assembly,4,,,,male
 d0a373c4-df59-40f2-a5d9-8800b6df412c,Mehmet Nazif Sirel,Mehmet Nazif Sirel,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,4,,,,male
 efeb3698-88a9-4f71-965a-16e01642ee3d,Mehmet Numan Aksoy,Mehmet Numan Aksoy,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,4,,,,male
-4fb43215-aa33-4a48-9438-beedc5cfa945,Mehmet Nuri Conker,Mehmet Nuri Conker,,,,Cumhuriyet Halk Partisi,CHP,area/gaziantep,Gaziantep,Grand National Assembly,4,,,,
+4fb43215-aa33-4a48-9438-beedc5cfa945,Mehmet Nuri Conker,Mehmet Nuri Conker,,,,Cumhuriyet Halk Partisi,CHP,area/gaziantep,Gaziantep,Grand National Assembly,4,,,,male
 8a33eecb-1bf2-423f-9288-74883105fb2c,Mehmet Nuri Tuna,Mehmet Nuri Tuna,,,,Cumhuriyet Halk Partisi,CHP,area/muğla,Muğla,Grand National Assembly,4,,,,male
 6c7494d3-66fa-408f-8ec3-2c4bc57e3426,Mehmet Nuri Ural,Mehmet Nuri Ural,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,4,,,,male
 e43b1a93-2ef6-48ac-973d-5267e711aae9,Mehmet Ragıp Akça,Mehmet Ragıp Akça,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,4,,,,male
@@ -218,29 +218,29 @@ e6461c70-690a-410d-9afb-f779b1a9bb99,Muhittin Başay,Muhittin Başay,,,,Cumhuriy
 81747339-ad31-49a1-8c9d-7ee9997fa5f2,Mustafa Abdülhalik Renda,Mustafa Abdülhalik Renda,,,,Cumhuriyet Halk Partisi,CHP,area/Çankırı,Çankırı,Grand National Assembly,4,,,,male
 dd6c86e7-e8ab-4d88-ab57-2707a0530fad,Mustafa Bacak,Mustafa Bacak,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,4,,,,male
 742a7bb8-c9b3-479a-aa37-60237f09ab8e,Mustafa Cantekin,Mustafa Cantekin,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,4,,,,male
-e9524a9b-7cba-4c05-aca0-ed88468b323e,Mustafa Edip Tör,Mustafa Edip Tör,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,4,,,,
+e9524a9b-7cba-4c05-aca0-ed88468b323e,Mustafa Edip Tör,Mustafa Edip Tör,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/e/ed/Edip_Servet_Tör.jpg,male
 9ae94ee8-947d-46bb-8832-004bd892f3ed,Mustafa Eken,Mustafa Eken,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,4,,,,male
 3a934ecb-84fa-4722-978d-8f44c708065b,Mustafa Fehmi Gerçeker,Mustafa Fehmi Gerçeker,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/a/a2/Mustafa_Fehmi_Efendi_(Gerçeker).jpg,male
 db5792b5-ed7f-467a-91ec-a0d11eb0883a,Mustafa Fevzi Sarhan,Mustafa Fevzi Sarhan,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,4,,,,male
 fe61a430-358a-4eb4-8074-fe9512abd074,Mustafa Kamil Dursun,Mustafa Kamil Dursun,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,4,,,,male
-b0713117-c1a3-4ae4-afba-5928c8ba4331,Mustafa Kemal Atatürk,Mustafa Kemal Atatürk,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/c/cc/MustafaKemalAtaturk_crop.jpg,male
+b0713117-c1a3-4ae4-afba-5928c8ba4331,Mustafa Kemal Atatürk,Mustafa Kemal Atatürk,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,4,,,,
 76e36e4d-e5d4-4f0a-baf6-b380f92624ab,Mustafa Naşit Uluğ,Mustafa Naşit Uluğ,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,4,,,,male
 54f96e04-0c2f-43c6-aec5-cd2f0eb960c1,Mustafa Rahmi Köken,Mustafa Rahmi Köken,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,4,,,,male
 a37b4f30-1ecf-4ad9-a0cf-2a9854ee3d70,Mustafa Reşit Özsoy,Mustafa Reşit Özsoy,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,4,,,,male
-29609f07-f6a1-4554-95b3-213a85e2148f,Mustafa Sabri Süsoy,Mustafa Sabri Süsoy,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,4,,,,
+29609f07-f6a1-4554-95b3-213a85e2148f,Mustafa Sabri Süsoy,Mustafa Sabri Süsoy,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/6/6b/Mustafa_Vasfi_Bey_Süsoy.jpg,male
 530919e5-2a29-4344-8722-cc17a8f91ffb,Mustafa Ulusan,Mustafa Ulusan,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,4,,,,male
 b4ffdee5-203e-49be-bf4c-be58b4db40a4,Mustafa Şeref Özkan,Mustafa Şeref Özkan,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,4,,,,male
 821dbb9b-968b-47a9-a82e-3d6ced649b04,Muzaffer Akpınar,Muzaffer Akpınar,,,,Cumhuriyet Halk Partisi,CHP,area/balıkesir,Balıkesir,Grand National Assembly,4,,,,
 f5a3f437-5ccb-4198-bdf1-7eb10615add1,Münip Boya,Münip Boya,,,,Cumhuriyet Halk Partisi,CHP,area/van,Van,Grand National Assembly,4,,,,
 3d9ccdd4-6bc2-4682-aec2-4fc3fb471349,Nabi Rıza Yıldırımtekin,Nabi Rıza Yıldırımtekin,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,4,,,,
-c6f10a6c-08e0-4e19-a0b5-ce4115e3456e,Naci Eldeniz,Naci Eldeniz,,,,Cumhuriyet Halk Partisi,CHP,area/cebel-i_bereket_(osmaniye),Cebel-i Bereket (Osmaniye),Grand National Assembly,4,,,,male
+c6f10a6c-08e0-4e19-a0b5-ce4115e3456e,Naci Eldeniz,Naci Eldeniz,,,,Cumhuriyet Halk Partisi,CHP,area/cebel-i_bereket_(osmaniye),Cebel-i Bereket (Osmaniye),Grand National Assembly,4,,,,
 c589fe5e-b215-4dbe-bea4-62d3a0a05d71,Nafi Atuf Kansu,Nafi Atuf Kansu,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,4,,,,
 2c73bae7-c30d-4854-8037-cd582bbcb69d,Nahit Kerven,Nahit Kerven,,,,Cumhuriyet Halk Partisi,CHP,area/kırklareli,Kırklareli,Grand National Assembly,4,,,,
 710db25b-61ee-46e6-b3cf-0f9fefde6a63,Nazifi Şerif Nabel,Nazifi Şerif Nabel,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,4,,,,
 c9171f7b-acd9-42d5-8246-cac33c1f34de,Nazım Poroy,Nazım Poroy,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,4,,,,
 da8ab36a-6f9b-46bd-ae95-1655f283954f,Necip Ali Küçüka,Necip Ali Küçüka,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/6/63/Necip_Ali_Küçükağa.jpg,male
 2dfff97e-b657-4240-b87f-066e4e61f9e9,Necip Asım Yazıksız,Necip Asım Yazıksız,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/4/40/Necip_Asım_Bey_Yazıksız.jpg,
-a5980128-93fd-428f-9928-f03e76e10b82,Necmettin Sadık Sadak,Necmettin Sadık Sadak,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,4,,,,
+a5980128-93fd-428f-9928-f03e76e10b82,Necmettin Sadık Sadak,Necmettin Sadık Sadak,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/9/9e/Necmettin_Sadık_Bey.jpg,male
 5d9441c5-2f15-4c08-a8f8-73a09678fbc8,Osman Coşkun,Osman Coşkun,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,4,,,,male
 a720bc90-db3e-42de-b721-eb96a0df8389,Osman Erçin,Osman Erçin,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,4,,,,male
 5df23d5e-981d-4225-9766-2bdeb4f38df9,Osman Niyazi Burcu,Osman Niyazi Burcu,,,,Cumhuriyet Halk Partisi,CHP,area/Çanakkale,Çanakkale,Grand National Assembly,4,,,,male
@@ -254,7 +254,7 @@ f164a534-5156-4b94-91b8-17ef8f91041c,Pertev Etçioğlu,Pertev Etçioğlu,,,,Cumh
 aea8e1ed-3593-4016-b804-ace53d3321d0,Recep Peker,Recep Peker,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/e/ef/RECEP_PEKER.jpg,male
 32c4c15a-2ec6-4e4b-bc53-169c23a3fc31,Recep Zühtü Soyak,Recep Zühtü Soyak,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,4,,,,
 320561fc-f4ea-4e54-8e48-e610a4b8564d,Refet Topçuoğlu,Refet Topçuoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/urfa,Urfa,Grand National Assembly,4,,,,
-05f819e7-9d1b-4bd3-be24-9ef2fc9c3989,Refik Güran,Refik Güran,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,4,,,,
+05f819e7-9d1b-4bd3-be24-9ef2fc9c3989,Refik Güran,Refik Güran,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,4,,,,male
 a925e47e-f648-483a-a319-63b5395dc609,Refik Ilgaz,Refik Ilgaz,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,4,,,,
 d493f63d-29fd-47ea-86be-cfb81239c06c,Refik Koraltan,Refik Koraltan,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/7/7c/Bekir_Refik_Bey_Koraltan.jpg,male
 f669c61b-05bf-4ebb-bc4d-c496e21c5bab,Refik Saydam,Refik Saydam,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/3/3c/Refik_Saydam.jpg,male
@@ -298,7 +298,7 @@ dab79c7e-e965-4935-ae40-9c4422fa0968,Tevfik Rüştü Aras,Tevfik Rüştü Aras,,
 fdd92963-1e3a-4a88-aac6-5ebf8cd3d453,Yahya Kemal Beyatlı,Yahya Kemal Beyatlı,,,,Cumhuriyet Halk Partisi,CHP,area/yozgat,Yozgat,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/f/f4/Yahya_Kemal_Bey.jpg,male
 95f285e7-32e4-4fb0-bbc2-0e8497dffb82,Yakup Kadri Karaosmanoğlu,Yakup Kadri Karaosmanoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/5/5e/Yakup_Kadri_Karaosmanoğlu.jpg,male
 23852149-e92f-46f9-b592-fa4075b2687e,Yunus Nadi Abalıoğlu,Yunus Nadi Abalıoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/muğla,Muğla,Grand National Assembly,4,,,,male
-c999f612-40a2-4233-91c4-1e64472f8ac2,Yusuf Akçora,Yusuf Akçora,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,4,,,,
+c999f612-40a2-4233-91c4-1e64472f8ac2,Yusuf Akçora,Yusuf Akçora,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/9/92/Yusuf_akcura.jpg,male
 f9d793a6-3dcb-4bf2-9b64-a9066d19932c,Yusuf Başkaya,Yusuf Başkaya,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,4,,,,male
 388e0ed1-d63b-4e42-9141-c7a7faeb0ae2,Yusuf Hikmet Bayur,Yusuf Hikmet Bayur,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,4,,,https://upload.wikimedia.org/wikipedia/commons/e/e9/Yusuf_Hikmet_Bey.jpg,male
 e382f965-bc25-42d6-be02-475f53c2a69e,Yusuf Kemal Tengirşenk,Yusuf Kemal Tengirşenk,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,4,,,,male

--- a/data/Turkey/Assembly/term-5.csv
+++ b/data/Turkey/Assembly/term-5.csv
@@ -10,7 +10,7 @@ db3bac76-5239-4a36-8de9-626801170c0a,Ahmet Cemal Tunca,Ahmet Cemal Tunca,,,,Cumh
 c0824aa8-ce8e-4f0d-8693-c733fe8244ed,Ahmet Cevat Emre,Ahmet Cevat Emre,,,,Cumhuriyet Halk Partisi,CHP,area/Çanakkale,Çanakkale,Grand National Assembly,5,,,,male
 02732b7e-a415-4a2b-8eed-bbc3bdf62fe4,Ahmet Esat Uras,Ahmet Esat Uras,,,,Cumhuriyet Halk Partisi,CHP,area/amasya,Amasya,Grand National Assembly,5,,,,male
 32089e16-b4e3-44b3-9689-23dca1057857,Ahmet Fikri Tüzer,Ahmet Fikri Tüzer,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,5,,,,male
-222a2464-7586-4687-a098-62c9b83764d1,Ahmet Fuat Bulca,Ahmet Fuat Bulca,,,,Cumhuriyet Halk Partisi,CHP,area/Çoruh_(artvin),Çoruh (Artvin),Grand National Assembly,5,,,,
+222a2464-7586-4687-a098-62c9b83764d1,Ahmet Fuat Bulca,Ahmet Fuat Bulca,,,,Cumhuriyet Halk Partisi,CHP,area/Çoruh_(artvin),Çoruh (Artvin),Grand National Assembly,5,,,,male
 ff674f1b-5daa-4e02-a2d6-7d78554daddc,Ahmet Hamdi Denizmen,Ahmet Hamdi Denizmen,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/1/16/A._Hamdi_Denizmen.jpg,male
 48234d32-3e97-4b9d-bb67-3ec0cb18ae48,Ahmet Hamdi Dikmen,Ahmet Hamdi Dikmen,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,5,,,,male
 3031c415-aab9-4f62-a409-8d73e9d38fbc,Ahmet Hamdi Gürsoy,Ahmet Hamdi Gürsoy,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,5,,,,male
@@ -21,7 +21,7 @@ e8f27fc2-7416-4662-ab02-f5ce9b8d0494,Ahmet Hazım Börekçi,Ahmet Hazım Börek�
 e6e9072c-8bc1-4d79-ba47-7a6415fd7c38,Ahmet Hilmi Ergeneli,Ahmet Hilmi Ergeneli,,,,Cumhuriyet Halk Partisi,CHP,area/Çanakkale,Çanakkale,Grand National Assembly,5,,,,male
 11dbb8d3-23ea-40a1-86d3-1925c7977ee3,Ahmet Hilmi Kalaç,Ahmet Hilmi Kalaç,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,5,,,,male
 ce51e796-1726-485c-af1d-4fd0140d68bc,Ahmet Hulusi Alataş,Ahmet Hulusi Alataş,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,5,,,,male
-52fe9f39-65d8-4a73-a5e3-747ce85e6c52,Ahmet Kemalettin Turan,Ahmet Kemalettin Turan,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,5,,,,
+52fe9f39-65d8-4a73-a5e3-747ce85e6c52,Ahmet Kemalettin Turan,Ahmet Kemalettin Turan,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,5,,,,male
 0c86647d-3e8b-4dc6-b005-249121fd131e,Ahmet Münir Akkaya,Ahmet Münir Akkaya,,,,Cumhuriyet Halk Partisi,CHP,area/giresun,Giresun,Grand National Assembly,5,,,,male
 4e18eee2-fc4d-4d86-bbb8-519cb136ea08,Ahmet Nuri Göktepe,Ahmet Nuri Göktepe,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,5,,,,male
 8bc8823d-dfd1-45cc-933b-db666bab0160,Ahmet Ragıp Özdemiroğlu,Ahmet Ragıp Özdemiroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,5,,,,male
@@ -30,7 +30,7 @@ f74a1435-d7a1-4a94-a3d7-40dd4cf86655,Ahmet Saffet Ohkay,Ahmet Saffet Ohkay,,,,Cu
 bb9553fc-5bcd-4294-9761-d700cadd7ead,Ahmet Süreyya Örgeevren,Ahmet Süreyya Örgeevren,,,,Cumhuriyet Halk Partisi,CHP,area/balıkesir,Balıkesir,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/3/3f/Süreyya_Örgeevren.jpg,male
 e296e27a-0382-4a20-a7a7-d6b6fe07a9de,Ahmet Talat Onay,Ahmet Talat Onay,,,,Cumhuriyet Halk Partisi,CHP,area/giresun,Giresun,Grand National Assembly,5,,,,male
 ca136cc7-cc4c-458f-a6c5-cd428034b724,Ahmet Ulus,Ahmet Ulus,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,5,,,,male
-bef95561-bf86-4178-bc27-b13fa14eb227,Ahmet Uluçay,Ahmet Uluçay,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,5,,,,
+bef95561-bf86-4178-bc27-b13fa14eb227,Ahmet Uluçay,Ahmet Uluçay,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,5,,,,male
 6aa62b9d-a548-4561-9e87-0a23a6667665,Ahmet Yazgan,Ahmet Yazgan,,,,Cumhuriyet Halk Partisi,CHP,area/urfa,Urfa,Grand National Assembly,5,,,,male
 50081ead-0f06-48f6-b35c-2bce95a73609,Ahmet Zeki Soydemir,Ahmet Zeki Soydemir,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,5,,,,male
 34b64782-8001-4149-aa25-53ff23157e31,Ahmet Özdemir,Ahmet Özdemir,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,5,,,,male
@@ -43,9 +43,9 @@ c3777bdf-12df-49cd-96bf-d8ae07d115bc,Alaattin Tiritoğlu,Alaattin Tiritoğlu,,,,
 0deb59bf-7542-42c5-8180-712da6601aef,Ali Barlas,Ali Barlas,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,5,,,,
 f7c87437-722c-4baf-8d73-b1aa975ee385,Ali Behçet Günay,Ali Behçet Günay,,,,Cumhuriyet Halk Partisi,CHP,area/urfa,Urfa,Grand National Assembly,5,,,,male
 84bd52f2-1b6d-4ee7-bf02-5dd7d45dacfb,Ali Canip Yöntem,Ali Canip Yöntem,,,,Cumhuriyet Halk Partisi,CHP,area/ordu,Ordu,Grand National Assembly,5,,,,
-2cdaaec0-ddef-42e1-8892-b0cc0ffb9077,Ali Cavit Oral,Ali Cavit Oral,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,5,,,,male
+2cdaaec0-ddef-42e1-8892-b0cc0ffb9077,Ali Cavit Oral,Ali Cavit Oral,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,5,,,,
 6ca42f2f-55c6-411a-ab0a-911cc8e05ed8,Ali Dikmen,Ali Dikmen,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,5,,,,
-3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44,Ali Fethi Okyar,Ali Fethi Okyar,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,5,,,,
+3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44,Ali Fethi Okyar,Ali Fethi Okyar,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/9/99/Ali_Fethi_Okyar.jpg,male
 7da075c8-1f09-40b1-a9f4-957caa15a55e,Ali Fuat Cebesoy,Ali Fuat Cebesoy,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/0/09/Ali_Fuat_Pasha.jpg,male
 bc2d7a2f-74a5-4219-ae08-74f6daa8a4db,Ali Galip Pekel,Ali Galip Pekel,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,5,,,,male
 9990a134-c9cc-44b7-bf26-69243bc4c0e8,Ali Haydar Çerçel,Ali Haydar Çerçel,,,,Cumhuriyet Halk Partisi,CHP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,5,,,,
@@ -81,8 +81,8 @@ c3929778-c7a4-4fc0-b895-b3d36edbdf3b,Benal Nevzat İstar Arıman,Benal Nevzat İ
 44f220cf-4b49-415e-957b-ba9e591ba958,Besim Ömer Akalın,Besim Ömer Akalın,,,,Cumhuriyet Halk Partisi,CHP,area/bilecik,Bilecik,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/2/23/Besim_Ömer_Akalin.jpg,male
 9b6e96d1-e990-4e08-a481-e9b04a263df3,Celal Arat,Celal Arat,,,,Cumhuriyet Halk Partisi,CHP,area/yozgat,Yozgat,Grand National Assembly,5,,,,
 9d31bd17-78b5-4883-84f9-c58db8b38b0d,Celal Mengilibörü,Celal Mengilibörü,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,5,,,,
-7a59a813-b07b-452f-ba43-3813b85116e6,Celal Sahir Erozan,Celal Sahir Erozan,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,5,,,,
-98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/9/9b/Celal_bayar.jpg,male
+7a59a813-b07b-452f-ba43-3813b85116e6,Celal Sahir Erozan,Celal Sahir Erozan,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,5,,,,male
+98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,5,,,,
 0a9f2fc2-d556-4ec9-83a1-fc344423dec7,Cemal Akçin,Cemal Akçin,,,,Cumhuriyet Halk Partisi,CHP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,5,,,,male
 feb0801d-32d7-4f4e-8ba3-e4a6d32779d0,Cemal Esener,Cemal Esener,,,,Cumhuriyet Halk Partisi,CHP,area/balıkesir,Balıkesir,Grand National Assembly,5,,,,
 9d95d988-0207-42d7-8215-5f2f19fc7c12,Cemal Hüsnü Taray,Cemal Hüsnü Taray,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,5,,,,male
@@ -95,7 +95,7 @@ c64e1c08-1625-47fd-a5e5-75e4d628faff,Emin Aslan Tokat,Emin Aslan Tokat,,,,Cumhur
 d254bd36-ee72-4d6b-ad8e-0b9a1507516b,Emin Cemal Suda,Emin Cemal Suda,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,5,,,,male
 8cd8c9bb-149d-4f10-ac94-33fcf2a621c7,Emin Sazak,Emin Sazak,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,5,,,,male
 2e94df0a-4396-4ec6-87a6-e0d17a5cb007,Emrullah Barkan,Emrullah Barkan,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,5,,,,
-c8eab67a-fe54-44b3-8792-bccb4c6dc468,Enis Avni Akagündüz,Enis Avni Akagündüz,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,5,,,,
+c8eab67a-fe54-44b3-8792-bccb4c6dc468,Enis Avni Akagündüz,Enis Avni Akagündüz,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/c/cc/Enis_Avni_Bey_Akagündüz.jpg,male
 c44015f6-07e3-46ea-af0b-b7d04416758f,Enver Adakan,Enver Adakan,,,,Cumhuriyet Halk Partisi,CHP,area/balıkesir,Balıkesir,Grand National Assembly,5,,,,male
 1c61fdcd-e366-4e36-b164-0cb4933bf3e1,Esat Sagay,Esat Sagay,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,5,,,,male
 79bd137e-782e-40f0-8912-6a5bfa42c078,Esat Özoğuz,Esat Özoğuz,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,5,,,,
@@ -130,13 +130,13 @@ ee10e749-a615-49a6-8cf8-c6a9f4937458,Hafız İbrahim Demiralay,Hafız İbrahim D
 b85e88b1-46aa-4822-ac9d-a4774a50fdf8,Hakkı Ungan,Hakkı Ungan,,,,Cumhuriyet Halk Partisi,CHP,area/van,Van,Grand National Assembly,5,,,,male
 8ac114ac-8076-4888-9008-41e1c25dc9ee,Halil Boztepe,Halil Boztepe,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,5,,,,male
 9014b727-3f57-4325-9747-43823dcd6988,Halil Ethem Eldem,Halil Ethem Eldem,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,5,,,,male
-2e825a8d-4b7b-40e7-8266-37b4eb8c6743,Halil Hulki Ayrım,Halil Hulki Ayrım,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,5,,,,
+2e825a8d-4b7b-40e7-8266-37b4eb8c6743,Halil Hulki Ayrım,Halil Hulki Ayrım,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,5,,,,male
 1df8d114-caed-4422-b594-c3c6e6e64a62,Halil Menteşe,Halil Menteşe,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,5,,,,male
 c9428e1e-97d1-4e60-8b13-18b54ca841d6,Halil Türkmen,Halil Türkmen,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,5,,,,male
 8e63f7dd-e4d7-4f4b-b0aa-96d61afda8a7,Halit Bayrak,Halit Bayrak,,,,Cumhuriyet Halk Partisi,CHP,area/bayazıt_(ağrı),Bayazıt (Ağrı),Grand National Assembly,5,,,,
 5399a60a-3724-4238-bdac-bb8de0ffa1ac,Halit Hami Mengi,Halit Hami Mengi,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/9/99/HalitHamiMengi1.jpg,
 3879660f-d50d-48c2-811d-5745fa17993d,Halit Onaran,Halit Onaran,,,,Cumhuriyet Halk Partisi,CHP,area/burdur,Burdur,Grand National Assembly,5,,,,
-ecaf7ab8-0a58-4cb2-ab36-ba0ead338830,Hamdi Aksoy,Hamdi Aksoy,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,5,,,,male
+ecaf7ab8-0a58-4cb2-ab36-ba0ead338830,Hamdi Aksoy,Hamdi Aksoy,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,5,,,,
 6854f8bc-1a2a-47f4-9f23-6b4d99abf3db,Hamdi Berkman,Hamdi Berkman,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,5,,,,male
 30ab5add-1773-4aa2-834d-137454215510,Hasan Cavit Belül,Hasan Cavit Belül,,,,Cumhuriyet Halk Partisi,CHP,area/Çoruh_(artvin),Çoruh (Artvin),Grand National Assembly,5,,,,male
 92ae0cbb-d8ce-442c-aba0-9bf898e8f640,Hasan Cemil Çambel,Hasan Cemil Çambel,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,5,,,,male
@@ -176,14 +176,14 @@ cedd2881-6c6b-441d-afc2-0e3194de3031,Hüseyin Fatin Güvendiren,Hüseyin Fatin G
 1e88456d-ff8e-4089-994e-9f0e31d68b81,Hüseyin Hüsnü Konay,Hüseyin Hüsnü Konay,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,5,,,,male
 840a754e-cec4-49ff-a3c8-7ea4ec9e6eaa,Hüseyin Hüsnü Çakır,Hüseyin Hüsnü Çakır,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,5,,,,male
 df5d46c7-fce5-487f-8323-198732f202a1,Hüseyin Hüsnü Özdamar,Hüseyin Hüsnü Özdamar,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/e/e7/Hussein_Husnu_Efendi.jpg,male
-c5beef1e-2f00-42c9-a53a-a65caf50ef60,Hüseyin Rahmi Apak,Hüseyin Rahmi Apak,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,5,,,,
+c5beef1e-2f00-42c9-a53a-a65caf50ef60,Hüseyin Rahmi Apak,Hüseyin Rahmi Apak,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,5,,,,male
 dc88f973-6086-4bf3-a31e-43475bd6505b,Hüseyin Rahmi Gürpınar,Hüseyin Rahmi Gürpınar,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,5,,,,male
 fd4fb680-3b52-4d9e-851d-737c6d7638ab,Hüsrev Gerede,Hüsrev Gerede,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,5,,,,male
 d7d65767-330d-48c2-8a37-6f5b0054588b,Hüsrev Sami Kızıldoğan,Hüsrev Sami Kızıldoğan,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,5,,,,
 2f9ee92c-9cb1-4eae-b244-6f98353a7648,Kazım Karabekir,Kazım Karabekir,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,5,,,,
 8adcd0c6-f6ca-4a3f-bea7-a5060b0fdf6f,Kazım Nami Duru,Kazım Nami Duru,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,5,,,,
 3ed7d865-486c-4486-87af-6337d7ad3a71,Kazım Samanlı,Kazım Samanlı,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,5,,,,
-a4884bcd-8e0d-4c12-a532-a8804da6c9ed,Kazım Sevüktekin,Kazım Sevüktekin,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,5,,,,
+a4884bcd-8e0d-4c12-a532-a8804da6c9ed,Kazım Sevüktekin,Kazım Sevüktekin,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/c/c7/KSevuktekin.jpg,male
 363bb9a2-ba18-4e07-ad72-d9fffdb2a711,Kemalettin Olpak,Kemalettin Olpak,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,5,,,,
 ff08a751-e06c-43bc-bd79-f86c8f5c7c11,Kâzım Özalp,Kâzım Özalp,,,,Cumhuriyet Halk Partisi,CHP,area/balıkesir,Balıkesir,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/5/57/Özalp.jpg,male
 eb8843c8-4ffd-47bd-95cf-cabda53d89d7,Kâzım İnanç,Kâzım İnanç,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,5,,,,male
@@ -211,12 +211,12 @@ d9f6798e-d69e-4adb-9fa9-e90d5389e9be,Mehmet Emin Yurdakul,Mehmet Emin Yurdakul,,
 43a55189-7019-450f-94e1-993dd5814eaa,Mehmet Erten,Mehmet Erten,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,5,,,,male
 35ba49e5-2223-4bc4-84d8-777fc4159b8c,Mehmet Fahri Engin,Mehmet Fahri Engin,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,5,,,,male
 b0e7968d-ae6c-44ba-ac1e-e287406ff99b,Mehmet Faik Baysal,Mehmet Faik Baysal,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,5,,,,male
-402dda26-7adf-4019-9211-f1c86178da48,Mehmet Fuad Köprülü,Mehmet Fuad Köprülü,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/f/fd/Mehmet_Fuat_Köprülü.jpg,male
+402dda26-7adf-4019-9211-f1c86178da48,Mehmet Fuad Köprülü,Mehmet Fuad Köprülü,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,5,,,,
 2b824104-0615-4592-8254-aba08b8cb7d2,Mehmet Güneşdoğdu,Mehmet Güneşdoğdu,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,5,,,,male
 7ced9cba-d2b5-4d7d-a9bf-6e4d9f5b0ea0,Mehmet Hakkı Saydam,Mehmet Hakkı Saydam,,,,Cumhuriyet Halk Partisi,CHP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,5,,,,male
 970ad0b8-2ed8-4fe8-beff-cfd942a4b4b7,Mehmet Kamil İrdelp,Mehmet Kamil İrdelp,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,5,,,,male
 f6f73dc8-7659-4088-bd93-62373413fa81,Mehmet Kani Karaosmanoğlu,Mehmet Kani Karaosmanoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,5,,,,male
-f4bdf57f-104d-472e-a5da-769df2ecc757,Mehmet Kusun,Mehmet Kusun,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,5,,,,
+f4bdf57f-104d-472e-a5da-769df2ecc757,Mehmet Kusun,Mehmet Kusun,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,5,,,,male
 645883ca-3934-4c2e-bf92-f055699ffa9b,Mehmet Mithat Alan,Mehmet Mithat Alan,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,5,,,,male
 8e985396-14d1-4f8a-96ec-e96816837736,Mehmet Münir Çağıl,Mehmet Münir Çağıl,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,5,,,,male
 7aa44374-2059-413b-9ebf-7c0eb604da0d,Mehmet Nafiz Aktin,Mehmet Nafiz Aktin,,,,Cumhuriyet Halk Partisi,CHP,area/amasya,Amasya,Grand National Assembly,5,,,,male
@@ -225,7 +225,7 @@ a2042120-25f4-4e79-8815-db1acf6fceac,Mehmet Naim Onat,Mehmet Naim Onat,,,,Cumhur
 6272c4f6-895a-413c-af49-c2a8cd003414,Mehmet Naki Yücekök,Mehmet Naki Yücekök,,,,Cumhuriyet Halk Partisi,CHP,area/muş,Muş,Grand National Assembly,5,,,,male
 d0a373c4-df59-40f2-a5d9-8800b6df412c,Mehmet Nazif Sirel,Mehmet Nazif Sirel,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,5,,,,male
 efeb3698-88a9-4f71-965a-16e01642ee3d,Mehmet Numan Aksoy,Mehmet Numan Aksoy,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,5,,,,male
-4fb43215-aa33-4a48-9438-beedc5cfa945,Mehmet Nuri Conker,Mehmet Nuri Conker,,,,Cumhuriyet Halk Partisi,CHP,area/gaziantep,Gaziantep,Grand National Assembly,5,,,,
+4fb43215-aa33-4a48-9438-beedc5cfa945,Mehmet Nuri Conker,Mehmet Nuri Conker,,,,Cumhuriyet Halk Partisi,CHP,area/gaziantep,Gaziantep,Grand National Assembly,5,,,,male
 8a33eecb-1bf2-423f-9288-74883105fb2c,Mehmet Nuri Tuna,Mehmet Nuri Tuna,,,,Cumhuriyet Halk Partisi,CHP,area/muğla,Muğla,Grand National Assembly,5,,,,male
 6c7494d3-66fa-408f-8ec3-2c4bc57e3426,Mehmet Nuri Ural,Mehmet Nuri Ural,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,5,,,,male
 e43b1a93-2ef6-48ac-973d-5267e711aae9,Mehmet Ragıp Akça,Mehmet Ragıp Akça,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,5,,,,male
@@ -266,12 +266,12 @@ e9287f21-6d5e-48ea-a10b-66d0af813464,Mithat Aydın,Mithat Aydın,,,,Cumhuriyet H
 082ccd52-f478-49c9-8b86-970ae3b1928e,Mustafa Bengisu,Mustafa Bengisu,,,,Cumhuriyet Halk Partisi,CHP,area/Çanakkale,Çanakkale,Grand National Assembly,5,,,,male
 742a7bb8-c9b3-479a-aa37-60237f09ab8e,Mustafa Cantekin,Mustafa Cantekin,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,5,,,,male
 fb0fb07c-e45e-4989-b372-3b92be6e4f82,Mustafa Durak Sakarya,Mustafa Durak Sakarya,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,5,,,,male
-e9524a9b-7cba-4c05-aca0-ed88468b323e,Mustafa Edip Tör,Mustafa Edip Tör,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,5,,,,
+e9524a9b-7cba-4c05-aca0-ed88468b323e,Mustafa Edip Tör,Mustafa Edip Tör,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/e/ed/Edip_Servet_Tör.jpg,male
 9ae94ee8-947d-46bb-8832-004bd892f3ed,Mustafa Eken,Mustafa Eken,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,5,,,,male
 3a934ecb-84fa-4722-978d-8f44c708065b,Mustafa Fehmi Gerçeker,Mustafa Fehmi Gerçeker,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/a/a2/Mustafa_Fehmi_Efendi_(Gerçeker).jpg,male
 042443ae-b2df-4860-bce6-2f23ecae76c7,Mustafa Halit Üner,Mustafa Halit Üner,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,5,,,,
 fe61a430-358a-4eb4-8074-fe9512abd074,Mustafa Kamil Dursun,Mustafa Kamil Dursun,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,5,,,,male
-b0713117-c1a3-4ae4-afba-5928c8ba4331,Mustafa Kemal Atatürk,Mustafa Kemal Atatürk,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/c/cc/MustafaKemalAtaturk_crop.jpg,male
+b0713117-c1a3-4ae4-afba-5928c8ba4331,Mustafa Kemal Atatürk,Mustafa Kemal Atatürk,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,5,,,,
 76e36e4d-e5d4-4f0a-baf6-b380f92624ab,Mustafa Naşit Uluğ,Mustafa Naşit Uluğ,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,5,,,,male
 54f96e04-0c2f-43c6-aec5-cd2f0eb960c1,Mustafa Rahmi Köken,Mustafa Rahmi Köken,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,5,,,,male
 a37b4f30-1ecf-4ad9-a0cf-2a9854ee3d70,Mustafa Reşit Özsoy,Mustafa Reşit Özsoy,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,5,,,,male
@@ -283,8 +283,8 @@ c5beb545-7893-435a-b9ff-e940702aa859,Mümtaz Ökmen,Mümtaz Ökmen,,,,Cumhuriyet
 f5a3f437-5ccb-4198-bdf1-7eb10615add1,Münip Boya,Münip Boya,,,,Cumhuriyet Halk Partisi,CHP,area/van,Van,Grand National Assembly,5,,,,
 dc0e14fc-427a-4014-8c83-be517b472b49,Müşfik Ayaşlı,Müşfik Ayaşlı,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,5,,,,
 3d9ccdd4-6bc2-4682-aec2-4fc3fb471349,Nabi Rıza Yıldırımtekin,Nabi Rıza Yıldırımtekin,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,5,,,,
-c6f10a6c-08e0-4e19-a0b5-ce4115e3456e,Naci Eldeniz,Naci Eldeniz,,,,Cumhuriyet Halk Partisi,CHP,area/seyhan_(adana),Seyhan (Adana),Grand National Assembly,5,,,,male
-147464d1-31a3-42ef-8102-e2b054786316,Naci Tınaz,Naci Tınaz,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,5,,,,male
+c6f10a6c-08e0-4e19-a0b5-ce4115e3456e,Naci Eldeniz,Naci Eldeniz,,,,Cumhuriyet Halk Partisi,CHP,area/seyhan_(adana),Seyhan (Adana),Grand National Assembly,5,,,,
+147464d1-31a3-42ef-8102-e2b054786316,Naci Tınaz,Naci Tınaz,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,5,,,,
 c589fe5e-b215-4dbe-bea4-62d3a0a05d71,Nafi Atuf Kansu,Nafi Atuf Kansu,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,5,,,,
 2c73bae7-c30d-4854-8037-cd582bbcb69d,Nahit Kerven,Nahit Kerven,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,5,,,,
 72396ee1-afbf-45c5-a2ac-22f8b68ca827,Naki Bekmen,Naki Bekmen,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,5,,,,
@@ -293,7 +293,7 @@ f7058313-cae7-437a-a29d-a107f3c6fae4,Nazmi Topçuoğlu,Nazmi Topçuoğlu,,,,Cumh
 c9171f7b-acd9-42d5-8246-cac33c1f34de,Nazım Poroy,Nazım Poroy,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,5,,,,
 da8ab36a-6f9b-46bd-ae95-1655f283954f,Necip Ali Küçüka,Necip Ali Küçüka,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/6/63/Necip_Ali_Küçükağa.jpg,male
 2dfff97e-b657-4240-b87f-066e4e61f9e9,Necip Asım Yazıksız,Necip Asım Yazıksız,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/4/40/Necip_Asım_Bey_Yazıksız.jpg,
-a5980128-93fd-428f-9928-f03e76e10b82,Necmettin Sadık Sadak,Necmettin Sadık Sadak,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,5,,,,
+a5980128-93fd-428f-9928-f03e76e10b82,Necmettin Sadık Sadak,Necmettin Sadık Sadak,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/9/9e/Necmettin_Sadık_Bey.jpg,male
 eebfa8e6-49b1-4ce6-b189-6163443bb955,Nedim Bozatık,Nedim Bozatık,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,5,,,,
 ed2cb6d1-0c07-413e-843d-13d47f5522d0,Neşet Ömer İrdelp,Neşet Ömer İrdelp,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,5,,,,
 59f98d04-431a-49d6-b833-c936226f2935,Nikola Taptas,Nikola Taptas,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,5,,,,
@@ -320,7 +320,7 @@ b23e5708-8466-40fd-af41-241347a51bed,Osman Nuri Koptagel,Osman Nuri Koptagel,,,,
 aea8e1ed-3593-4016-b804-ace53d3321d0,Recep Peker,Recep Peker,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/e/ef/RECEP_PEKER.jpg,male
 32c4c15a-2ec6-4e4b-bc53-169c23a3fc31,Recep Zühtü Soyak,Recep Zühtü Soyak,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,5,,,,
 364075d5-ba05-4694-8fd4-0b5496f00435,Refet Bele,Refet Bele,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/6/67/İbrahim_Refet_Bele.jpg,male
-05f819e7-9d1b-4bd3-be24-9ef2fc9c3989,Refik Güran,Refik Güran,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,5,,,,
+05f819e7-9d1b-4bd3-be24-9ef2fc9c3989,Refik Güran,Refik Güran,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,5,,,,male
 f669c61b-05bf-4ebb-bc4d-c496e21c5bab,Refik Saydam,Refik Saydam,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/3/3c/Refik_Saydam.jpg,male
 1c65aac7-fceb-4b3a-b034-38c13128b7d9,Refik Şevket İnce,Refik Şevket İnce,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,5,,,,
 82826e33-28cd-43a9-97b4-f2ed45d957d9,Remzi Güres,Remzi Güres,,,,Cumhuriyet Halk Partisi,CHP,area/gaziantep,Gaziantep,Grand National Assembly,5,,,,
@@ -369,7 +369,7 @@ ca138ee0-0f1b-482a-84a6-962f8c47b38e,Tevfik Fikret Sılay,Tevfik Fikret Sılay,,
 dab79c7e-e965-4935-ae40-9c4422fa0968,Tevfik Rüştü Aras,Tevfik Rüştü Aras,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/7/77/Ahmet_Tevfik_Rüştü_Aras.jpg,male
 f5b40c92-d78a-47db-9fca-0f60ca0d154f,Tevfik Tarman,Tevfik Tarman,,,,Cumhuriyet Halk Partisi,CHP,area/seyhan_(adana),Seyhan (Adana),Grand National Assembly,5,,,,male
 20eba921-655f-4f80-b9ab-879700670370,Turgut Türkoğlu,Turgut Türkoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,5,,,,
-e0a15f90-000a-4458-9f03-8d82d7b35aa8,Türkan Örs Baştuğ,Türkan Örs Baştuğ,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,5,,,,
+e0a15f90-000a-4458-9f03-8d82d7b35aa8,Türkan Örs Baştuğ,Türkan Örs Baştuğ,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,5,,,,female
 3e43738d-b8fb-4abb-84cb-ea3d65707c39,Vasıf Çinay,Vasıf Çinay,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,5,,,,
 8da92bdc-886a-485a-9f44-839d0fdb9228,Vedit Uzgören,Vedit Uzgören,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,5,,,,
 884c8266-2d76-409f-adb1-03e2ccc71776,Veled Çelebi İzbudak,Veled Çelebi İzbudak,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,5,,,,male
@@ -377,7 +377,7 @@ e23c6155-58bc-4067-a8a8-fc7620132c81,Veli Yaşın,Veli Yaşın,,,,Cumhuriyet Hal
 282cd480-4554-463d-8f9e-d1be8bd00e19,Yahya Galip Kargı,Yahya Galip Kargı,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,5,,,,male
 fdd92963-1e3a-4a88-aac6-5ebf8cd3d453,Yahya Kemal Beyatlı,Yahya Kemal Beyatlı,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/f/f4/Yahya_Kemal_Bey.jpg,male
 23852149-e92f-46f9-b592-fa4075b2687e,Yunus Nadi Abalıoğlu,Yunus Nadi Abalıoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/muğla,Muğla,Grand National Assembly,5,,,,male
-c999f612-40a2-4233-91c4-1e64472f8ac2,Yusuf Akçora,Yusuf Akçora,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,5,,,,
+c999f612-40a2-4233-91c4-1e64472f8ac2,Yusuf Akçora,Yusuf Akçora,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/9/92/Yusuf_akcura.jpg,male
 f9d793a6-3dcb-4bf2-9b64-a9066d19932c,Yusuf Başkaya,Yusuf Başkaya,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,5,,,,male
 388e0ed1-d63b-4e42-9141-c7a7faeb0ae2,Yusuf Hikmet Bayur,Yusuf Hikmet Bayur,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/e/e9/Yusuf_Hikmet_Bey.jpg,male
 e382f965-bc25-42d6-be02-475f53c2a69e,Yusuf Kemal Tengirşenk,Yusuf Kemal Tengirşenk,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,5,,,,male
@@ -421,7 +421,7 @@ bb6ed503-75dc-4c08-abea-5b95b9d45ffc,İsmail Hakkı Uzunçarşılı,İsmail Hakk
 08a52925-85d9-459a-a6fd-1c44ee2e6c88,İsmail Hakkı Veral,İsmail Hakkı Veral,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,5,,,,male
 4e7f14c4-1192-4331-a56c-468cbc82cdc3,İsmail Kemal Alpsar,İsmail Kemal Alpsar,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,5,,,https://upload.wikimedia.org/wikipedia/commons/a/a7/İsmail_Kemal_Bey_(Alpsar).jpg,male
 a1f3f513-35bf-47aa-ab80-96602e3303c2,İsmail Memet Uğur,İsmail Memet Uğur,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,5,,,,male
-3ab71523-bb75-4210-afb4-b3a6e3a0fd35,İsmail Müştak Mayokan,İsmail Müştak Mayokan,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,5,,,,
+3ab71523-bb75-4210-afb4-b3a6e3a0fd35,İsmail Müştak Mayokan,İsmail Müştak Mayokan,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,5,,,,male
 0019a4f1-9038-4170-b9e6-492bcfa4581d,İsmail Sabuncu,İsmail Sabuncu,,,,Cumhuriyet Halk Partisi,CHP,area/giresun,Giresun,Grand National Assembly,5,,,,male
 5ef0e5f9-6dff-42d9-811d-29a3bbdfefcd,İsmail Çamaş,İsmail Çamaş,,,,Cumhuriyet Halk Partisi,CHP,area/ordu,Ordu,Grand National Assembly,5,,,,male
 5e6898eb-db71-4a24-8e0f-f382eb811f61,İsmet Eker,İsmet Eker,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,5,,,,

--- a/data/Turkey/Assembly/term-6.csv
+++ b/data/Turkey/Assembly/term-6.csv
@@ -9,9 +9,9 @@ a889fbf8-7561-4bfd-bbfe-74cff08796d2,Abdurrahman Şeref Uluğ,Abdurrahman Şeref
 b92bd44c-c77d-4829-bd00-2d1f66ccc18f,Abidin Binkaya,Abidin Binkaya,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,6,,,,
 fca83ba7-4dee-4262-8639-6edf0b9278cc,Abidin Daver,Abidin Daver,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,6,,,,
 53fb1443-3f41-414c-b1bb-007c533633c7,Adnan Menderes,Adnan Menderes,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,6,,,https://upload.wikimedia.org/wikipedia/commons/4/45/Adnan_Menderes_MSB.jpg,male
-f1c9fe06-134e-46c6-888a-1eb8e58824a5,Agah Sırrı Levent,Agah Sırrı Levent,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,6,,,,
+f1c9fe06-134e-46c6-888a-1eb8e58824a5,Agah Sırrı Levent,Agah Sırrı Levent,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,6,,,,male
 87be4d60-3c4d-4318-a741-ab664132ed9e,Ahmed Mükerrem Karaağaç,Ahmed Mükerrem Karaağaç,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,6,,,,male
-88e0212b-0ca6-4475-a257-02590534be35,Ahmet Aksu,Ahmet Aksu,,,,Cumhuriyet Halk Partisi,CHP,area/gaziantep,Gaziantep,Grand National Assembly,6,,,,
+88e0212b-0ca6-4475-a257-02590534be35,Ahmet Aksu,Ahmet Aksu,,,,Cumhuriyet Halk Partisi,CHP,area/gaziantep,Gaziantep,Grand National Assembly,6,,,,male
 986af966-7743-44f8-a9ae-9bc4f91f551d,Ahmet Besim Atalay,Ahmet Besim Atalay,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,6,,,,
 db3bac76-5239-4a36-8de9-626801170c0a,Ahmet Cemal Tunca,Ahmet Cemal Tunca,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,6,,,,male
 02732b7e-a415-4a2b-8eed-bbc3bdf62fe4,Ahmet Esat Uras,Ahmet Esat Uras,,,,Cumhuriyet Halk Partisi,CHP,area/amasya,Amasya,Grand National Assembly,6,,,,male
@@ -26,13 +26,13 @@ e8f27fc2-7416-4662-ab02-f5ce9b8d0494,Ahmet Hazım Börekçi,Ahmet Hazım Börek�
 e6e9072c-8bc1-4d79-ba47-7a6415fd7c38,Ahmet Hilmi Ergeneli,Ahmet Hilmi Ergeneli,,,,Cumhuriyet Halk Partisi,CHP,area/Çanakkale,Çanakkale,Grand National Assembly,6,,,,male
 11dbb8d3-23ea-40a1-86d3-1925c7977ee3,Ahmet Hilmi Kalaç,Ahmet Hilmi Kalaç,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,6,,,,male
 ce51e796-1726-485c-af1d-4fd0140d68bc,Ahmet Hulusi Alataş,Ahmet Hulusi Alataş,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,6,,,,male
-52fe9f39-65d8-4a73-a5e3-747ce85e6c52,Ahmet Kemalettin Turan,Ahmet Kemalettin Turan,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,6,,,,
+52fe9f39-65d8-4a73-a5e3-747ce85e6c52,Ahmet Kemalettin Turan,Ahmet Kemalettin Turan,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,6,,,,male
 a46c7f44-253f-4abd-806d-4b09d1c9a968,Ahmet Kutsi Tecer,Ahmet Kutsi Tecer,,,,Cumhuriyet Halk Partisi,CHP,area/seyhan_(adana),Seyhan (Adana),Grand National Assembly,6,,,,male
 fc165982-366f-4261-bdb3-6e9e84b7024a,Ahmet Mithat Yenel,Ahmet Mithat Yenel,,,,Cumhuriyet Halk Partisi,CHP,area/tunceli,Tunceli,Grand National Assembly,6,,,,male
 7d669510-e2e5-46ca-a8ae-f0385f49dd0f,Ahmet Muhtar Berker,Ahmet Muhtar Berker,,,,Cumhuriyet Halk Partisi,CHP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,6,,,,male
 0c86647d-3e8b-4dc6-b005-249121fd131e,Ahmet Münir Akkaya,Ahmet Münir Akkaya,,,,Cumhuriyet Halk Partisi,CHP,area/giresun,Giresun,Grand National Assembly,6,,,,male
-7de7d51e-03de-4885-9acf-7bafe2554f83,Ahmet Naci Eldeniz,Ahmet Naci Eldeniz,,,,Cumhuriyet Halk Partisi,CHP,area/seyhan_(adana),Seyhan (Adana),Grand National Assembly,6,,,,
-9256d486-6351-4914-beb2-cb60848d8b6b,Ahmet Naci Tınaz,Ahmet Naci Tınaz,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,6,,,,
+7de7d51e-03de-4885-9acf-7bafe2554f83,Ahmet Naci Eldeniz,Ahmet Naci Eldeniz,,,,Cumhuriyet Halk Partisi,CHP,area/seyhan_(adana),Seyhan (Adana),Grand National Assembly,6,,,,male
+9256d486-6351-4914-beb2-cb60848d8b6b,Ahmet Naci Tınaz,Ahmet Naci Tınaz,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,6,,,,male
 b8fabebf-dbf1-44e8-ba73-d7edd49d7384,Ahmet Nazmi İlker,Ahmet Nazmi İlker,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,6,,,,
 a7623850-caae-4146-94f2-a91f7c3abc16,Ahmet Naşit Fırat,Ahmet Naşit Fırat,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,6,,,,
 4e18eee2-fc4d-4d86-bbb8-519cb136ea08,Ahmet Nuri Göktepe,Ahmet Nuri Göktepe,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,6,,,,male
@@ -53,9 +53,9 @@ c86daf56-2f58-4c40-8ac8-1be8c7c2762e,Akif Arkan,Akif Arkan,,,,Cumhuriyet Halk Pa
 e3c6b751-908c-4cd5-a4ff-fe36a4a39bc3,Akif Erdemgil,Akif Erdemgil,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,6,,,,male
 c3777bdf-12df-49cd-96bf-d8ae07d115bc,Alaattin Tiritoğlu,Alaattin Tiritoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,6,,,,
 84bd52f2-1b6d-4ee7-bf02-5dd7d45dacfb,Ali Canip Yöntem,Ali Canip Yöntem,,,,Cumhuriyet Halk Partisi,CHP,area/ordu,Ordu,Grand National Assembly,6,,,,
-2cdaaec0-ddef-42e1-8892-b0cc0ffb9077,Ali Cavit Oral,Ali Cavit Oral,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,6,,,,male
+2cdaaec0-ddef-42e1-8892-b0cc0ffb9077,Ali Cavit Oral,Ali Cavit Oral,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,6,,,,
 6ca42f2f-55c6-411a-ab0a-911cc8e05ed8,Ali Dikmen,Ali Dikmen,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,6,,,,
-3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44,Ali Fethi Okyar,Ali Fethi Okyar,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,6,,,,
+3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44,Ali Fethi Okyar,Ali Fethi Okyar,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,6,,,https://upload.wikimedia.org/wikipedia/commons/9/99/Ali_Fethi_Okyar.jpg,male
 7da075c8-1f09-40b1-a9f4-957caa15a55e,Ali Fuat Cebesoy,Ali Fuat Cebesoy,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,6,,,https://upload.wikimedia.org/wikipedia/commons/0/09/Ali_Fuat_Pasha.jpg,male
 bc2d7a2f-74a5-4219-ae08-74f6daa8a4db,Ali Galip Pekel,Ali Galip Pekel,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,6,,,,male
 9990a134-c9cc-44b7-bf26-69243bc4c0e8,Ali Haydar Çerçel,Ali Haydar Çerçel,,,,Cumhuriyet Halk Partisi,CHP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,6,,,,
@@ -106,7 +106,7 @@ e7243b4a-a9da-4b0c-9a61-b69ff264b36e,Cevat Dursunoğlu,Cevat Dursunoğlu,,,,Cumh
 2d9f198c-34fa-45ad-9844-47b0ff1727d2,Cevdet Kerim İncedayı,Cevdet Kerim İncedayı,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,6,,,,
 0160d391-e46e-4978-8fae-a724e2491012,Cezmi Erçin,Cezmi Erçin,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,6,,,,
 da7a1891-05c4-42b6-9237-80b0c9ba3192,Ebubekir Hâzım Tepeyran,Ebubekir Hâzım Tepeyran,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,6,,,https://upload.wikimedia.org/wikipedia/commons/b/be/Ebubekir_Hazim_Bey.jpg,male
-2f649ab8-dbee-4ccb-87bd-ebf23f3b8a09,Edip Servet Tör,Edip Servet Tör,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,6,,,https://upload.wikimedia.org/wikipedia/commons/e/ed/Edip_Servet_Tör.jpg,male
+2f649ab8-dbee-4ccb-87bd-ebf23f3b8a09,Edip Servet Tör,Edip Servet Tör,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,6,,,,
 bf284c59-5eab-483f-b00b-9b721aeba4dd,Ekrem Ergun,Ekrem Ergun,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,6,,,,
 7b32bcd8-59a8-4cf2-85a6-6ae3d7e410a4,Ekrem Pekel,Ekrem Pekel,,,,Cumhuriyet Halk Partisi,CHP,area/yozgat,Yozgat,Grand National Assembly,6,,,,male
 c64e1c08-1625-47fd-a5e5-75e4d628faff,Emin Aslan Tokat,Emin Aslan Tokat,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,6,,,,male
@@ -114,7 +114,7 @@ d254bd36-ee72-4d6b-ad8e-0b9a1507516b,Emin Cemal Suda,Emin Cemal Suda,,,,Cumhuriy
 8cd8c9bb-149d-4f10-ac94-33fcf2a621c7,Emin Sazak,Emin Sazak,,,,Cumhuriyet Halk Partisi,CHP,area/eskişehir,Eskişehir,Grand National Assembly,6,,,,male
 c69bf06e-da2c-404a-b5e8-3cba4e1d21b5,Emin Yerlikaya,Emin Yerlikaya,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,6,,,,
 2e94df0a-4396-4ec6-87a6-e0d17a5cb007,Emrullah Barkan,Emrullah Barkan,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,6,,,,
-c8eab67a-fe54-44b3-8792-bccb4c6dc468,Enis Avni Akagündüz,Enis Avni Akagündüz,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,6,,,,
+c8eab67a-fe54-44b3-8792-bccb4c6dc468,Enis Avni Akagündüz,Enis Avni Akagündüz,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,6,,,https://upload.wikimedia.org/wikipedia/commons/c/cc/Enis_Avni_Bey_Akagündüz.jpg,male
 79bd137e-782e-40f0-8912-6a5bfa42c078,Esat Özoğuz,Esat Özoğuz,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,6,,,,
 0404d298-2860-4fb9-977b-5ab493c2584d,Ethem İzzet Benice,Ethem İzzet Benice,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,6,,,,
 43297b39-53d7-49f1-80db-d21f06984ab2,Eyüp Sabri Akgöl,Eyüp Sabri Akgöl,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,6,,,,male
@@ -153,7 +153,7 @@ f37dd435-7336-4c91-9900-b837b38a575d,Hacim Muhittin Çarıklı,Hacim Muhittin Ç
 ee10e749-a615-49a6-8cf8-c6a9f4937458,Hafız İbrahim Demiralay,Hafız İbrahim Demiralay,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,6,,,,
 b85e88b1-46aa-4822-ac9d-a4774a50fdf8,Hakkı Ungan,Hakkı Ungan,,,,Cumhuriyet Halk Partisi,CHP,area/van,Van,Grand National Assembly,6,,,,male
 8ac114ac-8076-4888-9008-41e1c25dc9ee,Halil Boztepe,Halil Boztepe,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,6,,,,male
-2e825a8d-4b7b-40e7-8266-37b4eb8c6743,Halil Hulki Ayrım,Halil Hulki Ayrım,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,6,,,,
+2e825a8d-4b7b-40e7-8266-37b4eb8c6743,Halil Hulki Ayrım,Halil Hulki Ayrım,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,6,,,,male
 1df8d114-caed-4422-b594-c3c6e6e64a62,Halil Menteşe,Halil Menteşe,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,6,,,,male
 c9428e1e-97d1-4e60-8b13-18b54ca841d6,Halil Türkmen,Halil Türkmen,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,6,,,,male
 8e63f7dd-e4d7-4f4b-b0aa-96d61afda8a7,Halit Bayrak,Halit Bayrak,,,,Cumhuriyet Halk Partisi,CHP,area/ağrı,Ağrı,Grand National Assembly,6,,,,
@@ -200,9 +200,9 @@ cedd2881-6c6b-441d-afc2-0e3194de3031,Hüseyin Fatin Güvendiren,Hüseyin Fatin G
 a1505171-4544-4c8f-9576-4acef0f551c5,Hüseyin Hüsnü Yaman,Hüseyin Hüsnü Yaman,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,6,,,,male
 840a754e-cec4-49ff-a3c8-7ea4ec9e6eaa,Hüseyin Hüsnü Çakır,Hüseyin Hüsnü Çakır,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,6,,,,male
 df5d46c7-fce5-487f-8323-198732f202a1,Hüseyin Hüsnü Özdamar,Hüseyin Hüsnü Özdamar,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,6,,,https://upload.wikimedia.org/wikipedia/commons/e/e7/Hussein_Husnu_Efendi.jpg,male
-c5beef1e-2f00-42c9-a53a-a65caf50ef60,Hüseyin Rahmi Apak,Hüseyin Rahmi Apak,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,6,,,,
+c5beef1e-2f00-42c9-a53a-a65caf50ef60,Hüseyin Rahmi Apak,Hüseyin Rahmi Apak,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,6,,,,male
 dc88f973-6086-4bf3-a31e-43475bd6505b,Hüseyin Rahmi Gürpınar,Hüseyin Rahmi Gürpınar,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,6,,,,male
-c897a10b-39ef-4ea8-a585-ddfe834a92a0,Hüseyin Rauf Orbay,Hüseyin Rauf Orbay,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,6,,,,
+c897a10b-39ef-4ea8-a585-ddfe834a92a0,Hüseyin Rauf Orbay,Hüseyin Rauf Orbay,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,6,,,,male
 806e4447-4cd8-46ca-9811-dcd04a52d397,Hüseyin Sami İşbay,Hüseyin Sami İşbay,,,,Cumhuriyet Halk Partisi,CHP,area/urfa,Urfa,Grand National Assembly,6,,,,
 4d1b23a2-d1e0-4282-995f-bd2bd5832503,Hüsnü Açıksöz,Hüsnü Açıksöz,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,6,,,,
 d7d65767-330d-48c2-8a37-6f5b0054588b,Hüsrev Sami Kızıldoğan,Hüsrev Sami Kızıldoğan,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,6,,,,
@@ -211,7 +211,7 @@ d7d65767-330d-48c2-8a37-6f5b0054588b,Hüsrev Sami Kızıldoğan,Hüsrev Sami Kı
 5f568629-1edb-4b4d-aad3-4b551816204a,Kazım Fikri Özalp,Kazım Fikri Özalp,,,,Cumhuriyet Halk Partisi,CHP,area/balıkesir,Balıkesir,Grand National Assembly,6,,,,
 8adcd0c6-f6ca-4a3f-bea7-a5060b0fdf6f,Kazım Nami Duru,Kazım Nami Duru,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,6,,,,
 3ed7d865-486c-4486-87af-6337d7ad3a71,Kazım Samanlı,Kazım Samanlı,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,6,,,,
-a4884bcd-8e0d-4c12-a532-a8804da6c9ed,Kazım Sevüktekin,Kazım Sevüktekin,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,6,,,,
+a4884bcd-8e0d-4c12-a532-a8804da6c9ed,Kazım Sevüktekin,Kazım Sevüktekin,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,6,,,https://upload.wikimedia.org/wikipedia/commons/c/c7/KSevuktekin.jpg,male
 085be837-53f1-490c-bc00-4c77b1c18c9e,Kemal Doğan,Kemal Doğan,,,,Cumhuriyet Halk Partisi,CHP,area/ağrı,Ağrı,Grand National Assembly,6,,,,male
 e04a9f61-6889-4c14-add4-488fea135859,Kemalettin Kamu,Kemalettin Kamu,,,,Cumhuriyet Halk Partisi,CHP,area/rize,Rize,Grand National Assembly,6,,,,
 363bb9a2-ba18-4e07-ad72-d9fffdb2a711,Kemalettin Olpak,Kemalettin Olpak,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,6,,,,
@@ -236,7 +236,7 @@ d9f6798e-d69e-4adb-9fa9-e90d5389e9be,Mehmet Emin Yurdakul,Mehmet Emin Yurdakul,,
 43a55189-7019-450f-94e1-993dd5814eaa,Mehmet Erten,Mehmet Erten,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,6,,,,male
 35ba49e5-2223-4bc4-84d8-777fc4159b8c,Mehmet Fahri Engin,Mehmet Fahri Engin,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,6,,,,male
 b0e7968d-ae6c-44ba-ac1e-e287406ff99b,Mehmet Faik Baysal,Mehmet Faik Baysal,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,6,,,,male
-402dda26-7adf-4019-9211-f1c86178da48,Mehmet Fuad Köprülü,Mehmet Fuad Köprülü,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,6,,,https://upload.wikimedia.org/wikipedia/commons/f/fd/Mehmet_Fuat_Köprülü.jpg,male
+402dda26-7adf-4019-9211-f1c86178da48,Mehmet Fuad Köprülü,Mehmet Fuad Köprülü,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,6,,,,
 f6f73dc8-7659-4088-bd93-62373413fa81,Mehmet Kani Karaosmanoğlu,Mehmet Kani Karaosmanoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,6,,,,male
 8e985396-14d1-4f8a-96ec-e96816837736,Mehmet Münir Çağıl,Mehmet Münir Çağıl,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,6,,,,male
 7aa44374-2059-413b-9ebf-7c0eb604da0d,Mehmet Nafiz Aktin,Mehmet Nafiz Aktin,,,,Cumhuriyet Halk Partisi,CHP,area/amasya,Amasya,Grand National Assembly,6,,,,male
@@ -247,7 +247,7 @@ e43b1a93-2ef6-48ac-973d-5267e711aae9,Mehmet Ragıp Akça,Mehmet Ragıp Akça,,,,
 00a27340-6a1b-4795-8e2a-dbd4b0ec16c4,Mehmet Refet Ülgen,Mehmet Refet Ülgen,,,,Cumhuriyet Halk Partisi,CHP,area/urfa,Urfa,Grand National Assembly,6,,,,
 055af63b-b39a-4a2f-9da0-3b0814bdbede,Mehmet Rifat Vardar,Mehmet Rifat Vardar,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,6,,,,male
 53c10b11-1b89-4113-a079-e2588d3185a5,Mehmet Rüştü Bekit,Mehmet Rüştü Bekit,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,6,,,,male
-5862b388-6f4a-426b-ace7-1369cd044307,Mehmet Sabit Sağıroğlu,Mehmet Sabit Sağıroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/elazığ,Elazığ,Grand National Assembly,6,,,https://upload.wikimedia.org/wikipedia/commons/6/63/Sabit_Bey_Sağıroğlu.jpg,male
+5862b388-6f4a-426b-ace7-1369cd044307,Mehmet Sabit Sağıroğlu,Mehmet Sabit Sağıroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/elazığ,Elazığ,Grand National Assembly,6,,,,
 ba176328-9aae-40f6-beed-d1c4eb0e94f9,Mehmet Sadettin Serim,Mehmet Sadettin Serim,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,6,,,,male
 a98caf4b-f5a6-4fd1-8ef5-831a6ca4932c,Mehmet Sanlı,Mehmet Sanlı,,,,Cumhuriyet Halk Partisi,CHP,area/burdur,Burdur,Grand National Assembly,6,,,,male
 f607a133-e7b1-43dd-ada2-25cd90e1db40,Mehmet Seyfelioğlu,Mehmet Seyfelioğlu,,,,Cumhuriyet Halk Partisi,CHP,area/kırşehir,Kırşehir,Grand National Assembly,6,,,,male
@@ -305,7 +305,7 @@ f7058313-cae7-437a-a29d-a107f3c6fae4,Nazmi Topçuoğlu,Nazmi Topçuoğlu,,,,Cumh
 6894e9d4-8cf5-4ddb-b7cf-5107e16d556d,Nazmi Trak,Nazmi Trak,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,6,,,,
 c9171f7b-acd9-42d5-8246-cac33c1f34de,Nazım Poroy,Nazım Poroy,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,6,,,,
 da8ab36a-6f9b-46bd-ae95-1655f283954f,Necip Ali Küçüka,Necip Ali Küçüka,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,6,,,https://upload.wikimedia.org/wikipedia/commons/6/63/Necip_Ali_Küçükağa.jpg,male
-a5980128-93fd-428f-9928-f03e76e10b82,Necmettin Sadık Sadak,Necmettin Sadık Sadak,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,6,,,,
+a5980128-93fd-428f-9928-f03e76e10b82,Necmettin Sadık Sadak,Necmettin Sadık Sadak,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,6,,,https://upload.wikimedia.org/wikipedia/commons/9/9e/Necmettin_Sadık_Bey.jpg,male
 319b417b-8bf2-4173-b080-6400d83d1274,Necmettin Sahir Sılan,Necmettin Sahir Sılan,,,,Cumhuriyet Halk Partisi,CHP,area/bingöl,Bingöl,Grand National Assembly,6,,,,male
 05b88234-cef6-45c1-83db-35a5e5540123,Nevzad Ayas,Nevzad Ayas,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,6,,,,
 ecd67f4d-bc14-4dc3-add3-6286f6b1a52c,Nihat Anılmış,Nihat Anılmış,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,6,,,,male
@@ -332,7 +332,7 @@ ccf49bf8-5cb4-40de-a7cc-aace868204e1,Osman Şahinbaş,Osman Şahinbaş,,,,Cumhur
 f6aa7323-363b-4150-8b28-479f87c76c1e,Razi Soyer,Razi Soyer,,,,Cumhuriyet Halk Partisi,CHP,area/urfa,Urfa,Grand National Assembly,6,,,,male
 aea8e1ed-3593-4016-b804-ace53d3321d0,Recep Peker,Recep Peker,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,6,,,https://upload.wikimedia.org/wikipedia/commons/e/ef/RECEP_PEKER.jpg,male
 364075d5-ba05-4694-8fd4-0b5496f00435,Refet Bele,Refet Bele,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,6,,,https://upload.wikimedia.org/wikipedia/commons/6/67/İbrahim_Refet_Bele.jpg,male
-05f819e7-9d1b-4bd3-be24-9ef2fc9c3989,Refik Güran,Refik Güran,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,6,,,,
+05f819e7-9d1b-4bd3-be24-9ef2fc9c3989,Refik Güran,Refik Güran,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,6,,,,male
 d493f63d-29fd-47ea-86be-cfb81239c06c,Refik Koraltan,Refik Koraltan,,,,Cumhuriyet Halk Partisi,CHP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,6,,,https://upload.wikimedia.org/wikipedia/commons/7/7c/Bekir_Refik_Bey_Koraltan.jpg,male
 f669c61b-05bf-4ebb-bc4d-c496e21c5bab,Refik Saydam,Refik Saydam,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,6,,,https://upload.wikimedia.org/wikipedia/commons/3/3c/Refik_Saydam.jpg,male
 1c65aac7-fceb-4b3a-b034-38c13128b7d9,Refik Şevket İnce,Refik Şevket İnce,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,6,,,,
@@ -389,7 +389,7 @@ ca138ee0-0f1b-482a-84a6-962f8c47b38e,Tevfik Fikret Sılay,Tevfik Fikret Sılay,,
 f5b40c92-d78a-47db-9fca-0f60ca0d154f,Tevfik Tarman,Tevfik Tarman,,,,Cumhuriyet Halk Partisi,CHP,area/seyhan_(adana),Seyhan (Adana),Grand National Assembly,6,,,,male
 fa851f0b-8e5e-4844-ab3b-5986f703d7ae,Tevfik Temelli,Tevfik Temelli,,,,Cumhuriyet Halk Partisi,CHP,area/bitlis,Bitlis,Grand National Assembly,6,,,,male
 e890fd44-8ee4-4427-a2e0-a7cd655a3520,Turhan Cemal Beriker,Turhan Cemal Beriker,,,,Cumhuriyet Halk Partisi,CHP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,6,,,,
-e0a15f90-000a-4458-9f03-8d82d7b35aa8,Türkan Örs Baştuğ,Türkan Örs Baştuğ,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,6,,,,
+e0a15f90-000a-4458-9f03-8d82d7b35aa8,Türkan Örs Baştuğ,Türkan Örs Baştuğ,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,6,,,,female
 3e43738d-b8fb-4abb-84cb-ea3d65707c39,Vasıf Çinay,Vasıf Çinay,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,6,,,,
 8da92bdc-886a-485a-9f44-839d0fdb9228,Vedit Uzgören,Vedit Uzgören,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,6,,,,
 fc23c972-7505-46ca-8791-1714e0af43cb,Vehbi Demir,Vehbi Demir,,,,Cumhuriyet Halk Partisi,CHP,area/ordu,Ordu,Grand National Assembly,6,,,,

--- a/data/Turkey/Assembly/term-7.csv
+++ b/data/Turkey/Assembly/term-7.csv
@@ -12,7 +12,7 @@ b92bd44c-c77d-4829-bd00-2d1f66ccc18f,Abidin Binkaya,Abidin Binkaya,,,,Cumhuriyet
 23c98c55-9275-4e8e-9e95-b14ad4638942,Abidin Yurdakul,Abidin Yurdakul,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,7,,,,
 1c0b4cba-55a8-42b9-b92e-82447a1d158d,Abidin Çakır,Abidin Çakır,,,,Cumhuriyet Halk Partisi,CHP,area/muğla,Muğla,Grand National Assembly,7,,,,
 53fb1443-3f41-414c-b1bb-007c533633c7,Adnan Menderes,Adnan Menderes,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,7,,,https://upload.wikimedia.org/wikipedia/commons/4/45/Adnan_Menderes_MSB.jpg,male
-f1c9fe06-134e-46c6-888a-1eb8e58824a5,Agah Sırrı Levent,Agah Sırrı Levent,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,7,,,,
+f1c9fe06-134e-46c6-888a-1eb8e58824a5,Agah Sırrı Levent,Agah Sırrı Levent,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,7,,,,male
 87be4d60-3c4d-4318-a741-ab664132ed9e,Ahmed Mükerrem Karaağaç,Ahmed Mükerrem Karaağaç,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,7,,,,male
 986af966-7743-44f8-a9ae-9bc4f91f551d,Ahmet Besim Atalay,Ahmet Besim Atalay,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,7,,,,
 db3bac76-5239-4a36-8de9-626801170c0a,Ahmet Cemal Tunca,Ahmet Cemal Tunca,,,,Cumhuriyet Halk Partisi,CHP,area/antalya,Antalya,Grand National Assembly,7,,,,male
@@ -29,12 +29,12 @@ bafa1d09-3239-4553-b38b-6f50eede6ed7,Ahmet Hamdi Yalman,Ahmet Hamdi Yalman,,,,Cu
 e6e9072c-8bc1-4d79-ba47-7a6415fd7c38,Ahmet Hilmi Ergeneli,Ahmet Hilmi Ergeneli,,,,Cumhuriyet Halk Partisi,CHP,area/Çanakkale,Çanakkale,Grand National Assembly,7,,,,male
 11dbb8d3-23ea-40a1-86d3-1925c7977ee3,Ahmet Hilmi Kalaç,Ahmet Hilmi Kalaç,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,7,,,,male
 ce51e796-1726-485c-af1d-4fd0140d68bc,Ahmet Hulusi Alataş,Ahmet Hulusi Alataş,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,7,,,,male
-52fe9f39-65d8-4a73-a5e3-747ce85e6c52,Ahmet Kemalettin Turan,Ahmet Kemalettin Turan,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,7,,,,
+52fe9f39-65d8-4a73-a5e3-747ce85e6c52,Ahmet Kemalettin Turan,Ahmet Kemalettin Turan,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,7,,,,male
 a46c7f44-253f-4abd-806d-4b09d1c9a968,Ahmet Kutsi Tecer,Ahmet Kutsi Tecer,,,,Cumhuriyet Halk Partisi,CHP,area/urfa,Urfa,Grand National Assembly,7,,,,male
 7d669510-e2e5-46ca-a8ae-f0385f49dd0f,Ahmet Muhtar Berker,Ahmet Muhtar Berker,,,,Cumhuriyet Halk Partisi,CHP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,7,,,,male
 0c86647d-3e8b-4dc6-b005-249121fd131e,Ahmet Münir Akkaya,Ahmet Münir Akkaya,,,,Cumhuriyet Halk Partisi,CHP,area/giresun,Giresun,Grand National Assembly,7,,,,male
 29a99f5c-d70a-4058-b257-1bf0b3723c08,Ahmet Münir Erhan,Ahmet Münir Erhan,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,7,,,,male
-9256d486-6351-4914-beb2-cb60848d8b6b,Ahmet Naci Tınaz,Ahmet Naci Tınaz,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,7,,,,
+9256d486-6351-4914-beb2-cb60848d8b6b,Ahmet Naci Tınaz,Ahmet Naci Tınaz,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,7,,,,male
 e3feb9b6-afab-4dd4-85fb-4defb48563d7,Ahmet Nail Öztuzcu,Ahmet Nail Öztuzcu,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,7,,,,
 4e18eee2-fc4d-4d86-bbb8-519cb136ea08,Ahmet Nuri Göktepe,Ahmet Nuri Göktepe,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,7,,,,male
 b4cd17e8-e737-4295-9e6a-3b984d15e826,Ahmet Nuri Gürel,Ahmet Nuri Gürel,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,7,,,,
@@ -48,9 +48,9 @@ ca136cc7-cc4c-458f-a6c5-cd428034b724,Ahmet Ulus,Ahmet Ulus,,,,Cumhuriyet Halk Pa
 4c9c63ec-8b2b-49a0-b977-1fc17d27d670,Ahmet Şükrü Esmer,Ahmet Şükrü Esmer,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,7,,,,male
 c86daf56-2f58-4c40-8ac8-1be8c7c2762e,Akif Arkan,Akif Arkan,,,,Cumhuriyet Halk Partisi,CHP,area/Çankırı,Çankırı,Grand National Assembly,7,,,,
 c3777bdf-12df-49cd-96bf-d8ae07d115bc,Alaattin Tiritoğlu,Alaattin Tiritoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,7,,,,
-2cdaaec0-ddef-42e1-8892-b0cc0ffb9077,Ali Cavit Oral,Ali Cavit Oral,,,,Cumhuriyet Halk Partisi,CHP,area/seyhan_(adana),Seyhan (Adana),Grand National Assembly,7,,,,male
+2cdaaec0-ddef-42e1-8892-b0cc0ffb9077,Ali Cavit Oral,Ali Cavit Oral,,,,Cumhuriyet Halk Partisi,CHP,area/seyhan_(adana),Seyhan (Adana),Grand National Assembly,7,,,,
 6ca42f2f-55c6-411a-ab0a-911cc8e05ed8,Ali Dikmen,Ali Dikmen,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,7,,,,
-3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44,Ali Fethi Okyar,Ali Fethi Okyar,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,7,,,,
+3f1e9f3d-12ef-4e7e-aaf8-03ea11d47c44,Ali Fethi Okyar,Ali Fethi Okyar,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,7,,,https://upload.wikimedia.org/wikipedia/commons/9/99/Ali_Fethi_Okyar.jpg,male
 7da075c8-1f09-40b1-a9f4-957caa15a55e,Ali Fuat Cebesoy,Ali Fuat Cebesoy,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,7,,,https://upload.wikimedia.org/wikipedia/commons/0/09/Ali_Fuat_Pasha.jpg,male
 bc2d7a2f-74a5-4219-ae08-74f6daa8a4db,Ali Galip Pekel,Ali Galip Pekel,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,7,,,,male
 9990a134-c9cc-44b7-bf26-69243bc4c0e8,Ali Haydar Çerçel,Ali Haydar Çerçel,,,,Cumhuriyet Halk Partisi,CHP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,7,,,,
@@ -103,7 +103,7 @@ d5d2b32f-9ea4-4e82-b544-7ca039e81396,Cafer Tüzel,Cafer Tüzel,,,,Cumhuriyet Hal
 9b6e96d1-e990-4e08-a481-e9b04a263df3,Celal Arat,Celal Arat,,,,Cumhuriyet Halk Partisi,CHP,area/yozgat,Yozgat,Grand National Assembly,7,,,,
 f45b8c82-58ac-4e7a-ad0c-0b6dcec3ccf0,Celal Esad Arseven,Celal Esad Arseven,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,7,,,,
 b34e3d21-78a0-4065-82fc-b99ecf5e9a37,Celal Sait Siren,Celal Sait Siren,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,7,,,,
-98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,7,,,https://upload.wikimedia.org/wikipedia/commons/9/9b/Celal_bayar.jpg,male
+98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,7,,,,
 cb482b5d-c7bc-4579-976a-6ca94b10bf4f,Cemal Karamuğla,Cemal Karamuğla,,,,Cumhuriyet Halk Partisi,CHP,area/muğla,Muğla,Grand National Assembly,7,,,,male
 cd01bcda-34f2-492b-81ea-8fc2b14a17a4,Cemal Kazancıoğlu,Cemal Kazancıoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,7,,,,
 ec435273-bbe6-477a-8d41-bd236aa7f183,Cemal Kovalı,Cemal Kovalı,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,7,,,,male
@@ -117,7 +117,7 @@ e7243b4a-a9da-4b0c-9a61-b69ff264b36e,Cevat Dursunoğlu,Cevat Dursunoğlu,,,,Cumh
 2d9f198c-34fa-45ad-9844-47b0ff1727d2,Cevdet Kerim İncedayı,Cevdet Kerim İncedayı,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,7,,,,
 da7a1891-05c4-42b6-9237-80b0c9ba3192,Ebubekir Hâzım Tepeyran,Ebubekir Hâzım Tepeyran,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,7,,,https://upload.wikimedia.org/wikipedia/commons/b/be/Ebubekir_Hazim_Bey.jpg,male
 dde49b8b-d4d9-40d7-8e9f-719545303f1f,Edip Alpsar,Edip Alpsar,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,7,,,,male
-2f649ab8-dbee-4ccb-87bd-ebf23f3b8a09,Edip Servet Tör,Edip Servet Tör,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,7,,,https://upload.wikimedia.org/wikipedia/commons/e/ed/Edip_Servet_Tör.jpg,male
+2f649ab8-dbee-4ccb-87bd-ebf23f3b8a09,Edip Servet Tör,Edip Servet Tör,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,7,,,,
 7a90d202-461b-4257-ac6c-976205199bcb,Ekrem Demiray,Ekrem Demiray,,,,Cumhuriyet Halk Partisi,CHP,area/edirne,Edirne,Grand National Assembly,7,,,,
 0913ad22-b708-41ae-8f9c-f804b9f278b4,Ekrem Oran,Ekrem Oran,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,7,,,,
 7b32bcd8-59a8-4cf2-85a6-6ae3d7e410a4,Ekrem Pekel,Ekrem Pekel,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,7,,,,male
@@ -220,7 +220,7 @@ cedd2881-6c6b-441d-afc2-0e3194de3031,Hüseyin Fatin Güvendiren,Hüseyin Fatin G
 3b4fddd3-552a-4c6d-8efb-91b8bbee3d7d,Hüseyin Hulki Cura,Hüseyin Hulki Cura,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,7,,,,male
 840a754e-cec4-49ff-a3c8-7ea4ec9e6eaa,Hüseyin Hüsnü Çakır,Hüseyin Hüsnü Çakır,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,7,,,,male
 df5d46c7-fce5-487f-8323-198732f202a1,Hüseyin Hüsnü Özdamar,Hüseyin Hüsnü Özdamar,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,7,,,https://upload.wikimedia.org/wikipedia/commons/e/e7/Hussein_Husnu_Efendi.jpg,male
-c5beef1e-2f00-42c9-a53a-a65caf50ef60,Hüseyin Rahmi Apak,Hüseyin Rahmi Apak,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,7,,,,
+c5beef1e-2f00-42c9-a53a-a65caf50ef60,Hüseyin Rahmi Apak,Hüseyin Rahmi Apak,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,7,,,,male
 3bd18077-f26f-42f7-ab77-dc7bce4745a9,Hüseyin Sami Coşar,Hüseyin Sami Coşar,,,,Cumhuriyet Halk Partisi,CHP,area/urfa,Urfa,Grand National Assembly,7,,,,
 d3e2af48-31f9-4678-9a5f-ac96db6bd1c0,Hüseyin Ulusoy,Hüseyin Ulusoy,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,7,,,,male
 e0dce5e0-7084-46ff-b7d2-607e5bc61ec9,Hüsnü Kortel,Hüsnü Kortel,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,7,,,,
@@ -231,7 +231,7 @@ e4feaeb8-b027-4088-bd1b-17b20590dd48,Kamil Kotan,Kamil Kotan,,,,Cumhuriyet Halk 
 2717e0d4-a042-4e17-b711-f5798246ef1a,Kamran Örs,Kamran Örs,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,7,,,,male
 4f6202c4-d900-48f5-831c-109060bc99dd,Kasım Gülek,Kasım Gülek,,,,Cumhuriyet Halk Partisi,CHP,area/bilecik,Bilecik,Grand National Assembly,7,,,,male
 9471faa9-325e-4295-9259-4d546e33faa8,Kazım Aydar,Kazım Aydar,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,7,,,,
-a4884bcd-8e0d-4c12-a532-a8804da6c9ed,Kazım Sevüktekin,Kazım Sevüktekin,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,7,,,,
+a4884bcd-8e0d-4c12-a532-a8804da6c9ed,Kazım Sevüktekin,Kazım Sevüktekin,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,7,,,https://upload.wikimedia.org/wikipedia/commons/c/c7/KSevuktekin.jpg,male
 f31cced9-1f65-4461-a693-3784ff4ec4a6,Kazım Özalp,Kazım Özalp,,,,Cumhuriyet Halk Partisi,CHP,area/balıkesir,Balıkesir,Grand National Assembly,7,,,,
 7c98f5f2-7adc-4918-a623-45fda177f6c0,Kemal Cenap Berksoy,Kemal Cenap Berksoy,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,7,,,,male
 085be837-53f1-490c-bc00-4c77b1c18c9e,Kemal Doğan,Kemal Doğan,,,,Cumhuriyet Halk Partisi,CHP,area/kırklareli,Kırklareli,Grand National Assembly,7,,,,male
@@ -266,7 +266,7 @@ d9f6798e-d69e-4adb-9fa9-e90d5389e9be,Mehmet Emin Yurdakul,Mehmet Emin Yurdakul,,
 fa856318-0586-4f09-aca6-c5c454d024fa,Mehmet Fahrettin Ecevit,Mehmet Fahrettin Ecevit,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,7,,,,male
 35ba49e5-2223-4bc4-84d8-777fc4159b8c,Mehmet Fahri Engin,Mehmet Fahri Engin,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,7,,,,male
 b0e7968d-ae6c-44ba-ac1e-e287406ff99b,Mehmet Faik Baysal,Mehmet Faik Baysal,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,7,,,,male
-402dda26-7adf-4019-9211-f1c86178da48,Mehmet Fuad Köprülü,Mehmet Fuad Köprülü,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,7,,,https://upload.wikimedia.org/wikipedia/commons/f/fd/Mehmet_Fuat_Köprülü.jpg,male
+402dda26-7adf-4019-9211-f1c86178da48,Mehmet Fuad Köprülü,Mehmet Fuad Köprülü,,,,Cumhuriyet Halk Partisi,CHP,area/kars,Kars,Grand National Assembly,7,,,,
 0ee95e52-20d2-439c-a0f0-7797f0d48acd,Mehmet Hikmet Onat,Mehmet Hikmet Onat,,,,Cumhuriyet Halk Partisi,CHP,area/balıkesir,Balıkesir,Grand National Assembly,7,,,,male
 f6f73dc8-7659-4088-bd93-62373413fa81,Mehmet Kani Karaosmanoğlu,Mehmet Kani Karaosmanoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,7,,,,male
 21f65cc5-3d56-4edf-b734-6b9b914b3592,Mehmet Kazım Berker,Mehmet Kazım Berker,,,,Cumhuriyet Halk Partisi,CHP,area/urfa,Urfa,Grand National Assembly,7,,,,male
@@ -282,7 +282,7 @@ e43b1a93-2ef6-48ac-973d-5267e711aae9,Mehmet Ragıp Akça,Mehmet Ragıp Akça,,,,
 80bb44d4-81ba-4b46-8339-eae6ec5392c5,Mehmet Rifat Gürsoy,Mehmet Rifat Gürsoy,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,7,,,,male
 055af63b-b39a-4a2f-9da0-3b0814bdbede,Mehmet Rifat Vardar,Mehmet Rifat Vardar,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,7,,,,male
 53c10b11-1b89-4113-a079-e2588d3185a5,Mehmet Rüştü Bekit,Mehmet Rüştü Bekit,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,7,,,,male
-5862b388-6f4a-426b-ace7-1369cd044307,Mehmet Sabit Sağıroğlu,Mehmet Sabit Sağıroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/elazığ,Elazığ,Grand National Assembly,7,,,https://upload.wikimedia.org/wikipedia/commons/6/63/Sabit_Bey_Sağıroğlu.jpg,male
+5862b388-6f4a-426b-ace7-1369cd044307,Mehmet Sabit Sağıroğlu,Mehmet Sabit Sağıroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/elazığ,Elazığ,Grand National Assembly,7,,,,
 ba176328-9aae-40f6-beed-d1c4eb0e94f9,Mehmet Sadettin Serim,Mehmet Sadettin Serim,,,,Cumhuriyet Halk Partisi,CHP,area/kayseri,Kayseri,Grand National Assembly,7,,,,male
 a98caf4b-f5a6-4fd1-8ef5-831a6ca4932c,Mehmet Sanlı,Mehmet Sanlı,,,,Cumhuriyet Halk Partisi,CHP,area/burdur,Burdur,Grand National Assembly,7,,,,male
 d6e831cf-6e5e-4282-b55c-d7ed54ae9571,Mehmet Sedat Çumralı,Mehmet Sedat Çumralı,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,7,,,,male
@@ -292,7 +292,7 @@ e27d5ac1-d336-4e16-a417-41ecee11ec72,Mehmet Yaşar Özey,Mehmet Yaşar Özey,,,,
 59a7819f-d145-4167-b64f-9d22254a406e,Mehmet Şevket Özpazarbaşı,Mehmet Şevket Özpazarbaşı,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,7,,,,male
 14281ee9-388c-48f3-98c6-45d3da3bfe2f,Mekki Hikmet Gelenbeğ,Mekki Hikmet Gelenbeğ,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,7,,,,
 45967855-639e-42d6-ba6d-fb9682171ddc,Memduh Şevket Esendal,Memduh Şevket Esendal,,,,Cumhuriyet Halk Partisi,CHP,area/bilecik,Bilecik,Grand National Assembly,7,,,https://upload.wikimedia.org/wikipedia/commons/6/6b/Memduh_Şevket_Bey.jpg,male
-96b1d015-3bfc-4106-a8fb-34b2cd2c4f7c,Mihal Kayaoğlu,Mihal Kayaoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,7,,,,
+96b1d015-3bfc-4106-a8fb-34b2cd2c4f7c,Mihal Kayaoğlu,Mihal Kayaoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,7,,,,male
 a54889a2-9e35-455b-b463-35f1da74a3d8,Mihri Pektaş,Mihri Pektaş,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,7,,,,female
 e9287f21-6d5e-48ea-a10b-66d0af813464,Mithat Aydın,Mithat Aydın,,,,Cumhuriyet Halk Partisi,CHP,area/trabzon,Trabzon,Grand National Assembly,7,,,,
 806b0ea2-c319-4fde-b5c8-69b4670c5883,Mithat Şükrü Bleda,Mithat Şükrü Bleda,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,7,,,,male
@@ -324,7 +324,7 @@ c5beb545-7893-435a-b9ff-e940702aa859,Mümtaz Ökmen,Mümtaz Ökmen,,,,Cumhuriyet
 f5a3f437-5ccb-4198-bdf1-7eb10615add1,Münip Boya,Münip Boya,,,,Cumhuriyet Halk Partisi,CHP,area/van,Van,Grand National Assembly,7,,,,
 9ee28409-cde4-4ab5-b702-baaada5e578b,Münir Hüsrev Göle,Münir Hüsrev Göle,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,7,,,https://upload.wikimedia.org/wikipedia/commons/e/e5/Münir_Hüsrev_Bey_Göle.jpg,
 947e8b14-db6a-487a-ac95-c45c6092f843,Mürsel Bakü,Mürsel Bakü,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,7,,,https://upload.wikimedia.org/wikipedia/commons/d/d3/MBaku.jpg,male
-c6f10a6c-08e0-4e19-a0b5-ce4115e3456e,Naci Eldeniz,Naci Eldeniz,,,,Cumhuriyet Halk Partisi,CHP,area/seyhan_(adana),Seyhan (Adana),Grand National Assembly,7,,,,male
+c6f10a6c-08e0-4e19-a0b5-ce4115e3456e,Naci Eldeniz,Naci Eldeniz,,,,Cumhuriyet Halk Partisi,CHP,area/seyhan_(adana),Seyhan (Adana),Grand National Assembly,7,,,,
 c589fe5e-b215-4dbe-bea4-62d3a0a05d71,Nafi Atuf Kansu,Nafi Atuf Kansu,,,,Cumhuriyet Halk Partisi,CHP,area/kırklareli,Kırklareli,Grand National Assembly,7,,,,
 bbe7455b-5e4d-4b9c-b980-57d480b51e8f,Naili Küçüka,Naili Küçüka,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,7,,,,
 93872a8a-8519-4afe-ac6a-ce8289ff13f1,Naim Atalay,Naim Atalay,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,7,,,,
@@ -335,7 +335,7 @@ d2012842-30a2-429c-9812-e8b8d2b29847,Nasuhi Erzurumlu,Nasuhi Erzurumlu,,,,Cumhur
 6894e9d4-8cf5-4ddb-b7cf-5107e16d556d,Nazmi Trak,Nazmi Trak,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,7,,,,
 c9171f7b-acd9-42d5-8246-cac33c1f34de,Nazım Poroy,Nazım Poroy,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,7,,,,
 fa4aa08c-d7e3-4239-8a3c-802659b4bfee,Naşit Fırat,Naşit Fırat,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,7,,,,
-a5980128-93fd-428f-9928-f03e76e10b82,Necmettin Sadık Sadak,Necmettin Sadık Sadak,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,7,,,,
+a5980128-93fd-428f-9928-f03e76e10b82,Necmettin Sadık Sadak,Necmettin Sadık Sadak,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,7,,,https://upload.wikimedia.org/wikipedia/commons/9/9e/Necmettin_Sadık_Bey.jpg,male
 319b417b-8bf2-4173-b080-6400d83d1274,Necmettin Sahir Sılan,Necmettin Sahir Sılan,,,,Cumhuriyet Halk Partisi,CHP,area/tunceli,Tunceli,Grand National Assembly,7,,,,male
 9c900008-81c7-44dd-916d-672ee3133125,Necmi Osten,Necmi Osten,,,,Cumhuriyet Halk Partisi,CHP,area/giresun,Giresun,Grand National Assembly,7,,,,
 f36f723f-1815-4c1c-9987-14d2600e2867,Nihat Erim,Nihat Erim,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,7,,,,male
@@ -365,7 +365,7 @@ c2427b56-e3b2-4f25-bbfd-0226a0801962,Refet Alpman,Refet Alpman,,,,Cumhuriyet Hal
 364075d5-ba05-4694-8fd4-0b5496f00435,Refet Bele,Refet Bele,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,7,,,https://upload.wikimedia.org/wikipedia/commons/6/67/İbrahim_Refet_Bele.jpg,male
 16188330-1f6d-4bb5-ab5a-e085c9094b47,Refik Ahmet Sevengil,Refik Ahmet Sevengil,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,7,,,,male
 33cd4758-5cfa-4449-b9c3-01b139ee0926,Refik Fenmen,Refik Fenmen,,,,Cumhuriyet Halk Partisi,CHP,area/kocaeli,Kocaeli,Grand National Assembly,7,,,,
-05f819e7-9d1b-4bd3-be24-9ef2fc9c3989,Refik Güran,Refik Güran,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,7,,,,
+05f819e7-9d1b-4bd3-be24-9ef2fc9c3989,Refik Güran,Refik Güran,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,7,,,,male
 d493f63d-29fd-47ea-86be-cfb81239c06c,Refik Koraltan,Refik Koraltan,,,,Cumhuriyet Halk Partisi,CHP,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,7,,,https://upload.wikimedia.org/wikipedia/commons/7/7c/Bekir_Refik_Bey_Koraltan.jpg,male
 b7d3d3f6-33d2-4468-905f-590d43b0268a,Resai Erişken,Resai Erişken,,,,Cumhuriyet Halk Partisi,CHP,area/tokat,Tokat,Grand National Assembly,7,,,,
 c248ff41-3e4c-480e-9e2a-1b9e39d96c16,Reşat Muhlis Erkmen,Reşat Muhlis Erkmen,,,,Cumhuriyet Halk Partisi,CHP,area/kütahya,Kütahya,Grand National Assembly,7,,,,male
@@ -458,7 +458,7 @@ d25bfb00-b230-4c2f-a499-338ff1917821,İbrahim Talî Öngören,İbrahim Talî Ön
 b77c632f-67cd-44a2-86f1-7ef0d940d3ee,İhsan Yalçın,İhsan Yalçın,,,,Cumhuriyet Halk Partisi,CHP,area/elazığ,Elazığ,Grand National Assembly,7,,,,male
 d98e298f-c643-4ae1-8e3f-1137e9351cf3,İrfan Ferit Alpaya,İrfan Ferit Alpaya,,,,Cumhuriyet Halk Partisi,CHP,area/mardin,Mardin,Grand National Assembly,7,,,,
 fa7a1660-fc9b-4491-abe3-90860448c5e3,İsmail Ertem,İsmail Ertem,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,7,,,,
-ccbfaef2-8c17-4265-8c5a-389961bcea1c,İsmail Habib Sevük,İsmail Habib Sevük,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,7,,,,
+ccbfaef2-8c17-4265-8c5a-389961bcea1c,İsmail Habib Sevük,İsmail Habib Sevük,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,7,,,,male
 69603703-2a83-460b-9423-6652ad5cfc63,İsmail Hakkı Baltacıoğlu,İsmail Hakkı Baltacıoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/afyonkarahisar,Afyonkarahisar,Grand National Assembly,7,,,,male
 fe4c9c4d-0204-4f87-aa24-f73fc02dbcd6,İsmail Hakkı Başak,İsmail Hakkı Başak,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,7,,,,
 50bdfd4f-55ff-465d-aa40-2996a6143610,İsmail Hakkı Kılıçoğlu,İsmail Hakkı Kılıçoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/muş,Muş,Grand National Assembly,7,,,,male

--- a/data/Turkey/Assembly/term-8.csv
+++ b/data/Turkey/Assembly/term-8.csv
@@ -8,7 +8,7 @@ fed581fd-0a65-4167-b7d0-fb4363a2bbf4,Abdullah Yaycıoğlu,Abdullah Yaycıoğlu,,
 b94f090c-7dfb-40b8-bc26-aabbd0b94993,Abdurrahman Melek,Abdurrahman Melek,,,,Cumhuriyet Halk Partisi,CHP,area/gaziantep,Gaziantep,Grand National Assembly,8,,,https://upload.wikimedia.org/wikipedia/commons/e/e8/Abdur_rahman_Melek.jpg,male
 a889fbf8-7561-4bfd-bbfe-74cff08796d2,Abdurrahman Şeref Uluğ,Abdurrahman Şeref Uluğ,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,8,,,,
 56d75e45-a00d-4291-a65e-a06d1207a03e,Abdülgani Türkmen,Abdülgani Türkmen,,,,Cumhuriyet Halk Partisi,CHP,area/hatay,Hatay,Grand National Assembly,8,,,,
-73bb95f9-84ca-4c76-a779-ec5a3052c806,Abdülhak Adnan Adıvar,Abdülhak Adnan Adıvar,,,,Bağımsız,ind,area/İstanbul,İstanbul,Grand National Assembly,8,,,https://upload.wikimedia.org/wikipedia/commons/1/16/Adnan_Bey.jpg,male
+73bb95f9-84ca-4c76-a779-ec5a3052c806,Abdülhak Adnan Adıvar,Abdülhak Adnan Adıvar,,,,Bağımsız,ind,area/İstanbul,İstanbul,Grand National Assembly,8,,,,
 1820c040-668c-4fbd-8d31-0d278d3a71e2,Abdülhak Fırat,Abdülhak Fırat,,,,Cumhuriyet Halk Partisi,CHP,area/erzincan,Erzincan,Grand National Assembly,8,,,https://upload.wikimedia.org/wikipedia/commons/5/54/Abdülhak_Bey_(Fırat).jpg,
 a9870e15-b53d-4154-ba47-a85b587154c7,Abdülkadir Kalav,Abdülkadir Kalav,,,,Cumhuriyet Halk Partisi,CHP,area/mardin,Mardin,Grand National Assembly,8,,,,male
 9b05692b-b47b-4dc3-958e-b2fb097c897b,Abdülkadir Taşangil,Abdülkadir Taşangil,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,8,,,,
@@ -32,7 +32,7 @@ bafa1d09-3239-4553-b38b-6f50eede6ed7,Ahmet Hamdi Yalman,Ahmet Hamdi Yalman,,,,Cu
 ce51e796-1726-485c-af1d-4fd0140d68bc,Ahmet Hulusi Alataş,Ahmet Hulusi Alataş,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,8,,,,male
 84bc4350-19c9-4871-9668-7cd1cc0fa331,Ahmet Kemal Silivrili,Ahmet Kemal Silivrili,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,8,,,,
 2121fd99-5478-4016-a4e0-c0fbb62cfc23,Ahmet Kemal Varınca,Ahmet Kemal Varınca,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,8,,,,male
-52fe9f39-65d8-4a73-a5e3-747ce85e6c52,Ahmet Kemalettin Turan,Ahmet Kemalettin Turan,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,8,,,,
+52fe9f39-65d8-4a73-a5e3-747ce85e6c52,Ahmet Kemalettin Turan,Ahmet Kemalettin Turan,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,8,,,,male
 95284128-4e83-46b5-8ef0-d5767916ac58,Ahmet Mithat Altan,Ahmet Mithat Altan,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,8,,,,
 0c86647d-3e8b-4dc6-b005-249121fd131e,Ahmet Münir Akkaya,Ahmet Münir Akkaya,,,,Cumhuriyet Halk Partisi,CHP,area/giresun,Giresun,Grand National Assembly,8,,,,male
 29a99f5c-d70a-4058-b257-1bf0b3723c08,Ahmet Münir Erhan,Ahmet Münir Erhan,,,,Cumhuriyet Halk Partisi,CHP,area/bursa,Bursa,Grand National Assembly,8,,,,male
@@ -103,7 +103,7 @@ be508d87-507b-4485-9a2b-5bf35a35badc,Benal Nevzat Arıman,Benal Nevzat Arıman,,
 df41edc8-cde6-4bb3-9ce2-487588e887c9,Burhan Cahit Morkaya,Burhan Cahit Morkaya,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,8,,,,male
 0aa12b60-750c-4d68-8200-72e4b580021e,Cafer Özelçi,Cafer Özelçi,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,8,,,,
 bc4363b7-f1d7-441f-a81a-c701bfeeae87,Cavit Ekin,Cavit Ekin,,,,Cumhuriyet Halk Partisi,CHP,area/diyarbakır,Diyarbakır,Grand National Assembly,8,,,https://upload.wikimedia.org/wikipedia/commons/5/54/Abdulkadir_Cavit_Bey_Ekin.jpg,male
-1adb90dc-9199-44a3-b389-7ade1a7874f2,Cavit Oral,Cavit Oral,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,8,,,,
+1adb90dc-9199-44a3-b389-7ade1a7874f2,Cavit Oral,Cavit Oral,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,8,,,,male
 9b6e96d1-e990-4e08-a481-e9b04a263df3,Celal Arat,Celal Arat,,,,Cumhuriyet Halk Partisi,CHP,area/yozgat,Yozgat,Grand National Assembly,8,,,,
 f45b8c82-58ac-4e7a-ad0c-0b6dcec3ccf0,Celal Esad Arseven,Celal Esad Arseven,,,,Cumhuriyet Halk Partisi,CHP,area/giresun,Giresun,Grand National Assembly,8,,,,
 d85fda45-004c-4d5f-8e79-b77cd6c0e874,Celal Ramazanoğlu,Celal Ramazanoğlu,,,,Demokrat Parti,DP46,area/İçel_(mersin),İçel (Mersin),Grand National Assembly,8,,,,
@@ -122,9 +122,9 @@ da1e848e-1524-4c94-9c27-546ee783a88f,Cemil Sait Barlas,Cemil Sait Barlas,,,,Cumh
 e7243b4a-a9da-4b0c-9a61-b69ff264b36e,Cevat Dursunoğlu,Cevat Dursunoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,8,,,,male
 7b144158-465b-4d78-b5fc-857f584fd803,Cevdet Gölet,Cevdet Gölet,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,8,,,,
 2d9f198c-34fa-45ad-9844-47b0ff1727d2,Cevdet Kerim İncedayı,Cevdet Kerim İncedayı,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,8,,,,
-b9c82a94-23ea-4f7d-ace4-e917e539da6a,Cihat Baban,Cihat Baban,,,,Bağımsız,ind,area/İstanbul,İstanbul,Grand National Assembly,8,,,,
+b9c82a94-23ea-4f7d-ace4-e917e539da6a,Cihat Baban,Cihat Baban,,,,Bağımsız,ind,area/İstanbul,İstanbul,Grand National Assembly,8,,,,male
 dde49b8b-d4d9-40d7-8e9f-719545303f1f,Edip Alpsar,Edip Alpsar,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,8,,,,male
-2f649ab8-dbee-4ccb-87bd-ebf23f3b8a09,Edip Servet Tör,Edip Servet Tör,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,8,,,https://upload.wikimedia.org/wikipedia/commons/e/ed/Edip_Servet_Tör.jpg,male
+2f649ab8-dbee-4ccb-87bd-ebf23f3b8a09,Edip Servet Tör,Edip Servet Tör,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,8,,,,
 330728d1-d731-42f8-a11d-32aba0481f90,Ekrem Amaç,Ekrem Amaç,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,8,,,,
 0913ad22-b708-41ae-8f9c-f804b9f278b4,Ekrem Oran,Ekrem Oran,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,8,,,,
 7b32bcd8-59a8-4cf2-85a6-6ae3d7e410a4,Ekrem Pekel,Ekrem Pekel,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,8,,,,male
@@ -225,7 +225,7 @@ b9f1cac1-5641-43fb-8ff8-54293c2e5389,Hüseyin Bingül,Hüseyin Bingül,,,,Demokr
 996bf2b1-6a6d-4f15-99b6-253ba97a129e,Hüseyin Cahit Yalçın,Hüseyin Cahit Yalçın,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,8,,,,male
 3b4fddd3-552a-4c6d-8efb-91b8bbee3d7d,Hüseyin Hulki Cura,Hüseyin Hulki Cura,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,8,,,,male
 840a754e-cec4-49ff-a3c8-7ea4ec9e6eaa,Hüseyin Hüsnü Çakır,Hüseyin Hüsnü Çakır,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,8,,,,male
-c5beef1e-2f00-42c9-a53a-a65caf50ef60,Hüseyin Rahmi Apak,Hüseyin Rahmi Apak,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,8,,,,
+c5beef1e-2f00-42c9-a53a-a65caf50ef60,Hüseyin Rahmi Apak,Hüseyin Rahmi Apak,,,,Cumhuriyet Halk Partisi,CHP,area/tekirdağ,Tekirdağ,Grand National Assembly,8,,,,male
 98e82f0a-9712-49f0-9218-8e5153f38214,Hüseyin Sami Gülcüoğlu,Hüseyin Sami Gülcüoğlu,,,,Cumhuriyet Halk Partisi,CHP,area/İzmir,İzmir,Grand National Assembly,8,,,,
 d3e2af48-31f9-4678-9a5f-ac96db6bd1c0,Hüseyin Ulusoy,Hüseyin Ulusoy,,,,Cumhuriyet Halk Partisi,CHP,area/niğde,Niğde,Grand National Assembly,8,,,,male
 eead1e2b-c314-48c7-ab3a-a3f2963b1ac0,Hıfzı Oğuz Bekata,Hıfzı Oğuz Bekata,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,8,,,,
@@ -240,7 +240,7 @@ a428794d-d61d-4af7-be9d-1e4788d6cb3c,Kamil Kitapçı,Kamil Kitapçı,,,,Cumhuriy
 4f6202c4-d900-48f5-831c-109060bc99dd,Kasım Gülek,Kasım Gülek,,,,Cumhuriyet Halk Partisi,CHP,area/adana,Adana,Grand National Assembly,8,,,,male
 9471faa9-325e-4295-9259-4d546e33faa8,Kazım Aydar,Kazım Aydar,,,,Cumhuriyet Halk Partisi,CHP,area/isparta,Isparta,Grand National Assembly,8,,,,
 2f9ee92c-9cb1-4eae-b244-6f98353a7648,Kazım Karabekir,Kazım Karabekir,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,8,,,,
-a4884bcd-8e0d-4c12-a532-a8804da6c9ed,Kazım Sevüktekin,Kazım Sevüktekin,,,,Cumhuriyet Halk Partisi,CHP,area/mardin,Mardin,Grand National Assembly,8,,,,
+a4884bcd-8e0d-4c12-a532-a8804da6c9ed,Kazım Sevüktekin,Kazım Sevüktekin,,,,Cumhuriyet Halk Partisi,CHP,area/mardin,Mardin,Grand National Assembly,8,,,https://upload.wikimedia.org/wikipedia/commons/c/c7/KSevuktekin.jpg,male
 f31cced9-1f65-4461-a693-3784ff4ec4a6,Kazım Özalp,Kazım Özalp,,,,Cumhuriyet Halk Partisi,CHP,area/balıkesir,Balıkesir,Grand National Assembly,8,,,,
 897ac892-3070-497b-9be8-89a0c321c672,Kemal Cemal Öncel,Kemal Cemal Öncel,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,8,,,,
 7c98f5f2-7adc-4918-a623-45fda177f6c0,Kemal Cenap Berksoy,Kemal Cenap Berksoy,,,,Cumhuriyet Halk Partisi,CHP,area/yozgat,Yozgat,Grand National Assembly,8,,,,male
@@ -257,7 +257,7 @@ e59f5b61-6598-4a41-aac1-4e41ff3e484c,Lütfi Aksoy,Lütfi Aksoy,,,,Cumhuriyet Hal
 da46a06b-003c-448e-a058-fe820670e554,Lütfi Gören,Lütfi Gören,,,,Cumhuriyet Halk Partisi,CHP,area/bolu,Bolu,Grand National Assembly,8,,,,
 fb502bcc-5bac-4f3e-aa1e-85501b6ac8aa,Lütfi Kırdar,Lütfi Kırdar,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,8,,,https://upload.wikimedia.org/wikipedia/commons/5/51/Mehmet_Lütfi_Kırdar.jpg,male
 2d51d679-46dc-41ed-9868-2f04717a09b7,Lütfi Yavuz,Lütfi Yavuz,,,,Cumhuriyet Halk Partisi,CHP,area/siirt,Siirt,Grand National Assembly,8,,,,
-dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890,Mahmut Celal Bayar,Mahmut Celal Bayar,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,8,,,,
+dcc4ad49-8a3f-4eca-88ff-55fb8fe0e890,Mahmut Celal Bayar,Mahmut Celal Bayar,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,8,,,https://upload.wikimedia.org/wikipedia/commons/9/9b/Celal_bayar.jpg,male
 f78d115d-9fd1-4855-88ef-51b9282c0808,Mahmut Nedim Gündüzalp,Mahmut Nedim Gündüzalp,,,,Cumhuriyet Halk Partisi,CHP,area/edirne,Edirne,Grand National Assembly,8,,,,male
 4a9a6a1e-a4ac-452a-8f58-bb8c4db996f0,Mahmut Nedim Zabcı,Mahmut Nedim Zabcı,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,8,,,,male
 7995115b-0c72-4705-a415-aa804fd94933,Mahmut Tan,Mahmut Tan,,,,Cumhuriyet Halk Partisi,CHP,area/tunceli,Tunceli,Grand National Assembly,8,,,,male
@@ -274,7 +274,7 @@ d0d6895e-8404-4d1c-96b4-1ef5e18b1746,Mehmet Cemil Uybadın,Mehmet Cemil Uybadın
 8a76c094-b7ec-4825-9cf3-621a1b480b27,Mehmet Emin Erişirgil,Mehmet Emin Erişirgil,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,8,,,,male
 fa856318-0586-4f09-aca6-c5c454d024fa,Mehmet Fahrettin Ecevit,Mehmet Fahrettin Ecevit,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,8,,,,male
 ccca0890-7ba2-4ce9-ae9a-1185998d5cc7,Mehmet Fethi Mağara,Mehmet Fethi Mağara,,,,Cumhuriyet Halk Partisi,CHP,area/kastamonu,Kastamonu,Grand National Assembly,8,,,,
-01d9e29d-19fb-4fbb-b23b-ca027d00c45f,Mehmet Fuat Köprülü,Mehmet Fuat Köprülü,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,8,,,,
+01d9e29d-19fb-4fbb-b23b-ca027d00c45f,Mehmet Fuat Köprülü,Mehmet Fuat Köprülü,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,8,,,https://upload.wikimedia.org/wikipedia/commons/f/fd/Mehmet_Fuat_Köprülü.jpg,male
 be9769ed-197b-4c93-9920-0ea9396dd0db,Mehmet Furtun,Mehmet Furtun,,,,Cumhuriyet Halk Partisi,CHP,area/ordu,Ordu,Grand National Assembly,8,,,,
 0e347e95-6f73-47af-a110-3d63a7f44106,Mehmet Kamil Boran,Mehmet Kamil Boran,,,,Cumhuriyet Halk Partisi,CHP,area/mardin,Mardin,Grand National Assembly,8,,,,male
 2cb5d279-eb14-42e3-84fc-6f470aead211,Mehmet Mesut Çankaya,Mehmet Mesut Çankaya,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,8,,,,male
@@ -290,7 +290,7 @@ efeb3698-88a9-4f71-965a-16e01642ee3d,Mehmet Numan Aksoy,Mehmet Numan Aksoy,,,,Cu
 16878f73-9598-414e-a91e-6efaee462276,Mehmet Sadi Bekter,Mehmet Sadi Bekter,,,,Cumhuriyet Halk Partisi,CHP,area/İstanbul,İstanbul,Grand National Assembly,8,,,,male
 d466ff60-95a0-4335-a589-c9ccd795170d,Mehmet Sadık Eti,Mehmet Sadık Eti,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,8,,,,male
 d6e831cf-6e5e-4282-b55c-d7ed54ae9571,Mehmet Sedat Çumralı,Mehmet Sedat Çumralı,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,8,,,,male
-b3eebe73-3d18-49a5-9338-cbb97497c5a8,Mehmet Suphi Batur,Mehmet Suphi Batur,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,8,,,,
+b3eebe73-3d18-49a5-9338-cbb97497c5a8,Mehmet Suphi Batur,Mehmet Suphi Batur,,,,Cumhuriyet Halk Partisi,CHP,area/sinop,Sinop,Grand National Assembly,8,,,,male
 e27d5ac1-d336-4e16-a417-41ecee11ec72,Mehmet Yaşar Özey,Mehmet Yaşar Özey,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,8,,,,male
 ffa62d08-7abc-49d6-8037-68d62693cf1f,Mehmet İhsan Olgun,Mehmet İhsan Olgun,,,,Cumhuriyet Halk Partisi,CHP,area/yozgat,Yozgat,Grand National Assembly,8,,,,male
 2f8741d9-bc65-43ff-9be4-b510c0dad720,Mehmet Şevket Erdoğan,Mehmet Şevket Erdoğan,,,,Cumhuriyet Halk Partisi,CHP,area/gümüşhane,Gümüşhane,Grand National Assembly,8,,,,male
@@ -335,7 +335,7 @@ c5beb545-7893-435a-b9ff-e940702aa859,Mümtaz Ökmen,Mümtaz Ökmen,,,,Cumhuriyet
 2335f80a-7c01-46e0-94d8-527417bfc0cc,Münip Berkan,Münip Berkan,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,8,,,,
 9ee28409-cde4-4ab5-b702-baaada5e578b,Münir Hüsrev Göle,Münir Hüsrev Göle,,,,Cumhuriyet Halk Partisi,CHP,area/erzurum,Erzurum,Grand National Assembly,8,,,https://upload.wikimedia.org/wikipedia/commons/e/e5/Münir_Hüsrev_Bey_Göle.jpg,
 a0509251-59dc-4ed7-9f99-b02e7953031c,Müştak Aktan,Müştak Aktan,,,,Cumhuriyet Halk Partisi,CHP,area/ağrı,Ağrı,Grand National Assembly,8,,,,
-147464d1-31a3-42ef-8102-e2b054786316,Naci Tınaz,Naci Tınaz,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,8,,,,male
+147464d1-31a3-42ef-8102-e2b054786316,Naci Tınaz,Naci Tınaz,,,,Cumhuriyet Halk Partisi,CHP,area/ankara,Ankara,Grand National Assembly,8,,,,
 c589fe5e-b215-4dbe-bea4-62d3a0a05d71,Nafi Atuf Kansu,Nafi Atuf Kansu,,,,Cumhuriyet Halk Partisi,CHP,area/kırklareli,Kırklareli,Grand National Assembly,8,,,,
 393b490c-3a66-4d89-9971-949221f84b82,Nahit Pekcan,Nahit Pekcan,,,,Cumhuriyet Halk Partisi,CHP,area/erzincan,Erzincan,Grand National Assembly,8,,,,
 bbe7455b-5e4d-4b9c-b980-57d480b51e8f,Naili Küçüka,Naili Küçüka,,,,Cumhuriyet Halk Partisi,CHP,area/denizli,Denizli,Grand National Assembly,8,,,,
@@ -346,7 +346,7 @@ c9171f7b-acd9-42d5-8246-cac33c1f34de,Nazım Poroy,Nazım Poroy,,,,Cumhuriyet Hal
 fa4aa08c-d7e3-4239-8a3c-802659b4bfee,Naşit Fırat,Naşit Fırat,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,8,,,,
 0833104a-10b5-4719-a111-12d1ad2e11a4,Necati Erdem,Necati Erdem,,,,Demokrat Parti,DP46,area/muğla,Muğla,Grand National Assembly,8,,,,
 997ed8b1-fe11-4891-ac95-7914e5cf80eb,Necdet Otaman,Necdet Otaman,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,8,,,,
-a5980128-93fd-428f-9928-f03e76e10b82,Necmettin Sadık Sadak,Necmettin Sadık Sadak,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,8,,,,
+a5980128-93fd-428f-9928-f03e76e10b82,Necmettin Sadık Sadak,Necmettin Sadık Sadak,,,,Cumhuriyet Halk Partisi,CHP,area/sivas,Sivas,Grand National Assembly,8,,,https://upload.wikimedia.org/wikipedia/commons/9/9e/Necmettin_Sadık_Bey.jpg,male
 319b417b-8bf2-4173-b080-6400d83d1274,Necmettin Sahir Sılan,Necmettin Sahir Sılan,,,,Cumhuriyet Halk Partisi,CHP,area/tunceli,Tunceli,Grand National Assembly,8,,,,male
 80ba35b2-65f3-4ddc-be01-b2351472b6cd,Nejdet Yücer,Nejdet Yücer,,,,Cumhuriyet Halk Partisi,CHP,area/Çorum,Çorum,Grand National Assembly,8,,,,
 8eeef90a-958c-4ce3-a20f-cb15c79ccd70,Neşet Akkor,Neşet Akkor,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,8,,,,
@@ -390,7 +390,7 @@ de55e43b-6fbe-440f-a6ad-76e672d92679,Rüştü Oktar,Rüştü Oktar,,,,Cumhuriyet
 993abec9-19fe-471e-90cf-fc4775512bb7,Rıdvan Nafiz Edgüer,Rıdvan Nafiz Edgüer,,,,Cumhuriyet Halk Partisi,CHP,area/manisa,Manisa,Grand National Assembly,8,,,,
 081bee0a-2f29-47b4-914b-16f738085810,Rıza Işıtan,Rıza Işıtan,,,,Cumhuriyet Halk Partisi,CHP,area/samsun,Samsun,Grand National Assembly,8,,,,
 daef9c5c-6c22-4ea0-9523-56a0838efc08,Rıza Çuhadar,Rıza Çuhadar,,,,Cumhuriyet Halk Partisi,CHP,area/maraş,Maraş,Grand National Assembly,8,,,,
-ed20a0e7-d197-4d38-97cf-ccac305e6a6d,Sabit Sağıroğlu,Sabit Sağıroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/erzincan,Erzincan,Grand National Assembly,8,,,,
+ed20a0e7-d197-4d38-97cf-ccac305e6a6d,Sabit Sağıroğlu,Sabit Sağıroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/erzincan,Erzincan,Grand National Assembly,8,,,https://upload.wikimedia.org/wikipedia/commons/6/63/Sabit_Bey_Sağıroğlu.jpg,male
 6c817be7-99f1-4d42-9b88-08084796c7f2,Sabri Akın,Sabri Akın,,,,Cumhuriyet Halk Partisi,CHP,area/aydın,Aydın,Grand National Assembly,8,,,,
 8d94368d-97f6-4453-953a-3cb84b74ab03,Sabri Koçer,Sabri Koçer,,,,Cumhuriyet Halk Partisi,CHP,area/zonguldak,Zonguldak,Grand National Assembly,8,,,,
 e29dcd2d-fcb2-43d7-a46a-37f738e9fab8,Sadi Irmak,Sadi Irmak,,,,Cumhuriyet Halk Partisi,CHP,area/konya,Konya,Grand National Assembly,8,,,,male

--- a/data/Turkey/Assembly/term-9.csv
+++ b/data/Turkey/Assembly/term-9.csv
@@ -93,9 +93,9 @@ b34e3d21-78a0-4065-82fc-b99ecf5e9a37,Celal Sait Siren,Celal Sait Siren,,,,Cumhur
 5b67f397-8bd9-44c7-b12d-ae43c1633dee,Celal Türkgeldi,Celal Türkgeldi,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,9,,,,
 fa346812-6806-4637-b312-499ae0a21870,Celal Yardımcı,Celal Yardımcı,,,,Demokrat Parti,DP46,area/ağrı,Ağrı,Grand National Assembly,9,,,,
 760dd0d3-5b40-4545-930b-2e2c1834510e,Celal Öncel,Celal Öncel,,,,Demokrat Parti,DP46,area/urfa,Urfa,Grand National Assembly,9,,,,
-98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,9,,,https://upload.wikimedia.org/wikipedia/commons/9/9b/Celal_bayar.jpg,male
+98dc21b4-167d-4069-b3f2-1ab5cda127e8,Celâl Bayar,Celâl Bayar,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,9,,,,
 adabb334-3da1-4418-a355-763e04c37aa6,Cemal Gönenç,Cemal Gönenç,,,,Cumhuriyet Halk Partisi,CHP,area/erzincan,Erzincan,Grand National Assembly,9,,,,male
-e524e7ee-8e1a-4cc0-a383-ff884901e74f,Cemal Hünal,Cemal Hünal,,,,Demokrat Parti,DP46,area/muğla,Muğla,Grand National Assembly,9,,,,
+e524e7ee-8e1a-4cc0-a383-ff884901e74f,Cemal Hünal,Cemal Hünal,,,,Demokrat Parti,DP46,area/muğla,Muğla,Grand National Assembly,9,,,,male
 b6f12988-0a98-4e66-9380-052aeb40bd4e,Cemal Köprülü,Cemal Köprülü,,,,Demokrat Parti,DP46,area/edirne,Edirne,Grand National Assembly,9,,,,
 97127725-f24c-49f9-985d-d1f5d2305997,Cemal Kıpçak,Cemal Kıpçak,,,,Demokrat Parti,DP46,area/zonguldak,Zonguldak,Grand National Assembly,9,,,,male
 20807b72-61de-477e-8dff-773f6970f65d,Cemal Reşit Eyüboğlu,Cemal Reşit Eyüboğlu,,,,Demokrat Parti,DP46,area/trabzon,Trabzon,Grand National Assembly,9,,,,male
@@ -107,7 +107,7 @@ e97a08d2-7f80-408d-8e3b-9aba3a856172,Cevat Ülkü,Cevat Ülkü,,,,Demokrat Parti
 7f4317f7-bf2a-4f29-af91-102fb553ec2c,Cevdet Topçu,Cevdet Topçu,,,,Demokrat Parti,DP46,area/amasya,Amasya,Grand National Assembly,9,,,,
 30949694-d001-4227-97a0-c1f5f4395113,Cevdet Öztürk,Cevdet Öztürk,,,,Demokrat Parti,DP46,area/mardin,Mardin,Grand National Assembly,9,,,,
 a31aff32-540e-4dc6-a979-42b36fadf60a,Cezmi Türk,Cezmi Türk,,,,Demokrat Parti,DP46,area/seyhan_(adana),Seyhan (Adana),Grand National Assembly,9,,,,
-b9c82a94-23ea-4f7d-ace4-e917e539da6a,Cihat Baban,Cihat Baban,,,,Demokrat Parti,DP46,area/İzmir,İzmir,Grand National Assembly,9,,,,
+b9c82a94-23ea-4f7d-ace4-e917e539da6a,Cihat Baban,Cihat Baban,,,,Demokrat Parti,DP46,area/İzmir,İzmir,Grand National Assembly,9,,,,male
 dccd7541-26bf-472a-8ec2-5ea917f8bba2,Dağıstan Binerbay,Dağıstan Binerbay,,,,Demokrat Parti,DP46,area/ankara,Ankara,Grand National Assembly,9,,,,
 a1e536db-a8b2-43b8-be51-75cf9c07162a,Doğan Köymen,Doğan Köymen,,,,Demokrat Parti,DP46,area/giresun,Giresun,Grand National Assembly,9,,,,
 df5ac660-62c0-41f4-8d03-378e5be2cc97,Ekrem Alican,Ekrem Alican,,,,Demokrat Parti,DP46,area/kocaeli,Kocaeli,Grand National Assembly,9,,,,male
@@ -258,7 +258,7 @@ d34955c1-ef3c-4e02-9a31-a0bb90abb1e6,Mehmet Daim Süalp,Mehmet Daim Süalp,,,,De
 3bb93fd5-1631-41a7-ae36-633e717fc730,Mehmet Enginün,Mehmet Enginün,,,,Demokrat Parti,DP46,area/edirne,Edirne,Grand National Assembly,9,,,,
 337431dd-0b1d-4dea-909d-449d06018ff9,Mehmet Erkazancı,Mehmet Erkazancı,,,,Demokrat Parti,DP46,area/burdur,Burdur,Grand National Assembly,9,,,,
 46ded72c-2910-4496-904d-49f8a0346f5d,Mehmet Fahri Mete,Mehmet Fahri Mete,,,,Demokrat Parti,DP46,area/rize,Rize,Grand National Assembly,9,,,,male
-402dda26-7adf-4019-9211-f1c86178da48,Mehmet Fuad Köprülü,Mehmet Fuad Köprülü,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,9,,,https://upload.wikimedia.org/wikipedia/commons/f/fd/Mehmet_Fuat_Köprülü.jpg,male
+402dda26-7adf-4019-9211-f1c86178da48,Mehmet Fuad Köprülü,Mehmet Fuad Köprülü,,,,Demokrat Parti,DP46,area/İstanbul,İstanbul,Grand National Assembly,9,,,,
 0e347e95-6f73-47af-a110-3d63a7f44106,Mehmet Kamil Boran,Mehmet Kamil Boran,,,,Cumhuriyet Halk Partisi,CHP,area/mardin,Mardin,Grand National Assembly,9,,,,male
 4be2d3d8-f4ca-4db5-8e4b-738f1f8f5086,Mehmet Kartal,Mehmet Kartal,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,9,,,,male
 b823fb02-bc55-43c7-8e8d-5b9ebbdbe169,Mehmet Kemal Balta,Mehmet Kemal Balta,,,,Demokrat Parti,DP46,area/rize,Rize,Grand National Assembly,9,,,,male
@@ -267,7 +267,7 @@ b8bb7a27-9b56-4014-b3ac-62d11cf22a59,Mehmet Kurkut,Mehmet Kurkut,,,,Demokrat Par
 e052109b-c4f7-42fa-a171-62b516f2947d,Mehmet Muhlis Ete,Mehmet Muhlis Ete,,,,Demokrat Parti,DP46,area/ankara,Ankara,Grand National Assembly,9,,,,male
 1c5505e7-5340-4c9e-8ba9-244675baafad,Mehmet Nevher Yılmaz,Mehmet Nevher Yılmaz,,,,Demokrat Parti,DP46,area/kocaeli,Kocaeli,Grand National Assembly,9,,,,
 6ba9d799-2a74-4954-9915-83ea2905b035,Mehmet Rüstem Bahadır,Mehmet Rüstem Bahadır,,,,Demokrat Parti,DP46,area/kars,Kars,Grand National Assembly,9,,,,male
-5862b388-6f4a-426b-ace7-1369cd044307,Mehmet Sabit Sağıroğlu,Mehmet Sabit Sağıroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/erzincan,Erzincan,Grand National Assembly,9,,,https://upload.wikimedia.org/wikipedia/commons/6/63/Sabit_Bey_Sağıroğlu.jpg,male
+5862b388-6f4a-426b-ace7-1369cd044307,Mehmet Sabit Sağıroğlu,Mehmet Sabit Sağıroğlu,,,,Cumhuriyet Halk Partisi,CHP,area/erzincan,Erzincan,Grand National Assembly,9,,,,
 d466ff60-95a0-4335-a589-c9ccd795170d,Mehmet Sadık Eti,Mehmet Sadık Eti,,,,Cumhuriyet Halk Partisi,CHP,area/malatya,Malatya,Grand National Assembly,9,,,,male
 99815aff-9d23-4d8c-8bce-423e3e369b1c,Mehmet Özbey,Mehmet Özbey,,,,Demokrat Parti,DP46,area/burdur,Burdur,Grand National Assembly,9,,,,male
 75620e03-404f-4222-9d26-b207c77f0793,Mehmet Özdemir,Mehmet Özdemir,,,,Demokrat Parti,DP46,area/kayseri,Kayseri,Grand National Assembly,9,,,,male


### PR DESCRIPTION
We should match on the page names displayed as links (as that's what we're
using in the original fetch), not on the actual name (as that might be
post-redirect, and different).

This matches an extra 145 people.