### PR TITLE
Make sure skipping moves the progress bar

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -1444,9 +1444,9 @@
         "slug": "Commons",
         "sources_directory": "data/Canada/Commons/sources",
         "popolo": "data/Canada/Commons/ep-popolo-v1.0.json",
-        "lastmod": "1447094925",
+        "lastmod": "1447202889",
         "person_count": 541,
-        "sha": "f12720d",
+        "sha": "f9298b0",
         "legislative_periods": [
           {
             "id": "term/42",

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -20,7 +20,9 @@ var vote = function vote($choice){
   var vote = [];
 
   if($choice.is('.skip-person')) {
-    // do nothing
+    // Insert a null value to indicate skip, these are removed when
+    // serializing to CSV.
+    window.votes.push( null );
   } else if($choice.is('.no-matches')){
     window.votes.push( [incomingPersonID, null] );
   } else {
@@ -47,7 +49,7 @@ var updateProgressBar = function updateProgressBar(){
 var generateCSV = function generateCSV(){
   return Papa.unparse({
     fields: ['id', 'uuid'],
-    data: window.reconciled.concat(window.votes)
+    data: window.reconciled.concat(_.compact(window.votes))
   });
 }
 


### PR DESCRIPTION
We calculate the width of the progress bar based on how big the votes
array is. So in order to make it work for skips we insert a null value
into the votes array. We then compact the votes array before creating
the CSV.

Closes https://github.com/everypolitician/everypolitician/issues/205