### PR TITLE
Estonia: Add Area information from Wikidata

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -2142,9 +2142,9 @@
         "slug": "Riigikogu",
         "sources_directory": "data/Estonia/Riigikogu/sources",
         "popolo": "data/Estonia/Riigikogu/ep-popolo-v1.0.json",
-        "lastmod": "1447530501",
+        "lastmod": "1447760675",
         "person_count": 120,
-        "sha": "0fdd841",
+        "sha": "3380791",
         "legislative_periods": [
           {
             "id": "term/13",

--- a/data/Estonia/Riigikogu/ep-popolo-v1.0.json
+++ b/data/Estonia/Riigikogu/ep-popolo-v1.0.json
@@ -14054,62 +14054,338 @@
   "areas": [
     {
       "id": "area/harju-_ja_raplamaa",
+      "identifiers": [
+        {
+          "identifier": "Q3413626",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Harju- ja Raplamaa",
+      "other_names": [
+        {
+          "lang": "fr",
+          "name": "Quatrième circonscription législative d'Estonie",
+          "note": "multilingual"
+        },
+        {
+          "lang": "et",
+          "name": "Valimisringkond nr 4",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Electoral District 4 (Harju- and Raplamaa)",
+          "note": "multilingual"
+        }
+      ],
       "type": "constituency"
     },
     {
       "id": "area/hiiu-,_lääne-_ja_saaremaa",
+      "identifiers": [
+        {
+          "identifier": "Q2972997",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Hiiu-, Lääne- ja Saaremaa",
+      "other_names": [
+        {
+          "lang": "fr",
+          "name": "Cinquième circonscription législative d'Estonie",
+          "note": "multilingual"
+        },
+        {
+          "lang": "et",
+          "name": "Valimisringkond nr 5",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Electoral District 5 (Hiiu-, Lääne- and Saaremaa)",
+          "note": "multilingual"
+        }
+      ],
       "type": "constituency"
     },
     {
       "id": "area/ida-virumaa",
+      "identifiers": [
+        {
+          "identifier": "Q3479058",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Ida-Virumaa",
+      "other_names": [
+        {
+          "lang": "fr",
+          "name": "Septième circonscription législative d'Estonie",
+          "note": "multilingual"
+        },
+        {
+          "lang": "et",
+          "name": "Valimisringkond nr 7",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Electoral District 7 (Ida-Virumaa)",
+          "note": "multilingual"
+        }
+      ],
       "type": "constituency"
     },
     {
       "id": "area/järva-_ja_viljandimaa",
+      "identifiers": [
+        {
+          "identifier": "Q3142965",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Järva- ja Viljandimaa",
+      "other_names": [
+        {
+          "lang": "fr",
+          "name": "Huitième circonscription législative d'Estonie",
+          "note": "multilingual"
+        },
+        {
+          "lang": "et",
+          "name": "Valimisringkond nr 8",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Electoral District 8 (Järva- and Viljandimaa)",
+          "note": "multilingual"
+        }
+      ],
       "type": "constituency"
     },
     {
       "id": "area/jõgeva-_ja_tartumaa",
+      "identifiers": [
+        {
+          "identifier": "Q3338787",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Jõgeva- ja Tartumaa",
+      "other_names": [
+        {
+          "lang": "fr",
+          "name": "Neuvième circonscription législative d'Estonie",
+          "note": "multilingual"
+        },
+        {
+          "lang": "et",
+          "name": "Valimisringkond nr 9",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Electoral District 9 (Jõgeva- and Tartumaa)",
+          "note": "multilingual"
+        }
+      ],
       "type": "constituency"
     },
     {
       "id": "area/lääne-virumaa",
+      "identifiers": [
+        {
+          "identifier": "Q3485728",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Lääne-Virumaa",
+      "other_names": [
+        {
+          "lang": "fr",
+          "name": "Sixième circonscription législative d'Estonie",
+          "note": "multilingual"
+        },
+        {
+          "lang": "et",
+          "name": "Valimisringkond nr 6",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Electoral District 6 (Lääne-Virumaa)",
+          "note": "multilingual"
+        }
+      ],
       "type": "constituency"
     },
     {
       "id": "area/pärnumaa",
+      "identifiers": [
+        {
+          "identifier": "Q3038253",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Pärnumaa",
+      "other_names": [
+        {
+          "lang": "fr",
+          "name": "Douzième circonscription législative d'Estonie",
+          "note": "multilingual"
+        },
+        {
+          "lang": "et",
+          "name": "Valimisringkond nr 12",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Electoral District 12 (Pärnumaa)",
+          "note": "multilingual"
+        }
+      ],
       "type": "constituency"
     },
     {
       "id": "area/tallinna_haabersti,_põhja-tallinna_ja_kristiine_linnaosa",
+      "identifiers": [
+        {
+          "identifier": "Q3402163",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Tallinna Haabersti, Põhja-Tallinna ja Kristiine linnaosa",
+      "other_names": [
+        {
+          "lang": "fr",
+          "name": "Première circonscription législative d'Estonie",
+          "note": "multilingual"
+        },
+        {
+          "lang": "et",
+          "name": "Valimisringkond nr 1",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Electoral District 1 (Haabersti, Põhja-Tallinn and Kristiine)",
+          "note": "multilingual"
+        }
+      ],
       "type": "constituency"
     },
     {
       "id": "area/tallinna_kesklinna,_lasnamäe_ja_pirita_linnaosa",
+      "identifiers": [
+        {
+          "identifier": "Q3025278",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Tallinna Kesklinna, Lasnamäe ja Pirita linnaosa",
+      "other_names": [
+        {
+          "lang": "fr",
+          "name": "Deuxième circonscription législative d'Estonie",
+          "note": "multilingual"
+        },
+        {
+          "lang": "et",
+          "name": "Valimisringkond nr 2",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Electoral District 2 (Kesklinn, Lasnamäe and Pirita)",
+          "note": "multilingual"
+        }
+      ],
       "type": "constituency"
     },
     {
       "id": "area/tallinna_mustamäe_ja_nõmme_linnaosa",
+      "identifiers": [
+        {
+          "identifier": "Q2420663",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Tallinna Mustamäe ja Nõmme linnaosa",
+      "other_names": [
+        {
+          "lang": "fr",
+          "name": "Troisième circonscription législative d'Estonie",
+          "note": "multilingual"
+        },
+        {
+          "lang": "et",
+          "name": "Valimisringkond nr 3",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Electoral District 3 (Mustamäe and Nõmme)",
+          "note": "multilingual"
+        }
+      ],
       "type": "constituency"
     },
     {
       "id": "area/tartu_linn",
+      "identifiers": [
+        {
+          "identifier": "Q3032626",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Tartu linn",
+      "other_names": [
+        {
+          "lang": "fr",
+          "name": "Dixième circonscription législative d'Estonie",
+          "note": "multilingual"
+        },
+        {
+          "lang": "et",
+          "name": "Valimisringkond nr 10",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Electoral District 10 (Tartu)",
+          "note": "multilingual"
+        }
+      ],
       "type": "constituency"
     },
     {
       "id": "area/võru-,_valga-_ja_põlvamaa",
+      "identifiers": [
+        {
+          "identifier": "Q3352911",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Võru-, Valga- ja Põlvamaa",
+      "other_names": [
+        {
+          "lang": "fr",
+          "name": "Onzième circonscription législative d'Estonie",
+          "note": "multilingual"
+        },
+        {
+          "lang": "et",
+          "name": "Valimisringkond nr 11",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Electoral District 11 (Võru-, Valga- and Põlvamaa)",
+          "note": "multilingual"
+        }
+      ],
       "type": "constituency"
     }
   ]

--- a/data/Estonia/Riigikogu/sources/instructions.json
+++ b/data/Estonia/Riigikogu/sources/instructions.json
@@ -42,6 +42,14 @@
         "type": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
+    },
+    {
+      "file": "wikidata/areas.json",
+      "type": "area-wikidata",
+      "create": {
+        "type": "area-wikidata",
+        "source": "manual/area_wikidata.csv"
+      }
     }
   ]
 }

--- a/data/Estonia/Riigikogu/sources/manual/area_wikidata.csv
+++ b/data/Estonia/Riigikogu/sources/manual/area_wikidata.csv
@@ -1,0 +1,13 @@
+id,wikidata
+"tallinna_haabersti,_põhja-tallinna_ja_kristiine_linnaosa",Q3402163
+"tallinna_kesklinna,_lasnamäe_ja_pirita_linnaosa",Q3025278
+tallinna_mustamäe_ja_nõmme_linnaosa,Q2420663
+harju-_ja_raplamaa,Q3413626
+"hiiu-,_lääne-_ja_saaremaa",Q2972997
+lääne-virumaa,Q3485728
+ida-virumaa,Q3479058
+järva-_ja_viljandimaa,Q3142965
+jõgeva-_ja_tartumaa,Q3338787
+tartu_linn,Q3032626
+"võru-,_valga-_ja_põlvamaa",Q3352911
+pärnumaa,Q3038253

--- a/data/Estonia/Riigikogu/sources/wikidata/areas.json
+++ b/data/Estonia/Riigikogu/sources/wikidata/areas.json
@@ -1,0 +1,302 @@
+{
+  "tallinna_haabersti,_põhja-tallinna_ja_kristiine_linnaosa": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q3402163"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "fr",
+        "name": "Première circonscription législative d'Estonie",
+        "note": "multilingual"
+      },
+      {
+        "lang": "et",
+        "name": "Valimisringkond nr 1",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Electoral District 1 (Haabersti, Põhja-Tallinn and Kristiine)",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "tallinna_kesklinna,_lasnamäe_ja_pirita_linnaosa": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q3025278"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "fr",
+        "name": "Deuxième circonscription législative d'Estonie",
+        "note": "multilingual"
+      },
+      {
+        "lang": "et",
+        "name": "Valimisringkond nr 2",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Electoral District 2 (Kesklinn, Lasnamäe and Pirita)",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "tallinna_mustamäe_ja_nõmme_linnaosa": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q2420663"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "fr",
+        "name": "Troisième circonscription législative d'Estonie",
+        "note": "multilingual"
+      },
+      {
+        "lang": "et",
+        "name": "Valimisringkond nr 3",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Electoral District 3 (Mustamäe and Nõmme)",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "harju-_ja_raplamaa": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q3413626"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "fr",
+        "name": "Quatrième circonscription législative d'Estonie",
+        "note": "multilingual"
+      },
+      {
+        "lang": "et",
+        "name": "Valimisringkond nr 4",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Electoral District 4 (Harju- and Raplamaa)",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "hiiu-,_lääne-_ja_saaremaa": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q2972997"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "fr",
+        "name": "Cinquième circonscription législative d'Estonie",
+        "note": "multilingual"
+      },
+      {
+        "lang": "et",
+        "name": "Valimisringkond nr 5",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Electoral District 5 (Hiiu-, Lääne- and Saaremaa)",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "lääne-virumaa": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q3485728"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "fr",
+        "name": "Sixième circonscription législative d'Estonie",
+        "note": "multilingual"
+      },
+      {
+        "lang": "et",
+        "name": "Valimisringkond nr 6",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Electoral District 6 (Lääne-Virumaa)",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "ida-virumaa": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q3479058"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "fr",
+        "name": "Septième circonscription législative d'Estonie",
+        "note": "multilingual"
+      },
+      {
+        "lang": "et",
+        "name": "Valimisringkond nr 7",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Electoral District 7 (Ida-Virumaa)",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "järva-_ja_viljandimaa": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q3142965"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "fr",
+        "name": "Huitième circonscription législative d'Estonie",
+        "note": "multilingual"
+      },
+      {
+        "lang": "et",
+        "name": "Valimisringkond nr 8",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Electoral District 8 (Järva- and Viljandimaa)",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "jõgeva-_ja_tartumaa": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q3338787"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "fr",
+        "name": "Neuvième circonscription législative d'Estonie",
+        "note": "multilingual"
+      },
+      {
+        "lang": "et",
+        "name": "Valimisringkond nr 9",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Electoral District 9 (Jõgeva- and Tartumaa)",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "tartu_linn": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q3032626"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "fr",
+        "name": "Dixième circonscription législative d'Estonie",
+        "note": "multilingual"
+      },
+      {
+        "lang": "et",
+        "name": "Valimisringkond nr 10",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Electoral District 10 (Tartu)",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "võru-,_valga-_ja_põlvamaa": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q3352911"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "fr",
+        "name": "Onzième circonscription législative d'Estonie",
+        "note": "multilingual"
+      },
+      {
+        "lang": "et",
+        "name": "Valimisringkond nr 11",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Electoral District 11 (Võru-, Valga- and Põlvamaa)",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "pärnumaa": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q3038253"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "fr",
+        "name": "Douzième circonscription législative d'Estonie",
+        "note": "multilingual"
+      },
+      {
+        "lang": "et",
+        "name": "Valimisringkond nr 12",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Electoral District 12 (Pärnumaa)",
+        "note": "multilingual"
+      }
+    ]
+  }
+}

--- a/lib/area_wikidata.rb
+++ b/lib/area_wikidata.rb
@@ -1,0 +1,46 @@
+require 'wikisnakker'
+
+# Takes an array of hashes containing area 'id' and 'wikidata' then returns
+# wikidata information about each area.
+# TODO: combine this with GroupWikidata
+
+class AreaWikidata
+  attr_reader :wikidata_id_lookup
+
+  def initialize(mapping)
+    @wikidata_id_lookup = Hash[
+      mapping.map { |item| [item[:wikidata], item[:id]] }
+    ]
+  end
+
+  def to_hash
+    area_information = wikidata_results.map do |result|
+      [wikidata_id_lookup[result.id], fields_for(result)]
+    end
+    Hash[area_information]
+  end
+
+  def wikidata_results
+    @wikidata_results ||= Wikisnakker::Item.find(wikidata_id_lookup.keys)
+  end
+
+  private
+
+  def fields_for(result)
+    {
+      identifiers: [
+        {
+          scheme: 'wikidata',
+          identifier: result.id
+        }
+      ],
+      other_names: result.labels.values.map do |label|
+        {
+          lang: label['language'],
+          name: label['value'],
+          note: 'multilingual'
+        }
+      end
+    }
+  end
+end

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -1,5 +1,6 @@
 require 'sass'
 require_relative '../lib/group_wikidata'
+require_relative '../lib/area_wikidata'
 
 class String
   def tidy
@@ -149,6 +150,10 @@ namespace :merge_sources do
           mapping = csv_table("sources/#{c[:source]}")
           group_wikidata = GroupWikidata.new(mapping)
           File.write(i[:file], JSON.pretty_generate(group_wikidata.to_hash))
+        elsif c[:type] == 'area-wikidata'
+          mapping = csv_table("sources/#{c[:source]}")
+          area_wikidata = AreaWikidata.new(mapping)
+          File.write(i[:file], JSON.pretty_generate(area_wikidata.to_hash))
         else
           raise "Don't know how to fetch #{i[:file]}" unless c[:type] == 'morph'
         end

--- a/rake_helpers/generate_ep_popolo.rb
+++ b/rake_helpers/generate_ep_popolo.rb
@@ -136,6 +136,21 @@ namespace :transform do
   end
 
   #---------------------------------------------------------------------
+  # Add area wikidata information
+  #---------------------------------------------------------------------
+  task :write => :area_wikidata
+  task :area_wikidata => :load do
+    instructions(:sources).find_all { |src| src[:type].to_s.downcase == 'area-wikidata' }.each do |src|
+      area_data = JSON.parse(File.read(src[:file]), symbolize_names: true)
+      @json[:areas].each do |area|
+        next unless area[:type] == 'constituency'
+        # FIXME: This doesn't do a deep merge. Nested arrays will be clobbered 
+        area.merge!(area_data.fetch(area[:id].sub(/^area\//, '').to_sym, {}))
+      end
+    end
+  end
+
+  #---------------------------------------------------------------------
   # Add group wikidata information
   #---------------------------------------------------------------------
   task :write => :group_wikidata
@@ -150,4 +165,5 @@ namespace :transform do
       end
     end
   end
+
 end


### PR DESCRIPTION
Similarly to how we fetch Party information from Wikidata, do the same thing for Areas

(There's a lot of overlap here that can be factored away later, but let's leave that until we've also done this for People, Terms, and the Legislature itself to avoid prematurely finding the wrong abstractions).