### PR TITLE
Disable converters for reconciled CSVs

### DIFF
--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -267,7 +267,7 @@ namespace :merge_sources do
 
           reconciled = CSV::Table.new([])
           if File.exist? rec_filename
-            reconciled = CSV.table(rec_filename)
+            reconciled = CSV.table(rec_filename, converters: nil)
           end
           reconciler = Reconciler.new(merged_rows, merger, reconciled)
           need_reconciling = incoming_data.find_all do |d|


### PR DESCRIPTION
We want to treat all cells in the reconciliation CSV as strings, so we
disable all converters to avoid any surprises.

This should fix the problem @tmtmtmtm was having in https://github.com/everypolitician/everypolitician-data/commit/31fefa1d3fccfee803da3b3a0876282fc8b6d2e4.