### PR TITLE
Reconciliation improvements

### DIFF
--- a/lib/reconciliation.rb
+++ b/lib/reconciliation.rb
@@ -1,3 +1,4 @@
 require_relative './reconciliation/interface'
 require_relative './reconciliation/fuzzer'
 require_relative './reconciliation/legacy_csv'
+require_relative './reconciliation/template'

--- a/lib/reconciliation.rb
+++ b/lib/reconciliation.rb
@@ -1,2 +1,3 @@
 require_relative './reconciliation/interface'
+require_relative './reconciliation/fuzzer'
 require_relative './reconciliation/legacy_csv'

--- a/lib/reconciliation.rb
+++ b/lib/reconciliation.rb
@@ -1,0 +1,2 @@
+require_relative './reconciliation/interface'
+require_relative './reconciliation/legacy_csv'

--- a/lib/reconciliation/fuzzer.rb
+++ b/lib/reconciliation/fuzzer.rb
@@ -1,0 +1,60 @@
+require 'fuzzy_match'
+
+module Reconciliation
+  # Does a fuzzy match to find existing rows that match incoming rows.
+  class Fuzzer
+    attr_reader :fuzzer
+    attr_reader :incoming_rows
+    attr_reader :instructions
+
+    def initialize(existing_rows, incoming_rows, instructions)
+      @incoming_rows = incoming_rows
+      @instructions = instructions
+      @fuzzer ||= FuzzyMatch.new(
+        existing_rows.uniq { |r| r[:uuid] }, read: existing_field
+      )
+    end
+
+    def find_all
+      incoming_rows.map do |incoming_row|
+        if incoming_row[incoming_field].to_s.empty?
+          warn "No #{incoming_field} in #{incoming_row}".red
+          next
+        end
+        matches = fuzzer.find_all_with_score(incoming_row[incoming_field])
+        unless matches.any?
+          warn "No matches for #{incoming_row}"
+          next
+        end
+        data = {
+          incoming: incoming_row,
+          existing: matches[0...3]
+        }
+        warn "Fuzzed #{display(data)}"
+        data
+      end.compact
+    end
+
+    private
+
+    def incoming_field
+      instructions[:incoming_field].to_sym
+    rescue NoMethodError
+      raise('Need an `incoming_field` to match on')
+    end
+
+    def existing_field
+      instructions[:existing_field].to_sym
+    rescue NoMethodError
+      raise('Need an `existing_field` to match on')
+    end
+
+    def display(row)
+      {
+        row[:incoming][incoming_field] => row[:existing].map do |r|
+          [r[0][existing_field], r[1].to_f * 100]
+        end
+      }
+    end
+  end
+end

--- a/lib/reconciliation/interface.rb
+++ b/lib/reconciliation/interface.rb
@@ -61,17 +61,11 @@ module Reconciliation
     end
 
     def matched
-      @matched ||= fuzzer.find_all.sort_by(&:last).reverse
+      @matched ||= fuzzer.find_all.sort_by { |row| row[:existing].first[1] }.reverse
     end
 
     def reconciler
       @reconciler ||= Reconciler.new(merged_rows, merger, reconciled)
-    end
-
-    def existing_people
-      @existing_people ||= merged_rows
-                           .uniq { |row| row[:uuid] }
-                           .sort_by { |row| row[:name] }
     end
 
     def incoming_field

--- a/lib/reconciliation/interface.rb
+++ b/lib/reconciliation/interface.rb
@@ -1,0 +1,121 @@
+module Reconciliation
+  # Interface for reconciling incoming data
+  class Interface
+    attr_reader :merged_rows
+    attr_reader :incoming_data
+    attr_reader :merger
+
+    def initialize(merged_rows, incoming_data, merger)
+      @merged_rows = merged_rows
+      @incoming_data = incoming_data
+      @merger = merger
+    end
+
+    def generate!
+      return unless merger[:reconciliation_file]
+
+      # FIXME: Remove this once all CSVs have 'id,uuid' headers.
+      LegacyCsv.try_to_upgrade(reconciler, reconciled, incoming_data)
+
+      FileUtils.mkdir_p(File.dirname(csv_file))
+      File.write(html_file, render)
+      if need_reconciling.any?
+        warn "#{need_reconciling.size} out of #{incoming_data.size} rows " \
+          'not reconciled'.red
+      end
+      return if File.exist?(csv_file)
+      warn "Need to create #{csv_file}".cyan
+      abort "Created #{html_file} — please check it and re-run".green
+    end
+
+    def reconciled
+      reconciled = CSV::Table.new([])
+      reconciled = CSV.table(csv_file, converters: nil) if File.exist?(csv_file)
+      reconciled
+    end
+
+    private
+
+    def need_reconciling
+      @need_reconciling ||= incoming_data.find_all do |d|
+        reconciler.find_all(d).to_a.empty? && !reconciled.any? do |r|
+          r[:id].to_s == d[:id]
+        end
+      end
+    end
+
+    def csv_file
+      @csv_file ||= File.join('sources', merger[:reconciliation_file])
+    end
+
+    def render
+      template.result(binding)
+    end
+
+    def html_file
+      @html_file ||= csv_file.gsub('.csv', '.html')
+    end
+
+    def fuzzer
+      @fuzzer ||= Fuzzer.new(merged_rows, need_reconciling, merger)
+    end
+
+    def matched
+      @matched ||= fuzzer.find_all.sort_by(&:last).reverse
+    end
+
+    def reconciler
+      @reconciler ||= Reconciler.new(merged_rows, merger, reconciled)
+    end
+
+    def existing_people
+      @existing_people ||= merged_rows
+                           .uniq { |row| row[:uuid] }
+                           .sort_by { |row| row[:name] }
+    end
+
+    def incoming_field
+      merger[:incoming_field]
+    end
+
+    def existing_field
+      merger[:existing_field]
+    end
+
+    def template
+      ERB.new(reconciliation_html)
+    end
+
+    def templates_dir
+      @templates_dir ||= File.expand_path('../../../templates', __FILE__)
+    end
+
+    def reconciliation_html
+      @reconciliation_html ||= File.read(
+        File.join(templates_dir, 'reconciliation.html.erb')
+      )
+    end
+
+    def reconciliation_js
+      @reconciliation_js ||= File.read(
+        File.join(templates_dir, 'reconciliation.js')
+      )
+    end
+
+    def reconciliation_scss
+      @reconciliation_scss ||= File.read(
+        File.join(templates_dir, 'reconciliation.scss')
+      )
+    end
+
+    def reconciliation_css
+      @reconciliation_css ||= sass_engine.render
+    end
+
+    def sass_engine
+      @sass_engine ||= Sass::Engine.new(
+        reconciliation_scss, syntax: :scss, load_paths: [templates_dir]
+      )
+    end
+  end
+end

--- a/lib/reconciliation/interface.rb
+++ b/lib/reconciliation/interface.rb
@@ -23,14 +23,14 @@ module Reconciliation
         warn "#{need_reconciling.size} out of #{incoming_data.size} rows " \
           'not reconciled'.red
       end
-      return if File.exist?(csv_file)
+      return if csv_file_exists?
       warn "Need to create #{csv_file}".cyan
       abort "Created #{html_file} — please check it and re-run".green
     end
 
     def reconciled
       reconciled = CSV::Table.new([])
-      reconciled = CSV.table(csv_file, converters: nil) if File.exist?(csv_file)
+      reconciled = CSV.table(csv_file, converters: nil) if csv_file_exists?
       reconciled
     end
 
@@ -53,7 +53,12 @@ module Reconciliation
       end
     end
 
+    def csv_file_exists?
+      csv_file && File.exist?(csv_file)
+    end
+
     def csv_file
+      return unless merger[:reconciliation_file]
       @csv_file ||= File.join('sources', merger[:reconciliation_file])
     end
 

--- a/lib/reconciliation/legacy_csv.rb
+++ b/lib/reconciliation/legacy_csv.rb
@@ -1,0 +1,23 @@
+module Reconciliation
+  class LegacyCsv
+    def self.try_to_upgrade(reconciler, reconciled, incoming_data)
+      if reconciled.any? && reconciled.headers != [:id, :uuid]
+        warn 'Legacy reconciliation CSV detected'.red
+        reconciled_rows = incoming_data.map do |row|
+          found = reconciler.find_all(row, false).uniq { |r| r[:id] }
+          next unless found.any?
+          binding.pry if found.size != 1
+          unless row[:id]
+            warn "Can't automatically migrate legacy reconciliation for incoming data with no :id #{row}"
+            break
+          end
+          CSV::Row.new([:id, :uuid], [row[:id], found.first[:uuid]])
+        end
+        if reconciled_rows
+          reconciled = CSV::Table.new(reconciled_rows.compact)
+          File.write(csv_file, reconciled.to_csv)
+        end
+      end
+    end
+  end
+end

--- a/lib/reconciliation/template.rb
+++ b/lib/reconciliation/template.rb
@@ -1,0 +1,57 @@
+module Reconciliation
+  class Template
+    attr_reader :matched
+    attr_reader :reconciled
+    attr_reader :incoming_field
+    attr_reader :existing_field
+
+    def initialize(opts)
+      @matched = opts[:matched]
+      @reconciled = opts[:reconciled]
+      @incoming_field = opts[:incoming_field]
+      @existing_field = opts[:existing_field]
+    end
+
+    def render
+      erb_template.result(binding)
+    end
+
+    private
+
+    def erb_template
+      ERB.new(reconciliation_html)
+    end
+
+    def reconciliation_html
+      @reconciliation_html ||= File.read(
+        File.join(templates_dir, 'reconciliation.html.erb')
+      )
+    end
+
+    def templates_dir
+      @templates_dir ||= File.expand_path('../../../templates', __FILE__)
+    end
+
+    def reconciliation_js
+      @reconciliation_js ||= File.read(
+        File.join(templates_dir, 'reconciliation.js')
+      )
+    end
+
+    def reconciliation_css
+      @reconciliation_css ||= sass_engine.render
+    end
+
+    def reconciliation_scss
+      @reconciliation_scss ||= File.read(
+        File.join(templates_dir, 'reconciliation.scss')
+      )
+    end
+
+    def sass_engine
+      @sass_engine ||= Sass::Engine.new(
+        reconciliation_scss, syntax: :scss, load_paths: [templates_dir]
+      )
+    end
+  end
+end

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -9,41 +9,6 @@ class String
   end
 end
 
-class Fuzzer
-
-  def initialize(existing_rows, incoming_rows, instructions)
-    @_existing_rows = existing_rows
-    @_incoming_rows = incoming_rows
-    @_instructions  = instructions
-    @_existing_field = instructions[:existing_field].to_sym rescue raise("Need an `existing_field` to match on")
-    @_incoming_field = instructions[:incoming_field].to_sym rescue raise("Need an `incoming_field` to match on")
-  end
-
-  def fuzzer
-    @_fuzzer ||= FuzzyMatch.new(@_existing_rows.uniq { |r| r[:uuid] }, read: @_existing_field)
-  end
-
-  def find_all
-    @_incoming_rows.map do |incoming_row|
-      if incoming_row[@_incoming_field].to_s.empty?
-        warn "No #{@_incoming_field} in #{incoming_row}".red
-        nil
-      else
-        matches = fuzzer.find_all_with_score(incoming_row[@_incoming_field])
-        unless matches.any?
-          warn "No matches for #{incoming_row}"
-          next
-        end
-        matched_uuids = matches[0...3].map { |match| match.first[:uuid] }
-        data = [incoming_row[:id], matched_uuids, matches.first[1].to_f * 100]
-        warn "Fuzzed #{data.to_s}"
-        data
-      end
-    end.compact
-  end
-
-end
-
 class Reconciler
 
   def initialize(existing_rows, instructions, reconciled_csv)

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -1,6 +1,7 @@
 require 'sass'
 require_relative '../lib/group_wikidata'
 require_relative '../lib/area_wikidata'
+require_relative '../lib/reconciliation'
 
 class String
   def tidy
@@ -257,67 +258,14 @@ namespace :merge_sources do
           merger[:report_missing] = (i == approaches.size - 1)
         end
 
+
         # TODO complain if this isn't the last step — all prior ones
         # should be exact matches
-        if rec_file = merger[:reconciliation_file]
-          rec_filename = File.join "sources", rec_file
-
-          incoming_field = merger[:incoming_field]
-          existing_field = merger[:existing_field]
-
-          reconciled = CSV::Table.new([])
-          if File.exist? rec_filename
-            reconciled = CSV.table(rec_filename, converters: nil)
-          end
-          reconciler = Reconciler.new(merged_rows, merger, reconciled)
-          need_reconciling = incoming_data.find_all do |d|
-            reconciler.find_all(d).to_a.empty? && !reconciled.any? { |r| r[:id].to_s == d[:id] }
-          end
-
-          if reconciled.headers != [:id, :uuid]
-            warn "Legacy reconciliation CSV detected".red
-            reconciled_rows = incoming_data.map do |row|
-              found = reconciler.find_all(row, false).uniq { |r| r[:id] }
-              next unless found.any?
-              if found.size != 1
-                binding.pry
-              end
-              unless row[:id]
-                warn "Can't automatically migrate legacy reconciliation for incoming data with no :id #{row}"
-                break
-              end
-              CSV::Row.new([:id, :uuid], [row[:id], found.first[:uuid]])
-            end
-            if reconciled_rows
-              reconciled = CSV::Table.new(reconciled_rows.compact)
-              File.write(rec_filename, reconciled.to_csv)
-            end
-          end
-
-          fuzzer = Fuzzer.new(merged_rows, need_reconciling, merger)
-          matched = fuzzer.find_all.sort_by { |m| m.last }.reverse
-          FileUtils.mkpath File.dirname rec_filename
-          existing_people = merged_rows.uniq { |row| row[:uuid] }.sort_by { |row| row[:name] }
-          templates_dir = File.expand_path('../../templates', __FILE__)
-          reconciliation_js = File.read(File.join(templates_dir, 'reconciliation.js'))
-          reconciliation_scss = File.read(File.join(templates_dir, 'reconciliation.scss'))
-          engine = Sass::Engine.new(reconciliation_scss, syntax: :scss, load_paths: [templates_dir])
-          reconciliation_css = engine.render
-          html = ERB.new(File.read(File.join(templates_dir, 'reconciliation.html.erb')))
-          html_filename = rec_filename.gsub('.csv', '.html')
-          File.write(html_filename, html.result(binding))
-          if need_reconciling.any?
-            warn "#{need_reconciling.size} out of #{incoming_data.size} rows not reconciled".red
-          end
-          if !File.exist?(rec_filename)
-            warn "Need to create #{rec_file}".cyan
-            abort "Created #{html_filename} — please check it and re-run".green
-          end
-        end
-
+        reconciliation = Reconciliation::Interface.new(merged_rows, incoming_data, merger)
+        reconciliation.generate!
 
         unmatched = []
-        reconciler = Reconciler.new(merged_rows, merger, reconciled)
+        reconciler = Reconciler.new(merged_rows, merger, reconciliation.reconciled)
         incoming_data.each do |incoming_row|
 
           incoming_row[:identifier__wikidata] ||= incoming_row[:id] if pd[:type] == 'wikidata'

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -38,7 +38,7 @@
 
     <!--
     <a href="#" id="generate-csv">Generate CSV</a>
-    <p>Paste this CSV into <code><%= rec_filename %></code></p>
+    <p>Paste this CSV into <code><%= csv_file %></code></p>
     <textarea id="csv-output" rows="10"></textarea>
     -->
 

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -9,8 +9,6 @@
       window.existingField = <%= Yajl::Encoder.encode(existing_field, html_safe: true) %>
       window.incomingField = <%= Yajl::Encoder.encode(incoming_field, html_safe: true) %>
       window.matches = <%= Yajl::Encoder.encode(matched, html_safe: true) %>;
-      window.existingPeople = <%= Yajl::Encoder.encode(existing_people, html_safe: true) %>;
-      window.incomingPeople = <%= Yajl::Encoder.encode(need_reconciling, html_safe: true) %>;
       window.votes = [];
       window.reconciled = <%= Yajl::Encoder.encode(reconciled.map(&:fields), html_safe: true) %>;
     </script>

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -59,22 +59,18 @@
       {% } %}
             <h1>{{ person[field] || person.name }}</h1>
             <dl>
-              {% if(person.gender){ %}
-                <dt>Gender:</dt>
-                <dd>{{ person.gender }}</dd>
-              {% } %}
-              {% if(person.birth_date){ %}
-                <dt>Born:</dt>
-                <dd>{{ person.birth_date }}</dd>
-              {% } %}
-              {% if(person.death_date){ %}
-                <dt>Died:</dt>
-                <dd>{{ person.death_date }}</dd>
-              {% } %}
-              {% if(person.area){ %}
-                <dt>Represents:</dt>
-                <dd>{{ person.area }}</dd>
-              {% } %}
+              {% fields.forEach(function(field) { %}
+                {% if(field !== 'id' && person[field]){ %}
+                  <dt>{{ field }}:</dt>
+                  <dd>
+                  {% if (field == 'image') { %}
+                    <img src="{{ person[field] }}" width="150">
+                  {% } else { %}
+                    {{ person[field] }}
+                  {% } %}
+                  </dd>
+                {% } %}
+              {% }) %}
             </dl>
         </div>
     </script>

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -34,12 +34,6 @@
 
     <div class="pairings"></div>
 
-    <!--
-    <a href="#" id="generate-csv">Generate CSV</a>
-    <p>Paste this CSV into <code><%= csv_file %></code></p>
-    <textarea id="csv-output" rows="10"></textarea>
-    -->
-
     <script type="text/html" id="pairing">
         <div class="pairing">
             <div class="row">

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -100,15 +100,29 @@ jQuery(function($) {
     if (incomingPerson[incomingField].toLowerCase() == existingPerson[existingField].toLowerCase()) {
       return;
     }
-
+    var incomingPersonFields = _.filter(Object.keys(incomingPerson), function(field) {
+      return incomingPerson[field];
+    });
     var existingPersonHTML = _.map(match.existing, function(existing) {
       var person = existing[0];
-      return renderTemplate('person', { person: person, field: existingField });
+      var fields = _.intersection(incomingPersonFields, Object.keys(person));
+      return renderTemplate('person', { person: person, field: existingField, fields: fields });
     });
+
+    var fields = match.existing.map(function(existing) {
+      var person = existing[0];
+      return Object.keys(person);
+    });
+
+    var commonFields = _.intersection(incomingPersonFields, _.uniq(_.flatten(fields)));
 
     var html = renderTemplate('pairing', {
       existingPersonHTML: existingPersonHTML.join("\n"),
-      incomingPersonHTML: renderTemplate('person', { person: incomingPerson, field: incomingField })
+      incomingPersonHTML: renderTemplate('person', {
+        person: incomingPerson,
+        field: incomingField,
+        fields: commonFields
+      })
     });
     $('.pairings').append(html);
   });

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -93,16 +93,16 @@ var updateUndoButton = function updateUndoButton(){
 
 jQuery(function($) {
   $.each(matches, function(i, match) {
-    var incomingPerson = _.findWhere(incomingPeople, { id: match[0] });
-    var existingPerson = _.findWhere(existingPeople, { uuid: match[1][0] });
+    var incomingPerson = match.incoming;
+    var existingPerson = match.existing[0][0];
 
     // Skip exact matches for now
     if (incomingPerson[incomingField].toLowerCase() == existingPerson[existingField].toLowerCase()) {
       return;
     }
 
-    var existingPersonHTML = _.map(match[1], function(uuid) {
-      var person = _.findWhere(existingPeople, { uuid: uuid });
+    var existingPersonHTML = _.map(match.existing, function(existing) {
+      var person = existing[0];
       return renderTemplate('person', { person: person, field: existingField });
     });
 

--- a/test/reconciliation_fuzzer_test.rb
+++ b/test/reconciliation_fuzzer_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+require 'reconciliation'
+
+describe Reconciliation::Fuzzer do
+  let(:existing_rows) do
+    [{ uuid: 'd50ab88c-8c56-4530-90b2-868adb2b94cd', name: 'Seamus' }]
+  end
+
+  let(:incoming_rows) do
+    [{ id: '123', name: 'Shamus' }]
+  end
+
+  let(:instructions) do
+    {
+      incoming_field: 'name',
+      existing_field: 'name'
+    }
+  end
+
+  subject { Reconciliation::Fuzzer.new(existing_rows, incoming_rows, instructions) }
+
+  it 'returns matches for the incoming rows' do
+    subject.find_all.must_equal [
+      {
+        incoming: { id: '123', name: 'Shamus' },
+        existing: [
+          [
+            {
+              :uuid=>"d50ab88c-8c56-4530-90b2-868adb2b94cd",
+              :name=>"Seamus"
+            },
+            0.6,
+            0.8333333333333334
+          ]
+        ]
+      }
+    ]
+  end
+end


### PR DESCRIPTION
Moves most of the reconciliation logic out of the `rake_helpers/combine_sources.rb` file and into separate classes in the `lib` directory. This makes it easier to focus in on particular bits of the code for refactoring, rather than having to comprehend what the whole blob of code is doing.

I've also added some extra logic to the reconciliation interface which displays fields which are common to both the existing and incoming fields, including images.

![screen shot 2015-11-20 at 17 43 16](https://cloud.githubusercontent.com/assets/57483/11307143/399053c2-8fae-11e5-9194-fa3312e9884c.png)

Related to https://github.com/everypolitician/everypolitician/issues/204

Closes https://github.com/everypolitician/everypolitician-data/issues/1215



