### PR TITLE
UK: remove obsolete parlparse data and instructions

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -5793,9 +5793,9 @@
         "sources_directory": "data/Northern_Ireland/Assembly/sources",
         "popolo": "data/Northern_Ireland/Assembly/ep-popolo-v1.0.json",
         "names": "data/Northern_Ireland/Assembly/names.csv",
-        "lastmod": "1448466499",
+        "lastmod": "1448475055",
         "person_count": 239,
-        "sha": "8a94d0b",
+        "sha": "7f2ed41",
         "legislative_periods": [
           {
             "id": "term/4",
@@ -6900,9 +6900,9 @@
         "sources_directory": "data/Scotland/Parliament/sources",
         "popolo": "data/Scotland/Parliament/ep-popolo-v1.0.json",
         "names": "data/Scotland/Parliament/names.csv",
-        "lastmod": "1448466499",
+        "lastmod": "1448475017",
         "person_count": 253,
-        "sha": "8a94d0b",
+        "sha": "237a4b1",
         "legislative_periods": [
           {
             "id": "term/4",
@@ -8526,9 +8526,9 @@
         "sources_directory": "data/UK/Commons/sources",
         "popolo": "data/UK/Commons/ep-popolo-v1.0.json",
         "names": "data/UK/Commons/names.csv",
-        "lastmod": "1448466499",
+        "lastmod": "1448475083",
         "person_count": 1337,
-        "sha": "8a94d0b",
+        "sha": "c68c980",
         "legislative_periods": [
           {
             "id": "term/56",

--- a/data/Northern_Ireland/Assembly/sources/parlparse/README
+++ b/data/Northern_Ireland/Assembly/sources/parlparse/README
@@ -1,5 +1,0 @@
-# This should all move to morph.io, but currently blows its memory limits
-# so for now you can load the data by:
-
-ruby $(git rev-parse --show-toplevel)/bin/parlparse_to_csv.rb instructions.json > data.csv
-

--- a/data/Scotland/Parliament/sources/parlparse/README
+++ b/data/Scotland/Parliament/sources/parlparse/README
@@ -1,5 +1,0 @@
-# This should all move to morph.io, but currently blows its memory limits
-# so for now you can load the data by:
-
-ruby $(git rev-parse --show-toplevel)/bin/parlparse_to_csv.rb instructions.json > data.csv
-

--- a/data/UK/Commons/sources/parlparse/README
+++ b/data/UK/Commons/sources/parlparse/README
@@ -1,6 +1,0 @@
-# This should all move to morph.io, but currently blows its memory limits
-# so for now you can load the data by:
-
-curl -o twfy.json https://raw.githubusercontent.com/mysociety/parlparse/master/members/people.json 
-
-ruby $(git rev-parse --show-toplevel)/bin/parlparse_to_csv.rb instructions.json > data.csv


### PR DESCRIPTION
We now fetch a streamlined CSV as part of the normal `rake` build, so
don't need the full JSON, or the instructions on how to do the
out-of-band pre-build.