### PR TITLE
Add website to Party information from Wikidata

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/everypolitician/wikisnakker
-  revision: 35d84f0a58482c373da58cf7842982d5155c7b2b
+  revision: ded13e3e7fb46bfb2523a48c752ffd5823c16b8d
   branch: master
   specs:
     wikisnakker (0.0.1)

--- a/countries.json
+++ b/countries.json
@@ -210,9 +210,9 @@
         "sources_directory": "data/Angola/National_Assembly/sources",
         "popolo": "data/Angola/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Angola/National_Assembly/names.csv",
-        "lastmod": "1448466499",
+        "lastmod": "1448645549",
         "person_count": 216,
-        "sha": "8a94d0b",
+        "sha": "7a73276",
         "legislative_periods": [
           {
             "id": "term/3",
@@ -440,9 +440,9 @@
         "sources_directory": "data/Armenia/Assembly/sources",
         "popolo": "data/Armenia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Armenia/Assembly/names.csv",
-        "lastmod": "1448524158",
+        "lastmod": "1448645556",
         "person_count": 130,
-        "sha": "ffc9f47",
+        "sha": "fd96e24",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -494,9 +494,9 @@
         "sources_directory": "data/Australia/Representatives/sources",
         "popolo": "data/Australia/Representatives/ep-popolo-v1.0.json",
         "names": "data/Australia/Representatives/names.csv",
-        "lastmod": "1448466499",
+        "lastmod": "1448645569",
         "person_count": 474,
-        "sha": "8a94d0b",
+        "sha": "72733c7",
         "legislative_periods": [
           {
             "id": "term/44",
@@ -585,9 +585,9 @@
         "sources_directory": "data/Australia/Senate/sources",
         "popolo": "data/Australia/Senate/ep-popolo-v1.0.json",
         "names": "data/Australia/Senate/names.csv",
-        "lastmod": "1448466499",
+        "lastmod": "1448645619",
         "person_count": 93,
-        "sha": "8a94d0b",
+        "sha": "9179af3",
         "legislative_periods": [
           {
             "id": "term/44",
@@ -1486,9 +1486,9 @@
         "sources_directory": "data/Canada/Commons/sources",
         "popolo": "data/Canada/Commons/ep-popolo-v1.0.json",
         "names": "data/Canada/Commons/names.csv",
-        "lastmod": "1448587334",
+        "lastmod": "1448645681",
         "person_count": 541,
-        "sha": "01107db",
+        "sha": "be1ef38",
         "legislative_periods": [
           {
             "id": "term/42",
@@ -2206,9 +2206,9 @@
         "sources_directory": "data/Estonia/Riigikogu/sources",
         "popolo": "data/Estonia/Riigikogu/ep-popolo-v1.0.json",
         "names": "data/Estonia/Riigikogu/names.csv",
-        "lastmod": "1448574851",
+        "lastmod": "1448645849",
         "person_count": 120,
-        "sha": "5364008",
+        "sha": "fcd8957",
         "legislative_periods": [
           {
             "id": "term/13",
@@ -2869,9 +2869,9 @@
         "sources_directory": "data/Ghana/Parliament/sources",
         "popolo": "data/Ghana/Parliament/ep-popolo-v1.0.json",
         "names": "data/Ghana/Parliament/names.csv",
-        "lastmod": "1448466499",
+        "lastmod": "1448645873",
         "person_count": 272,
-        "sha": "8a94d0b",
+        "sha": "ff3e7a7",
         "legislative_periods": [
           {
             "id": "term/6",
@@ -3316,9 +3316,9 @@
         "sources_directory": "data/Guam/Parliament/sources",
         "popolo": "data/Guam/Parliament/ep-popolo-v1.0.json",
         "names": "data/Guam/Parliament/names.csv",
-        "lastmod": "1448466499",
+        "lastmod": "1448645881",
         "person_count": 28,
-        "sha": "8a94d0b",
+        "sha": "d6f666f",
         "legislative_periods": [
           {
             "id": "term/33",
@@ -3367,9 +3367,9 @@
         "sources_directory": "data/Guatemala/Congress/sources",
         "popolo": "data/Guatemala/Congress/ep-popolo-v1.0.json",
         "names": "data/Guatemala/Congress/names.csv",
-        "lastmod": "1448466499",
+        "lastmod": "1448645931",
         "person_count": 158,
-        "sha": "8a94d0b",
+        "sha": "b3bb036",
         "legislative_periods": [
           {
             "end_date": "2016-01-14",
@@ -3761,9 +3761,9 @@
         "sources_directory": "data/Ireland/Dail/sources",
         "popolo": "data/Ireland/Dail/ep-popolo-v1.0.json",
         "names": "data/Ireland/Dail/names.csv",
-        "lastmod": "1448466499",
+        "lastmod": "1448645939",
         "person_count": 166,
-        "sha": "8a94d0b",
+        "sha": "d918606",
         "legislative_periods": [
           {
             "id": "term/31",
@@ -4040,9 +4040,9 @@
         "sources_directory": "data/Jamaica/House_of_Representatives/sources",
         "popolo": "data/Jamaica/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Jamaica/House_of_Representatives/names.csv",
-        "lastmod": "1448640290",
+        "lastmod": "1448645541",
         "person_count": 63,
-        "sha": "6d94446",
+        "sha": "5707a55",
         "legislative_periods": [
           {
             "id": "term/2011",
@@ -5657,9 +5657,9 @@
         "sources_directory": "data/Nigeria/Assembly/sources",
         "popolo": "data/Nigeria/Assembly/ep-popolo-v1.0.json",
         "names": "data/Nigeria/Assembly/names.csv",
-        "lastmod": "1448466499",
+        "lastmod": "1448645961",
         "person_count": 362,
-        "sha": "8a94d0b",
+        "sha": "46147f2",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -5793,9 +5793,9 @@
         "sources_directory": "data/Northern_Ireland/Assembly/sources",
         "popolo": "data/Northern_Ireland/Assembly/ep-popolo-v1.0.json",
         "names": "data/Northern_Ireland/Assembly/names.csv",
-        "lastmod": "1448530979",
+        "lastmod": "1448645971",
         "person_count": 239,
-        "sha": "d0806d9",
+        "sha": "a3c9146",
         "legislative_periods": [
           {
             "id": "term/4",
@@ -5875,9 +5875,9 @@
         "sources_directory": "data/Norway/Storting/sources",
         "popolo": "data/Norway/Storting/ep-popolo-v1.0.json",
         "names": "data/Norway/Storting/names.csv",
-        "lastmod": "1448466499",
+        "lastmod": "1448646059",
         "person_count": 1141,
-        "sha": "8a94d0b",
+        "sha": "34ad39e",
         "legislative_periods": [
           {
             "end_date": "2017-09-30",
@@ -6066,9 +6066,9 @@
         "sources_directory": "data/Pakistan/Assembly/sources",
         "popolo": "data/Pakistan/Assembly/ep-popolo-v1.0.json",
         "names": "data/Pakistan/Assembly/names.csv",
-        "lastmod": "1448466499",
+        "lastmod": "1448646163",
         "person_count": 339,
-        "sha": "8a94d0b",
+        "sha": "72e9946",
         "legislative_periods": [
           {
             "id": "term/14",
@@ -6452,9 +6452,9 @@
         "sources_directory": "data/Puerto_Rico/House_of_Representatives/sources",
         "popolo": "data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Puerto_Rico/House_of_Representatives/names.csv",
-        "lastmod": "1448466499",
+        "lastmod": "1448646171",
         "person_count": 51,
-        "sha": "8a94d0b",
+        "sha": "2d79eb3",
         "legislative_periods": [
           {
             "end_date": "2017-01-08",
@@ -6507,9 +6507,9 @@
         "sources_directory": "data/Russia/Duma/sources",
         "popolo": "data/Russia/Duma/ep-popolo-v1.0.json",
         "names": "data/Russia/Duma/names.csv",
-        "lastmod": "1448466499",
+        "lastmod": "1448646178",
         "person_count": 450,
-        "sha": "8a94d0b",
+        "sha": "a320d28",
         "legislative_periods": [
           {
             "id": "term/6",
@@ -6900,9 +6900,9 @@
         "sources_directory": "data/Scotland/Parliament/sources",
         "popolo": "data/Scotland/Parliament/ep-popolo-v1.0.json",
         "names": "data/Scotland/Parliament/names.csv",
-        "lastmod": "1448546330",
+        "lastmod": "1448646189",
         "person_count": 253,
-        "sha": "cd0111d",
+        "sha": "317244e",
         "legislative_periods": [
           {
             "id": "term/4",
@@ -7484,9 +7484,9 @@
         "sources_directory": "data/Spain/Congress/sources",
         "popolo": "data/Spain/Congress/ep-popolo-v1.0.json",
         "names": "data/Spain/Congress/names.csv",
-        "lastmod": "1448466499",
+        "lastmod": "1448646204",
         "person_count": 397,
-        "sha": "8a94d0b",
+        "sha": "13b0542",
         "legislative_periods": [
           {
             "id": "term/10",
@@ -7608,9 +7608,9 @@
         "sources_directory": "data/Sweden/Riksdag/sources",
         "popolo": "data/Sweden/Riksdag/ep-popolo-v1.0.json",
         "names": "data/Sweden/Riksdag/names.csv",
-        "lastmod": "1448505113",
+        "lastmod": "1448646218",
         "person_count": 356,
-        "sha": "92c8ee7",
+        "sha": "ea37e66",
         "legislative_periods": [
           {
             "id": "term/2014",

--- a/data/Angola/National_Assembly/ep-popolo-v1.0.json
+++ b/data/Angola/National_Assembly/ep-popolo-v1.0.json
@@ -4796,6 +4796,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.fnla.net/"
+        }
+      ],
       "name": "FNLA",
       "other_names": [
         {
@@ -4902,6 +4908,12 @@
         {
           "identifier": "Q28551",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.mpla.org/"
         }
       ],
       "name": "MPLA",
@@ -5154,6 +5166,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.prs-angola.com"
+        }
+      ],
       "name": "PRS",
       "other_names": [
         {
@@ -5185,6 +5203,12 @@
         {
           "identifier": "Q28699",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.unitaangola.org"
         }
       ],
       "name": "UNITA",

--- a/data/Angola/National_Assembly/sources/wikidata/groups.json
+++ b/data/Angola/National_Assembly/sources/wikidata/groups.json
@@ -232,6 +232,12 @@
         "name": "Անգոլայի ազատագրության ժողովրդական շարժում",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.mpla.org/",
+        "note": "website"
+      }
     ]
   },
   "unita": {
@@ -462,6 +468,12 @@
         "name": "യൂണീറ്റ",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.unitaangola.org",
+        "note": "website"
+      }
     ]
   },
   "casa-ce": {
@@ -521,6 +533,12 @@
         "lang": "pt",
         "name": "Partido de Renovação Social",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.prs-angola.com",
+        "note": "website"
       }
     ]
   },
@@ -626,6 +644,12 @@
         "lang": "ko",
         "name": "앙골라 해방 민족 전선",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.fnla.net/",
+        "note": "website"
       }
     ]
   }

--- a/data/Armenia/Assembly/ep-popolo-v1.0.json
+++ b/data/Armenia/Assembly/ep-popolo-v1.0.json
@@ -4141,6 +4141,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.anc.am/"
+        }
+      ],
       "name": "Armenian National Congress",
       "other_names": [
         {
@@ -4202,6 +4208,12 @@
         {
           "identifier": "Q318657",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.arfd.info/"
         }
       ],
       "name": "Armenian Revolutionary Federation",
@@ -4392,6 +4404,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.heritage.am"
+        }
+      ],
       "name": "Heritage",
       "other_names": [
         {
@@ -4472,6 +4490,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.bhk.am/"
+        }
+      ],
       "name": "Prosperous Armenia",
       "other_names": [
         {
@@ -4543,6 +4567,12 @@
         {
           "identifier": "Q1144610",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.hhk.am"
         }
       ],
       "name": "Republican",
@@ -4686,6 +4716,12 @@
         {
           "identifier": "Q1346313",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.oek.am"
         }
       ],
       "name": "Rule of Law",

--- a/data/Armenia/Assembly/sources/wikidata/groups.json
+++ b/data/Armenia/Assembly/sources/wikidata/groups.json
@@ -137,6 +137,12 @@
         "name": "Republikánská strana Arménie",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.hhk.am",
+        "note": "website"
+      }
     ]
   },
   "PA": {
@@ -207,6 +213,12 @@
         "name": "აყვავებული სომხეთი",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.bhk.am/",
+        "note": "website"
+      }
     ]
   },
   "H": {
@@ -266,6 +278,12 @@
         "lang": "ka",
         "name": "მემკვიდრეობა (სომხეთი)",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.heritage.am",
+        "note": "website"
       }
     ]
   },
@@ -327,6 +345,12 @@
         "name": "სომხეთის ეროვნული კონგრესი",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.anc.am/",
+        "note": "website"
+      }
     ]
   },
   "ROL": {
@@ -386,6 +410,12 @@
         "lang": "et",
         "name": "Seaduse Võim",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.oek.am",
+        "note": "website"
       }
     ]
   },
@@ -571,6 +601,12 @@
         "lang": "lrc",
         "name": "فدراسیون وضع آلیشت کار ارمنی",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.arfd.info/",
+        "note": "website"
       }
     ]
   }

--- a/data/Australia/Representatives/ep-popolo-v1.0.json
+++ b/data/Australia/Representatives/ep-popolo-v1.0.json
@@ -39289,6 +39289,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.greens.org.au/"
+        }
+      ],
       "name": "Australian Greens",
       "other_names": [
         {
@@ -39420,6 +39426,12 @@
         {
           "identifier": "Q216082",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.alp.org.au/"
         }
       ],
       "name": "Australian Labor Party",
@@ -39723,6 +39735,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.clp.org.au/"
+        }
+      ],
       "name": "Country Liberal Party",
       "other_names": [
         {
@@ -39801,6 +39819,12 @@
         {
           "identifier": "Q241149",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.liberal.org.au"
         }
       ],
       "name": "Liberal Party",
@@ -40031,6 +40055,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.nationals.org.au/"
+        }
+      ],
       "name": "National Party",
       "other_names": [
         {
@@ -40167,6 +40197,12 @@
         {
           "identifier": "Q15130081",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://palmerunited.com/"
         }
       ],
       "name": "Palmer United Party",

--- a/data/Australia/Representatives/sources/wikidata/groups.json
+++ b/data/Australia/Representatives/sources/wikidata/groups.json
@@ -257,6 +257,12 @@
         "name": "Ausztrál Munkáspárt",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.alp.org.au/",
+        "note": "website"
+      }
     ]
   },
   "liberal_party": {
@@ -482,6 +488,12 @@
         "name": "Australia Chū-iû Tóng",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.liberal.org.au",
+        "note": "website"
+      }
     ]
   },
   "national_party": {
@@ -617,6 +629,12 @@
         "name": "Australská národní strana",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.nationals.org.au/",
+        "note": "website"
+      }
     ]
   },
   "country_liberal_party": {
@@ -676,6 +694,12 @@
         "lang": "nan",
         "name": "Kok-ka Chū-iû Tóng",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.clp.org.au/",
+        "note": "website"
       }
     ]
   },
@@ -806,6 +830,12 @@
         "lang": "nan",
         "name": "Australia Le̍k Tóng",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.greens.org.au/",
+        "note": "website"
       }
     ]
   },
@@ -941,6 +971,12 @@
         "lang": "nan",
         "name": "Palmer Liân-ha̍p Tóng",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://palmerunited.com/",
+        "note": "website"
       }
     ]
   }

--- a/data/Australia/Senate/ep-popolo-v1.0.json
+++ b/data/Australia/Senate/ep-popolo-v1.0.json
@@ -2009,6 +2009,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.greens.org.au/"
+        }
+      ],
       "name": "Australian Greens",
       "other_names": [
         {
@@ -2140,6 +2146,12 @@
         {
           "identifier": "Q216082",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.alp.org.au/"
         }
       ],
       "name": "Australian Labor Party",
@@ -2405,6 +2417,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.australianmotoringenthusiastparty.org.au/"
+        }
+      ],
       "name": "Australian Motoring Enthusiast Party",
       "other_names": [
         {
@@ -2436,6 +2454,12 @@
         {
           "identifier": "Q2496080",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.clp.org.au/"
         }
       ],
       "name": "Country Liberal Party",
@@ -2499,6 +2523,12 @@
         {
           "identifier": "Q1395400",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.familyfirst.org.au/"
         }
       ],
       "name": "Family First Party",
@@ -2579,6 +2609,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.ldp.org.au/"
+        }
+      ],
       "name": "Liberal Democratic Party",
       "other_names": [
         {
@@ -2615,6 +2651,12 @@
         {
           "identifier": "Q15130081",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://palmerunited.com/"
         }
       ],
       "name": "Palmer United Party",
@@ -2665,6 +2707,12 @@
         {
           "identifier": "Q946040",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.nationals.org.au/"
         }
       ],
       "name": "The Nationals",

--- a/data/Australia/Senate/sources/wikidata/groups.json
+++ b/data/Australia/Senate/sources/wikidata/groups.json
@@ -257,6 +257,12 @@
         "name": "Ausztrál Munkáspárt",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.alp.org.au/",
+        "note": "website"
+      }
     ]
   },
   "liberal_party": {
@@ -482,6 +488,12 @@
         "name": "Australia Chū-iû Tóng",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.liberal.org.au",
+        "note": "website"
+      }
     ]
   },
   "country_liberal_party": {
@@ -541,6 +553,12 @@
         "lang": "nan",
         "name": "Kok-ka Chū-iû Tóng",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.clp.org.au/",
+        "note": "website"
       }
     ]
   },
@@ -672,6 +690,12 @@
         "name": "Australia Le̍k Tóng",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.greens.org.au/",
+        "note": "website"
+      }
     ]
   },
   "palmer_united_party": {
@@ -706,6 +730,12 @@
         "lang": "nan",
         "name": "Palmer Liân-ha̍p Tóng",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://palmerunited.com/",
+        "note": "website"
       }
     ]
   },
@@ -842,6 +872,12 @@
         "name": "Australská národní strana",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.nationals.org.au/",
+        "note": "website"
+      }
     ]
   },
   "australian_motoring_enthusiast_party": {
@@ -872,6 +908,12 @@
         "name": "Australia Chhia Ài-hòⁿ-chiá Tóng",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.australianmotoringenthusiastparty.org.au/",
+        "note": "website"
+      }
     ]
   },
   "liberal_democratic_party": {
@@ -901,6 +943,12 @@
         "lang": "nan",
         "name": "Chū-iû Bîn-chú Tóng",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.ldp.org.au/",
+        "note": "website"
       }
     ]
   },
@@ -971,6 +1019,12 @@
         "lang": "nan",
         "name": "Ka-cho̍k Iu-sian Tóng",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.familyfirst.org.au/",
+        "note": "website"
       }
     ]
   }

--- a/data/Canada/Commons/ep-popolo-v1.0.json
+++ b/data/Canada/Commons/ep-popolo-v1.0.json
@@ -43585,6 +43585,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.blocquebecois.org/"
+        }
+      ],
       "name": "Bloc Québécois",
       "other_names": [
         {
@@ -43711,6 +43717,12 @@
         {
           "identifier": "Q488523",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.conservative.ca/"
         }
       ],
       "name": "Conservative",
@@ -43921,6 +43933,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.greenparty.ca"
+        }
+      ],
       "name": "Green",
       "other_names": [
         {
@@ -44049,6 +44067,12 @@
         {
           "identifier": "Q138345",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.liberal.ca/"
         }
       ],
       "name": "Liberal",
@@ -44272,6 +44296,12 @@
         {
           "identifier": "Q130765",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.ndp.ca"
         }
       ],
       "name": "NDP",

--- a/data/Canada/Commons/sources/wikidata/groups.json
+++ b/data/Canada/Commons/sources/wikidata/groups.json
@@ -202,6 +202,12 @@
         "name": "حزب محافظه‌کار کانادا",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.conservative.ca/",
+        "note": "website"
+      }
     ]
   },
   "liberal": {
@@ -422,6 +428,12 @@
         "name": "Partidul Liberal din Canada",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.liberal.ca/",
+        "note": "website"
+      }
     ]
   },
   "ndp": {
@@ -637,6 +649,12 @@
         "name": "พรรคประชาธิปไตยใหม่",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.ndp.ca",
+        "note": "website"
+      }
     ]
   },
   "bloc_québécois": {
@@ -762,6 +780,12 @@
         "name": "Bloc Québécois",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.blocquebecois.org/",
+        "note": "website"
+      }
     ]
   },
   "green_party": {
@@ -877,6 +901,12 @@
         "name": "حزب سبز کانادا",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.greenparty.ca",
+        "note": "website"
+      }
     ]
   },
   "forces_et_démocratie": {
@@ -911,6 +941,12 @@
         "lang": "zh",
         "name": "加拿大民主与力量党",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.forcesetdemocratie.org/",
+        "note": "website"
       }
     ]
   }

--- a/data/Estonia/Riigikogu/ep-popolo-v1.0.json
+++ b/data/Estonia/Riigikogu/ep-popolo-v1.0.json
@@ -14105,6 +14105,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.keskerakond.ee/"
+        }
+      ],
       "name": "Eesti Keskerakonna fraktsioon",
       "other_names": [
         {
@@ -14268,6 +14274,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.ekre.ee/"
+        }
+      ],
       "name": "Eesti Konservatiivse Rahvaerakonna fraktsioon",
       "other_names": [
         {
@@ -14384,6 +14396,12 @@
         {
           "identifier": "Q738947",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.reform.ee"
         }
       ],
       "name": "Eesti Reformierakonna fraktsioon",
@@ -14632,6 +14650,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.irl.ee/"
+        }
+      ],
       "name": "Isamaa ja Res Publica Liidu fraktsioon",
       "other_names": [
         {
@@ -14750,6 +14774,12 @@
         {
           "identifier": "Q913551",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.sotsdem.ee"
         }
       ],
       "name": "Sotsiaaldemokraatliku Erakonna fraktsioon",

--- a/data/Estonia/Riigikogu/sources/wikidata/groups.json
+++ b/data/Estonia/Riigikogu/sources/wikidata/groups.json
@@ -187,6 +187,12 @@
         "name": "에스토니아 개혁당",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.reform.ee",
+        "note": "website"
+      }
     ]
   },
   "KESK": {
@@ -347,6 +353,12 @@
         "name": "Keskerakond",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.keskerakond.ee/",
+        "note": "website"
+      }
     ]
   },
   "SDE": {
@@ -487,6 +499,12 @@
         "name": "Социалдемократическа партия",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.sotsdem.ee",
+        "note": "website"
+      }
     ]
   },
   "IRL": {
@@ -591,6 +609,12 @@
         "lang": "he",
         "name": "IRL",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.irl.ee/",
+        "note": "website"
       }
     ]
   },
@@ -751,6 +775,12 @@
         "lang": "pl",
         "name": "Estońska Konserwatywna Partia Ludowa",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.ekre.ee/",
+        "note": "website"
       }
     ]
   }

--- a/data/Ghana/Parliament/ep-popolo-v1.0.json
+++ b/data/Ghana/Parliament/ep-popolo-v1.0.json
@@ -5481,6 +5481,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://conventionpeoplesparty.org/"
+        }
+      ],
       "name": "Convention People's Party",
       "other_names": [
         {
@@ -5542,6 +5548,12 @@
         {
           "identifier": "Q200875",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.ndc.org.gh/"
         }
       ],
       "name": "National Democratic Congress",
@@ -5620,6 +5632,12 @@
         {
           "identifier": "Q1148441",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.newpatrioticparty.org/"
         }
       ],
       "name": "New Patriotic Party",

--- a/data/Ghana/Parliament/sources/wikidata/groups.json
+++ b/data/Ghana/Parliament/sources/wikidata/groups.json
@@ -72,6 +72,12 @@
         "name": "국민민주회의",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.ndc.org.gh/",
+        "note": "website"
+      }
     ]
   },
   "new_patriotic_party": {
@@ -126,6 +132,12 @@
         "lang": "bg",
         "name": "Нова патриотична партия",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.newpatrioticparty.org/",
+        "note": "website"
       }
     ]
   },
@@ -206,6 +218,12 @@
         "lang": "fr",
         "name": "Convention People's Party",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://conventionpeoplesparty.org/",
+        "note": "website"
       }
     ]
   }

--- a/data/Guam/Parliament/ep-popolo-v1.0.json
+++ b/data/Guam/Parliament/ep-popolo-v1.0.json
@@ -939,6 +939,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.democrats.org/"
+        }
+      ],
       "name": "Democratic",
       "other_names": [
         {

--- a/data/Guam/Parliament/sources/wikidata/groups.json
+++ b/data/Guam/Parliament/sources/wikidata/groups.json
@@ -17,6 +17,12 @@
         "name": "Democratic Party of Guam",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.democrats.org/",
+        "note": "website"
+      }
     ]
   },
   "rep": {

--- a/data/Guatemala/Congress/ep-popolo-v1.0.json
+++ b/data/Guatemala/Congress/ep-popolo-v1.0.json
@@ -4593,6 +4593,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://creo.org.gt"
+        }
+      ],
       "name": "CREO",
       "other_names": [
         {
@@ -4628,6 +4634,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://encuentro.gt/"
+        }
+      ],
       "name": "EG",
       "other_names": [
         {
@@ -4654,6 +4666,12 @@
         {
           "identifier": "Q1062788",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.gana.com.gt/"
         }
       ],
       "name": "GANA",
@@ -4714,6 +4732,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.baldizon.com"
+        }
+      ],
       "name": "LIDER",
       "other_names": [
         {
@@ -4740,6 +4764,12 @@
         {
           "identifier": "Q1803640",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.partidopatriota.com/"
         }
       ],
       "name": "PP",
@@ -4815,6 +4845,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.pri.gt"
+        }
+      ],
       "name": "PRI",
       "other_names": [
         {
@@ -4863,6 +4899,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.unionistas.org"
+        }
+      ],
       "name": "PU",
       "other_names": [
         {
@@ -4883,6 +4925,11 @@
         {
           "lang": "ru",
           "name": "Юнионистская партия",
+          "note": "multilingual"
+        },
+        {
+          "lang": "it",
+          "name": "Partito Unionista",
           "note": "multilingual"
         }
       ]
@@ -4917,6 +4964,12 @@
         {
           "identifier": "Q1237557",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.une.org.gt/"
         }
       ],
       "name": "UNE",
@@ -4992,6 +5045,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.urng-maiz.org.gt/new/drupal/"
+        }
+      ],
       "name": "URNG",
       "other_names": [
         {
@@ -5045,6 +5104,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://inicio.viva.com.gt/"
+        }
+      ],
       "name": "VIVA",
       "other_names": [
         {
@@ -5066,6 +5131,12 @@
         {
           "identifier": "Q8023686",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.winaq.org.gt/"
         }
       ],
       "name": "WINAQ",

--- a/data/Guatemala/Congress/sources/wikidata/groups.json
+++ b/data/Guatemala/Congress/sources/wikidata/groups.json
@@ -22,6 +22,12 @@
         "name": "Förnyade demokratiska frihetspartiet",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.baldizon.com",
+        "note": "website"
+      }
     ]
   },
   "pp": {
@@ -91,6 +97,12 @@
         "lang": "uk",
         "name": "Патріотична партія",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.partidopatriota.com/",
+        "note": "website"
       }
     ]
   },
@@ -162,6 +174,12 @@
         "name": "Національний союз надії",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.une.org.gt/",
+        "note": "website"
+      }
     ]
   },
   "creo": {
@@ -181,6 +199,12 @@
         "lang": "en",
         "name": "Commitment, Renewal and Order",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://creo.org.gt",
+        "note": "website"
       }
     ]
   },
@@ -206,6 +230,12 @@
         "lang": "nl",
         "name": "Encuentro por Guatemala",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://encuentro.gt/",
+        "note": "website"
       }
     ]
   },
@@ -257,6 +287,12 @@
         "name": "全国大联盟 (危地马拉)",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.gana.com.gt/",
+        "note": "website"
+      }
     ]
   },
   "urng": {
@@ -307,6 +343,12 @@
         "name": "Unidad Revolucionaria Nacional Guatemalteca",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.urng-maiz.org.gt/new/drupal/",
+        "note": "website"
+      }
     ]
   },
   "pri": {
@@ -352,6 +394,12 @@
         "name": "Гватемальский республиканский фронт",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.pri.gt",
+        "note": "website"
+      }
     ]
   },
   "pu": {
@@ -381,6 +429,17 @@
         "lang": "ru",
         "name": "Юнионистская партия",
         "note": "multilingual"
+      },
+      {
+        "lang": "it",
+        "name": "Partito Unionista",
+        "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.unionistas.org",
+        "note": "website"
       }
     ]
   },
@@ -402,6 +461,12 @@
         "name": "VIVA",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://inicio.viva.com.gt/",
+        "note": "website"
+      }
     ]
   },
   "winaq": {
@@ -421,6 +486,12 @@
         "lang": "es",
         "name": "Partido WINAQ",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.winaq.org.gt/",
+        "note": "website"
       }
     ]
   },

--- a/data/Ireland/Dail/ep-popolo-v1.0.json
+++ b/data/Ireland/Dail/ep-popolo-v1.0.json
@@ -14534,6 +14534,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.fiannafail.ie/"
+        }
+      ],
       "name": "Fianna Fáil",
       "other_names": [
         {
@@ -14757,6 +14763,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.finegael.ie/"
+        }
+      ],
       "name": "Fine Gael",
       "other_names": [
         {
@@ -14923,6 +14935,12 @@
         {
           "identifier": "Q503614",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.labour.ie/"
         }
       ],
       "name": "Labour",
@@ -15116,6 +15134,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://renuaireland.com/"
+        }
+      ],
       "name": "Renua Ireland",
       "other_names": [
         {
@@ -15137,6 +15161,12 @@
         {
           "identifier": "Q76382",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.sinnfein.ie/"
         }
       ],
       "name": "Sinn Féin",
@@ -15442,6 +15472,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.socialdemocrats.ie/"
+        }
+      ],
       "name": "Social Democrats",
       "other_names": [
         {
@@ -15463,6 +15499,12 @@
         {
           "identifier": "Q1549074",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.socialistparty.net/"
         }
       ],
       "name": "Socialist Party",

--- a/data/Ireland/Dail/sources/wikidata/groups.json
+++ b/data/Ireland/Dail/sources/wikidata/groups.json
@@ -157,6 +157,12 @@
         "name": "Fine Gael",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.finegael.ie/",
+        "note": "website"
+      }
     ]
   },
   "LAB": {
@@ -321,6 +327,12 @@
         "lang": "zh",
         "name": "爱尔兰工党",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.labour.ie/",
+        "note": "website"
       }
     ]
   },
@@ -541,6 +553,12 @@
         "lang": "scn",
         "name": "Fianna Fáil",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.fiannafail.ie/",
+        "note": "website"
       }
     ]
   },
@@ -842,6 +860,12 @@
         "name": "சின் பெயின்",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.sinnfein.ie/",
+        "note": "website"
+      }
     ]
   },
   "REN": {
@@ -862,6 +886,12 @@
         "name": "Renua Éireann",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://renuaireland.com/",
+        "note": "website"
+      }
     ]
   },
   "SD": {
@@ -881,6 +911,12 @@
         "lang": "ga",
         "name": "Na Daonlathaigh Shóisialta",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.socialdemocrats.ie/",
+        "note": "website"
       }
     ]
   },
@@ -966,6 +1002,12 @@
         "lang": "pt",
         "name": "Partido Socialista",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.socialistparty.net/",
+        "note": "website"
       }
     ]
   },

--- a/data/Jamaica/House_of_Representatives/ep-popolo-v1.0.json
+++ b/data/Jamaica/House_of_Representatives/ep-popolo-v1.0.json
@@ -3141,6 +3141,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.jamaicalabourparty.com"
+        }
+      ],
       "name": "Jamaica Labour Party",
       "other_names": [
         {
@@ -3237,6 +3243,12 @@
         {
           "identifier": "Q1162691",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.pnpjamaica.com/"
         }
       ],
       "name": "People's National Party",

--- a/data/Jamaica/House_of_Representatives/sources/wikidata/groups.json
+++ b/data/Jamaica/House_of_Representatives/sources/wikidata/groups.json
@@ -127,6 +127,12 @@
         "name": "People's National Party",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.pnpjamaica.com/",
+        "note": "website"
+      }
     ]
   },
   "jamaica_labour_party": {
@@ -221,6 +227,12 @@
         "lang": "nb",
         "name": "Jamaica Labour Party",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.jamaicalabourparty.com",
+        "note": "website"
       }
     ]
   }

--- a/data/Nigeria/Assembly/ep-popolo-v1.0.json
+++ b/data/Nigeria/Assembly/ep-popolo-v1.0.json
@@ -7618,6 +7618,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.apc.com.ng/"
+        }
+      ],
       "name": "All Progressives Congress",
       "other_names": [
         {
@@ -7671,6 +7677,12 @@
         {
           "identifier": "Q1551163",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.peoplesdemocraticparty.net/"
         }
       ],
       "name": "Peoples Democratic Party",

--- a/data/Nigeria/Assembly/sources/wikidata/groups.json
+++ b/data/Nigeria/Assembly/sources/wikidata/groups.json
@@ -27,6 +27,12 @@
         "name": "All Progressives Congress",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.apc.com.ng/",
+        "note": "website"
+      }
     ]
   },
   "PDP": {
@@ -126,6 +132,12 @@
         "lang": "sr",
         "name": "Народна демократска странка",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.peoplesdemocraticparty.net/",
+        "note": "website"
       }
     ]
   }

--- a/data/Northern_Ireland/Assembly/ep-popolo-v1.0.json
+++ b/data/Northern_Ireland/Assembly/ep-popolo-v1.0.json
@@ -15307,6 +15307,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.allianceparty.org/"
+        }
+      ],
       "name": "Alliance",
       "other_names": [
         {
@@ -15418,6 +15424,12 @@
         {
           "identifier": "Q215519",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.mydup.com/"
         }
       ],
       "name": "DUP",
@@ -15603,6 +15615,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.greenpartyni.org"
+        }
+      ],
       "name": "Green",
       "other_names": [
         {
@@ -15719,6 +15737,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.pupni.com/"
+        }
+      ],
       "name": "PUP",
       "other_names": [
         {
@@ -15765,6 +15789,12 @@
         {
           "identifier": "Q76382",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.sinnfein.ie/"
         }
       ],
       "name": "Sinn Féin",
@@ -16070,6 +16100,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.sdlp.ie"
+        }
+      ],
       "name": "Social Democratic and Labour Party",
       "other_names": [
         {
@@ -16233,6 +16269,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.tuv.org.uk/"
+        }
+      ],
       "name": "Traditional Unionist Voice",
       "other_names": [
         {
@@ -16350,6 +16392,12 @@
         {
           "identifier": "Q841045",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.uup.org/"
         }
       ],
       "name": "UUP",

--- a/data/Northern_Ireland/Assembly/sources/wikidata/groups.json
+++ b/data/Northern_Ireland/Assembly/sources/wikidata/groups.json
@@ -177,6 +177,12 @@
         "name": "המפלגה היוניוניסטית הדמוקרטית",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.mydup.com/",
+        "note": "website"
+      }
     ]
   },
   "sinn-fein": {
@@ -477,6 +483,12 @@
         "name": "சின் பெயின்",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.sinnfein.ie/",
+        "note": "website"
+      }
     ]
   },
   "uup": {
@@ -611,6 +623,12 @@
         "lang": "el",
         "name": "Ενωτικό Κόμμα του Όλστερ",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.uup.org/",
+        "note": "website"
       }
     ]
   },
@@ -767,6 +785,12 @@
         "name": "Partido Social Democrata e Trabalhista",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.sdlp.ie",
+        "note": "website"
+      }
     ]
   },
   "alliance": {
@@ -877,6 +901,12 @@
         "name": "Alliance Party of Northern Ireland",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.allianceparty.org/",
+        "note": "website"
+      }
     ]
   },
   "ukup": {
@@ -967,6 +997,12 @@
         "name": "An Páirtí Aontachtach Forásach",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.pupni.com/",
+        "note": "website"
+      }
     ]
   },
   "uuap": {
@@ -1052,6 +1088,12 @@
         "name": "Green Party in Northern Ireland",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.greenpartyni.org",
+        "note": "website"
+      }
     ]
   },
   "niwc": {
@@ -1111,6 +1153,12 @@
         "lang": "sv",
         "name": "Traditional Unionist Voice",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.tuv.org.uk/",
+        "note": "website"
       }
     ]
   }

--- a/data/Norway/Storting/ep-popolo-v1.0.json
+++ b/data/Norway/Storting/ep-popolo-v1.0.json
@@ -96594,6 +96594,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://arbeiderpartiet.no/"
+        }
+      ],
       "name": "Arbeiderpartiet",
       "other_names": [
         {
@@ -96938,6 +96944,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.frp.no/"
+        }
+      ],
       "name": "Fremskrittspartiet",
       "other_names": [
         {
@@ -97114,6 +97126,12 @@
         {
           "identifier": "Q586364",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.hoyre.no/"
         }
       ],
       "name": "Høyre",
@@ -97299,6 +97317,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.krf.no/"
+        }
+      ],
       "name": "Kristelig Folkeparti",
       "other_names": [
         {
@@ -97442,6 +97466,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.kystpartiet.no/"
+        }
+      ],
       "name": "Kystpartiet",
       "other_names": [
         {
@@ -97508,6 +97538,12 @@
         {
           "identifier": "Q1518568",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.mdg.no/"
         }
       ],
       "name": "Miljøpartiet De Grønne",
@@ -97611,6 +97647,12 @@
         {
           "identifier": "Q587803",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.nkp.no/"
         }
       ],
       "name": "Norges Kommunistiske Parti",
@@ -97747,6 +97789,12 @@
         {
           "identifier": "Q493685",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.senterpartiet.no"
         }
       ],
       "name": "Senterpartiet",
@@ -97968,6 +98016,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.sv.no/Language/English"
+        }
+      ],
       "name": "Sosialistisk Venstreparti",
       "other_names": [
         {
@@ -98141,6 +98195,12 @@
         {
           "identifier": "Q500190",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.venstre.no/"
         }
       ],
       "name": "Venstre",

--- a/data/Norway/Storting/sources/wikidata/groups.json
+++ b/data/Norway/Storting/sources/wikidata/groups.json
@@ -262,6 +262,12 @@
         "name": "Norse Labour Pairty",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://arbeiderpartiet.no/",
+        "note": "website"
+      }
     ]
   },
   "H": {
@@ -442,6 +448,12 @@
         "name": "Olgešbellodat",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.hoyre.no/",
+        "note": "website"
+      }
     ]
   },
   "KrF": {
@@ -582,6 +594,12 @@
         "name": "Kristelig Folkeparti (KrF)",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.krf.no/",
+        "note": "website"
+      }
     ]
   },
   "Sp": {
@@ -716,6 +734,12 @@
         "lang": "cs",
         "name": "Senterpartiet",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.senterpartiet.no",
+        "note": "website"
       }
     ]
   },
@@ -892,6 +916,12 @@
         "name": "挪威進步黨",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.frp.no/",
+        "note": "website"
+      }
     ]
   },
   "V": {
@@ -1047,6 +1077,12 @@
         "name": "Venstre",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.venstre.no/",
+        "note": "website"
+      }
     ]
   },
   "SV": {
@@ -1197,6 +1233,12 @@
         "name": "사회주의 좌파당",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.sv.no/Language/English",
+        "note": "website"
+      }
     ]
   },
   "SVf": {
@@ -1301,6 +1343,12 @@
         "lang": "zh",
         "name": "挪威共产党",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.nkp.no/",
+        "note": "website"
       }
     ]
   },
@@ -1497,6 +1545,12 @@
         "name": "Factio viridis",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.mdg.no/",
+        "note": "website"
+      }
     ]
   },
   "FFF": {
@@ -1596,6 +1650,12 @@
         "lang": "nb",
         "name": "Kystpartiet",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.kystpartiet.no/",
+        "note": "website"
       }
     ]
   },

--- a/data/Pakistan/Assembly/ep-popolo-v1.0.json
+++ b/data/Pakistan/Assembly/ep-popolo-v1.0.json
@@ -9056,6 +9056,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://awaminationalparty.org/news/index.php"
+        }
+      ],
       "name": "ANP",
       "other_names": [
         {
@@ -9122,6 +9128,12 @@
         {
           "identifier": "Q3130113",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.apmlpak.com/"
         }
       ],
       "name": "APML",
@@ -9266,6 +9278,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.mqm.org"
+        }
+      ],
       "name": "MQM",
       "other_names": [
         {
@@ -9332,6 +9350,12 @@
         {
           "identifier": "Q13219795",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.nationalparty.org.pk"
         }
       ],
       "name": "NP",
@@ -9440,6 +9464,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.pml.org.pk/pml-minorities.php"
+        }
+      ],
       "name": "PML",
       "other_names": [
         {
@@ -9521,6 +9551,12 @@
         {
           "identifier": "Q799577",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.pmln.org/home/"
         }
       ],
       "name": "PML(N)",
@@ -9710,6 +9746,12 @@
         {
           "identifier": "Q186591",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.ppp.org.pk/"
         }
       ],
       "name": "PPPP",
@@ -10008,6 +10050,12 @@
         {
           "identifier": "Q284454",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.insaf.pk"
         }
       ],
       "name": "PTI",

--- a/data/Pakistan/Assembly/sources/wikidata/groups.json
+++ b/data/Pakistan/Assembly/sources/wikidata/groups.json
@@ -117,6 +117,12 @@
         "name": "Pákistánská muslimská liga",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.pmln.org/home/",
+        "note": "website"
+      }
     ]
   },
   "pppp": {
@@ -412,6 +418,12 @@
         "name": "ਪਾਕਿਸਤਾਨ ਪੀਪਲਜ਼ ਪਾਰਟੀ",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.ppp.org.pk/",
+        "note": "website"
+      }
     ]
   },
   "pti": {
@@ -507,6 +519,12 @@
         "name": "پاڪستان تحريڪ انصاف",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.insaf.pk",
+        "note": "website"
+      }
     ]
   },
   "mqm": {
@@ -571,6 +589,12 @@
         "lang": "ml",
         "name": "എം ക്യു എം",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.mqm.org",
+        "note": "website"
       }
     ]
   },
@@ -757,6 +781,12 @@
         "name": "巴基斯坦穆斯林联盟（领袖派）",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.pml.org.pk/pml-minorities.php",
+        "note": "website"
+      }
     ]
   },
   "anp": {
@@ -822,6 +852,12 @@
         "name": "アワーミー国民党",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://awaminationalparty.org/news/index.php",
+        "note": "website"
+      }
     ]
   },
   "pmlz": {
@@ -881,6 +917,12 @@
         "lang": "pnb",
         "name": "نیشنل پارٹی",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.nationalparty.org.pk",
+        "note": "website"
       }
     ]
   },
@@ -1051,6 +1093,12 @@
         "lang": "bn",
         "name": "নিখিল পাকিস্তান মুসলিম লীগ",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.apmlpak.com/",
+        "note": "website"
       }
     ]
   }

--- a/data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json
+++ b/data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json
@@ -4226,6 +4226,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.pnppr.com"
+        }
+      ],
       "name": "PNP",
       "other_names": [
         {
@@ -4292,6 +4298,12 @@
         {
           "identifier": "Q199319",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.ppdpr.net/"
         }
       ],
       "name": "PPD",

--- a/data/Puerto_Rico/House_of_Representatives/sources/wikidata/groups.json
+++ b/data/Puerto_Rico/House_of_Representatives/sources/wikidata/groups.json
@@ -62,6 +62,12 @@
         "name": "Partit Nou Progressista",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.pnppr.com",
+        "note": "website"
+      }
     ]
   },
   "ppd": {
@@ -121,6 +127,12 @@
         "lang": "ca",
         "name": "Partit Popular Democràtic",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.ppdpr.net/",
+        "note": "website"
       }
     ]
   }

--- a/data/Russia/Duma/ep-popolo-v1.0.json
+++ b/data/Russia/Duma/ep-popolo-v1.0.json
@@ -9473,6 +9473,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://er.ru/"
+        }
+      ],
       "name": "«ЕДИНАЯ РОССИЯ»",
       "other_names": [
         {
@@ -9831,6 +9837,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.spravedlivo.ru/"
+        }
+      ],
       "name": "«СПРАВЕДЛИВАЯ РОССИЯ»",
       "other_names": [
         {
@@ -10047,6 +10059,12 @@
         {
           "identifier": "Q192187",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://kprf.ru"
         }
       ],
       "name": "КПРФ",
@@ -10320,6 +10338,12 @@
         {
           "identifier": "Q212115",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.ldpr.ru"
         }
       ],
       "name": "ЛДПР",

--- a/data/Russia/Duma/sources/wikidata/groups.json
+++ b/data/Russia/Duma/sources/wikidata/groups.json
@@ -352,6 +352,12 @@
         "name": "Адзіная Расея",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://er.ru/",
+        "note": "website"
+      }
     ]
   },
   "КПРФ": {
@@ -622,6 +628,12 @@
         "name": "რუსეთის ფედერაციის კომუნისტური პარტია",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://kprf.ru",
+        "note": "website"
+      }
     ]
   },
   "«СПРАВЕДЛИВАЯ_РОССИЯ»": {
@@ -836,6 +848,12 @@
         "lang": "tr",
         "name": "Sadece Rusya",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.spravedlivo.ru/",
+        "note": "website"
       }
     ]
   },
@@ -1081,6 +1099,12 @@
         "lang": "hy",
         "name": "Ռուսաստանի Լիբերալ-դեմոկրատական կուսակցություն",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.ldpr.ru",
+        "note": "website"
       }
     ]
   }

--- a/data/Scotland/Parliament/ep-popolo-v1.0.json
+++ b/data/Scotland/Parliament/ep-popolo-v1.0.json
@@ -19141,6 +19141,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.scottishconservatives.com/"
+        }
+      ],
       "name": "Conservative",
       "other_names": [
         {
@@ -19187,6 +19193,12 @@
         {
           "identifier": "Q1256956",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.scottishgreens.org.uk/"
         }
       ],
       "name": "Green",
@@ -19302,6 +19314,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.scottishlabour.org.uk/"
+        }
+      ],
       "name": "Labour",
       "other_names": [
         {
@@ -19375,6 +19393,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.scotlibdems.org.uk/"
+        }
+      ],
       "name": "Liberal Democrat",
       "other_names": [
         {
@@ -19416,6 +19440,12 @@
         {
           "identifier": "Q975284",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.solidarityscotland.org/"
         }
       ],
       "name": "SG",
@@ -19467,6 +19497,12 @@
         {
           "identifier": "Q891900",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.scottishsocialistparty.org/"
         }
       ],
       "name": "SSP",
@@ -19550,6 +19586,12 @@
         {
           "identifier": "Q10658",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.snp.org/"
         }
       ],
       "name": "Scottish National Party",

--- a/data/Scotland/Parliament/sources/wikidata/groups.json
+++ b/data/Scotland/Parliament/sources/wikidata/groups.json
@@ -67,6 +67,12 @@
         "name": "Partido Laborista Escocés",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.scottishlabour.org.uk/",
+        "note": "website"
+      }
     ]
   },
   "scottish-national-party": {
@@ -437,6 +443,12 @@
         "name": "Partidul Național Scoțian",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.snp.org/",
+        "note": "website"
+      }
     ]
   },
   "conservative": {
@@ -482,6 +494,12 @@
         "name": "Parti conservateur écossais",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.scottishconservatives.com/",
+        "note": "website"
+      }
     ]
   },
   "liberal-democrat": {
@@ -516,6 +534,12 @@
         "lang": "nb",
         "name": "Scottish Liberal Democrats",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.scotlibdems.org.uk/",
+        "note": "website"
       }
     ]
   },
@@ -622,6 +646,12 @@
         "name": "Şotlandiya Yaşıllar Partiyası",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.scottishgreens.org.uk/",
+        "note": "website"
+      }
     ]
   },
   "ssp": {
@@ -702,6 +732,12 @@
         "name": "苏格兰社会党",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.scottishsocialistparty.org/",
+        "note": "website"
+      }
     ]
   },
   "sg": {
@@ -731,6 +767,12 @@
         "lang": "en",
         "name": "Solidarity",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.solidarityscotland.org/",
+        "note": "website"
       }
     ]
   },

--- a/data/Spain/Congress/ep-popolo-v1.0.json
+++ b/data/Spain/Congress/ep-popolo-v1.0.json
@@ -23417,6 +23417,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.ciu.cat/"
+        }
+      ],
       "name": "CiU",
       "other_names": [
         {
@@ -23600,6 +23606,12 @@
         {
           "identifier": "Q43093",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.eaj-pnv.eus"
         }
       ],
       "name": "EAJ-PNV",
@@ -23803,6 +23815,12 @@
         {
           "identifier": "Q185088",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.pp.es"
         }
       ],
       "name": "PP",
@@ -24118,6 +24136,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.psoe.es/"
+        }
+      ],
       "name": "PSOE",
       "other_names": [
         {
@@ -24429,6 +24453,12 @@
         {
           "identifier": "Q1144342",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.upyd.es"
         }
       ],
       "name": "UPyD",

--- a/data/Spain/Congress/sources/wikidata/groups.json
+++ b/data/Spain/Congress/sources/wikidata/groups.json
@@ -292,6 +292,12 @@
         "name": "พรรคประชาชน",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.pp.es",
+        "note": "website"
+      }
     ]
   },
   "5": {
@@ -597,6 +603,12 @@
         "name": "Partido dagiti Agtrabtrabaho a Sosialista nga Espaniol",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.psoe.es/",
+        "note": "website"
+      }
     ]
   },
   "9": {
@@ -767,6 +779,12 @@
         "name": "Convergència i Unió (CiU)",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.ciu.cat/",
+        "note": "website"
+      }
     ]
   },
   "3": {
@@ -926,6 +944,12 @@
         "lang": "pt-br",
         "name": "União, Progresso e Democracia",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.upyd.es",
+        "note": "website"
       }
     ]
   },
@@ -1091,6 +1115,12 @@
         "lang": "uk",
         "name": "Баскська націоналістична партія",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.eaj-pnv.eus",
+        "note": "website"
       }
     ]
   }

--- a/data/Sweden/Riksdag/ep-popolo-v1.0.json
+++ b/data/Sweden/Riksdag/ep-popolo-v1.0.json
@@ -25055,6 +25055,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.centerpartiet.se/"
+        }
+      ],
       "name": "Centerpartiet",
       "other_names": [
         {
@@ -25266,6 +25272,12 @@
         {
           "identifier": "Q110857",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.folkpartiet.se/"
         }
       ],
       "name": "Folkpartiet liberalerna",
@@ -25496,6 +25508,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.kristdemokraterna.se/"
+        }
+      ],
       "name": "Kristdemokraterna",
       "other_names": [
         {
@@ -25692,6 +25710,12 @@
         {
           "identifier": "Q213451",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.mp.se/"
         }
       ],
       "name": "Miljöpartiet de gröna",
@@ -25895,6 +25919,12 @@
         {
           "identifier": "Q110843",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.moderat.se"
         }
       ],
       "name": "Moderata samlingspartiet",
@@ -26165,6 +26195,12 @@
         {
           "identifier": "Q105112",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.socialdemokraterna.se/"
         }
       ],
       "name": "Socialdemokraterna",
@@ -26465,6 +26501,12 @@
           "scheme": "wikidata"
         }
       ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://sverigedemokraterna.se/"
+        }
+      ],
       "name": "Sverigedemokraterna",
       "other_names": [
         {
@@ -26661,6 +26703,12 @@
         {
           "identifier": "Q110837",
           "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.vansterpartiet.se/"
         }
       ],
       "name": "Vänsterpartiet",

--- a/data/Sweden/Riksdag/sources/wikidata/groups.json
+++ b/data/Sweden/Riksdag/sources/wikidata/groups.json
@@ -292,6 +292,12 @@
         "name": "Շվեդիայի սոցիալ-դեմոկրատական կուսակցություն",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.socialdemokraterna.se/",
+        "note": "website"
+      }
     ]
   },
   "M": {
@@ -547,6 +553,12 @@
         "name": "מפלגת אסיפת המתונים",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.moderat.se",
+        "note": "website"
+      }
     ]
   },
   "SD": {
@@ -741,6 +753,12 @@
         "lang": "uk",
         "name": "Шведські демократи",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://sverigedemokraterna.se/",
+        "note": "website"
       }
     ]
   },
@@ -941,6 +959,12 @@
         "lang": "fo",
         "name": "Miljöpartiet",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.mp.se/",
+        "note": "website"
       }
     ]
   },
@@ -1152,6 +1176,12 @@
         "name": "Centerpartiet",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.centerpartiet.se/",
+        "note": "website"
+      }
     ]
   },
   "V": {
@@ -1351,6 +1381,12 @@
         "lang": "li",
         "name": "Vänsterpartiet",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.vansterpartiet.se/",
+        "note": "website"
       }
     ]
   },
@@ -1572,6 +1608,12 @@
         "name": "Folkpartiet liberalerna",
         "note": "multilingual"
       }
+    ],
+    "links": [
+      {
+        "url": "http://www.folkpartiet.se/",
+        "note": "website"
+      }
     ]
   },
   "KD": {
@@ -1766,6 +1808,12 @@
         "lang": "li",
         "name": "Kristdemokraterna",
         "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.kristdemokraterna.se/",
+        "note": "website"
       }
     ]
   }

--- a/lib/wikidata_lookup.rb
+++ b/lib/wikidata_lookup.rb
@@ -39,6 +39,31 @@ class WikidataLookup
           note: 'multilingual'
         }
       end
-    }
+    }.merge(other_fields_for(result))
+  end
+
+  # to override in subclasses
+  def other_fields_for(result)
+    {}
   end
 end
+
+class GroupLookup < WikidataLookup
+
+  def other_fields_for(result)
+    {
+      links: links(result)
+    }.reject { |k, v| v.nil? }
+  end
+
+  def links(result)
+    url = result.P856 or return nil
+    return [
+      {
+        url: url.value,
+        note: "website",
+      }
+    ]
+  end
+end
+

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -113,7 +113,7 @@ namespace :merge_sources do
           IO.copy_stream(open(remote), i[:file])
         elsif c[:type] == 'group-wikidata'
           mapping = csv_table("sources/#{c[:source]}")
-          group_wikidata = WikidataLookup.new(mapping)
+          group_wikidata = GroupLookup.new(mapping)
           File.write(i[:file], JSON.pretty_generate(group_wikidata.to_hash))
         elsif c[:type] == 'area-wikidata'
           mapping = csv_table("sources/#{c[:source]}")


### PR DESCRIPTION
Where Wikidata has a URL to a Party/Faction website, include it in the 'links' section for the Organization.