### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # everypolitician-data
 
-This repo contains the data powering [EveryPolitician.org](http://everypolitician.org/), and other sites such as [Gender-Balance.org](gender-balance.org)
+This repo contains the data powering [EveryPolitician.org](http://everypolitician.org/), and other sites such as [Gender-Balance.org](http://www.gender-balance.org/).
 
 Information on how to _use_ the data can be found at http://everypolitician.org/technical.html, and high-level information about how to contribute is at http://everypolitician.org/contribute.html
 


### PR DESCRIPTION
The link to gender-balance.org is missing `http`, which means it clicking on it will lead the user to [a 404 page on GitHub](https://github.com/everypolitician/everypolitician-data/blob/master/gender-balance.org), and not the site.