### PR TITLE
Combine "Skip" and "No matches" buttons

### DIFF
--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -44,8 +44,7 @@
                 <div class="column-6 pairing__choices">
                     <h2>Potential matches from existing data</h2>
                     {{ existingPersonHTML }}
-                    <div class="no-matches">None of these match</div>
-                    <div class="skip-person">Skip for now</div>
+                    <div class="skip">None of these match</div>
                 </div>
             </div>
         </div>

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -135,7 +135,7 @@ jQuery(function($) {
   });
 
   $(document).on('keydown', function(e){
-    if(e.which == 48){
+    if(e.which == 39){
       var $choice = $('.pairing:visible .skip');
       vote($choice);
     } else if(e.which > 48 && e.which < 58){

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -19,12 +19,10 @@ var vote = function vote($choice){
   var incomingPersonID = $('.pairing__incoming .person', $pairing).attr('data-id');
   var vote = [];
 
-  if($choice.is('.skip-person')) {
+  if($choice.is('.skip')) {
     // Insert a null value to indicate skip, these are removed when
     // serializing to CSV.
     window.votes.push( null );
-  } else if($choice.is('.no-matches')){
-    window.votes.push( [incomingPersonID, null] );
   } else {
     window.votes.push( [incomingPersonID, $choice.attr('data-uuid')] );
   }
@@ -137,11 +135,8 @@ jQuery(function($) {
   });
 
   $(document).on('keydown', function(e){
-    if(e.which == 39){
-      var $choice = $('.pairing:visible .skip-person');
-      vote($choice);
-    } else if(e.which == 48){
-      var $choice = $('.pairing:visible .no-matches');
+    if(e.which == 48){
+      var $choice = $('.pairing:visible .skip');
       vote($choice);
     } else if(e.which > 48 && e.which < 58){
       var $choice = $('.pairing:visible .pairing__choices .person').eq(e.which - 49);

--- a/templates/sass/_styles.scss
+++ b/templates/sass/_styles.scss
@@ -154,7 +154,7 @@ h2 {
 
   .skip {
     &:before {
-      content: "0";
+      content: "\2794";
     }
   }
 

--- a/templates/sass/_styles.scss
+++ b/templates/sass/_styles.scss
@@ -152,21 +152,14 @@ h2 {
     }
   }
 
-  .no-matches {
+  .skip {
     &:before {
       content: "0";
     }
   }
 
-  .skip-person {
-    &:before {
-      content: '\2794';
-    }
-  }
-
   .person,
-  .no-matches,
-  .skip-person {
+  .skip {
     position: relative;
     background-color: #fff;
     border: none;


### PR DESCRIPTION
The new unified "No matches" button does what the old "Skip" button used to do (ie: adds a null row to window.votes, which is skipped by the CSV compiler).

Fixes everypolitician/everypolitician#216.

![screen shot 2015-12-01 at 12 19 52](https://cloud.githubusercontent.com/assets/57483/11500582/e586cce0-9825-11e5-97b1-c0798077342e.png)
