### PR TITLE
Colour-code existing matches based on match strength

### DIFF
--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -62,11 +62,15 @@
       {% } %}
           {% if (person.matchStrength) { %}
             <header class="person__meta">
-              <div class="person__match-strength">{{ person.matchStrength }}% match</div>
+              <h1>
+                {{ person[field] || person.name }}
+                <span class="person__match-strength">{{ person.matchStrength }}% match</span>
+              </h1>
               <div class="progress-bar"><div style="width: {{ person.matchStrength }}%"></div></div>
             </header>
-          {% } %}
+          {% } else { %}
             <h1>{{ person[field] || person.name }}</h1>
+          {% } %}
             <dl>
               {% fields.forEach(function(field) { %}
                 {% if(field !== 'id' && person[field]){ %}

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -54,7 +54,7 @@
 
     <script type="text/html" id="person">
       {% if(person.uuid){ %}
-        <div class="person" data-uuid="{{ person.uuid }}">
+        <div class="person {{ person.matchStrength }}" data-uuid="{{ person.uuid }}">
       {% } else if(person.id){ %}
         <div class="person" data-id="{{ person.id }}">
       {% } %}

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -46,7 +46,9 @@
                 <div class="column-6 pairing__choices">
                     <h2>Potential matches from existing data</h2>
                     {{ existingPersonHTML }}
-                    <div class="skip">None of these match</div>
+                    <div class="skip">
+                      <header class="person__meta">None of these match</header>
+                    </div>
                 </div>
             </div>
         </div>
@@ -54,10 +56,16 @@
 
     <script type="text/html" id="person">
       {% if(person.uuid){ %}
-        <div class="person {{ person.matchStrength }}" data-uuid="{{ person.uuid }}">
+        <div class="person" data-uuid="{{ person.uuid }}">
       {% } else if(person.id){ %}
         <div class="person" data-id="{{ person.id }}">
       {% } %}
+          {% if (person.matchStrength) { %}
+            <header class="person__meta">
+              <div class="person__match-strength">{{ person.matchStrength }}% match</div>
+              <div class="progress-bar"><div style="width: {{ person.matchStrength }}%"></div></div>
+            </header>
+          {% } %}
             <h1>{{ person[field] || person.name }}</h1>
             <dl>
               {% fields.forEach(function(field) { %}

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -103,7 +103,7 @@ jQuery(function($) {
     var existingPerson = match.existing[0][0];
 
     // Skip exact matches for now
-    if (incomingPerson[incomingField].toLowerCase() == existingPerson[existingField].toLowerCase()) {
+    if (incomingPerson[window.incomingField].toLowerCase() == existingPerson[window.existingField].toLowerCase()) {
       return;
     }
     var incomingPersonFields = _.filter(Object.keys(incomingPerson), function(field) {
@@ -111,8 +111,19 @@ jQuery(function($) {
     });
     var existingPersonHTML = _.map(match.existing, function(existing) {
       var person = existing[0];
+      if(existing[1] > 0.9){
+        person.matchStrength = 'person--strong-match'
+      } else if(existing[1] > 0.6) {
+        person.matchStrength = 'person--medium-match'
+      } else {
+        person.matchStrength = 'person--weak-match'
+      }
       var fields = _.intersection(incomingPersonFields, Object.keys(person));
-      return renderTemplate('person', { person: person, field: existingField, fields: fields });
+      return renderTemplate('person', {
+        person: person,
+        field: window.existingField,
+        fields: fields
+      });
     });
 
     var fields = match.existing.map(function(existing) {
@@ -126,7 +137,7 @@ jQuery(function($) {
       existingPersonHTML: existingPersonHTML.join("\n"),
       incomingPersonHTML: renderTemplate('person', {
         person: incomingPerson,
-        field: incomingField,
+        field: window.incomingField,
         fields: commonFields
       })
     });

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -39,7 +39,7 @@ var vote = function vote($choice){
 
 var updateProgressBar = function updateProgressBar(){
   var progress = window.votes.length / $('.pairing').length * 100;
-  $('.progress-bar div').animate({
+  $('.progress .progress-bar div').animate({
     width: '' + progress + '%'
   }, 100);
 }
@@ -92,7 +92,7 @@ var updateUndoButton = function updateUndoButton(){
 jQuery(function($) {
   if(matches.length == 0){
     $('.messages').append('<h1>Nothing to reconcile!</h1>');
-    $('.progress-bar div').animate({
+    $('.progress .progress-bar div').animate({
       width: '100%'
     }, 500);
     updateUndoButton();
@@ -111,13 +111,7 @@ jQuery(function($) {
     });
     var existingPersonHTML = _.map(match.existing, function(existing) {
       var person = existing[0];
-      if(existing[1] > 0.9){
-        person.matchStrength = 'person--strong-match'
-      } else if(existing[1] > 0.6) {
-        person.matchStrength = 'person--medium-match'
-      } else {
-        person.matchStrength = 'person--weak-match'
-      }
+      person.matchStrength = Math.ceil(existing[1] * 100);
       var fields = _.intersection(incomingPersonFields, Object.keys(person));
       return renderTemplate('person', {
         person: person,

--- a/templates/sass/_styles.scss
+++ b/templates/sass/_styles.scss
@@ -139,6 +139,47 @@ h2 {
   }
 }
 
+.skip {
+  padding: 2em;
+  background-color: #fff;
+}
+
+.person__meta {
+  position: relative;
+  padding-left: 3em;
+  margin-bottom: 1.5em;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  &:before {
+    font-size: 3em;
+    line-height: 1em;
+    display: block;
+    position: absolute;
+    top: 50%;
+    left: 0;
+    margin-top: -0.5em;
+    color: $color_off_white;
+    text-shadow: 0 -1px 0 $color_light_grey;
+    font-weight: bold;
+  }
+
+  .progress-bar {
+    background-color: $color_off_white;
+    box-shadow: inset 0 1px 0 $color_light_grey;
+    margin-top: 0.5em;
+  }
+}
+
+.person__match-strength {
+  color: darken($color_green, 5%);
+  font-weight: bold;
+  font-size: 0.8em;
+  text-transform: uppercase;
+}
+
 .pairing {
   padding: 2em;
 }
@@ -146,67 +187,32 @@ h2 {
 .pairing__choices {
   counter-reset: choices;
 
+  .person,
+  .skip {
+    box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+    margin-bottom: 2em;
+    cursor: pointer;
+
+    &:hover {
+      position: relative;
+      top: -1px;
+      box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+    }
+  }
+
   .person {
-    &:before {
+    .person__meta:before {
       counter-increment: choices;
       content: counter(choices);
     }
   }
 
   .skip {
-    &:before {
+    .person__meta:before {
       content: "\2794";
+      left: -0.2em; // the arrow is wider than the numbers, so give it more space
     }
   }
-
-  .person,
-  .skip {
-    position: relative;
-    background-color: #fff;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.2);
-    margin-bottom: 2em;
-    padding: 2em 4em 2em 2em;
-    cursor: pointer;
-
-    &:hover {
-      box-shadow: 0 4px 10px rgba(0,0,0,0.1);
-      top: -1px;
-    }
-
-    &:before {
-      font-size: 3em;
-      line-height: 1em;
-      display: block;
-      position: absolute;
-      top: 50%;
-      right: 0.33em;
-      margin-top: -0.5em;
-      color: $color_off_white;
-      text-shadow: 0 -1px 0 $color_light_grey;
-      font-weight: bold;
-    }
-  }
-}
-
-.person--weak-match {
-  border-left: 0.3em solid $color_grey;
-  color: $color_grey;
-
-  dt {
-    color: $color_light_grey;
-  }
-
-  img {
-    opacity: 0.7;
-  }
-}
-
-.person--medium-match {
-  border-left: 0.3em solid $color_mustard_yellow;
-}
-
-.person--strong-match {
-  border-left: 0.3em solid $color_green;
 }
 
 .messages {

--- a/templates/sass/_styles.scss
+++ b/templates/sass/_styles.scss
@@ -160,24 +160,29 @@ h2 {
     position: absolute;
     top: 50%;
     left: 0;
-    margin-top: -0.5em;
+    margin-top: -0.45em;
     color: $color_off_white;
     text-shadow: 0 -1px 0 $color_light_grey;
     font-weight: bold;
   }
 
+  h1 {
+    margin-bottom: 0.3em;
+  }
+
   .progress-bar {
     background-color: $color_off_white;
     box-shadow: inset 0 1px 0 $color_light_grey;
-    margin-top: 0.5em;
+    margin-top: 0;
   }
 }
 
 .person__match-strength {
   color: darken($color_green, 5%);
   font-weight: bold;
-  font-size: 0.8em;
+  font-size: 0.5em;
   text-transform: uppercase;
+  margin-left: 0.2em;
 }
 
 .pairing {

--- a/templates/sass/_styles.scss
+++ b/templates/sass/_styles.scss
@@ -103,6 +103,12 @@ h2 {
 
 .person {
   padding: 2em;
+  background-color: #fff;
+
+  .pairing__incoming & {
+    background-color: mix(#fff, $color_off_white, 60%);
+    border: 1px solid $color_light_grey;
+  }
 
   h1 {
     margin: 0 0 0.5em 0;
@@ -135,11 +141,6 @@ h2 {
 
 .pairing {
   padding: 2em;
-
-  .person {
-    background-color: mix(#fff, $color_off_white, 60%);
-    border: 1px solid $color_light_grey;
-  }
 }
 
 .pairing__choices {
@@ -162,7 +163,6 @@ h2 {
   .skip {
     position: relative;
     background-color: #fff;
-    border: none;
     box-shadow: 0 1px 3px rgba(0,0,0,0.2);
     margin-bottom: 2em;
     padding: 2em 4em 2em 2em;
@@ -186,6 +186,27 @@ h2 {
       font-weight: bold;
     }
   }
+}
+
+.person--weak-match {
+  border-left: 0.3em solid $color_grey;
+  color: $color_grey;
+
+  dt {
+    color: $color_light_grey;
+  }
+
+  img {
+    opacity: 0.7;
+  }
+}
+
+.person--medium-match {
+  border-left: 0.3em solid $color_mustard_yellow;
+}
+
+.person--strong-match {
+  border-left: 0.3em solid $color_green;
 }
 
 .messages {


### PR DESCRIPTION
We use the Dice coefficient for each match to highlight strong matches, and de-emphasise weak matches. Middling matches (0.6-0.9) are pulled out in yellow.

![screen shot 2015-12-01 at 16 22 20](https://cloud.githubusercontent.com/assets/739624/11506585/1019191e-9848-11e5-8f2e-86f8c4d3e33b.png)

Fixes everypolitician/everypolitician#201.