### PR TITLE
Reconciler: show matching fields as green or red

### DIFF
--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -79,7 +79,15 @@
                   {% if (field == 'image') { %}
                     <img src="{{ person[field] }}" width="150">
                   {% } else { %}
-                    {{ person[field] }}
+                    {% if (comparison) { %} 
+                      {% if (comparison[field] == person[field]) { %} 
+                        <span class="match">{{ person[field] }}</span>
+                      {% } else { %}
+                        <span class="nomatch">{{ person[field] }}</span>
+                      {% } %}
+                    {% } else { %}
+                      {{ person[field] }} 
+                    {% } %}
                   {% } %}
                   </dd>
                 {% } %}

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -144,15 +144,18 @@ jQuery(function($) {
     if (incomingPerson[window.incomingField].toLowerCase() == existingPerson[window.existingField].toLowerCase()) {
       return;
     }
+
     var incomingPersonFields = _.filter(Object.keys(incomingPerson), function(field) {
       return incomingPerson[field];
     });
+
     var existingPersonHTML = _.map(match.existing, function(existing) {
       var person = existing[0];
       person.matchStrength = Math.ceil(existing[1] * 100);
       var fields = _.intersection(incomingPersonFields, Object.keys(person));
       return renderTemplate('person', {
         person: person,
+        comparison: incomingPerson,
         field: window.existingField,
         fields: fields
       });
@@ -169,6 +172,7 @@ jQuery(function($) {
       existingPersonHTML: existingPersonHTML.join("\n"),
       incomingPersonHTML: renderTemplate('person', {
         person: incomingPerson,
+        comparison: null,
         field: window.incomingField,
         fields: commonFields
       })

--- a/templates/sass/_styles.scss
+++ b/templates/sass/_styles.scss
@@ -137,6 +137,14 @@ h2 {
   dd:last-child {
     margin-bottom: 0;
   }
+
+  .match { 
+    background-color: #cf9;
+  }
+
+  .nomatch { 
+    background-color: #f99;
+  }
 }
 
 .skip {


### PR DESCRIPTION
When reconciling, show whether each field matches or not, to make it easier to scan for errors.

![screen shot 2015-12-04 at 15 05 54](https://cloud.githubusercontent.com/assets/57483/11593178/bb7fa80a-9a9a-11e5-947a-492a49bb1641.png)

Closes https://github.com/everypolitician/everypolitician/issues/234
