### PR TITLE
Rebuild any sources in REBUILD_SOURCE

### DIFF
--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -74,9 +74,15 @@ namespace :merge_sources do
     open(url).read
   end
 
+  def _should_refetch(file)
+    return true unless File.exist?(file)
+    return false unless ENV['REBUILD_SOURCE']
+    return file.include? ENV['REBUILD_SOURCE']
+  end
+
   def fetch_missing
     @recreatable.each do |i|
-      unless File.exist? i[:file]
+      if _should_refetch(i[:file])
         c = i[:create]
         FileUtils.mkpath File.dirname i[:file]
         warn "Regenerating #{i[:file]}"


### PR DESCRIPTION
Currently the two main approaches to rebuilding the data for a
legislature are:

  * bundle exec rake clean default
  * bundle exec rake clobber default

The first simply regenerates the output based on the data previously
fetched from all the individual sources (in `instructions.json`)

The second re-fetches all of those sources first.

It would sometimes be useful to have more fine-grained control, so that
we could, for example, re-fetch _only_ the parlparse data for the UK,
rather than the Wikidata. This would allow us to have some updates that
are 'trusted', and so could be merged automatically, without risk of
unwanted changes from other sources sneaking in.

Here we introduce an environment variable REBUILD_SOURCE. If this is
set, any source which includes the string set in that variable will be
rebuilt. This is slightly implementation-dependent, as it depends on the
filename to which we happen to write the fetched file, rather than a
more abstract 'name' for the source, (and means that setting it
something like "/" would rebuild everything), but this seems simpler
than having to change every `instructions.json` file to include a name
for each source. We can always add that later as something that could
also be checked, if required.

Example usage (UK):

```
  REBUILD_SOURCE=parlparse  bundle exec rake clean default
```
Closes https://github.com/everypolitician/everypolitician/issues/243