### PR TITLE
Reconciler: Highlight common words in the name

### DIFF
--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -68,14 +68,13 @@
       {% } %}
           {% if (person.matchStrength) { %}
             <header class="person__meta">
-              <h1>
-                {{ person[field] || person.name }}
+              <h1>{{ h1_name }}
                 <span class="person__match-strength">{{ person.matchStrength }}% match</span>
               </h1>
               <div class="progress-bar"><div style="width: {{ person.matchStrength }}%"></div></div>
             </header>
           {% } else { %}
-            <h1>{{ person[field] || person.name }}</h1>
+            <h1>{{ h1_name }}</h1>
           {% } %}
             <dl>
               {% fields.forEach(function(field) { %}

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -193,9 +193,19 @@ jQuery(function($) {
       var person = existing[0];
       person.matchStrength = Math.ceil(existing[1] * 100);
       var fields = _.intersection(incomingPersonFields, Object.keys(person));
+
+      var incomingNameWords = incomingPerson[window.incomingField].toLowerCase().split(/\s+/);
+      var markedName = _.map(person[window.existingField].split(/\s+/), function(word){
+        if (_.contains(incomingNameWords, word.toLowerCase())) { 
+          return '<span class="match">' + word + '</span>'
+        } else { 
+          return word
+        }
+      }).join(" ");
+      
       return renderTemplate('person', {
         person: person,
-        h1_name: person[window.existingField],
+        h1_name: markedName,
         comparison: incomingPerson,
         fields: fields
       });

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -195,8 +195,8 @@ jQuery(function($) {
       var fields = _.intersection(incomingPersonFields, Object.keys(person));
       return renderTemplate('person', {
         person: person,
+        h1_name: person[window.existingField],
         comparison: incomingPerson,
-        field: window.existingField,
         fields: fields
       });
     });
@@ -212,8 +212,8 @@ jQuery(function($) {
       existingPersonHTML: existingPersonHTML.join("\n"),
       incomingPersonHTML: renderTemplate('person', {
         person: incomingPerson,
+        h1_name: incomingPerson[window.incomingField],
         comparison: null,
-        field: window.incomingField,
         fields: commonFields
       })
     });


### PR DESCRIPTION
Highlight individual words in the 'name' field (or equivalent) for each
match that also exist in the original record. This will make it easier
to see differences, especially in different alphabets

![screen shot 2015-12-24 at 12 44 49](https://cloud.githubusercontent.com/assets/57483/11995217/d6ea159e-aa44-11e5-84d7-32ef7502dfd0.png)


Closes https://github.com/everypolitician/everypolitician/issues/262