### PR TITLE
Warn if GenderBalance differs from existing gender information

### DIFF
--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -299,14 +299,11 @@ namespace :merge_sources do
           next
         end
         next if winner.first == :skip
-        if r[:gender].to_s.empty?
-          r[:gender] = winner.first.to_s 
-          gb_votes += 1
-        else
-          if r[:gender] != winner.first.to_s
-            warn "Gender difference for #{r[:name]} (#{r[:uuid]}) — source: #{r[:gender]} | GB: #{winner.first.to_s}"
-          end
+        if !r[:gender].to_s.empty? && r[:gender] != winner.first.to_s
+          warn "Gender difference for #{r[:name]} (#{r[:uuid]}) — source: #{r[:gender]} | GB: #{winner.first.to_s}"
         end
+        r[:gender] = winner.first.to_s 
+        gb_votes += 1
       end
       puts "⚥ #{gb_votes}".cyan 
     end

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -291,7 +291,7 @@ namespace :merge_sources do
 
       # Only calculate the gender if we don't already have it
       # TODO: warn if the GB data differs from the pre-existing version
-      merged_rows.select { |r| r[:gender].to_s.empty? }.each do |r|
+      merged_rows.each do |r|
         votes = (gender[ r[:uuid] ] or next).first
         next if votes[:total].to_i < min_selections
         winner = votes.reject { |k, _| %i(uuid total).include? k }.find { |k, v| (v.to_f / votes[:total].to_f) > vote_threshold } or begin
@@ -299,8 +299,14 @@ namespace :merge_sources do
           next
         end
         next if winner.first == :skip
-        r[:gender] = winner.first.to_s 
-        gb_votes += 1
+        if r[:gender].to_s.empty?
+          r[:gender] = winner.first.to_s 
+          gb_votes += 1
+        else
+          if r[:gender] != winner.first.to_s
+            warn "Gender difference for #{r[:name]} (#{r[:uuid]}) — source: #{r[:gender]} | GB: #{winner.first.to_s}"
+          end
+        end
       end
       puts "⚥ #{gb_votes}".cyan 
     end

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -287,7 +287,7 @@ namespace :merge_sources do
       vote_threshold = 0.8 # and at least this ratio of votes were for it
 
       gender = CSV.table(gb[:file], converters: nil).group_by { |r| r[:uuid] }
-      gb_votes = 0
+      gb_votes = Set.new
 
       # Only calculate the gender if we don't already have it
       # TODO: warn if the GB data differs from the pre-existing version
@@ -303,9 +303,9 @@ namespace :merge_sources do
           warn "Gender difference for #{r[:name]} (#{r[:uuid]}) — source: #{r[:gender]} | GB: #{winner.first.to_s}"
         end
         r[:gender] = winner.first.to_s 
-        gb_votes += 1
+        gb_votes.add r[:uuid]
       end
-      puts "⚥ #{gb_votes}".cyan 
+      puts "⚥ #{gb_votes.count}".cyan 
     end
 
     # Map Areas


### PR DESCRIPTION
When merging GenderBalance information, prefer it over pre-existing sources, but warn if they differ.

We currently this for 9915 people, and it is reporting 10 differences, 9 of which seem to be errors in Wikidata:

* Belgium | Gilles Vanden Burre | wikidata: female | GB: male
* Denmark | Jan Erik Messmann | wikidata: female | GB: male
* Estonia | Terje Trei | wikidata: male | GB: female
* Estonia | Kadri Simson | wikidata: male | GB: female
* Finland | Lyly Rajala | wikidata: female | GB: male
* Sri Lanka | Thushara Indunil Amarasena | wikidata: female | GB: male
* Tanzania | Lolesia Jeremiah Maselle Bukwimba | wikidata: male | GB: female
* Tanzania | Waride Bakari Jabu | source: male | GB: female
* Tanzania | Faith Mohamed Mitambo | source: male | GB: female

However, we also have one case where GenderBalance gets it wrong:

* France | George Pau-Langevin | official: female | wikidata: female | GB: male

Currently we can't easily say that GenderBalance should be preferred
over Wikidata, but not over an official source, so we need to think
about how to best handle cases like this.