### PR TITLE
Reconciler: Add "Show me this card again later" option

### DIFF
--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -50,6 +50,9 @@
                     <div class="skip">
                       <header class="person__meta">None of these match</header>
                     </div>
+                    <div class="show-later">
+                      <header class="person__meta">Show me this card again later.</header>
+                    </div>
                 </div>
             </div>
         </div>

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -23,6 +23,10 @@ var vote = function vote($choice){
     // Insert a null value to indicate skip. 
     // These are removed when serializing to CSV.
     window.votes.push( [incomingPersonID, null] );
+  } else if ($choice.is('.show-later')) {
+    nextPairing($pairing);
+    $pairing.appendTo('.pairings');
+    return;
   } else {
     window.votes.push( [incomingPersonID, $choice.attr('data-uuid')] );
   }
@@ -161,6 +165,9 @@ var handleKeyPress = function handleKeyPress(e){
   if($('.pairing:visible').length && $('.csv').is(':hidden')){
     // right arrow
     if(e.which == 39){ return vote($('.pairing:visible .skip')); } 
+
+    // question mark
+    if(e.which == 191){ return vote($('.pairing:visible .show-later')); }
 
     // number key
     if(e.which > 48 && e.which < 58){

--- a/templates/sass/_styles.scss
+++ b/templates/sass/_styles.scss
@@ -147,7 +147,8 @@ h2 {
   }
 }
 
-.skip {
+.skip,
+.show-later {
   padding: 2em;
   background-color: #fff;
 }
@@ -201,7 +202,8 @@ h2 {
   counter-reset: choices;
 
   .person,
-  .skip {
+  .skip,
+  .show-later {
     box-shadow: 0 1px 3px rgba(0,0,0,0.2);
     margin-bottom: 2em;
     cursor: pointer;
@@ -224,6 +226,11 @@ h2 {
     .person__meta:before {
       content: "\2794";
       left: -0.2em; // the arrow is wider than the numbers, so give it more space
+    }
+  }
+  .show-later {
+    .person__meta:before {
+      content: "\003F";
     }
   }
 }


### PR DESCRIPTION

![screen shot 2016-01-14 at 09 53 53](https://cloud.githubusercontent.com/assets/22996/12321191/c4638ca0-baa4-11e5-8696-70f8a63b097d.png)


When there is an ambiguous match you might want to defer it until after
you've done the rest of the matching.

This change adds an option which can be activated with the '?' key, when
used this puts the card at the back of the stack so that it will be
shown again at the end of reconciliation.

Fixes https://github.com/everypolitician/everypolitician/issues/237