### PR TITLE
combine_sources: Speed up remap function

### DIFF
--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -151,11 +151,10 @@ namespace :merge_sources do
     start_date: %w(start started from since),
     term: %w(legislative_period),
     website: %w(homepage href url site),
-  }
-  REMAP_LOOKUP = {}
-  REMAP.each { |key, values| values.each { |value| REMAP_LOOKUP[value] = key } }
+  }.each_with_object({}) { |(k, vs), mapped| vs.each { |v| mapped[v] = k } }
+
   def remap(str)
-    REMAP_LOOKUP[str.to_s] || str.to_sym
+    REMAP[str.to_s] || str.to_sym
   end
 
   # http://codereview.stackexchange.com/questions/84290/combining-csvs-using-ruby-to-match-headers

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -152,8 +152,10 @@ namespace :merge_sources do
     term: %w(legislative_period),
     website: %w(homepage href url site),
   }
+  REMAP_LOOKUP = {}
+  REMAP.each { |key, values| values.each { |value| REMAP_LOOKUP[value] = key } }
   def remap(str)
-    REMAP.find(->{[str]}) { |k, v| v.include? str.to_s }.first.to_sym
+    REMAP_LOOKUP[str.to_s] || str.to_sym
   end
 
   # http://codereview.stackexchange.com/questions/84290/combining-csvs-using-ruby-to-match-headers


### PR DESCRIPTION
Wrapping the call to 'combine_sources' with stackprof revealed that this
was the most expensive method being called. This change optimizes it to
use a hash lookup, which seems to speed up rebuilding a country quite
significantly.