### PR TITLE
Report card for current terms

### DIFF
--- a/bin/current_term_info.rb
+++ b/bin/current_term_info.rb
@@ -1,0 +1,35 @@
+require 'json'
+require 'pry'
+require 'colorize'
+
+# Information about the current members of a given legislature
+
+def json_from(json_file)
+  JSON.parse(File.read(json_file), symbolize_names: true)
+end
+
+file = ARGV.first or abort "Usage: #$0 <popolo file>"
+@popolo = json_from(file)
+
+people = @popolo[:persons].group_by { |p| p[:id] }
+
+current_term = @popolo[:events].select { |e| e[:classification] == 'legislative period' }.sort_by { |e| e[:start_date] }.last[:id]
+current = @popolo[:memberships].select { |m| m[:legislative_period_id] == current_term && m[:end_date].to_s.empty? }.map { |m| people[ m[:person_id] ].first }
+total = current.count
+
+puts "TOTAL: #{total}".green
+
+totalise = ->(count) { "%s (%0.1f%%)" % [ count, count.to_f / total * 100 ] }
+has_column_value = ->(column) { current.partition { |p| !p[column.to_sym].to_s.empty? }.first.count }
+has_identifier = ->(type) { current.partition { |p| (p[:identifiers] || []).find { |i| i[:scheme] == type.to_s } }.first.count }
+has_link = ->(type) { current.partition { |p| (p[:links] || []).find { |i| i[:note].downcase == type.to_s.downcase } }.first.count }
+
+puts "Email: #{totalise.(has_column_value.(:email))}"
+puts "Facebook: #{totalise.(has_link.(:facebook))}"
+puts "Twitter: #{totalise.(has_link.(:twitter))}"
+puts "Wikidata: #{totalise.(has_identifier.(:wikidata))}"
+puts "Freebase: #{totalise.(has_identifier.(:freebase))}"
+puts "DOB: #{totalise.(has_column_value.(:birth_date))}"
+puts "Gender: #{totalise.(has_column_value.(:gender))}"
+puts "Image: #{totalise.(has_column_value.(:image))}"
+


### PR DESCRIPTION
Add a simple script to provide some stats on the data we have for
current members of a legislature.

This generates a report, for example for the UK, that tells us what % of
people have various fields filled currently:

e.g.

UK: 
* TOTAL: 650
* Email: 648 (99.7%)
* Facebook: 234 (36.0%)
* Twitter: 583 (89.7%)
* Wikidata: 649 (99.8%)
* Freebase: 62 (9.5%)
* DOB: 649 (99.8%)
* Gender: 649 (99.8%)
* Image: 637 (98.0%)

Estonia:
* TOTAL: 101
* Email: 101 (100.0%)
* Facebook: 0 (0.0%)
* Twitter: 1 (1.0%)
* Wikidata: 101 (100.0%)
* Freebase: 17 (16.8%)
* DOB: 101 (100.0%)
* Gender: 101 (100.0%)
* Image: 101 (100.0%)

Australia:
* TOTAL: 150
* Email: 150 (100.0%)
* Facebook: 127 (84.7%)
* Twitter: 0 (0.0%)
* Wikidata: 150 (100.0%)
* Freebase: 10 (6.7%)
* DOB: 149 (99.3%)
* Gender: 150 (100.0%)
* Image: 150 (100.0%)

Connected to https://github.com/everypolitician/everypolitician/issues/279