### PR TITLE
Simplify the Reconciler

### DIFF
--- a/lib/reconciliation/interface.rb
+++ b/lib/reconciliation/interface.rb
@@ -29,11 +29,8 @@ module Reconciliation
     end
 
     def need_reconciling
-      @need_reconciling ||= incoming_data.find_all do |d|
-        matcher.find_all(d).to_a.empty? && !previously_reconciled.any? do |r|
-          r[:id].to_s == d[:id]
-        end
-      end
+      done = Set.new(previously_reconciled.map { |r| r[:id].to_s })
+      incoming_data.reject { |r| done.include? r[:id].to_s }
     end
 
     def matched
@@ -42,10 +39,6 @@ module Reconciliation
 
     def fuzzer
       @fuzzer ||= Fuzzer.new(merged_rows, need_reconciling, merge_instructions)
-    end
-
-    def matcher
-      @matcher ||= Matcher::Reconciled.new(merged_rows, merge_instructions, previously_reconciled)
     end
   end
 end

--- a/lib/reconciliation/interface.rb
+++ b/lib/reconciliation/interface.rb
@@ -1,5 +1,5 @@
 module Reconciliation
-  # Interface for reconciling incoming data
+  # Produce an HTML interface for reconciling incoming data
   class Interface
     attr_reader :merged_rows
     attr_reader :incoming_data
@@ -13,16 +13,8 @@ module Reconciliation
       @merge_instructions = merge_instructions
     end
 
-    def generate!
-      return unless merge_instructions[:reconciliation_file]
-
-      FileUtils.mkdir_p(File.dirname(csv_file))
-      File.write(html_file, template.render)
-      if need_reconciling.any?
-        warn "#{need_reconciling.size} out of #{incoming_data.size} rows " \
-          'not reconciled'.red
-      end
-      return html_file
+    def html
+      template.render
     end
 
     private
@@ -42,19 +34,6 @@ module Reconciliation
           r[:id].to_s == d[:id]
         end
       end
-    end
-
-    def csv_file_exists?
-      csv_file && File.exist?(csv_file)
-    end
-
-    def csv_file
-      return unless merge_instructions[:reconciliation_file]
-      @csv_file ||= File.join('sources', merge_instructions[:reconciliation_file])
-    end
-
-    def html_file
-      @html_file ||= csv_file.gsub('.csv', '.html')
     end
 
     def matched

--- a/lib/reconciliation/interface.rb
+++ b/lib/reconciliation/interface.rb
@@ -21,7 +21,7 @@ module Reconciliation
 
     def template
       @template ||= Template.new(
-        matched: matched,
+        to_reconcile: to_reconcile,
         reconciled: previously_reconciled,
         incoming_field: merge_instructions[:incoming_field],
         existing_field: merge_instructions[:existing_field]
@@ -33,8 +33,8 @@ module Reconciliation
       incoming_data.reject { |r| done.include? r[:id].to_s }
     end
 
-    def matched
-      @matched ||= fuzzer.score_all.sort_by { |row| row[:existing].first[1] }.reverse
+    def to_reconcile
+      @to_reconcile ||= fuzzer.score_all.sort_by { |row| row[:existing].first[1] }.reverse
     end
 
     def fuzzer

--- a/lib/reconciliation/template.rb
+++ b/lib/reconciliation/template.rb
@@ -1,12 +1,12 @@
 module Reconciliation
   class Template
-    attr_reader :matched
+    attr_reader :to_reconcile
     attr_reader :reconciled
     attr_reader :incoming_field
     attr_reader :existing_field
 
     def initialize(opts)
-      @matched = opts[:matched]
+      @to_reconcile = opts[:to_reconcile]
       @reconciled = opts[:reconciled]
       @incoming_field = opts[:incoming_field]
       @existing_field = opts[:existing_field]

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -196,8 +196,9 @@ namespace :merge_sources do
           previously_reconciled = File.exist?(reconciliation_file) ? CSV.table(reconciliation_file, converters: nil) : CSV::Table.new([])
 
           if ENV['GENERATE_RECONCILIATION_INTERFACE']
-            reconciliation = Reconciliation::Interface.new(merged_rows, incoming_data, previously_reconciled, merge_instructions)
-            html_file = reconciliation.generate! 
+            html_file = reconciliation_file.sub('.csv', '.html')
+            interface = Reconciliation::Interface.new(merged_rows, incoming_data, previously_reconciled, merge_instructions)
+            File.write(html_file, interface.html)
             abort "Created #{html_file} — please check it and re-run".green 
           end
 

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -8,7 +8,7 @@
     <script>
       window.existingField = <%= Yajl::Encoder.encode(existing_field, html_safe: true) %>
       window.incomingField = <%= Yajl::Encoder.encode(incoming_field, html_safe: true) %>
-      window.toReconcile = <%= Yajl::Encoder.encode(matched, html_safe: true) %>;
+      window.toReconcile = <%= Yajl::Encoder.encode(to_reconcile, html_safe: true) %>;
       window.votes = [];
       window.autovotes = [];
       window.reconciled = <%= Yajl::Encoder.encode(reconciled.map(&:fields), html_safe: true) %>;


### PR DESCRIPTION
The Reconciliation Interface was responsible for too many things, making it difficult to reuse it in other places (e.g. for Membership as well as Person reconciliation). Simplify it.