### PR TITLE
Reconciler: Show full field name when hovering

### DIFF
--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -82,7 +82,7 @@
             <dl>
               {% fields.forEach(function(field) { %}
                 {% if(field !== 'id' && person[field]){ %}
-                  <dt>{{ field }}:</dt>
+                  <dt title="{{ field }}">{{ field }}:</dt>
                   <dd>
                   {% if (field == 'image') { %}
                     <img src="{{ person[field] }}" width="150">


### PR DESCRIPTION
Previously when a field name was truncated there was no way to see what the full field name was. This change adds a `title` tag to the `<dt>` so that the full field name appears on hover.

![screen shot 2016-01-25 at 10 14 49](https://cloud.githubusercontent.com/assets/22996/12548394/dbfd2ad6-c34d-11e5-8903-7648058241d4.png)

Fixes https://github.com/everypolitician/everypolitician/issues/295