### PR TITLE
Scotland: distinguish 'Independent' and 'None'

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -6925,9 +6925,9 @@
         "sources_directory": "data/Scotland/Parliament/sources",
         "popolo": "data/Scotland/Parliament/ep-popolo-v1.0.json",
         "names": "data/Scotland/Parliament/names.csv",
-        "lastmod": "1454149142",
+        "lastmod": "1454855863",
         "person_count": 254,
-        "sha": "5486983",
+        "sha": "99e218b",
         "legislative_periods": [
           {
             "id": "term/4",

--- a/data/Scotland/Parliament/ep-popolo-v1.0.json
+++ b/data/Scotland/Parliament/ep-popolo-v1.0.json
@@ -19622,156 +19622,13 @@
     {
       "classification": "party",
       "id": "independent",
-      "name": "Independent"
-    },
-    {
-      "classification": "party",
-      "id": "labour",
-      "identifiers": [
-        {
-          "identifier": "Q3179541",
-          "scheme": "wikidata"
-        }
-      ],
-      "links": [
-        {
-          "note": "website",
-          "url": "http://www.scottishlabour.org.uk/"
-        }
-      ],
-      "name": "Labour",
-      "other_names": [
-        {
-          "lang": "pl",
-          "name": "Szkocka Partia Pracy",
-          "note": "multilingual"
-        },
-        {
-          "lang": "gd",
-          "name": "Pàrtaidh Làbarach na h-Alba",
-          "note": "multilingual"
-        },
-        {
-          "lang": "fr",
-          "name": "Parti travailliste écossais",
-          "note": "multilingual"
-        },
-        {
-          "lang": "en",
-          "name": "Scottish Labour Party",
-          "note": "multilingual"
-        },
-        {
-          "lang": "ca",
-          "name": "Partit Laborista Escocès",
-          "note": "multilingual"
-        },
-        {
-          "lang": "de",
-          "name": "Schottische Arbeiterpartei",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Scottish Labour Party",
-          "note": "multilingual"
-        },
-        {
-          "lang": "zh",
-          "name": "苏格兰工党",
-          "note": "multilingual"
-        },
-        {
-          "lang": "cy",
-          "name": "Plaid Lafur yr Alban",
-          "note": "multilingual"
-        },
-        {
-          "lang": "da",
-          "name": "Scottish Labour Party",
-          "note": "multilingual"
-        },
-        {
-          "lang": "ru",
-          "name": "шотландская лейбористская партия",
-          "note": "multilingual"
-        },
-        {
-          "lang": "es",
-          "name": "Partido Laborista Escocés",
-          "note": "multilingual"
-        },
-        {
-          "lang": "eo",
-          "name": "Skota Laborista Partio",
-          "note": "multilingual"
-        }
-      ]
-    },
-    {
-      "classification": "party",
-      "id": "liberal-democrat",
-      "identifiers": [
-        {
-          "identifier": "Q3250438",
-          "scheme": "wikidata"
-        }
-      ],
-      "links": [
-        {
-          "note": "website",
-          "url": "http://www.scotlibdems.org.uk/"
-        }
-      ],
-      "name": "Liberal Democrat",
-      "other_names": [
-        {
-          "lang": "gd",
-          "name": "Pàrtaidh Libearal Deamocratach na h-Alba",
-          "note": "multilingual"
-        },
-        {
-          "lang": "en",
-          "name": "Scottish Liberal Democrats",
-          "note": "multilingual"
-        },
-        {
-          "lang": "ca",
-          "name": "Liberal Demòcrates Escocesos",
-          "note": "multilingual"
-        },
-        {
-          "lang": "pl",
-          "name": "Szkocka Partia Liberalnych Demokratów",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Scottish Liberal Democrats",
-          "note": "multilingual"
-        },
-        {
-          "lang": "fr",
-          "name": "Libéraux-démocrates écossais",
-          "note": "multilingual"
-        },
-        {
-          "lang": "eo",
-          "name": "Skotaj Liberalaj Demokratoj",
-          "note": "multilingual"
-        }
-      ]
-    },
-    {
-      "classification": "party",
-      "id": "none",
       "identifiers": [
         {
           "identifier": "Q327591",
           "scheme": "wikidata"
         }
       ],
-      "name": "None",
+      "name": "Independent",
       "other_names": [
         {
           "lang": "zh-hans",
@@ -20054,6 +19911,149 @@
           "note": "multilingual"
         }
       ]
+    },
+    {
+      "classification": "party",
+      "id": "labour",
+      "identifiers": [
+        {
+          "identifier": "Q3179541",
+          "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.scottishlabour.org.uk/"
+        }
+      ],
+      "name": "Labour",
+      "other_names": [
+        {
+          "lang": "pl",
+          "name": "Szkocka Partia Pracy",
+          "note": "multilingual"
+        },
+        {
+          "lang": "gd",
+          "name": "Pàrtaidh Làbarach na h-Alba",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Parti travailliste écossais",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Scottish Labour Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ca",
+          "name": "Partit Laborista Escocès",
+          "note": "multilingual"
+        },
+        {
+          "lang": "de",
+          "name": "Schottische Arbeiterpartei",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nb",
+          "name": "Scottish Labour Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh",
+          "name": "苏格兰工党",
+          "note": "multilingual"
+        },
+        {
+          "lang": "cy",
+          "name": "Plaid Lafur yr Alban",
+          "note": "multilingual"
+        },
+        {
+          "lang": "da",
+          "name": "Scottish Labour Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ru",
+          "name": "шотландская лейбористская партия",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Partido Laborista Escocés",
+          "note": "multilingual"
+        },
+        {
+          "lang": "eo",
+          "name": "Skota Laborista Partio",
+          "note": "multilingual"
+        }
+      ]
+    },
+    {
+      "classification": "party",
+      "id": "liberal-democrat",
+      "identifiers": [
+        {
+          "identifier": "Q3250438",
+          "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.scotlibdems.org.uk/"
+        }
+      ],
+      "name": "Liberal Democrat",
+      "other_names": [
+        {
+          "lang": "gd",
+          "name": "Pàrtaidh Libearal Deamocratach na h-Alba",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Scottish Liberal Democrats",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ca",
+          "name": "Liberal Demòcrates Escocesos",
+          "note": "multilingual"
+        },
+        {
+          "lang": "pl",
+          "name": "Szkocka Partia Liberalnych Demokratów",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nb",
+          "name": "Scottish Liberal Democrats",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Libéraux-démocrates écossais",
+          "note": "multilingual"
+        },
+        {
+          "lang": "eo",
+          "name": "Skotaj Liberalaj Demokratoj",
+          "note": "multilingual"
+        }
+      ]
+    },
+    {
+      "classification": "party",
+      "id": "none",
+      "name": "None"
     },
     {
       "classification": "party",

--- a/data/Scotland/Parliament/sources/manual/group_wikidata.csv
+++ b/data/Scotland/Parliament/sources/manual/group_wikidata.csv
@@ -8,4 +8,3 @@ ssp,Q891900
 sg,Q975284
 sscup,Q7437975
 independent,Q327591
-none,Q327591

--- a/data/Scotland/Parliament/sources/wikidata/groups.json
+++ b/data/Scotland/Parliament/sources/wikidata/groups.json
@@ -822,7 +822,7 @@
       }
     ]
   },
-  "none": {
+  "independent": {
     "identifiers": [
       {
         "scheme": "wikidata",

--- a/rake_helpers/generate_ep_popolo.rb
+++ b/rake_helpers/generate_ep_popolo.rb
@@ -90,14 +90,14 @@ namespace :transform do
   end
 
   #---------------------------------------------------------------------
-  # Remove all other memberships.
   # Don't duplicate start/end dates into memberships needlessly
   #   and ensure they're within the term
   #---------------------------------------------------------------------
   task :write => :tidy_memberships
   task :tidy_memberships => :ensure_term do
-    @json[:memberships].keep_if { |m| m[:role] == 'member' and m[:organization_id] == @legislature[:id] }.each do |m|
-      e = @json[:events].find { |e| e[:id] == m[:legislative_period_id] } or raise "#{m[:legislative_period_id]} is not a term"
+    @json[:memberships].each do |m|
+      e = @json[:events].find { |e| e[:id] == m[:legislative_period_id] } or abort "#{m[:legislative_period_id]} is not a term"
+
       m.delete :start_date if m[:start_date].to_s.empty? || (!e[:start_date].to_s.empty? && m[:start_date].to_s <= e[:start_date].to_s)
       m.delete :end_date   if m[:end_date].to_s.empty?   || (!e[:end_date].to_s.empty?   && m[:end_date].to_s   >= e[:end_date].to_s)
     end

--- a/rake_helpers/generate_ep_popolo.rb
+++ b/rake_helpers/generate_ep_popolo.rb
@@ -175,8 +175,8 @@ namespace :transform do
   task :group_wikidata => :load do
     instructions(:sources).find_all { |src| src[:type].to_s.downcase == 'group' }.each do |src|
       group_data = JSON.parse(File.read(src[:file]), symbolize_names: true)
-      @json[:organizations].each do |org|
-        next unless org[:classification] == 'party'
+      @json[:organizations].select { |o| o[:classification] == 'party' }.each do |org|
+
         # FIXME: This doesn't do a deep merge, so any nested arrays on 'org'
         # will be clobbered if they appear in 'group_data'.
         org.merge!(group_data.fetch(org[:id].sub(/^party\//, '').to_sym, {}))


### PR DESCRIPTION
A party of 'None' is used for the Presiding Officer, who has no alliances, and is slightly different from being an Independent.

Closes https://github.com/everypolitician/everypolitician/issues/304