### PR TITLE
Reconciler: Show names in multiple languages

### DIFF
--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -81,7 +81,7 @@
           {% } %}
             <dl>
               {% fields.forEach(function(field) { %}
-                {% if(field !== 'id' && person[field]){ %}
+                {% if(field !== 'id' && field !== 'name' && person[field]){ %}
                   <dt title="{{ field }}">{{ field }}:</dt>
                   <dd>
                   {% if (field == 'image') { %}

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -79,7 +79,15 @@
           {% } else { %}
             <h1>{{ h1_name }}</h1>
           {% } %}
+
             <dl>
+            {% if(!person.uuid) { %}
+              <dt title="Names">Names:</dt>
+              {% names.forEach(function(name) { %}
+                <dd>{{ name }}</dd>
+              {% }) %}
+            {% } %}
+
               {% fields.forEach(function(field) { %}
                 {% if(field !== 'id' && field !== 'name' && person[field]){ %}
                   <dt title="{{ field }}">{{ field }}:</dt>

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -231,7 +231,8 @@ jQuery(function($) {
         person: incomingPerson,
         h1_name: incomingPerson[window.incomingField],
         comparison: null,
-        fields: commonFields
+        fields: commonFields,
+        names: _.map(_.filter(incomingPersonFields, function(f) { return f.includes('name__') }), function(f) { return incomingPerson[f] })
       })
     });
     $('.pairings').append(html);


### PR DESCRIPTION
When reconciling, show names in as many languages as we have, so we can spot matches that aren't so obvious.

![screen shot 2016-02-27 at 17 30 36](https://cloud.githubusercontent.com/assets/57483/13374297/0d716750-dd78-11e5-8624-a38055e4fabc.png)


Part of https://github.com/everypolitician/everypolitician/issues/263 (still need to add aliases, and also to tie these into the fuzzing)