### PR TITLE
Wikidata positions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GIT
 
 GIT
   remote: https://github.com/everypolitician/wikisnakker
-  revision: b12d368f792efbbd010b28a49404c8eb6d60fdad
+  revision: a9d6711f0a08ba6024425e5ced0b7e89ef6e8b14
   branch: master
   specs:
     wikisnakker (0.0.1)

--- a/data/Wales/Assembly/sources/instructions.json
+++ b/data/Wales/Assembly/sources/instructions.json
@@ -44,6 +44,14 @@
         "type": "gender-balance",
         "source": "Wales/Assembly"
       }
+    },
+    {
+      "file": "wikidata/positions.json",
+      "type": "wikidata-positions",
+      "create": {
+        "type": "wikidata-raw",
+        "source": "reconciliation/wikidata.csv"
+      }
     }
   ]
 }

--- a/data/Wales/Assembly/sources/manual/position-filter.json
+++ b/data/Wales/Assembly/sources/manual/position-filter.json
@@ -1,0 +1,51 @@
+{
+  "exclude": [
+    {
+      "id": "Q3406079",
+      "name": "Member of the National Assembly for Wales"
+    }
+  ],
+  "include": [
+    {
+      "id": "Q16707842",
+      "name": "Member of Parliament in the United Kingdom"
+    },
+    {
+      "id": "Q18952564",
+      "name": "Member of the House of Lords"
+    },
+    {
+      "id": "Q5261031",
+      "name": "Deputy First Minister for Wales"
+    },
+    {
+      "id": "Q7241522",
+      "name": "Presiding Officer of the National Assembly for Wales"
+    },
+    {
+      "id": "Q5176615",
+      "name": "Counsel General for Wales"
+    },
+    {
+      "id": "Q18996",
+      "name": "First Minister of Wales"
+    }
+  ],
+  "unknown": [
+    {
+      "id": "Q3112646",
+      "name": "Welsh Government",
+      "count": 3
+    },
+    {
+      "id": "Q5260116",
+      "name": "Department for Education and Skills",
+      "count": 1
+    },
+    {
+      "id": "Q7981939",
+      "name": "Welsh Liberal Democrats",
+      "count": 1
+    }
+  ]
+}

--- a/data/Wales/Assembly/sources/wikidata/positions.json
+++ b/data/Wales/Assembly/sources/wikidata/positions.json
@@ -1,0 +1,477 @@
+{
+  "Q4766480": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6519732": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6662955": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q16734718": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q4897688": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q5110965": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6847187": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q16191114": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6153343": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6308404": [
+    {
+      "id": "Q16707842",
+      "label": "Member of Parliament in the United Kingdom",
+      "qualifiers": {
+        "P580": "1997-05-02",
+        "P582": "2010-04-12",
+        "P1365": "Gwilym Jones",
+        "P1366": "Jonathan Evans"
+      }
+    },
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q333841": [
+    {
+      "id": "Q7241522",
+      "label": "Presiding Officer of the National Assembly for Wales",
+      "qualifiers": {
+        "P580": "1999-05-12",
+        "P582": "2011-05-11",
+        "P1366": "Rosemary Butler"
+      }
+    },
+    {
+      "id": "Q16707842",
+      "label": "Member of Parliament in the United Kingdom",
+      "qualifiers": {
+        "P580": "1974-02-28",
+        "P582": "1992-04-09",
+        "P1365": "William Edwards",
+        "P1366": "Elfyn Llwyd"
+      }
+    },
+    {
+      "id": "Q18952564",
+      "label": "Member of the House of Lords"
+    },
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales",
+      "qualifiers": {
+        "P580": "1999-05-06"
+      }
+    }
+  ],
+  "Q5361084": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q10694": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6207115": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6530486": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q7917285": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6768190": [
+    {
+      "id": "Q3112646",
+      "label": "Welsh Government"
+    },
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q5225067": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6297656": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6175921": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q4758350": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q5660402": [
+    {
+      "id": "Q7981939",
+      "label": "Welsh Liberal Democrats"
+    },
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q5346948": [
+    {
+      "id": "Q3112646",
+      "label": "Welsh Government"
+    },
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q3396810": [
+    {
+      "id": "Q5261031",
+      "label": "Deputy First Minister for Wales",
+      "qualifiers": {
+        "P580": "2007-07-11",
+        "P582": "2011-05-13",
+        "P1365": "Mike German, Baron German"
+      }
+    },
+    {
+      "id": "Q16707842",
+      "label": "Member of Parliament in the United Kingdom",
+      "qualifiers": {
+        "P580": "1987-06-11",
+        "P582": "2001-06-07",
+        "P1365": "Keith Best",
+        "P1366": "Albert Owen"
+      }
+    },
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales",
+      "qualifiers": {
+        "P582": "2013-06-20",
+        "P580": "1999-05-06"
+      }
+    }
+  ],
+  "Q6388501": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q7150146": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6308284": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6236400": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q5040766": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q4737493": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q7381514": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q3404581": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6709399": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q7172838": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6767407": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q20065239": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q19958045": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q5951262": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q7321239": [
+    {
+      "id": "Q3112646",
+      "label": "Welsh Government"
+    },
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q4762396": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q111840": [
+    {
+      "id": "Q18996",
+      "label": "First Minister of Wales"
+    },
+    {
+      "id": "Q5176615",
+      "label": "Counsel General for Wales"
+    },
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q14420732": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6154241": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q5004338": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q16735288": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6838044": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q8010078": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q7368324": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6152404": [
+    {
+      "id": "Q5260116",
+      "label": "Department for Education and Skills"
+    },
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q3405148": [
+    {
+      "id": "Q16707842",
+      "label": "Member of Parliament in the United Kingdom",
+      "qualifiers": {
+        "P580": "2000-01-10",
+        "P582": "2005-05-05",
+        "P1365": "Cynog Dafis",
+        "P1366": "Mark Williams"
+      }
+    },
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q3405595": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q117720": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q7027777": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q7301733": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6552839": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q7417378": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q7651414": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q8017036": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q6384255": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q5367919": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q4775602": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q5237493": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ],
+  "Q16191105": [
+    {
+      "id": "Q3406079",
+      "label": "Member of the National Assembly for Wales"
+    }
+  ]
+}

--- a/data/Wales/Assembly/unstable/positions.csv
+++ b/data/Wales/Assembly/unstable/positions.csv
@@ -1,0 +1,10 @@
+id,name,position,start_date,end_date
+97bdfa57-6798-4098-a8f4-77e823837313,Carwyn Jones,First Minister of Wales,,
+97bdfa57-6798-4098-a8f4-77e823837313,Carwyn Jones,Counsel General for Wales,,
+1ee666d1-225f-4561-92da-cfcb94b91a6d,Dafydd Elis-Thomas,Presiding Officer of the National Assembly for Wales,1999-05-12,2011-05-11
+1ee666d1-225f-4561-92da-cfcb94b91a6d,Dafydd Elis-Thomas,Member of Parliament in the United Kingdom,1974-02-28,1992-04-09
+1ee666d1-225f-4561-92da-cfcb94b91a6d,Dafydd Elis-Thomas,Member of the House of Lords,,
+52d4caab-a7c7-418a-856a-8b4caa349a96,Ieuan Wyn Jones,Deputy First Minister for Wales,2007-07-11,2011-05-13
+52d4caab-a7c7-418a-856a-8b4caa349a96,Ieuan Wyn Jones,Member of Parliament in the United Kingdom,1987-06-11,2001-06-07
+1d2c8e4c-6dd2-4991-99a9-6030ef37a879,Julie Morgan,Member of Parliament in the United Kingdom,1997-05-02,2010-04-12
+c5f3e87c-b887-4915-866f-9766395faeb2,Simon Thomas,Member of Parliament in the United Kingdom,2000-01-10,2005-05-05

--- a/lib/fetcher.rb
+++ b/lib/fetcher.rb
@@ -121,3 +121,17 @@ class Fetcher::Wikidata::Group < Fetcher::Wikidata
   end
 end
 
+class Fetcher::Wikidata::Raw < Fetcher::Wikidata
+  def lookup_class
+    P39sLookup
+  end
+
+  def map_data
+    super.each { |h| h[:wikidata] = h[:id] }
+  end
+
+  def processed_wikidata
+    raw_wikidata.to_hash.each_with_object({}) { |(k, v), h| h[k] = v[:p39s] }.reject { |_, v| v.nil? }
+  end
+end
+

--- a/lib/fetcher.rb
+++ b/lib/fetcher.rb
@@ -91,10 +91,24 @@ class Fetcher::Wikidata < Fetcher
     WikidataLookup
   end
 
+  def csv_data
+    CSV.table("sources/#{source}", converters: nil)
+  end
+
+  def map_data
+    csv_data.map { |r| r.to_hash }
+  end
+
+  def raw_wikidata
+    lookup_class.new(map_data)
+  end
+  
+  def processed_wikidata
+    raw_wikidata.to_hash
+  end
+
   def write
-    mapping = CSV.table("sources/#{source}", converters: nil)
-    wikidata = lookup_class.new(mapping)
-    File.write(i(:file), JSON.pretty_generate(wikidata.to_hash))
+    File.write(i(:file), JSON.pretty_generate(processed_wikidata))
   end
 end
 

--- a/lib/wikidata_lookup.rb
+++ b/lib/wikidata_lookup.rb
@@ -85,3 +85,29 @@ class GroupLookup < WikidataLookup
   end
 end
 
+class P39sLookup < WikidataLookup
+
+  def fields_for(result)
+    {
+      p39s: p39s(result),
+    }.reject { |k, v| v.nil? }
+  end
+
+
+  def p39s(result)
+    return nil if (p39s = result.P39s).empty?
+    p39s.map do |posn|
+      qualifiers = posn.qualifiers
+      qual_data  = Hash[qualifiers.properties.map { |p| 
+        [p, qualifiers[p].value.to_s]
+      }]
+
+      {
+        id: posn.value.id,
+        label: posn.value.to_s,
+        qualifiers: qual_data,
+      }.reject { |_,v| v.empty? } rescue {}
+    end
+  end
+end
+

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -48,6 +48,8 @@ namespace :merge_sources do
           Fetcher::Wikidata::Group.regenerate(i)
         elsif c[:type] == 'area-wikidata'
           Fetcher::Wikidata::Area.regenerate(i)
+        elsif c[:type] == 'wikidata-raw'
+          Fetcher::Wikidata::Raw.regenerate(i)
         elsif c[:type] == 'gender-balance'
           Fetcher::GenderBalance.regenerate(i)
         else

--- a/rake_helpers/generate_final_csvs.rb
+++ b/rake_helpers/generate_final_csvs.rb
@@ -86,9 +86,13 @@ namespace :term_csvs do
     warn "Creating #{position_file}"
 
     positions = JSON.parse(File.read('sources/wikidata/positions.json'), symbolize_names: true) 
-    filter    = File.exist?(filter_file) ? JSON.parse(File.read(filter_file), symbolize_names: true).each do |s, fs|
-      fs.each { |f| f.delete :count }
-    end : { exclude: [], include: [] }
+    filter    = if File.exist?(filter_file) 
+      JSON.parse(File.read(filter_file), symbolize_names: true).each do |s, fs|
+        fs.each { |f| f.delete :count }
+      end
+    else 
+      { exclude: [], include: [] }
+    end
     to_include = filter[:include].map { |e| e[:id] }.to_set
     to_exclude = filter[:exclude].map { |e| e[:id] }.to_set
 

--- a/rake_helpers/generate_final_csvs.rb
+++ b/rake_helpers/generate_final_csvs.rb
@@ -97,6 +97,7 @@ namespace :term_csvs do
         positions[id[:identifier].to_sym].to_a.map { |posn| 
           {
             id: p[:id],
+            wikidata: id[:identifier],
             name: p[:name],
             position_id: posn[:id],
             position: posn[:label],
@@ -110,8 +111,8 @@ namespace :term_csvs do
     filter[:unknown] = unknown.
       group_by { |u| u[:position_id] }.
       sort_by { |u, us| us.count }.reverse.
-      map { |id, us| { id: id, name: us.first[:position], count: us.count } }.each do |u|
-        warn "  Unknown position (x#{u[:count]}): #{u[:name]} (#{u[:id]})"
+      map { |id, us| { id: id, name: us.first[:position], count: us.count, example: us.first[:wikidata] } }.each do |u|
+        warn "  Unknown position (x#{u[:count]}): #{u[:id]} #{u[:name]} — e.g. #{u[:example]}"
       end
 
     csv_columns = %w(id name position start_date end_date)

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -141,6 +141,26 @@ task :build_parties do
   File.write(@INSTRUCTIONS_FILE, JSON.pretty_generate(instr))
 end
 
+desc "Add a wikidata P39 file"
+task :build_p39s do
+  instr = clean_instructions_file
+  sources = instr[:sources]
+  abort "Already have position instructions" if sources.find { |s| s[:type] == 'wikidata-positions' }
+
+  wikidata = sources.find { |s| s[:type] == 'wikidata' } or abort "No wikidata section"
+  reconciliation = [wikidata[:merge]].flatten(1).find { |s| s.key? :reconciliation_file } or abort "No wikidata reconciliation file"
+
+  sources << { 
+    file: "wikidata/positions.json",
+    type: "wikidata-positions",
+    create: {
+      type: "wikidata-raw",
+      source: reconciliation[:reconciliation_file],
+    },
+  } 
+  File.write(@INSTRUCTIONS_FILE, JSON.pretty_generate(instr))
+end
+
 def instructions(key)
   @instructions ||= load_instructions_file
   @instructions[key]


### PR DESCRIPTION
Store P39 (position held) data for all people with Wikidata links.

To add these, from the directory of a legislature run:

1. `bundle exec rake build_p39s` — adds instructions for how to build
2. `bundle exec rake clean default` — build the legislature as normal
3. edit `sources/manual/position-filter.json` — move the entries from 'unknown' to 'exclude' or 'include'
4. `bundle exec rake clean default` — rebuild the legislature 