### PR TITLE
Position Files: arrange the Filter file by Position type

### DIFF
--- a/data/Estonia/Riigikogu/sources/instructions.json
+++ b/data/Estonia/Riigikogu/sources/instructions.json
@@ -72,6 +72,14 @@
         "type": "gender-balance",
         "source": "Estonia/Riigikogu"
       }
+    },
+    {
+      "file": "wikidata/positions.json",
+      "type": "wikidata-positions",
+      "create": {
+        "type": "wikidata-raw",
+        "source": "reconciliation/wikidata.csv"
+      }
     }
   ]
 }

--- a/data/Estonia/Riigikogu/sources/manual/position-filter.json
+++ b/data/Estonia/Riigikogu/sources/manual/position-filter.json
@@ -1,0 +1,64 @@
+{
+  "exclude": {
+    "self": [
+      {
+        "id": "Q21100241",
+        "name": "member of the Estonian Riigikogu"
+      }
+    ],
+    "other": [
+
+    ]
+  },
+  "include": {
+    "other_legislatures": [
+      {
+        "id": "Q27169",
+        "name": "member of the European Parliament"
+      }
+    ],
+    "executive": [
+      {
+        "id": "Q737115",
+        "name": "Prime Minister of Estonia"
+      },
+      {
+        "id": "Q21121665",
+        "name": "Minister of Economic Affairs and Communications"
+      },
+      {
+        "id": "Q6866110",
+        "name": "Minister of Education and Research"
+      },
+      {
+        "id": "Q6866431",
+        "name": "Minister of the Interior"
+      },
+      {
+        "id": "Q21103025",
+        "name": "Minister of Finance"
+      },
+      {
+        "id": "Q3741249",
+        "name": "Minister of Defence"
+      }
+    ],
+    "other": [
+      {
+        "id": "Q3740505",
+        "name": "Mayor of Tallinn"
+      },
+      {
+        "id": "Q948558",
+        "name": "European Commissioner for Digital Agenda"
+      },
+      {
+        "id": "Q6627739",
+        "name": "Mayor of Tartu"
+      }
+    ]
+  },
+  "unknown": [
+
+  ]
+}

--- a/data/Estonia/Riigikogu/sources/wikidata/positions.json
+++ b/data/Estonia/Riigikogu/sources/wikidata/positions.json
@@ -1,0 +1,1035 @@
+{
+  "Q1399189": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12373839": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q704436": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q4250802": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q57640": [
+    {
+      "id": "Q6627739",
+      "label": "Mayor of Tartu",
+      "qualifiers": {
+        "P580": "1998",
+        "P582": "2004"
+      }
+    },
+    {
+      "id": "Q27169",
+      "label": "member of the European Parliament",
+      "qualifiers": {
+        "P580": "2014-07-01",
+        "P582": "2014-10-31"
+      }
+    },
+    {
+      "id": "Q737115",
+      "label": "Prime Minister of Estonia",
+      "qualifiers": {
+        "P580": "2005-04-12",
+        "P582": "2014-03-26",
+        "P1365": "Juhan Parts",
+        "P1366": "Taavi Rõivas"
+      }
+    },
+    {
+      "id": "Q948558",
+      "label": "European Commissioner for Digital Agenda",
+      "qualifiers": {
+        "P580": "2014-11-01",
+        "P1365": "Neelie Kroes"
+      }
+    },
+    {
+      "id": "Q21121665",
+      "label": "Minister of Economic Affairs and Communications",
+      "qualifiers": {
+        "P580": "2004-09",
+        "P582": "2005-04",
+        "P1365": "Meelis Atonen",
+        "P1366": "Edgar Savisaar"
+      }
+    }
+  ],
+  "Q743319": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q11869429": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q3736786": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q16407757": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q618373": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12372254": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12360203": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q2128576": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q1676747": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q4755832": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q16403371": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q449851": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q724437": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q11032994": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q2000385": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q13607430": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12372781": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q11857954": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12365540": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q11869065": [
+    {
+      "id": "Q27169",
+      "label": "member of the European Parliament",
+      "qualifiers": {
+        "P580": "2014-07-01"
+      }
+    },
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q58100": [
+    {
+      "id": "Q27169",
+      "label": "member of the European Parliament"
+    }
+  ],
+  "Q12369996": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q13608089": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12378980": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12370075": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q17446941": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q20528880": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q460589": [
+    {
+      "id": "Q27169",
+      "label": "member of the European Parliament"
+    },
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12372782": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12379639": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q450523": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q3741812": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12366123": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q2067037": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q1149033": [
+    {
+      "id": "Q6866110",
+      "label": "Minister of Education and Research",
+      "qualifiers": {
+        "P580": "1999-03-25",
+        "P582": "2002-01-28"
+      }
+    },
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12366252": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q1410118": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12365796": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12372206": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12371428": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12376370": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12358481": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12366158": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12370928": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q616356": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q788525": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12363563": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q3741323": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q983831": [
+    {
+      "id": "Q21103025",
+      "label": "Minister of Finance"
+    },
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q743341": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12369884": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q439102": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12369791": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q3741792": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q2063457": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12376940": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q3785077": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    },
+    {
+      "id": "Q737115",
+      "label": "Prime Minister of Estonia",
+      "qualifiers": {
+        "P580": "2014-03-26",
+        "P155": "Andrus Ansip"
+      }
+    }
+  ],
+  "Q438802": [
+    {
+      "id": "Q27169",
+      "label": "member of the European Parliament"
+    },
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12369838": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q382654": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q1398025": [
+    {
+      "id": "Q27169",
+      "label": "member of the European Parliament"
+    },
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q16404500": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q645970": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12379326": [
+    {
+      "id": "Q27169",
+      "label": "member of the European Parliament",
+      "qualifiers": {
+        "P580": "2014"
+      }
+    },
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q4756115": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12374975": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q620859": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12368739": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q312894": [
+    {
+      "id": "Q737115",
+      "label": "Prime Minister of Estonia",
+      "qualifiers": {
+        "P580": "2003-04-10",
+        "P582": "2005-04-12",
+        "P1365": "Siim Kallas",
+        "P1366": "Andrus Ansip"
+      }
+    },
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q16407052": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q1375483": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q509232": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12368506": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q13570003": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q2621730": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12364933": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12366157": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q14191221": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q618349": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q518704": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12359125": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q3741900": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q16404020": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12366228": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12375092": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12378637": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q4232659": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q6760839": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q11716283": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q14542629": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12364518": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12376579": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q11023034": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12376376": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q334700": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q5993313": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12358062": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12364487": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q355241": [
+    {
+      "id": "Q737115",
+      "label": "Prime Minister of Estonia",
+      "qualifiers": {
+        "P580": "1991-08-20",
+        "P582": "1992-01-29",
+        "P1365": "Otto Tief",
+        "P1366": "Tiit Vähi"
+      }
+    },
+    {
+      "id": "Q3740505",
+      "label": "Mayor of Tallinn",
+      "qualifiers": {
+        "P580": "2001-12",
+        "P582": "2004-10",
+        "P155": "Tõnis Palts",
+        "P156": "Tõnis Palts"
+      }
+    },
+    {
+      "id": "Q3740505",
+      "label": "Mayor of Tallinn",
+      "qualifiers": {
+        "P580": "2007-04-09",
+        "P155": "Jüri Ratas"
+      }
+    },
+    {
+      "id": "Q6866431",
+      "label": "Minister of the Interior",
+      "qualifiers": {
+        "P580": "2005",
+        "P582": "2007",
+        "P155": "Kaido Kama",
+        "P156": "Märt Rask"
+      }
+    },
+    {
+      "id": "Q21121665",
+      "label": "Minister of Economic Affairs and Communications",
+      "qualifiers": {
+        "P580": "2005",
+        "P582": "2007",
+        "P155": "Andrus Ansip",
+        "P156": "Juhan Parts"
+      }
+    }
+  ],
+  "Q13629005": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q978349": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12369879": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q17447264": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q16405534": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12376881": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q13605609": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q465437": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12366267": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q7909441": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q16406782": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12373456": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q535290": [
+    {
+      "id": "Q27169",
+      "label": "member of the European Parliament"
+    },
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12366112": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q1900847": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q253515": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q1385792": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12364480": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q14483307": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q13234758": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q14188964": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q293175": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q16403448": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q1789192": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q458003": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q449939": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q544472": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q13603999": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q16407309": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q13608080": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q13628736": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q2097451": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q11158997": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q307473": [
+    {
+      "id": "Q3741249",
+      "label": "Minister of Defence",
+      "qualifiers": {
+        "P580": "2011-04-06",
+        "P582": "2012-05-11",
+        "P156": "Urmas Reinsalu"
+      }
+    },
+    {
+      "id": "Q27169",
+      "label": "member of the European Parliament",
+      "qualifiers": {
+        "P580": "2003-04-24",
+        "P582": "2004-07-19"
+      }
+    },
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    },
+    {
+      "id": "Q737115",
+      "label": "Prime Minister of Estonia",
+      "qualifiers": {
+        "P580": "1992",
+        "P582": "1994",
+        "P155": "Tiit Vähi",
+        "P156": "Andres Tarand"
+      }
+    },
+    {
+      "id": "Q737115",
+      "label": "Prime Minister of Estonia",
+      "qualifiers": {
+        "P580": "1999",
+        "P582": "2002",
+        "P155": "Mart Siimann",
+        "P156": "Siim Kallas"
+      }
+    }
+  ],
+  "Q12365130": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12373774": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12358088": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ],
+  "Q12373563": [
+    {
+      "id": "Q21100241",
+      "label": "member of the Estonian Riigikogu"
+    }
+  ]
+}

--- a/data/Estonia/Riigikogu/unstable/positions.csv
+++ b/data/Estonia/Riigikogu/unstable/positions.csv
@@ -1,0 +1,26 @@
+id,name,position,start_date,end_date
+062854b4-591c-4c47-83e4-bf0c20c64ef3,Andrus Ansip,Mayor of Tartu,1998,2004
+062854b4-591c-4c47-83e4-bf0c20c64ef3,Andrus Ansip,member of the European Parliament,2014-07-01,2014-10-31
+062854b4-591c-4c47-83e4-bf0c20c64ef3,Andrus Ansip,Prime Minister of Estonia,2005-04-12,2014-03-26
+062854b4-591c-4c47-83e4-bf0c20c64ef3,Andrus Ansip,European Commissioner for Digital Agenda,2014-11-01,
+062854b4-591c-4c47-83e4-bf0c20c64ef3,Andrus Ansip,Minister of Economic Affairs and Communications,2004-09,2005-04
+bfbf9f5e-8ccc-44f8-ac89-700922daa181,Edgar Savisaar,Prime Minister of Estonia,1991-08-20,1992-01-29
+bfbf9f5e-8ccc-44f8-ac89-700922daa181,Edgar Savisaar,Mayor of Tallinn,2001-12,2004-10
+bfbf9f5e-8ccc-44f8-ac89-700922daa181,Edgar Savisaar,Mayor of Tallinn,2007-04-09,
+bfbf9f5e-8ccc-44f8-ac89-700922daa181,Edgar Savisaar,Minister of the Interior,2005,2007
+bfbf9f5e-8ccc-44f8-ac89-700922daa181,Edgar Savisaar,Minister of Economic Affairs and Communications,2005,2007
+72e3aa88-8434-4da2-9760-0177ab88f56b,Ivari Padar,member of the European Parliament,,
+8288a3ee-f554-42a8-b98d-8f0f1e11bd86,Juhan Parts,Prime Minister of Estonia,2003-04-10,2005-04-12
+508adc11-672e-401d-bf60-7912e9ebf6fc,Jürgen Ligi,Minister of Finance,,
+228ba218-43db-4b81-9a34-44ec36b98b24,Kaja Kallas,member of the European Parliament,2014-07-01,
+6c6e3b63-d1ac-4744-affe-e8545737a830,Kristiina Ojuland,member of the European Parliament,,
+d88222df-a90a-4cbe-ad0a-317c4556c07b,Marianne Mikko,member of the European Parliament,,
+fb57a6ab-7353-4608-a7e8-6c7e8adf9997,Mart Laar,Minister of Defence,2011-04-06,2012-05-11
+fb57a6ab-7353-4608-a7e8-6c7e8adf9997,Mart Laar,member of the European Parliament,2003-04-24,2004-07-19
+fb57a6ab-7353-4608-a7e8-6c7e8adf9997,Mart Laar,Prime Minister of Estonia,1992,1994
+fb57a6ab-7353-4608-a7e8-6c7e8adf9997,Mart Laar,Prime Minister of Estonia,1999,2002
+6b71eefc-413d-4db6-88f0-d7ff845ebaf1,Taavi Rõivas,Prime Minister of Estonia,2014-03-26,
+3d3d1918-5637-49e1-ae01-14a1358ad702,Tõnis Lukas,Minister of Education and Research,1999-03-25,2002-01-28
+22d0ca41-c8a6-4475-9cad-6b932a909a48,Urmas Paet,member of the European Parliament,,
+2cced9a3-4f1c-4266-af00-a73dd22a47f9,Vilja Savisaar-Toomast,member of the European Parliament,,
+77605932-0f05-461e-8a0d-a5618f0fe6b8,Yana Toom,member of the European Parliament,2014,

--- a/data/Wales/Assembly/sources/manual/position-filter.json
+++ b/data/Wales/Assembly/sources/manual/position-filter.json
@@ -1,36 +1,50 @@
 {
-  "exclude": [
-    {
-      "id": "Q3406079",
-      "name": "Member of the National Assembly for Wales"
-    }
-  ],
-  "include": [
-    {
-      "id": "Q16707842",
-      "name": "Member of Parliament in the United Kingdom"
-    },
-    {
-      "id": "Q18952564",
-      "name": "Member of the House of Lords"
-    },
-    {
-      "id": "Q5261031",
-      "name": "Deputy First Minister for Wales"
-    },
-    {
-      "id": "Q7241522",
-      "name": "Presiding Officer of the National Assembly for Wales"
-    },
-    {
-      "id": "Q5176615",
-      "name": "Counsel General for Wales"
-    },
-    {
-      "id": "Q18996",
-      "name": "First Minister of Wales"
-    }
-  ],
+  "exclude": {
+    "self": [
+      {
+        "id": "Q3406079",
+        "name": "Member of the National Assembly for Wales"
+      }
+    ],
+    "other": [
+
+    ]
+  },
+  "include": {
+    "self": [
+      {
+        "id": "Q7241522",
+        "name": "Presiding Officer of the National Assembly for Wales"
+      }
+    ],
+    "other_legislatures": [
+      {
+        "id": "Q16707842",
+        "name": "Member of Parliament in the United Kingdom"
+      },
+      {
+        "id": "Q18952564",
+        "name": "Member of the House of Lords"
+      }
+    ],
+    "executive": [
+      {
+        "id": "Q5261031",
+        "name": "Deputy First Minister for Wales"
+      },
+      {
+        "id": "Q5176615",
+        "name": "Counsel General for Wales"
+      },
+      {
+        "id": "Q18996",
+        "name": "First Minister of Wales"
+      }
+    ],
+    "other": [
+
+    ]
+  },
   "unknown": [
     {
       "id": "Q3112646",

--- a/rake_helpers/generate_final_csvs.rb
+++ b/rake_helpers/generate_final_csvs.rb
@@ -91,13 +91,13 @@ namespace :term_csvs do
     positions = JSON.parse(File.read(positions_raw), symbolize_names: true) 
     filter    = if File.exist?(filter_file) 
       JSON.parse(File.read(filter_file), symbolize_names: true).each do |s, fs|
-        fs.each { |f| f.delete :count }
+        fs.each { |_,fs| fs.each { |f| f.delete :count } }
       end
     else 
-      { exclude: [], include: [] }
+      { exclude: { self: [], other: [] }, include: { self: [], other_legislatures: [], executive: [], other: [] } }
     end
-    to_include = filter[:include].map { |e| e[:id] }.to_set
-    to_exclude = filter[:exclude].map { |e| e[:id] }.to_set
+    to_include = filter[:include].map { |_, fs| fs.map { |f| f[:id] } }.flatten.to_set
+    to_exclude = filter[:exclude].map { |_, fs| fs.map { |f| f[:id] } }.flatten.to_set
 
     want, unknown = @json[:persons].map { |p| 
       (p[:identifiers] || []).find_all { |i| i[:scheme] == 'wikidata' }.map { |id|


### PR DESCRIPTION
Whilst we're building the Filter files, we should group the Positions by
what type they are — e.g. the Membership of this or other legislatures;
memberships of the Executive, etc.

This will let us process them differently, when we get around to doing more
(or output them better in Popolo)