### PR TITLE
Portugal (Assembly) — point at original source

### DIFF
--- a/data/Portugal/Assembly/ep-popolo-v1.0.json
+++ b/data/Portugal/Assembly/ep-popolo-v1.0.json
@@ -8513,7 +8513,7 @@
   ],
   "meta": {
     "sources": [
-      "https://morph.io/tmtmtmtm/portugal-democratica-scraper",
+      "http://demo.cratica.org/",
       "http://wikidata.org/"
     ]
   },

--- a/data/Portugal/Assembly/sources/instructions.json
+++ b/data/Portugal/Assembly/sources/instructions.json
@@ -7,7 +7,7 @@
         "scraper": "tmtmtmtm/portugal-democratica-scraper",
         "query": "SELECT * FROM data"
       },
-      "source": "https://morph.io/tmtmtmtm/portugal-democratica-scraper",
+      "source": "http://demo.cratica.org/",
       "type": "membership"
     },
     {


### PR DESCRIPTION
Make the source the original URL, rather than Morph.io