### PR TITLE
Cabo Verde (Assembly) — point at original source

### DIFF
--- a/data/Cabo_Verde/Assembly/ep-popolo-v1.0.json
+++ b/data/Cabo_Verde/Assembly/ep-popolo-v1.0.json
@@ -1162,7 +1162,7 @@
   ],
   "meta": {
     "sources": [
-      "https://morph.io/tmtmtmtm/cabo-verde-assembleia-nacionale"
+      "http://www.parlamento.cv"
     ]
   },
   "memberships": [

--- a/data/Cabo_Verde/Assembly/sources/instructions.json
+++ b/data/Cabo_Verde/Assembly/sources/instructions.json
@@ -7,7 +7,7 @@
         "scraper": "tmtmtmtm/cabo-verde-assembleia-nacionale",
         "query": "SELECT * FROM data"
       },
-      "source": "https://morph.io/tmtmtmtm/cabo-verde-assembleia-nacionale",
+      "source": "http://www.parlamento.cv",
       "type": "membership"
     },
     {


### PR DESCRIPTION
Make the source the original URL, rather than Morph.io