### PR TITLE
Build CSVs: Turn 'persons' into a hash

### DIFF
--- a/rake_helpers/generate_final_csvs.rb
+++ b/rake_helpers/generate_final_csvs.rb
@@ -25,11 +25,11 @@ namespace :term_csvs do
   task :term_tables => 'ep-popolo-v1.0.json' do
     @json = JSON.parse(File.read('ep-popolo-v1.0.json'), symbolize_names: true )
     popolo = EveryPolitician::Popolo.read('ep-popolo-v1.0.json')
-    persons = popolo.persons
+    people = Hash[ popolo.persons.map { |p| [p.id, p] } ]
     terms = {}
 
     data = @json[:memberships].find_all { |m| m.key? :legislative_period_id }.map do |m|
-      person = persons.find        { |r| (r[:id] == m[:person_id])       || (r[:id].end_with? "/#{m[:person_id]}") }
+      person = people[ m[:person_id] ]
       group  = @json[:organizations].find { |o| (o[:id] == m[:on_behalf_of_id]) || (o[:id].end_with? "/#{m[:on_behalf_of_id]}") }
       house  = @json[:organizations].find { |o| (o[:id] == m[:organization_id]) || (o[:id].end_with? "/#{m[:organization_id]}") }
       terms[m[:legislative_period_id]] ||= @json[:events].find { |e| e[:id].split('/').last == m[:legislative_period_id].split('/').last }


### PR DESCRIPTION
Look up by direct hash access on person.id, rather than scanning the
full list every time. This reduces the build time for this section
significantly (in Turkey, it drops from 115 seconds to 3 seconds on my
laptop)