### PR TITLE
Reconciler: warn if there are multiple IDs or UUIDs after matching

### DIFF
--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -118,5 +118,26 @@
       </div>
     </script>
 
+    <script type="text/html" id="duplicateIDs">
+      <div class="duplicates">
+        <p><strong>Warning:</strong> The following {{ groupedByType }}s have
+          multiple {{ otherType }}s:</p>
+        <dl>
+          {% for (k in duplicates) { %}
+            {% if (duplicates.hasOwnProperty(k)) { %}
+              <dt>{{ k }} has these {{ otherType }}s:</dt>
+              <dd>
+                <ul>
+                 {% for (var i = 0; i < duplicates[k].length; ++i) { %}
+                   <li>{{ duplicates[k][i] }}</li>
+                 {% } %}
+                </ul>
+              </dd>
+            {% } %}
+          {% } %}
+        </dl>
+      </div>
+    </script>
+
 </body>
 </html>

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -239,14 +239,14 @@ jQuery(function($) {
     var incomingPerson = match.incoming;
 
     // If there's one and only one 100% match, choose it automatically
-    var exactMatches  = _.filter(match.existing, function(e) {
-      return e[1] == 1;
-    });
-    if (exactMatches.length == 1) {
-      window.autovotes.push( [incomingPerson.id, exactMatches[0][0].uuid] );
-      return;
-    }
-
+    // var exactMatches  = _.filter(match.existing, function(e) { 
+      // return e[1] == 1;
+    // });
+    // if (exactMatches.length == 1) { 
+      // window.autovotes.push( [incomingPerson.id, exactMatches[0][0].uuid] );
+      // return;
+    // }
+    
     var incomingPersonFields = _.filter(Object.keys(incomingPerson), function(field) {
       return incomingPerson[field];
     });

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -20,7 +20,7 @@ var vote = function vote($choice){
   var vote = [];
 
   if($choice.is('.skip')) {
-    // Insert a null value to indicate skip. 
+    // Insert a null value to indicate skip.
     // These are removed when serializing to CSV.
     window.votes.push( [incomingPersonID, null] );
   } else if ($choice.is('.show-later')) {
@@ -95,7 +95,7 @@ var nextPairing = function nextPairing($currentPairing){
     highlightExistingVotes($nextPairing);
     $nextPairing.show();
   } else {
-    $('.messages').html('<h1>Reconciliation complete!</h1>'); 
+    $('.messages').html('<h1>Reconciliation complete!</h1>');
     showCSVtray();
   }
 }
@@ -147,7 +147,7 @@ var updateProgressBar = function updateProgressBar(){
   $('.progress .progress-bar div').animate({ width: progressAsPercentage() }, 100);
 }
 
-var allVotes = function allVotes() { 
+var allVotes = function allVotes() {
   return window.reconciled.concat(window.votes).concat(window.autovotes)
 }
 
@@ -192,9 +192,9 @@ var undo = function undo(){
   // Remove last vote from window.votes,
   // and re-show the most recently hidden pairing.
   var undoneVote = window.votes.pop();
-  if ($('.pairing:visible').length) { 
+  if ($('.pairing:visible').length) {
     $('.pairing:visible').hide().prev().show();
-  } else { 
+  } else {
     $('.pairing').last().show();
     hideCSVtray();
   }
@@ -214,12 +214,12 @@ var handleKeyPress = function handleKeyPress(e){
   if(e.keyCode == 27){ return toggleCSVtray(); }
 
   // Command-Z
-  if(e.keyCode == 90 && (e.metaKey || e.ctrlKey)) { return undo(); } 
-      
+  if(e.keyCode == 90 && (e.metaKey || e.ctrlKey)) { return undo(); }
+
   // Only if there is at least one pairing left to categorise
   if($('.pairing:visible').length && $('.csv').is(':hidden')){
     // right arrow
-    if(e.which == 39){ return vote($('.pairing:visible .skip')); } 
+    if(e.which == 39){ return vote($('.pairing:visible .skip')); }
 
     // question mark
     if(e.which == 191){ return vote($('.pairing:visible .show-later')); }
@@ -239,14 +239,14 @@ jQuery(function($) {
     var incomingPerson = match.incoming;
 
     // If there's one and only one 100% match, choose it automatically
-    var exactMatches  = _.filter(match.existing, function(e) { 
+    var exactMatches  = _.filter(match.existing, function(e) {
       return e[1] == 1;
     });
-    if (exactMatches.length == 1) { 
+    if (exactMatches.length == 1) {
       window.autovotes.push( [incomingPerson.id, exactMatches[0][0].uuid] );
       return;
     }
-    
+
     var incomingPersonFields = _.filter(Object.keys(incomingPerson), function(field) {
       return incomingPerson[field];
     });
@@ -258,13 +258,13 @@ jQuery(function($) {
 
       var incomingNameWords = incomingPerson[window.incomingField].toLowerCase().replace(',', '').split(/\s+/);
       var markedName = _.map(person[window.existingField].replace(',', '').split(/\s+/), function(word){
-        if (_.contains(incomingNameWords, word.toLowerCase())) { 
+        if (_.contains(incomingNameWords, word.toLowerCase())) {
           return '<span class="match">' + word + '</span>'
-        } else { 
+        } else {
           return word
         }
       }).join(" ");
-      
+
       return renderTemplate('person', {
         person: person,
         h1_name: markedName,
@@ -319,8 +319,8 @@ jQuery(function($) {
     $firstPairing.nextAll().hide();
     highlightExistingVotes($firstPairing);
     redrawTop();
-  } else { 
-    $('.messages').append('<h1>Nothing to reconcile!</h1>'); 
+  } else {
+    $('.messages').append('<h1>Nothing to reconcile!</h1>');
   }
 
 });

--- a/templates/sass/_styles.scss
+++ b/templates/sass/_styles.scss
@@ -262,3 +262,23 @@ h2 {
     text-shadow: 0 1px 0 #fff;
   }
 }
+
+.all-duplicates {
+  display: table;
+  text-align: left;
+  width: 50%;
+  margin: 0 auto;
+}
+
+.duplicates {
+  margin-bottom: 2em;
+  dt {
+    margin-left: 0;
+    padding-left: 1em;
+  }
+  dd {
+    margin-bottom: 0.5em;
+    margin-left: 0;
+    padding-left: 2em;
+  }
+}


### PR DESCRIPTION
At the end of matching all incoming people to existing people, it's
possible that the matches between IDs (of incoming people) to UUIDs
(of existing people) aren't one-to-one.  With the change in this
commit, a warning will be displayed at the end if this is the case,
including the IDs / UUIDs so this can be investigated further.

![reconciler-duplicate-ids](https://cloud.githubusercontent.com/assets/7907/13873578/493def02-ecea-11e5-9489-c64a47dbcae4.png)

(n.b. I slightly fiddled the data to make that screenshot, so the actual
IDs won't make sense...)

Fixes https://github.com/everypolitician/everypolitician/issues/240