### PR TITLE
Switch urls in countries.json to use GitHub directly

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -67,7 +67,7 @@ task 'countries.json' do
       legislatures: hs.map { |h|
         json_file = h + '/ep-popolo-v1.0.json'
         name_file = h + '/names.csv'
-        remote_source = 'https://cdn.rawgit.com/everypolitician/everypolitician-data/%s/%s'
+        remote_source = 'https://github.com/everypolitician/everypolitician-data/raw/%s/%s'
         popolo, statement_count = json_from(json_file)
 
         cmd = "git --no-pager log --format='%h|%at' -1 #{h}"

--- a/countries.json
+++ b/countries.json
@@ -10,7 +10,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Abkhazia/Assembly/sources",
         "popolo": "data/Abkhazia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/38c71c8/data/Abkhazia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/38c71c8/data/Abkhazia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Abkhazia/Assembly/names.csv",
         "lastmod": "1458143887",
         "person_count": 29,
@@ -22,7 +22,7 @@
             "start_date": "2012-04-03",
             "slug": "5",
             "csv": "data/Abkhazia/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/38c71c8/data/Abkhazia/Assembly/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/38c71c8/data/Abkhazia/Assembly/term-5.csv"
           }
         ],
         "statement_count": 597
@@ -40,7 +40,7 @@
         "slug": "Wolesi-Jirga",
         "sources_directory": "data/Afghanistan/Wolesi_Jirga/sources",
         "popolo": "data/Afghanistan/Wolesi_Jirga/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3a12410/data/Afghanistan/Wolesi_Jirga/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/3a12410/data/Afghanistan/Wolesi_Jirga/ep-popolo-v1.0.json",
         "names": "data/Afghanistan/Wolesi_Jirga/names.csv",
         "lastmod": "1457991602",
         "person_count": 228,
@@ -53,7 +53,7 @@
             "start_date": "2010",
             "slug": "2010",
             "csv": "data/Afghanistan/Wolesi_Jirga/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3a12410/data/Afghanistan/Wolesi_Jirga/term-2010.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/3a12410/data/Afghanistan/Wolesi_Jirga/term-2010.csv"
           }
         ],
         "statement_count": 3402
@@ -71,7 +71,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Albania/Assembly/sources",
         "popolo": "data/Albania/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0bdb662/data/Albania/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/0bdb662/data/Albania/Assembly/ep-popolo-v1.0.json",
         "names": "data/Albania/Assembly/names.csv",
         "lastmod": "1457872893",
         "person_count": 213,
@@ -83,7 +83,7 @@
             "start_date": "2013",
             "slug": "8",
             "csv": "data/Albania/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0bdb662/data/Albania/Assembly/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0bdb662/data/Albania/Assembly/term-8.csv"
           },
           {
             "end_date": "2013",
@@ -92,7 +92,7 @@
             "start_date": "2009",
             "slug": "7",
             "csv": "data/Albania/Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0bdb662/data/Albania/Assembly/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0bdb662/data/Albania/Assembly/term-7.csv"
           }
         ],
         "statement_count": 7616
@@ -110,7 +110,7 @@
         "slug": "States",
         "sources_directory": "data/Alderney/States/sources",
         "popolo": "data/Alderney/States/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/99d752b/data/Alderney/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/99d752b/data/Alderney/States/ep-popolo-v1.0.json",
         "names": "data/Alderney/States/names.csv",
         "lastmod": "1453735005",
         "person_count": 10,
@@ -123,7 +123,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/Alderney/States/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/99d752b/data/Alderney/States/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/99d752b/data/Alderney/States/term-2014.csv"
           }
         ],
         "statement_count": 145
@@ -141,7 +141,7 @@
         "slug": "Majlis",
         "sources_directory": "data/Algeria/Majlis/sources",
         "popolo": "data/Algeria/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4edc327/data/Algeria/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/4edc327/data/Algeria/Majlis/ep-popolo-v1.0.json",
         "names": "data/Algeria/Majlis/names.csv",
         "lastmod": "1456586643",
         "person_count": 478,
@@ -153,7 +153,7 @@
             "start_date": "2012",
             "slug": "7",
             "csv": "data/Algeria/Majlis/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4edc327/data/Algeria/Majlis/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/4edc327/data/Algeria/Majlis/term-7.csv"
           }
         ],
         "statement_count": 7519
@@ -171,7 +171,7 @@
         "slug": "House",
         "sources_directory": "data/American_Samoa/House/sources",
         "popolo": "data/American_Samoa/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cc1ee60/data/American_Samoa/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/cc1ee60/data/American_Samoa/House/ep-popolo-v1.0.json",
         "names": "data/American_Samoa/House/names.csv",
         "lastmod": "1457002791",
         "person_count": 17,
@@ -183,7 +183,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/American_Samoa/House/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cc1ee60/data/American_Samoa/House/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/cc1ee60/data/American_Samoa/House/term-2014.csv"
           }
         ],
         "statement_count": 268
@@ -201,7 +201,7 @@
         "slug": "General-Council",
         "sources_directory": "data/Andorra/General_Council/sources",
         "popolo": "data/Andorra/General_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a8438a2/data/Andorra/General_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/a8438a2/data/Andorra/General_Council/ep-popolo-v1.0.json",
         "names": "data/Andorra/General_Council/names.csv",
         "lastmod": "1457811860",
         "person_count": 30,
@@ -213,7 +213,7 @@
             "start_date": "2015-03-23",
             "slug": "2015",
             "csv": "data/Andorra/General_Council/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a8438a2/data/Andorra/General_Council/term-2015.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a8438a2/data/Andorra/General_Council/term-2015.csv"
           }
         ],
         "statement_count": 707
@@ -231,7 +231,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Angola/National_Assembly/sources",
         "popolo": "data/Angola/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8d31b7f/data/Angola/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/8d31b7f/data/Angola/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Angola/National_Assembly/names.csv",
         "lastmod": "1456586539",
         "person_count": 216,
@@ -243,7 +243,7 @@
             "start_date": "2012",
             "slug": "3",
             "csv": "data/Angola/National_Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8d31b7f/data/Angola/National_Assembly/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/8d31b7f/data/Angola/National_Assembly/term-3.csv"
           }
         ],
         "statement_count": 3487
@@ -261,7 +261,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Anguilla/Assembly/sources",
         "popolo": "data/Anguilla/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9dcf1ea/data/Anguilla/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/9dcf1ea/data/Anguilla/Assembly/ep-popolo-v1.0.json",
         "names": "data/Anguilla/Assembly/names.csv",
         "lastmod": "1453735279",
         "person_count": 18,
@@ -274,7 +274,7 @@
             "start_date": "2015",
             "slug": "2015",
             "csv": "data/Anguilla/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9dcf1ea/data/Anguilla/Assembly/term-2015.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/9dcf1ea/data/Anguilla/Assembly/term-2015.csv"
           },
           {
             "end_date": "2015",
@@ -283,7 +283,7 @@
             "start_date": "2010",
             "slug": "2010",
             "csv": "data/Anguilla/Assembly/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9dcf1ea/data/Anguilla/Assembly/term-2010.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/9dcf1ea/data/Anguilla/Assembly/term-2010.csv"
           },
           {
             "end_date": "2010",
@@ -292,7 +292,7 @@
             "start_date": "2005",
             "slug": "2005",
             "csv": "data/Anguilla/Assembly/term-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9dcf1ea/data/Anguilla/Assembly/term-2005.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/9dcf1ea/data/Anguilla/Assembly/term-2005.csv"
           },
           {
             "end_date": "2005",
@@ -301,7 +301,7 @@
             "start_date": "2000",
             "slug": "2000",
             "csv": "data/Anguilla/Assembly/term-2000.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9dcf1ea/data/Anguilla/Assembly/term-2000.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/9dcf1ea/data/Anguilla/Assembly/term-2000.csv"
           },
           {
             "end_date": "2000",
@@ -310,7 +310,7 @@
             "start_date": "1999",
             "slug": "1999",
             "csv": "data/Anguilla/Assembly/term-1999.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9dcf1ea/data/Anguilla/Assembly/term-1999.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/9dcf1ea/data/Anguilla/Assembly/term-1999.csv"
           },
           {
             "end_date": "1999",
@@ -319,7 +319,7 @@
             "start_date": "1994",
             "slug": "1994",
             "csv": "data/Anguilla/Assembly/term-1994.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9dcf1ea/data/Anguilla/Assembly/term-1994.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/9dcf1ea/data/Anguilla/Assembly/term-1994.csv"
           },
           {
             "end_date": "1994",
@@ -328,7 +328,7 @@
             "start_date": "1989",
             "slug": "1989",
             "csv": "data/Anguilla/Assembly/term-1989.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9dcf1ea/data/Anguilla/Assembly/term-1989.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/9dcf1ea/data/Anguilla/Assembly/term-1989.csv"
           }
         ],
         "statement_count": 748
@@ -346,7 +346,7 @@
         "slug": "Representatives",
         "sources_directory": "data/Antigua_and_Barbuda/Representatives/sources",
         "popolo": "data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d15f66/data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/2d15f66/data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
         "names": "data/Antigua_and_Barbuda/Representatives/names.csv",
         "lastmod": "1458184506",
         "person_count": 63,
@@ -359,7 +359,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d15f66/data/Antigua_and_Barbuda/Representatives/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2d15f66/data/Antigua_and_Barbuda/Representatives/term-2014.csv"
           },
           {
             "end_date": "2014",
@@ -368,7 +368,7 @@
             "start_date": "2009",
             "slug": "2009",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d15f66/data/Antigua_and_Barbuda/Representatives/term-2009.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2d15f66/data/Antigua_and_Barbuda/Representatives/term-2009.csv"
           },
           {
             "end_date": "2009",
@@ -377,7 +377,7 @@
             "start_date": "2004",
             "slug": "2004",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-2004.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d15f66/data/Antigua_and_Barbuda/Representatives/term-2004.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2d15f66/data/Antigua_and_Barbuda/Representatives/term-2004.csv"
           },
           {
             "end_date": "2004",
@@ -386,7 +386,7 @@
             "start_date": "1999",
             "slug": "1999",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1999.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d15f66/data/Antigua_and_Barbuda/Representatives/term-1999.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2d15f66/data/Antigua_and_Barbuda/Representatives/term-1999.csv"
           },
           {
             "end_date": "1999",
@@ -395,7 +395,7 @@
             "start_date": "1994",
             "slug": "1994",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1994.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d15f66/data/Antigua_and_Barbuda/Representatives/term-1994.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2d15f66/data/Antigua_and_Barbuda/Representatives/term-1994.csv"
           },
           {
             "end_date": "1994",
@@ -404,7 +404,7 @@
             "start_date": "1989",
             "slug": "1989",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1989.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d15f66/data/Antigua_and_Barbuda/Representatives/term-1989.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2d15f66/data/Antigua_and_Barbuda/Representatives/term-1989.csv"
           },
           {
             "end_date": "1989",
@@ -413,7 +413,7 @@
             "start_date": "1984",
             "slug": "1984",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1984.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d15f66/data/Antigua_and_Barbuda/Representatives/term-1984.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2d15f66/data/Antigua_and_Barbuda/Representatives/term-1984.csv"
           },
           {
             "end_date": "1984",
@@ -422,7 +422,7 @@
             "start_date": "1980",
             "slug": "1980",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1980.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d15f66/data/Antigua_and_Barbuda/Representatives/term-1980.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2d15f66/data/Antigua_and_Barbuda/Representatives/term-1980.csv"
           },
           {
             "end_date": "1980",
@@ -431,7 +431,7 @@
             "start_date": "1976",
             "slug": "1976",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1976.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d15f66/data/Antigua_and_Barbuda/Representatives/term-1976.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2d15f66/data/Antigua_and_Barbuda/Representatives/term-1976.csv"
           },
           {
             "end_date": "1976",
@@ -440,7 +440,7 @@
             "start_date": "1971",
             "slug": "1971",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1971.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d15f66/data/Antigua_and_Barbuda/Representatives/term-1971.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2d15f66/data/Antigua_and_Barbuda/Representatives/term-1971.csv"
           }
         ],
         "statement_count": 1686
@@ -458,7 +458,7 @@
         "slug": "Diputados",
         "sources_directory": "data/Argentina/Diputados/sources",
         "popolo": "data/Argentina/Diputados/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20e91f6/data/Argentina/Diputados/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/20e91f6/data/Argentina/Diputados/ep-popolo-v1.0.json",
         "names": "data/Argentina/Diputados/names.csv",
         "lastmod": "1458204772",
         "person_count": 385,
@@ -470,7 +470,7 @@
             "start_date": "2015",
             "slug": "133",
             "csv": "data/Argentina/Diputados/term-133.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20e91f6/data/Argentina/Diputados/term-133.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/20e91f6/data/Argentina/Diputados/term-133.csv"
           }
         ],
         "statement_count": 10889
@@ -488,7 +488,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Armenia/Assembly/sources",
         "popolo": "data/Armenia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a818e5/data/Armenia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/0a818e5/data/Armenia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Armenia/Assembly/names.csv",
         "lastmod": "1457878722",
         "person_count": 132,
@@ -500,7 +500,7 @@
             "start_date": "2012-05-31",
             "slug": "5",
             "csv": "data/Armenia/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a818e5/data/Armenia/Assembly/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0a818e5/data/Armenia/Assembly/term-5.csv"
           }
         ],
         "statement_count": 4988
@@ -518,7 +518,7 @@
         "slug": "Estates",
         "sources_directory": "data/Aruba/Estates/sources",
         "popolo": "data/Aruba/Estates/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640fac/data/Aruba/Estates/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/0640fac/data/Aruba/Estates/ep-popolo-v1.0.json",
         "names": "data/Aruba/Estates/names.csv",
         "lastmod": "1457387757",
         "person_count": 21,
@@ -530,7 +530,7 @@
             "start_date": "2013",
             "slug": "7",
             "csv": "data/Aruba/Estates/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640fac/data/Aruba/Estates/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0640fac/data/Aruba/Estates/term-7.csv"
           }
         ],
         "statement_count": 510
@@ -548,7 +548,7 @@
         "slug": "Representatives",
         "sources_directory": "data/Australia/Representatives/sources",
         "popolo": "data/Australia/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eace41f/data/Australia/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/eace41f/data/Australia/Representatives/ep-popolo-v1.0.json",
         "names": "data/Australia/Representatives/names.csv",
         "lastmod": "1458178514",
         "person_count": 475,
@@ -560,7 +560,7 @@
             "start_date": "2013-09-07",
             "slug": "44",
             "csv": "data/Australia/Representatives/term-44.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eace41f/data/Australia/Representatives/term-44.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/eace41f/data/Australia/Representatives/term-44.csv"
           },
           {
             "end_date": "2013-09-07",
@@ -569,7 +569,7 @@
             "start_date": "2010-08-21",
             "slug": "43",
             "csv": "data/Australia/Representatives/term-43.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eace41f/data/Australia/Representatives/term-43.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/eace41f/data/Australia/Representatives/term-43.csv"
           },
           {
             "end_date": "2010-08-21",
@@ -578,7 +578,7 @@
             "start_date": "2007-11-24",
             "slug": "42",
             "csv": "data/Australia/Representatives/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eace41f/data/Australia/Representatives/term-42.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/eace41f/data/Australia/Representatives/term-42.csv"
           },
           {
             "end_date": "2007-11-24",
@@ -587,7 +587,7 @@
             "start_date": "2004-10-09",
             "slug": "41",
             "csv": "data/Australia/Representatives/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eace41f/data/Australia/Representatives/term-41.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/eace41f/data/Australia/Representatives/term-41.csv"
           },
           {
             "end_date": "2004-10-09",
@@ -596,7 +596,7 @@
             "start_date": "2001-11-10",
             "slug": "40",
             "csv": "data/Australia/Representatives/term-40.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eace41f/data/Australia/Representatives/term-40.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/eace41f/data/Australia/Representatives/term-40.csv"
           },
           {
             "end_date": "2001-11-10",
@@ -605,7 +605,7 @@
             "start_date": "1998-10-03",
             "slug": "39",
             "csv": "data/Australia/Representatives/term-39.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eace41f/data/Australia/Representatives/term-39.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/eace41f/data/Australia/Representatives/term-39.csv"
           },
           {
             "end_date": "1998-10-03",
@@ -614,7 +614,7 @@
             "start_date": "1996-03-02",
             "slug": "38",
             "csv": "data/Australia/Representatives/term-38.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eace41f/data/Australia/Representatives/term-38.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/eace41f/data/Australia/Representatives/term-38.csv"
           },
           {
             "end_date": "1996-03-02",
@@ -623,7 +623,7 @@
             "start_date": "1993-03-13",
             "slug": "37",
             "csv": "data/Australia/Representatives/term-37.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eace41f/data/Australia/Representatives/term-37.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/eace41f/data/Australia/Representatives/term-37.csv"
           },
           {
             "end_date": "1993-03-13",
@@ -632,7 +632,7 @@
             "start_date": "1990-03-24",
             "slug": "36",
             "csv": "data/Australia/Representatives/term-36.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eace41f/data/Australia/Representatives/term-36.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/eace41f/data/Australia/Representatives/term-36.csv"
           },
           {
             "end_date": "1990-03-24",
@@ -641,7 +641,7 @@
             "start_date": "1987-07-11",
             "slug": "35",
             "csv": "data/Australia/Representatives/term-35.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eace41f/data/Australia/Representatives/term-35.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/eace41f/data/Australia/Representatives/term-35.csv"
           }
         ],
         "statement_count": 34520
@@ -651,7 +651,7 @@
         "slug": "Senate",
         "sources_directory": "data/Australia/Senate/sources",
         "popolo": "data/Australia/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/40c7952/data/Australia/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/40c7952/data/Australia/Senate/ep-popolo-v1.0.json",
         "names": "data/Australia/Senate/names.csv",
         "lastmod": "1458248293",
         "person_count": 94,
@@ -663,7 +663,7 @@
             "start_date": "2013-09-07",
             "slug": "44",
             "csv": "data/Australia/Senate/term-44.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/40c7952/data/Australia/Senate/term-44.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/40c7952/data/Australia/Senate/term-44.csv"
           }
         ],
         "statement_count": 1880
@@ -681,7 +681,7 @@
         "slug": "Nationalrat",
         "sources_directory": "data/Austria/Nationalrat/sources",
         "popolo": "data/Austria/Nationalrat/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/da2223c/data/Austria/Nationalrat/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/da2223c/data/Austria/Nationalrat/ep-popolo-v1.0.json",
         "names": "data/Austria/Nationalrat/names.csv",
         "lastmod": "1458177930",
         "person_count": 182,
@@ -693,7 +693,7 @@
             "start_date": "2013-09-29",
             "slug": "25",
             "csv": "data/Austria/Nationalrat/term-25.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/da2223c/data/Austria/Nationalrat/term-25.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/da2223c/data/Austria/Nationalrat/term-25.csv"
           }
         ],
         "statement_count": 9884
@@ -711,7 +711,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Azerbaijan/National_Assembly/sources",
         "popolo": "data/Azerbaijan/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3f0f4eb/data/Azerbaijan/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/3f0f4eb/data/Azerbaijan/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Azerbaijan/National_Assembly/names.csv",
         "lastmod": "1457996203",
         "person_count": 152,
@@ -723,7 +723,7 @@
             "start_date": "2015-12-01",
             "slug": "5",
             "csv": "data/Azerbaijan/National_Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3f0f4eb/data/Azerbaijan/National_Assembly/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/3f0f4eb/data/Azerbaijan/National_Assembly/term-5.csv"
           },
           {
             "end_date": "2015",
@@ -732,7 +732,7 @@
             "start_date": "2010",
             "slug": "4",
             "csv": "data/Azerbaijan/National_Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3f0f4eb/data/Azerbaijan/National_Assembly/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/3f0f4eb/data/Azerbaijan/National_Assembly/term-4.csv"
           }
         ],
         "statement_count": 4844
@@ -750,7 +750,7 @@
         "slug": "House-of-Assembly",
         "sources_directory": "data/Bahamas/House_of_Assembly/sources",
         "popolo": "data/Bahamas/House_of_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/99f3460/data/Bahamas/House_of_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/99f3460/data/Bahamas/House_of_Assembly/ep-popolo-v1.0.json",
         "names": "data/Bahamas/House_of_Assembly/names.csv",
         "lastmod": "1457940730",
         "person_count": 38,
@@ -762,7 +762,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Bahamas/House_of_Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/99f3460/data/Bahamas/House_of_Assembly/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/99f3460/data/Bahamas/House_of_Assembly/term-2012.csv"
           }
         ],
         "statement_count": 1076
@@ -780,7 +780,7 @@
         "slug": "Council-of-Representatives",
         "sources_directory": "data/Bahrain/Council_of_Representatives/sources",
         "popolo": "data/Bahrain/Council_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/79f0dcc/data/Bahrain/Council_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/79f0dcc/data/Bahrain/Council_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Bahrain/Council_of_Representatives/names.csv",
         "lastmod": "1450786699",
         "person_count": 40,
@@ -792,7 +792,7 @@
             "start_date": "2014-12-14",
             "slug": "2014",
             "csv": "data/Bahrain/Council_of_Representatives/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/79f0dcc/data/Bahrain/Council_of_Representatives/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/79f0dcc/data/Bahrain/Council_of_Representatives/term-2014.csv"
           }
         ],
         "statement_count": 493
@@ -810,7 +810,7 @@
         "slug": "House",
         "sources_directory": "data/Bangladesh/House/sources",
         "popolo": "data/Bangladesh/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a63094/data/Bangladesh/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/0a63094/data/Bangladesh/House/ep-popolo-v1.0.json",
         "names": "data/Bangladesh/House/names.csv",
         "lastmod": "1456990588",
         "person_count": 541,
@@ -822,7 +822,7 @@
             "start_date": "2014-01-29",
             "slug": "10",
             "csv": "data/Bangladesh/House/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a63094/data/Bangladesh/House/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0a63094/data/Bangladesh/House/term-10.csv"
           },
           {
             "end_date": "2014-01-24",
@@ -831,7 +831,7 @@
             "start_date": "2009-01-25",
             "slug": "9",
             "csv": "data/Bangladesh/House/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a63094/data/Bangladesh/House/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0a63094/data/Bangladesh/House/term-9.csv"
           }
         ],
         "statement_count": 9271
@@ -849,7 +849,7 @@
         "slug": "House-of-Assembly",
         "sources_directory": "data/Barbados/House_of_Assembly/sources",
         "popolo": "data/Barbados/House_of_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f48eaa4/data/Barbados/House_of_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/f48eaa4/data/Barbados/House_of_Assembly/ep-popolo-v1.0.json",
         "names": "data/Barbados/House_of_Assembly/names.csv",
         "lastmod": "1453735450",
         "person_count": 30,
@@ -861,7 +861,7 @@
             "start_date": "2013",
             "slug": "2013",
             "csv": "data/Barbados/House_of_Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f48eaa4/data/Barbados/House_of_Assembly/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/f48eaa4/data/Barbados/House_of_Assembly/term-2013.csv"
           }
         ],
         "statement_count": 646
@@ -879,7 +879,7 @@
         "slug": "Chamber",
         "sources_directory": "data/Belarus/Chamber/sources",
         "popolo": "data/Belarus/Chamber/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9c39363/data/Belarus/Chamber/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/9c39363/data/Belarus/Chamber/ep-popolo-v1.0.json",
         "names": "data/Belarus/Chamber/names.csv",
         "lastmod": "1457923782",
         "person_count": 109,
@@ -891,7 +891,7 @@
             "start_date": "2012-09-23",
             "slug": "5",
             "csv": "data/Belarus/Chamber/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9c39363/data/Belarus/Chamber/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/9c39363/data/Belarus/Chamber/term-5.csv"
           }
         ],
         "statement_count": 3018
@@ -909,7 +909,7 @@
         "slug": "Representatives",
         "sources_directory": "data/Belgium/Representatives/sources",
         "popolo": "data/Belgium/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7916945/data/Belgium/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/7916945/data/Belgium/Representatives/ep-popolo-v1.0.json",
         "names": "data/Belgium/Representatives/names.csv",
         "lastmod": "1458260041",
         "person_count": 168,
@@ -921,7 +921,7 @@
             "start_date": "2014",
             "slug": "54",
             "csv": "data/Belgium/Representatives/term-54.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7916945/data/Belgium/Representatives/term-54.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7916945/data/Belgium/Representatives/term-54.csv"
           }
         ],
         "statement_count": 9620
@@ -939,7 +939,7 @@
         "slug": "Representatives",
         "sources_directory": "data/Belize/Representatives/sources",
         "popolo": "data/Belize/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0d48672/data/Belize/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/0d48672/data/Belize/Representatives/ep-popolo-v1.0.json",
         "names": "data/Belize/Representatives/names.csv",
         "lastmod": "1457813777",
         "person_count": 27,
@@ -952,7 +952,7 @@
             "start_date": "2012-03-21",
             "slug": "2012",
             "csv": "data/Belize/Representatives/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0d48672/data/Belize/Representatives/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0d48672/data/Belize/Representatives/term-2012.csv"
           }
         ],
         "statement_count": 1072
@@ -970,7 +970,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Benin/National_Assembly/sources",
         "popolo": "data/Benin/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd19803/data/Benin/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/fd19803/data/Benin/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Benin/National_Assembly/names.csv",
         "lastmod": "1453735534",
         "person_count": 83,
@@ -982,7 +982,7 @@
             "start_date": "2015-04-26",
             "slug": "6",
             "csv": "data/Benin/National_Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd19803/data/Benin/National_Assembly/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd19803/data/Benin/National_Assembly/term-6.csv"
           }
         ],
         "statement_count": 1432
@@ -1000,7 +1000,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Bermuda/Assembly/sources",
         "popolo": "data/Bermuda/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0573e41/data/Bermuda/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/0573e41/data/Bermuda/Assembly/ep-popolo-v1.0.json",
         "names": "data/Bermuda/Assembly/names.csv",
         "lastmod": "1457388449",
         "person_count": 36,
@@ -1012,7 +1012,7 @@
             "start_date": "2012-12-17",
             "slug": "2012",
             "csv": "data/Bermuda/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0573e41/data/Bermuda/Assembly/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0573e41/data/Bermuda/Assembly/term-2012.csv"
           }
         ],
         "statement_count": 559
@@ -1030,7 +1030,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Bhutan/Assembly/sources",
         "popolo": "data/Bhutan/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a4b9d1/data/Bhutan/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/4a4b9d1/data/Bhutan/Assembly/ep-popolo-v1.0.json",
         "names": "data/Bhutan/Assembly/names.csv",
         "lastmod": "1456587626",
         "person_count": 47,
@@ -1042,7 +1042,7 @@
             "start_date": "2013-07-13",
             "slug": "2",
             "csv": "data/Bhutan/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a4b9d1/data/Bhutan/Assembly/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/4a4b9d1/data/Bhutan/Assembly/term-2.csv"
           }
         ],
         "statement_count": 816
@@ -1060,7 +1060,7 @@
         "slug": "Deputies",
         "sources_directory": "data/Bolivia/Deputies/sources",
         "popolo": "data/Bolivia/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6cf4e7/data/Bolivia/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/b6cf4e7/data/Bolivia/Deputies/ep-popolo-v1.0.json",
         "names": "data/Bolivia/Deputies/names.csv",
         "lastmod": "1457973039",
         "person_count": 128,
@@ -1072,7 +1072,7 @@
             "start_date": "2015",
             "slug": "2015",
             "csv": "data/Bolivia/Deputies/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6cf4e7/data/Bolivia/Deputies/term-2015.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6cf4e7/data/Bolivia/Deputies/term-2015.csv"
           }
         ],
         "statement_count": 2046
@@ -1090,7 +1090,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Bosnia_and_Herzegovina/House_of_Representatives/sources",
         "popolo": "data/Bosnia_and_Herzegovina/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/88202ac/data/Bosnia_and_Herzegovina/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/88202ac/data/Bosnia_and_Herzegovina/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Bosnia_and_Herzegovina/House_of_Representatives/names.csv",
         "lastmod": "1455383987",
         "person_count": 42,
@@ -1102,7 +1102,7 @@
             "start_date": "2014",
             "slug": "7",
             "csv": "data/Bosnia_and_Herzegovina/House_of_Representatives/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/88202ac/data/Bosnia_and_Herzegovina/House_of_Representatives/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/88202ac/data/Bosnia_and_Herzegovina/House_of_Representatives/term-7.csv"
           }
         ],
         "statement_count": 688
@@ -1120,7 +1120,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Botswana/Assembly/sources",
         "popolo": "data/Botswana/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/98d6d3e/data/Botswana/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/98d6d3e/data/Botswana/Assembly/ep-popolo-v1.0.json",
         "names": "data/Botswana/Assembly/names.csv",
         "lastmod": "1457971063",
         "person_count": 63,
@@ -1132,7 +1132,7 @@
             "start_date": "2014-10-29",
             "slug": "2014",
             "csv": "data/Botswana/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/98d6d3e/data/Botswana/Assembly/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/98d6d3e/data/Botswana/Assembly/term-2014.csv"
           }
         ],
         "statement_count": 1489
@@ -1150,7 +1150,7 @@
         "slug": "Deputies",
         "sources_directory": "data/Brazil/Deputies/sources",
         "popolo": "data/Brazil/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c0fb6f/data/Brazil/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/5c0fb6f/data/Brazil/Deputies/ep-popolo-v1.0.json",
         "names": "data/Brazil/Deputies/names.csv",
         "lastmod": "1458215841",
         "person_count": 525,
@@ -1162,7 +1162,7 @@
             "start_date": "2015",
             "slug": "55",
             "csv": "data/Brazil/Deputies/term-55.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c0fb6f/data/Brazil/Deputies/term-55.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5c0fb6f/data/Brazil/Deputies/term-55.csv"
           }
         ],
         "statement_count": 10365
@@ -1180,7 +1180,7 @@
         "slug": "Assembly",
         "sources_directory": "data/British_Virgin_Islands/Assembly/sources",
         "popolo": "data/British_Virgin_Islands/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02d862a/data/British_Virgin_Islands/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/02d862a/data/British_Virgin_Islands/Assembly/ep-popolo-v1.0.json",
         "names": "data/British_Virgin_Islands/Assembly/names.csv",
         "lastmod": "1458197153",
         "person_count": 23,
@@ -1192,7 +1192,7 @@
             "start_date": "2015",
             "slug": "2015",
             "csv": "data/British_Virgin_Islands/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02d862a/data/British_Virgin_Islands/Assembly/term-2015.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/02d862a/data/British_Virgin_Islands/Assembly/term-2015.csv"
           },
           {
             "end_date": "2015",
@@ -1201,7 +1201,7 @@
             "start_date": "2011",
             "slug": "2011",
             "csv": "data/British_Virgin_Islands/Assembly/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02d862a/data/British_Virgin_Islands/Assembly/term-2011.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/02d862a/data/British_Virgin_Islands/Assembly/term-2011.csv"
           },
           {
             "end_date": "2011",
@@ -1210,7 +1210,7 @@
             "start_date": "2007",
             "slug": "2007",
             "csv": "data/British_Virgin_Islands/Assembly/term-2007.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02d862a/data/British_Virgin_Islands/Assembly/term-2007.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/02d862a/data/British_Virgin_Islands/Assembly/term-2007.csv"
           }
         ],
         "statement_count": 702
@@ -1220,7 +1220,7 @@
         "slug": "Council",
         "sources_directory": "data/British_Virgin_Islands/Council/sources",
         "popolo": "data/British_Virgin_Islands/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/080d748/data/British_Virgin_Islands/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/080d748/data/British_Virgin_Islands/Council/ep-popolo-v1.0.json",
         "names": "data/British_Virgin_Islands/Council/names.csv",
         "lastmod": "1457207208",
         "person_count": 36,
@@ -1233,7 +1233,7 @@
             "start_date": "2003",
             "slug": "2003",
             "csv": "data/British_Virgin_Islands/Council/term-2003.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/080d748/data/British_Virgin_Islands/Council/term-2003.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/080d748/data/British_Virgin_Islands/Council/term-2003.csv"
           },
           {
             "end_date": "2003",
@@ -1242,7 +1242,7 @@
             "start_date": "1999",
             "slug": "1999",
             "csv": "data/British_Virgin_Islands/Council/term-1999.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/080d748/data/British_Virgin_Islands/Council/term-1999.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/080d748/data/British_Virgin_Islands/Council/term-1999.csv"
           },
           {
             "end_date": "1999",
@@ -1251,7 +1251,7 @@
             "start_date": "1995",
             "slug": "1995",
             "csv": "data/British_Virgin_Islands/Council/term-1995.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/080d748/data/British_Virgin_Islands/Council/term-1995.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/080d748/data/British_Virgin_Islands/Council/term-1995.csv"
           },
           {
             "end_date": "1995",
@@ -1260,7 +1260,7 @@
             "start_date": "1990",
             "slug": "1990",
             "csv": "data/British_Virgin_Islands/Council/term-1990.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/080d748/data/British_Virgin_Islands/Council/term-1990.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/080d748/data/British_Virgin_Islands/Council/term-1990.csv"
           },
           {
             "end_date": "1990",
@@ -1269,7 +1269,7 @@
             "start_date": "1986",
             "slug": "1986",
             "csv": "data/British_Virgin_Islands/Council/term-1986.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/080d748/data/British_Virgin_Islands/Council/term-1986.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/080d748/data/British_Virgin_Islands/Council/term-1986.csv"
           },
           {
             "end_date": "1986",
@@ -1278,7 +1278,7 @@
             "start_date": "1983",
             "slug": "1983",
             "csv": "data/British_Virgin_Islands/Council/term-1983.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/080d748/data/British_Virgin_Islands/Council/term-1983.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/080d748/data/British_Virgin_Islands/Council/term-1983.csv"
           },
           {
             "end_date": "1983",
@@ -1287,7 +1287,7 @@
             "start_date": "1979",
             "slug": "1979",
             "csv": "data/British_Virgin_Islands/Council/term-1979.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/080d748/data/British_Virgin_Islands/Council/term-1979.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/080d748/data/British_Virgin_Islands/Council/term-1979.csv"
           },
           {
             "end_date": "1979",
@@ -1296,7 +1296,7 @@
             "start_date": "1975",
             "slug": "1975",
             "csv": "data/British_Virgin_Islands/Council/term-1975.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/080d748/data/British_Virgin_Islands/Council/term-1975.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/080d748/data/British_Virgin_Islands/Council/term-1975.csv"
           },
           {
             "end_date": "1975",
@@ -1305,7 +1305,7 @@
             "start_date": "1971",
             "slug": "1971",
             "csv": "data/British_Virgin_Islands/Council/term-1971.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/080d748/data/British_Virgin_Islands/Council/term-1971.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/080d748/data/British_Virgin_Islands/Council/term-1971.csv"
           }
         ],
         "statement_count": 1239
@@ -1323,7 +1323,7 @@
         "slug": "Legislative-Council",
         "sources_directory": "data/Brunei/Legislative_Council/sources",
         "popolo": "data/Brunei/Legislative_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2974d8e/data/Brunei/Legislative_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/2974d8e/data/Brunei/Legislative_Council/ep-popolo-v1.0.json",
         "names": "data/Brunei/Legislative_Council/names.csv",
         "lastmod": "1450786763",
         "person_count": 19,
@@ -1336,7 +1336,7 @@
             "start_date": "2015-03-05",
             "slug": "11",
             "csv": "data/Brunei/Legislative_Council/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2974d8e/data/Brunei/Legislative_Council/term-11.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2974d8e/data/Brunei/Legislative_Council/term-11.csv"
           }
         ],
         "statement_count": 292
@@ -1354,7 +1354,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Bulgaria/National_Assembly/sources",
         "popolo": "data/Bulgaria/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3093d50/data/Bulgaria/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/3093d50/data/Bulgaria/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Bulgaria/National_Assembly/names.csv",
         "lastmod": "1458108263",
         "person_count": 939,
@@ -1367,7 +1367,7 @@
             "start_date": "2014-10-27",
             "slug": "43",
             "csv": "data/Bulgaria/National_Assembly/term-43.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3093d50/data/Bulgaria/National_Assembly/term-43.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/3093d50/data/Bulgaria/National_Assembly/term-43.csv"
           },
           {
             "end_date": "2014-08-05",
@@ -1376,7 +1376,7 @@
             "start_date": "2013-05-21",
             "slug": "42",
             "csv": "data/Bulgaria/National_Assembly/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3093d50/data/Bulgaria/National_Assembly/term-42.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/3093d50/data/Bulgaria/National_Assembly/term-42.csv"
           },
           {
             "end_date": "2013-03-14",
@@ -1385,7 +1385,7 @@
             "start_date": "2009-07-14",
             "slug": "41",
             "csv": "data/Bulgaria/National_Assembly/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3093d50/data/Bulgaria/National_Assembly/term-41.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/3093d50/data/Bulgaria/National_Assembly/term-41.csv"
           },
           {
             "end_date": "2009-06-25",
@@ -1394,7 +1394,7 @@
             "start_date": "2005-07-11",
             "slug": "40",
             "csv": "data/Bulgaria/National_Assembly/term-40.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3093d50/data/Bulgaria/National_Assembly/term-40.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/3093d50/data/Bulgaria/National_Assembly/term-40.csv"
           },
           {
             "end_date": "2005-06-17",
@@ -1403,7 +1403,7 @@
             "start_date": "2001-07-05",
             "slug": "39",
             "csv": "data/Bulgaria/National_Assembly/term-39.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3093d50/data/Bulgaria/National_Assembly/term-39.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/3093d50/data/Bulgaria/National_Assembly/term-39.csv"
           }
         ],
         "statement_count": 33565
@@ -1421,7 +1421,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Burkina_Faso/Assembly/sources",
         "popolo": "data/Burkina_Faso/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/486bc8c/data/Burkina_Faso/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/486bc8c/data/Burkina_Faso/Assembly/ep-popolo-v1.0.json",
         "names": "data/Burkina_Faso/Assembly/names.csv",
         "lastmod": "1457188673",
         "person_count": 126,
@@ -1433,7 +1433,7 @@
             "start_date": "2012-12-02",
             "slug": "2012",
             "csv": "data/Burkina_Faso/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/486bc8c/data/Burkina_Faso/Assembly/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/486bc8c/data/Burkina_Faso/Assembly/term-2012.csv"
           }
         ],
         "statement_count": 1931
@@ -1451,7 +1451,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Burundi/Assembly/sources",
         "popolo": "data/Burundi/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b280ca0/data/Burundi/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/b280ca0/data/Burundi/Assembly/ep-popolo-v1.0.json",
         "names": "data/Burundi/Assembly/names.csv",
         "lastmod": "1456589737",
         "person_count": 227,
@@ -1463,7 +1463,7 @@
             "start_date": "2015-07-27",
             "slug": "2015",
             "csv": "data/Burundi/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b280ca0/data/Burundi/Assembly/term-2015.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b280ca0/data/Burundi/Assembly/term-2015.csv"
           },
           {
             "end_date": "2015-04-30",
@@ -1472,7 +1472,7 @@
             "start_date": "2010",
             "slug": "2010",
             "csv": "data/Burundi/Assembly/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b280ca0/data/Burundi/Assembly/term-2010.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b280ca0/data/Burundi/Assembly/term-2010.csv"
           }
         ],
         "statement_count": 2724
@@ -1490,7 +1490,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Cabo_Verde/Assembly/sources",
         "popolo": "data/Cabo_Verde/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6883083/data/Cabo_Verde/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/6883083/data/Cabo_Verde/Assembly/ep-popolo-v1.0.json",
         "names": "data/Cabo_Verde/Assembly/names.csv",
         "lastmod": "1457189276",
         "person_count": 75,
@@ -1502,7 +1502,7 @@
             "start_date": "2011-03-11",
             "slug": "8",
             "csv": "data/Cabo_Verde/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6883083/data/Cabo_Verde/Assembly/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6883083/data/Cabo_Verde/Assembly/term-8.csv"
           }
         ],
         "statement_count": 885
@@ -1520,7 +1520,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Cambodia/National_Assembly/sources",
         "popolo": "data/Cambodia/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2b37ee1/data/Cambodia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/2b37ee1/data/Cambodia/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Cambodia/National_Assembly/names.csv",
         "lastmod": "1457819337",
         "person_count": 123,
@@ -1532,7 +1532,7 @@
             "start_date": "2013",
             "slug": "5",
             "csv": "data/Cambodia/National_Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2b37ee1/data/Cambodia/National_Assembly/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2b37ee1/data/Cambodia/National_Assembly/term-5.csv"
           }
         ],
         "statement_count": 2878
@@ -1550,7 +1550,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Cameroon/Assembly/sources",
         "popolo": "data/Cameroon/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/455b500/data/Cameroon/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/455b500/data/Cameroon/Assembly/ep-popolo-v1.0.json",
         "names": "data/Cameroon/Assembly/names.csv",
         "lastmod": "1457189422",
         "person_count": 964,
@@ -1562,7 +1562,7 @@
             "start_date": "2013",
             "slug": "9",
             "csv": "data/Cameroon/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/455b500/data/Cameroon/Assembly/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/455b500/data/Cameroon/Assembly/term-9.csv"
           },
           {
             "end_date": "2013",
@@ -1571,7 +1571,7 @@
             "start_date": "2007",
             "slug": "8",
             "csv": "data/Cameroon/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/455b500/data/Cameroon/Assembly/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/455b500/data/Cameroon/Assembly/term-8.csv"
           },
           {
             "end_date": "2007",
@@ -1580,7 +1580,7 @@
             "start_date": "2002",
             "slug": "7",
             "csv": "data/Cameroon/Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/455b500/data/Cameroon/Assembly/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/455b500/data/Cameroon/Assembly/term-7.csv"
           },
           {
             "end_date": "2002",
@@ -1589,7 +1589,7 @@
             "start_date": "1997",
             "slug": "6",
             "csv": "data/Cameroon/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/455b500/data/Cameroon/Assembly/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/455b500/data/Cameroon/Assembly/term-6.csv"
           },
           {
             "end_date": "1997",
@@ -1598,7 +1598,7 @@
             "start_date": "1992",
             "slug": "5",
             "csv": "data/Cameroon/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/455b500/data/Cameroon/Assembly/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/455b500/data/Cameroon/Assembly/term-5.csv"
           },
           {
             "end_date": "1992",
@@ -1607,7 +1607,7 @@
             "start_date": "1988",
             "slug": "4",
             "csv": "data/Cameroon/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/455b500/data/Cameroon/Assembly/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/455b500/data/Cameroon/Assembly/term-4.csv"
           },
           {
             "end_date": "1988",
@@ -1616,7 +1616,7 @@
             "start_date": "1983",
             "slug": "3",
             "csv": "data/Cameroon/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/455b500/data/Cameroon/Assembly/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/455b500/data/Cameroon/Assembly/term-3.csv"
           },
           {
             "end_date": "1978",
@@ -1625,7 +1625,7 @@
             "start_date": "1973",
             "slug": "1",
             "csv": "data/Cameroon/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/455b500/data/Cameroon/Assembly/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/455b500/data/Cameroon/Assembly/term-1.csv"
           }
         ],
         "statement_count": 11345
@@ -1635,7 +1635,7 @@
         "slug": "Senate",
         "sources_directory": "data/Cameroon/Senate/sources",
         "popolo": "data/Cameroon/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cae5581/data/Cameroon/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/cae5581/data/Cameroon/Senate/ep-popolo-v1.0.json",
         "names": "data/Cameroon/Senate/names.csv",
         "lastmod": "1450786824",
         "person_count": 100,
@@ -1647,7 +1647,7 @@
             "start_date": "2013",
             "slug": "9",
             "csv": "data/Cameroon/Senate/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cae5581/data/Cameroon/Senate/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/cae5581/data/Cameroon/Senate/term-9.csv"
           }
         ],
         "statement_count": 1162
@@ -1665,7 +1665,7 @@
         "slug": "Commons",
         "sources_directory": "data/Canada/Commons/sources",
         "popolo": "data/Canada/Commons/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d531f23/data/Canada/Commons/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/d531f23/data/Canada/Commons/ep-popolo-v1.0.json",
         "names": "data/Canada/Commons/names.csv",
         "lastmod": "1458274605",
         "person_count": 537,
@@ -1678,7 +1678,7 @@
             "wikidata": "Q21157957",
             "slug": "42",
             "csv": "data/Canada/Commons/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d531f23/data/Canada/Commons/term-42.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/d531f23/data/Canada/Commons/term-42.csv"
           },
           {
             "end_date": "2015-08-02",
@@ -1688,7 +1688,7 @@
             "wikidata": "Q2816776",
             "slug": "41",
             "csv": "data/Canada/Commons/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d531f23/data/Canada/Commons/term-41.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/d531f23/data/Canada/Commons/term-41.csv"
           }
         ],
         "statement_count": 31922
@@ -1706,7 +1706,7 @@
         "slug": "Legislative-Assembly",
         "sources_directory": "data/Cayman_Islands/Legislative_Assembly/sources",
         "popolo": "data/Cayman_Islands/Legislative_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cfcbd1c/data/Cayman_Islands/Legislative_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/cfcbd1c/data/Cayman_Islands/Legislative_Assembly/ep-popolo-v1.0.json",
         "names": "data/Cayman_Islands/Legislative_Assembly/names.csv",
         "lastmod": "1457189376",
         "person_count": 18,
@@ -1718,7 +1718,7 @@
             "start_date": "2013",
             "slug": "2013",
             "csv": "data/Cayman_Islands/Legislative_Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cfcbd1c/data/Cayman_Islands/Legislative_Assembly/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/cfcbd1c/data/Cayman_Islands/Legislative_Assembly/term-2013.csv"
           }
         ],
         "statement_count": 303
@@ -1736,7 +1736,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Chad/Assembly/sources",
         "popolo": "data/Chad/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/021accf/data/Chad/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/021accf/data/Chad/Assembly/ep-popolo-v1.0.json",
         "names": "data/Chad/Assembly/names.csv",
         "lastmod": "1457188503",
         "person_count": 191,
@@ -1748,7 +1748,7 @@
             "start_date": "2011",
             "slug": "3",
             "csv": "data/Chad/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/021accf/data/Chad/Assembly/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/021accf/data/Chad/Assembly/term-3.csv"
           }
         ],
         "statement_count": 2416
@@ -1766,7 +1766,7 @@
         "slug": "Deputies",
         "sources_directory": "data/Chile/Deputies/sources",
         "popolo": "data/Chile/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df4b2bc/data/Chile/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/df4b2bc/data/Chile/Deputies/ep-popolo-v1.0.json",
         "names": "data/Chile/Deputies/names.csv",
         "lastmod": "1458185257",
         "person_count": 372,
@@ -1779,7 +1779,7 @@
             "start_date": "2014-03-11",
             "slug": "8",
             "csv": "data/Chile/Deputies/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df4b2bc/data/Chile/Deputies/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/df4b2bc/data/Chile/Deputies/term-8.csv"
           },
           {
             "end_date": "2014-03-10",
@@ -1788,7 +1788,7 @@
             "start_date": "2010-03-11",
             "slug": "6",
             "csv": "data/Chile/Deputies/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df4b2bc/data/Chile/Deputies/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/df4b2bc/data/Chile/Deputies/term-6.csv"
           },
           {
             "end_date": "2010-03-10",
@@ -1797,7 +1797,7 @@
             "start_date": "2006-03-11",
             "slug": "5",
             "csv": "data/Chile/Deputies/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df4b2bc/data/Chile/Deputies/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/df4b2bc/data/Chile/Deputies/term-5.csv"
           },
           {
             "end_date": "2006-03-10",
@@ -1806,7 +1806,7 @@
             "start_date": "2002-03-11",
             "slug": "4",
             "csv": "data/Chile/Deputies/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df4b2bc/data/Chile/Deputies/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/df4b2bc/data/Chile/Deputies/term-4.csv"
           },
           {
             "end_date": "2002-03-10",
@@ -1815,7 +1815,7 @@
             "start_date": "1998-03-11",
             "slug": "3",
             "csv": "data/Chile/Deputies/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df4b2bc/data/Chile/Deputies/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/df4b2bc/data/Chile/Deputies/term-3.csv"
           },
           {
             "end_date": "1998-03-10",
@@ -1824,7 +1824,7 @@
             "start_date": "1994-03-11",
             "slug": "2",
             "csv": "data/Chile/Deputies/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df4b2bc/data/Chile/Deputies/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/df4b2bc/data/Chile/Deputies/term-2.csv"
           },
           {
             "end_date": "1994-03-10",
@@ -1833,7 +1833,7 @@
             "start_date": "1990-03-11",
             "slug": "1",
             "csv": "data/Chile/Deputies/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df4b2bc/data/Chile/Deputies/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/df4b2bc/data/Chile/Deputies/term-1.csv"
           }
         ],
         "statement_count": 16133
@@ -1851,7 +1851,7 @@
         "slug": "Congress",
         "sources_directory": "data/China/Congress/sources",
         "popolo": "data/China/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640fac/data/China/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/0640fac/data/China/Congress/ep-popolo-v1.0.json",
         "names": "data/China/Congress/names.csv",
         "lastmod": "1457387757",
         "person_count": 2956,
@@ -1863,7 +1863,7 @@
             "start_date": "2013-03-05",
             "slug": "12",
             "csv": "data/China/Congress/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640fac/data/China/Congress/term-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0640fac/data/China/Congress/term-12.csv"
           }
         ],
         "statement_count": 29864
@@ -1881,7 +1881,7 @@
         "slug": "Representatives",
         "sources_directory": "data/Colombia/Representatives/sources",
         "popolo": "data/Colombia/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640fac/data/Colombia/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/0640fac/data/Colombia/Representatives/ep-popolo-v1.0.json",
         "names": "data/Colombia/Representatives/names.csv",
         "lastmod": "1457387757",
         "person_count": 165,
@@ -1893,7 +1893,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/Colombia/Representatives/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640fac/data/Colombia/Representatives/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0640fac/data/Colombia/Representatives/term-2014.csv"
           }
         ],
         "statement_count": 3675
@@ -1911,7 +1911,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Comoros/Assembly/sources",
         "popolo": "data/Comoros/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/264c6c4/data/Comoros/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/264c6c4/data/Comoros/Assembly/ep-popolo-v1.0.json",
         "names": "data/Comoros/Assembly/names.csv",
         "lastmod": "1450786877",
         "person_count": 24,
@@ -1923,7 +1923,7 @@
             "start_date": "2015",
             "slug": "2015",
             "csv": "data/Comoros/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/264c6c4/data/Comoros/Assembly/term-2015.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/264c6c4/data/Comoros/Assembly/term-2015.csv"
           }
         ],
         "statement_count": 343
@@ -1941,7 +1941,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Congo-Brazzaville/Assembly/sources",
         "popolo": "data/Congo-Brazzaville/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5794cd9/data/Congo-Brazzaville/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/5794cd9/data/Congo-Brazzaville/Assembly/ep-popolo-v1.0.json",
         "names": "data/Congo-Brazzaville/Assembly/names.csv",
         "lastmod": "1457188392",
         "person_count": 122,
@@ -1953,7 +1953,7 @@
             "start_date": "2012",
             "slug": "13",
             "csv": "data/Congo-Brazzaville/Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5794cd9/data/Congo-Brazzaville/Assembly/term-13.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5794cd9/data/Congo-Brazzaville/Assembly/term-13.csv"
           }
         ],
         "statement_count": 2110
@@ -1971,7 +1971,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Congo-Kinshasa/Assembly/sources",
         "popolo": "data/Congo-Kinshasa/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6658a6e/data/Congo-Kinshasa/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/6658a6e/data/Congo-Kinshasa/Assembly/ep-popolo-v1.0.json",
         "names": "data/Congo-Kinshasa/Assembly/names.csv",
         "lastmod": "1450786887",
         "person_count": 498,
@@ -1983,7 +1983,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Congo-Kinshasa/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6658a6e/data/Congo-Kinshasa/Assembly/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6658a6e/data/Congo-Kinshasa/Assembly/term-2012.csv"
           }
         ],
         "statement_count": 6492
@@ -2001,7 +2001,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Cook_Islands/Parliament/sources",
         "popolo": "data/Cook_Islands/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bbded17/data/Cook_Islands/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/bbded17/data/Cook_Islands/Parliament/ep-popolo-v1.0.json",
         "names": "data/Cook_Islands/Parliament/names.csv",
         "lastmod": "1457745165",
         "person_count": 48,
@@ -2013,7 +2013,7 @@
             "start_date": "2014",
             "slug": "14",
             "csv": "data/Cook_Islands/Parliament/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bbded17/data/Cook_Islands/Parliament/term-14.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bbded17/data/Cook_Islands/Parliament/term-14.csv"
           },
           {
             "end_date": "2014-04-17",
@@ -2022,7 +2022,7 @@
             "start_date": "2011-02-18",
             "slug": "13",
             "csv": "data/Cook_Islands/Parliament/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bbded17/data/Cook_Islands/Parliament/term-13.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bbded17/data/Cook_Islands/Parliament/term-13.csv"
           },
           {
             "end_date": "2010-09-24",
@@ -2031,7 +2031,7 @@
             "start_date": "2006",
             "slug": "12",
             "csv": "data/Cook_Islands/Parliament/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bbded17/data/Cook_Islands/Parliament/term-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bbded17/data/Cook_Islands/Parliament/term-12.csv"
           }
         ],
         "statement_count": 1756
@@ -2049,7 +2049,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Costa_Rica/Assembly/sources",
         "popolo": "data/Costa_Rica/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b2db13/data/Costa_Rica/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/6b2db13/data/Costa_Rica/Assembly/ep-popolo-v1.0.json",
         "names": "data/Costa_Rica/Assembly/names.csv",
         "lastmod": "1457819091",
         "person_count": 57,
@@ -2062,7 +2062,7 @@
             "start_date": "2014-05-01",
             "slug": "2014",
             "csv": "data/Costa_Rica/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b2db13/data/Costa_Rica/Assembly/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6b2db13/data/Costa_Rica/Assembly/term-2014.csv"
           }
         ],
         "statement_count": 1648
@@ -2080,7 +2080,7 @@
         "slug": "Sabor",
         "sources_directory": "data/Croatia/Sabor/sources",
         "popolo": "data/Croatia/Sabor/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bb539d6/data/Croatia/Sabor/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/bb539d6/data/Croatia/Sabor/ep-popolo-v1.0.json",
         "names": "data/Croatia/Sabor/names.csv",
         "lastmod": "1458115096",
         "person_count": 249,
@@ -2092,7 +2092,7 @@
             "start_date": "2015-12-28",
             "slug": "8",
             "csv": "data/Croatia/Sabor/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bb539d6/data/Croatia/Sabor/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bb539d6/data/Croatia/Sabor/term-8.csv"
           },
           {
             "end_date": "2015-09-28",
@@ -2101,7 +2101,7 @@
             "start_date": "2011-12-22",
             "slug": "7",
             "csv": "data/Croatia/Sabor/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bb539d6/data/Croatia/Sabor/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bb539d6/data/Croatia/Sabor/term-7.csv"
           }
         ],
         "statement_count": 5258
@@ -2119,7 +2119,7 @@
         "slug": "Estates",
         "sources_directory": "data/Curacao/Estates/sources",
         "popolo": "data/Curacao/Estates/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640fac/data/Curacao/Estates/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/0640fac/data/Curacao/Estates/ep-popolo-v1.0.json",
         "names": "data/Curacao/Estates/names.csv",
         "lastmod": "1457387757",
         "person_count": 21,
@@ -2131,7 +2131,7 @@
             "start_date": "2012-09-11",
             "slug": "2",
             "csv": "data/Curacao/Estates/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640fac/data/Curacao/Estates/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0640fac/data/Curacao/Estates/term-2.csv"
           }
         ],
         "statement_count": 433
@@ -2149,7 +2149,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Cyprus/House_of_Representatives/sources",
         "popolo": "data/Cyprus/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/946d259/data/Cyprus/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/946d259/data/Cyprus/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Cyprus/House_of_Representatives/names.csv",
         "lastmod": "1457740959",
         "person_count": 63,
@@ -2161,7 +2161,7 @@
             "start_date": "2011-06-02",
             "slug": "2011",
             "csv": "data/Cyprus/House_of_Representatives/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/946d259/data/Cyprus/House_of_Representatives/term-2011.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/946d259/data/Cyprus/House_of_Representatives/term-2011.csv"
           }
         ],
         "statement_count": 2287
@@ -2179,7 +2179,7 @@
         "slug": "Deputies",
         "sources_directory": "data/Czech_Republic/Deputies/sources",
         "popolo": "data/Czech_Republic/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6737c85/data/Czech_Republic/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/6737c85/data/Czech_Republic/Deputies/ep-popolo-v1.0.json",
         "names": "data/Czech_Republic/Deputies/names.csv",
         "lastmod": "1458243432",
         "person_count": 892,
@@ -2191,7 +2191,7 @@
             "start_date": "2013-10-26",
             "slug": "7",
             "csv": "data/Czech_Republic/Deputies/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6737c85/data/Czech_Republic/Deputies/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6737c85/data/Czech_Republic/Deputies/term-7.csv"
           },
           {
             "end_date": "2013-08-28",
@@ -2200,7 +2200,7 @@
             "start_date": "2010-05-29",
             "slug": "6",
             "csv": "data/Czech_Republic/Deputies/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6737c85/data/Czech_Republic/Deputies/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6737c85/data/Czech_Republic/Deputies/term-6.csv"
           },
           {
             "end_date": "2010-06-03",
@@ -2209,7 +2209,7 @@
             "start_date": "2006-06-03",
             "slug": "5",
             "csv": "data/Czech_Republic/Deputies/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6737c85/data/Czech_Republic/Deputies/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6737c85/data/Czech_Republic/Deputies/term-5.csv"
           },
           {
             "end_date": "2006-06-15",
@@ -2218,7 +2218,7 @@
             "start_date": "2002-06-15",
             "slug": "4",
             "csv": "data/Czech_Republic/Deputies/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6737c85/data/Czech_Republic/Deputies/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6737c85/data/Czech_Republic/Deputies/term-4.csv"
           },
           {
             "end_date": "2002-06-20",
@@ -2227,7 +2227,7 @@
             "start_date": "1998-06-20",
             "slug": "3",
             "csv": "data/Czech_Republic/Deputies/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6737c85/data/Czech_Republic/Deputies/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6737c85/data/Czech_Republic/Deputies/term-3.csv"
           },
           {
             "end_date": "1998-06-19",
@@ -2236,7 +2236,7 @@
             "start_date": "1996-06-01",
             "slug": "2",
             "csv": "data/Czech_Republic/Deputies/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6737c85/data/Czech_Republic/Deputies/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6737c85/data/Czech_Republic/Deputies/term-2.csv"
           },
           {
             "end_date": "1996-06-06",
@@ -2245,7 +2245,7 @@
             "start_date": "1992-06-06",
             "slug": "1",
             "csv": "data/Czech_Republic/Deputies/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6737c85/data/Czech_Republic/Deputies/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6737c85/data/Czech_Republic/Deputies/term-1.csv"
           }
         ],
         "statement_count": 141697
@@ -2263,7 +2263,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Ivory_Coast/Assembly/sources",
         "popolo": "data/Ivory_Coast/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8438544/data/Ivory_Coast/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/8438544/data/Ivory_Coast/Assembly/ep-popolo-v1.0.json",
         "names": "data/Ivory_Coast/Assembly/names.csv",
         "lastmod": "1457183552",
         "person_count": 241,
@@ -2275,7 +2275,7 @@
             "start_date": "2012-03-12",
             "slug": "2.2",
             "csv": "data/Ivory_Coast/Assembly/term-2.2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8438544/data/Ivory_Coast/Assembly/term-2.2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/8438544/data/Ivory_Coast/Assembly/term-2.2.csv"
           }
         ],
         "statement_count": 3672
@@ -2293,7 +2293,7 @@
         "slug": "Folketing",
         "sources_directory": "data/Denmark/Folketing/sources",
         "popolo": "data/Denmark/Folketing/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3bc11ab/data/Denmark/Folketing/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/3bc11ab/data/Denmark/Folketing/ep-popolo-v1.0.json",
         "names": "data/Denmark/Folketing/names.csv",
         "lastmod": "1458202698",
         "person_count": 180,
@@ -2305,7 +2305,7 @@
             "start_date": "2015-06-20",
             "slug": "2015",
             "csv": "data/Denmark/Folketing/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3bc11ab/data/Denmark/Folketing/term-2015.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/3bc11ab/data/Denmark/Folketing/term-2015.csv"
           }
         ],
         "statement_count": 12347
@@ -2323,7 +2323,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Djibouti/Assembly/sources",
         "popolo": "data/Djibouti/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f4a9fa6/data/Djibouti/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/f4a9fa6/data/Djibouti/Assembly/ep-popolo-v1.0.json",
         "names": "data/Djibouti/Assembly/names.csv",
         "lastmod": "1457188050",
         "person_count": 65,
@@ -2335,7 +2335,7 @@
             "start_date": "2013",
             "slug": "6",
             "csv": "data/Djibouti/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f4a9fa6/data/Djibouti/Assembly/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/f4a9fa6/data/Djibouti/Assembly/term-6.csv"
           }
         ],
         "statement_count": 749
@@ -2353,7 +2353,7 @@
         "slug": "House-of-Assembly",
         "sources_directory": "data/Dominica/House_of_Assembly/sources",
         "popolo": "data/Dominica/House_of_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df9012f/data/Dominica/House_of_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/df9012f/data/Dominica/House_of_Assembly/ep-popolo-v1.0.json",
         "names": "data/Dominica/House_of_Assembly/names.csv",
         "lastmod": "1450786948",
         "person_count": 21,
@@ -2365,7 +2365,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/Dominica/House_of_Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df9012f/data/Dominica/House_of_Assembly/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/df9012f/data/Dominica/House_of_Assembly/term-2014.csv"
           }
         ],
         "statement_count": 331
@@ -2383,7 +2383,7 @@
         "slug": "Diputados",
         "sources_directory": "data/Dominican_Republic/Diputados/sources",
         "popolo": "data/Dominican_Republic/Diputados/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43e0435/data/Dominican_Republic/Diputados/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/43e0435/data/Dominican_Republic/Diputados/ep-popolo-v1.0.json",
         "names": "data/Dominican_Republic/Diputados/names.csv",
         "lastmod": "1458283043",
         "person_count": 190,
@@ -2395,7 +2395,7 @@
             "start_date": "2010",
             "slug": "2010",
             "csv": "data/Dominican_Republic/Diputados/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43e0435/data/Dominican_Republic/Diputados/term-2010.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/43e0435/data/Dominican_Republic/Diputados/term-2010.csv"
           }
         ],
         "statement_count": 3094
@@ -2413,7 +2413,7 @@
         "slug": "Asamblea",
         "sources_directory": "data/Ecuador/Asamblea/sources",
         "popolo": "data/Ecuador/Asamblea/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f1b5f62/data/Ecuador/Asamblea/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/f1b5f62/data/Ecuador/Asamblea/ep-popolo-v1.0.json",
         "names": "data/Ecuador/Asamblea/names.csv",
         "lastmod": "1458192670",
         "person_count": 138,
@@ -2425,7 +2425,7 @@
             "start_date": "2013",
             "slug": "2013",
             "csv": "data/Ecuador/Asamblea/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f1b5f62/data/Ecuador/Asamblea/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/f1b5f62/data/Ecuador/Asamblea/term-2013.csv"
           }
         ],
         "statement_count": 3786
@@ -2443,7 +2443,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Egypt/Parliament/sources",
         "popolo": "data/Egypt/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/092ea83/data/Egypt/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/092ea83/data/Egypt/Parliament/ep-popolo-v1.0.json",
         "names": "data/Egypt/Parliament/names.csv",
         "lastmod": "1458214658",
         "person_count": 596,
@@ -2455,7 +2455,7 @@
             "start_date": "2015",
             "slug": "2015",
             "csv": "data/Egypt/Parliament/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/092ea83/data/Egypt/Parliament/term-2015.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/092ea83/data/Egypt/Parliament/term-2015.csv"
           }
         ],
         "statement_count": 6691
@@ -2473,7 +2473,7 @@
         "slug": "Legislative-Assembly",
         "sources_directory": "data/El_Salvador/Legislative_Assembly/sources",
         "popolo": "data/El_Salvador/Legislative_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb068fd/data/El_Salvador/Legislative_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/eb068fd/data/El_Salvador/Legislative_Assembly/ep-popolo-v1.0.json",
         "names": "data/El_Salvador/Legislative_Assembly/names.csv",
         "lastmod": "1452785433",
         "person_count": 84,
@@ -2486,7 +2486,7 @@
             "start_date": "2015",
             "slug": "2015-2018",
             "csv": "data/El_Salvador/Legislative_Assembly/term-2015-2018.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb068fd/data/El_Salvador/Legislative_Assembly/term-2015-2018.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/eb068fd/data/El_Salvador/Legislative_Assembly/term-2015-2018.csv"
           }
         ],
         "statement_count": 1451
@@ -2504,7 +2504,7 @@
         "slug": "Riigikogu",
         "sources_directory": "data/Estonia/Riigikogu/sources",
         "popolo": "data/Estonia/Riigikogu/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a83c5e9/data/Estonia/Riigikogu/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/a83c5e9/data/Estonia/Riigikogu/ep-popolo-v1.0.json",
         "names": "data/Estonia/Riigikogu/names.csv",
         "lastmod": "1458256855",
         "person_count": 192,
@@ -2517,7 +2517,7 @@
             "wikidata": "Q20530392",
             "slug": "13",
             "csv": "data/Estonia/Riigikogu/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a83c5e9/data/Estonia/Riigikogu/term-13.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a83c5e9/data/Estonia/Riigikogu/term-13.csv"
           },
           {
             "end_date": "2015-03-23",
@@ -2527,7 +2527,7 @@
             "wikidata": "Q967549",
             "slug": "12",
             "csv": "data/Estonia/Riigikogu/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a83c5e9/data/Estonia/Riigikogu/term-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a83c5e9/data/Estonia/Riigikogu/term-12.csv"
           }
         ],
         "statement_count": 14431
@@ -2545,7 +2545,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Falkland_Islands/Assembly/sources",
         "popolo": "data/Falkland_Islands/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2bf41c/data/Falkland_Islands/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/b2bf41c/data/Falkland_Islands/Assembly/ep-popolo-v1.0.json",
         "names": "data/Falkland_Islands/Assembly/names.csv",
         "lastmod": "1458191942",
         "person_count": 49,
@@ -2558,7 +2558,7 @@
             "start_date": "2013",
             "slug": "2013",
             "csv": "data/Falkland_Islands/Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2bf41c/data/Falkland_Islands/Assembly/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b2bf41c/data/Falkland_Islands/Assembly/term-2013.csv"
           },
           {
             "end_date": "2013",
@@ -2567,7 +2567,7 @@
             "start_date": "2009",
             "slug": "2009",
             "csv": "data/Falkland_Islands/Assembly/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2bf41c/data/Falkland_Islands/Assembly/term-2009.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b2bf41c/data/Falkland_Islands/Assembly/term-2009.csv"
           },
           {
             "end_date": "2009",
@@ -2576,7 +2576,7 @@
             "start_date": "2005",
             "slug": "2005",
             "csv": "data/Falkland_Islands/Assembly/term-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2bf41c/data/Falkland_Islands/Assembly/term-2005.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b2bf41c/data/Falkland_Islands/Assembly/term-2005.csv"
           },
           {
             "end_date": "2005",
@@ -2585,7 +2585,7 @@
             "start_date": "2001",
             "slug": "2001",
             "csv": "data/Falkland_Islands/Assembly/term-2001.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2bf41c/data/Falkland_Islands/Assembly/term-2001.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b2bf41c/data/Falkland_Islands/Assembly/term-2001.csv"
           },
           {
             "end_date": "2001",
@@ -2594,7 +2594,7 @@
             "start_date": "1997",
             "slug": "1997",
             "csv": "data/Falkland_Islands/Assembly/term-1997.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2bf41c/data/Falkland_Islands/Assembly/term-1997.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b2bf41c/data/Falkland_Islands/Assembly/term-1997.csv"
           },
           {
             "end_date": "1997",
@@ -2603,7 +2603,7 @@
             "start_date": "1993",
             "slug": "1993",
             "csv": "data/Falkland_Islands/Assembly/term-1993.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2bf41c/data/Falkland_Islands/Assembly/term-1993.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b2bf41c/data/Falkland_Islands/Assembly/term-1993.csv"
           },
           {
             "end_date": "1993",
@@ -2612,7 +2612,7 @@
             "start_date": "1989",
             "slug": "1989",
             "csv": "data/Falkland_Islands/Assembly/term-1989.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2bf41c/data/Falkland_Islands/Assembly/term-1989.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b2bf41c/data/Falkland_Islands/Assembly/term-1989.csv"
           },
           {
             "end_date": "1989",
@@ -2621,7 +2621,7 @@
             "start_date": "1985",
             "slug": "1985",
             "csv": "data/Falkland_Islands/Assembly/term-1985.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2bf41c/data/Falkland_Islands/Assembly/term-1985.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b2bf41c/data/Falkland_Islands/Assembly/term-1985.csv"
           },
           {
             "end_date": "1985",
@@ -2630,7 +2630,7 @@
             "start_date": "1981",
             "slug": "1981",
             "csv": "data/Falkland_Islands/Assembly/term-1981.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2bf41c/data/Falkland_Islands/Assembly/term-1981.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b2bf41c/data/Falkland_Islands/Assembly/term-1981.csv"
           },
           {
             "end_date": "1981",
@@ -2639,7 +2639,7 @@
             "start_date": "1977",
             "slug": "1977",
             "csv": "data/Falkland_Islands/Assembly/term-1977.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2bf41c/data/Falkland_Islands/Assembly/term-1977.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b2bf41c/data/Falkland_Islands/Assembly/term-1977.csv"
           }
         ],
         "statement_count": 1567
@@ -2657,7 +2657,7 @@
         "slug": "Logting",
         "sources_directory": "data/Faroe_Islands/Logting/sources",
         "popolo": "data/Faroe_Islands/Logting/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/432a490/data/Faroe_Islands/Logting/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/432a490/data/Faroe_Islands/Logting/ep-popolo-v1.0.json",
         "names": "data/Faroe_Islands/Logting/names.csv",
         "lastmod": "1458285537",
         "person_count": 104,
@@ -2669,7 +2669,7 @@
             "start_date": "2015",
             "slug": "2015",
             "csv": "data/Faroe_Islands/Logting/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/432a490/data/Faroe_Islands/Logting/term-2015.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/432a490/data/Faroe_Islands/Logting/term-2015.csv"
           },
           {
             "end_date": "2015",
@@ -2678,7 +2678,7 @@
             "start_date": "2011",
             "slug": "2011",
             "csv": "data/Faroe_Islands/Logting/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/432a490/data/Faroe_Islands/Logting/term-2011.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/432a490/data/Faroe_Islands/Logting/term-2011.csv"
           },
           {
             "end_date": "2011",
@@ -2687,7 +2687,7 @@
             "start_date": "2008",
             "slug": "2008",
             "csv": "data/Faroe_Islands/Logting/term-2008.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/432a490/data/Faroe_Islands/Logting/term-2008.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/432a490/data/Faroe_Islands/Logting/term-2008.csv"
           },
           {
             "end_date": "2008",
@@ -2696,7 +2696,7 @@
             "start_date": "2004",
             "slug": "2004",
             "csv": "data/Faroe_Islands/Logting/term-2004.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/432a490/data/Faroe_Islands/Logting/term-2004.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/432a490/data/Faroe_Islands/Logting/term-2004.csv"
           },
           {
             "end_date": "2004",
@@ -2705,7 +2705,7 @@
             "start_date": "2002",
             "slug": "2002",
             "csv": "data/Faroe_Islands/Logting/term-2002.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/432a490/data/Faroe_Islands/Logting/term-2002.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/432a490/data/Faroe_Islands/Logting/term-2002.csv"
           },
           {
             "end_date": "2002",
@@ -2714,7 +2714,7 @@
             "start_date": "1998",
             "slug": "1998",
             "csv": "data/Faroe_Islands/Logting/term-1998.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/432a490/data/Faroe_Islands/Logting/term-1998.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/432a490/data/Faroe_Islands/Logting/term-1998.csv"
           },
           {
             "end_date": "1998",
@@ -2723,7 +2723,7 @@
             "start_date": "1994",
             "slug": "1994",
             "csv": "data/Faroe_Islands/Logting/term-1994.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/432a490/data/Faroe_Islands/Logting/term-1994.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/432a490/data/Faroe_Islands/Logting/term-1994.csv"
           },
           {
             "end_date": "1994",
@@ -2732,7 +2732,7 @@
             "start_date": "1990",
             "slug": "1990",
             "csv": "data/Faroe_Islands/Logting/term-1990.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/432a490/data/Faroe_Islands/Logting/term-1990.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/432a490/data/Faroe_Islands/Logting/term-1990.csv"
           }
         ],
         "statement_count": 5855
@@ -2750,7 +2750,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Fiji/Parliament/sources",
         "popolo": "data/Fiji/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8cd212e/data/Fiji/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/8cd212e/data/Fiji/Parliament/ep-popolo-v1.0.json",
         "names": "data/Fiji/Parliament/names.csv",
         "lastmod": "1457947159",
         "person_count": 53,
@@ -2762,7 +2762,7 @@
             "start_date": "2014-10-06",
             "slug": "2014",
             "csv": "data/Fiji/Parliament/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8cd212e/data/Fiji/Parliament/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/8cd212e/data/Fiji/Parliament/term-2014.csv"
           }
         ],
         "statement_count": 804
@@ -2780,7 +2780,7 @@
         "slug": "Eduskunta",
         "sources_directory": "data/Finland/Eduskunta/sources",
         "popolo": "data/Finland/Eduskunta/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1467bd8/data/Finland/Eduskunta/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/1467bd8/data/Finland/Eduskunta/ep-popolo-v1.0.json",
         "names": "data/Finland/Eduskunta/names.csv",
         "lastmod": "1458301006",
         "person_count": 492,
@@ -2793,7 +2793,7 @@
             "start_date": "2015-04-28",
             "slug": "37",
             "csv": "data/Finland/Eduskunta/term-37.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1467bd8/data/Finland/Eduskunta/term-37.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1467bd8/data/Finland/Eduskunta/term-37.csv"
           },
           {
             "end_date": "2015-03-14",
@@ -2802,7 +2802,7 @@
             "start_date": "2011-04-20",
             "slug": "36",
             "csv": "data/Finland/Eduskunta/term-36.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1467bd8/data/Finland/Eduskunta/term-36.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1467bd8/data/Finland/Eduskunta/term-36.csv"
           },
           {
             "end_date": "2011-04-19",
@@ -2811,7 +2811,7 @@
             "start_date": "2007-03-21",
             "slug": "35",
             "csv": "data/Finland/Eduskunta/term-35.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1467bd8/data/Finland/Eduskunta/term-35.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1467bd8/data/Finland/Eduskunta/term-35.csv"
           },
           {
             "end_date": "2007-03-20",
@@ -2820,7 +2820,7 @@
             "start_date": "2003-03-19",
             "slug": "34",
             "csv": "data/Finland/Eduskunta/term-34.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1467bd8/data/Finland/Eduskunta/term-34.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1467bd8/data/Finland/Eduskunta/term-34.csv"
           },
           {
             "end_date": "2003-03-18",
@@ -2829,7 +2829,7 @@
             "start_date": "1999-03-24",
             "slug": "33",
             "csv": "data/Finland/Eduskunta/term-33.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1467bd8/data/Finland/Eduskunta/term-33.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1467bd8/data/Finland/Eduskunta/term-33.csv"
           },
           {
             "end_date": "1999-03-23",
@@ -2838,7 +2838,7 @@
             "start_date": "1995-03-24",
             "slug": "32",
             "csv": "data/Finland/Eduskunta/term-32.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1467bd8/data/Finland/Eduskunta/term-32.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1467bd8/data/Finland/Eduskunta/term-32.csv"
           },
           {
             "end_date": "1995-03-23",
@@ -2847,7 +2847,7 @@
             "start_date": "1991-03-22",
             "slug": "31",
             "csv": "data/Finland/Eduskunta/term-31.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1467bd8/data/Finland/Eduskunta/term-31.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1467bd8/data/Finland/Eduskunta/term-31.csv"
           },
           {
             "end_date": "1991-03-21",
@@ -2856,7 +2856,7 @@
             "start_date": "1987-03-21",
             "slug": "30",
             "csv": "data/Finland/Eduskunta/term-30.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1467bd8/data/Finland/Eduskunta/term-30.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1467bd8/data/Finland/Eduskunta/term-30.csv"
           },
           {
             "end_date": "1987-03-20",
@@ -2865,7 +2865,7 @@
             "start_date": "1983-03-26",
             "slug": "29",
             "csv": "data/Finland/Eduskunta/term-29.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1467bd8/data/Finland/Eduskunta/term-29.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1467bd8/data/Finland/Eduskunta/term-29.csv"
           },
           {
             "end_date": "1983-03-25",
@@ -2874,7 +2874,7 @@
             "start_date": "1979-03-24",
             "slug": "28",
             "csv": "data/Finland/Eduskunta/term-28.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1467bd8/data/Finland/Eduskunta/term-28.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1467bd8/data/Finland/Eduskunta/term-28.csv"
           },
           {
             "end_date": "1979-03-23",
@@ -2883,7 +2883,7 @@
             "start_date": "1975-09-27",
             "slug": "27",
             "csv": "data/Finland/Eduskunta/term-27.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1467bd8/data/Finland/Eduskunta/term-27.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1467bd8/data/Finland/Eduskunta/term-27.csv"
           },
           {
             "end_date": "1975-09-26",
@@ -2892,7 +2892,7 @@
             "start_date": "1972-01-22",
             "slug": "26",
             "csv": "data/Finland/Eduskunta/term-26.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1467bd8/data/Finland/Eduskunta/term-26.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1467bd8/data/Finland/Eduskunta/term-26.csv"
           },
           {
             "end_date": "1972-01-21",
@@ -2901,7 +2901,7 @@
             "start_date": "1970-03-23",
             "slug": "25",
             "csv": "data/Finland/Eduskunta/term-25.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1467bd8/data/Finland/Eduskunta/term-25.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1467bd8/data/Finland/Eduskunta/term-25.csv"
           }
         ],
         "statement_count": 34766
@@ -2919,7 +2919,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/France/National_Assembly/sources",
         "popolo": "data/France/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5423cc6/data/France/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/5423cc6/data/France/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/France/National_Assembly/names.csv",
         "lastmod": "1458207181",
         "person_count": 636,
@@ -2931,7 +2931,7 @@
             "start_date": "2012-06-20",
             "slug": "14",
             "csv": "data/France/National_Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5423cc6/data/France/National_Assembly/term-14.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5423cc6/data/France/National_Assembly/term-14.csv"
           }
         ],
         "statement_count": 46510
@@ -2949,7 +2949,7 @@
         "slug": "Assembly",
         "sources_directory": "data/French_Polynesia/Assembly/sources",
         "popolo": "data/French_Polynesia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ec43fb7/data/French_Polynesia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/ec43fb7/data/French_Polynesia/Assembly/ep-popolo-v1.0.json",
         "names": "data/French_Polynesia/Assembly/names.csv",
         "lastmod": "1457187249",
         "person_count": 57,
@@ -2961,7 +2961,7 @@
             "start_date": "2013-05-17",
             "slug": "2013",
             "csv": "data/French_Polynesia/Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ec43fb7/data/French_Polynesia/Assembly/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ec43fb7/data/French_Polynesia/Assembly/term-2013.csv"
           }
         ],
         "statement_count": 901
@@ -2979,7 +2979,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Gabon/Assembly/sources",
         "popolo": "data/Gabon/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/670bab1/data/Gabon/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/670bab1/data/Gabon/Assembly/ep-popolo-v1.0.json",
         "names": "data/Gabon/Assembly/names.csv",
         "lastmod": "1457764485",
         "person_count": 114,
@@ -2991,7 +2991,7 @@
             "start_date": "2012",
             "slug": "12",
             "csv": "data/Gabon/Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/670bab1/data/Gabon/Assembly/term-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/670bab1/data/Gabon/Assembly/term-12.csv"
           }
         ],
         "statement_count": 1642
@@ -3009,7 +3009,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Gambia/National_Assembly/sources",
         "popolo": "data/Gambia/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dc53903/data/Gambia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/dc53903/data/Gambia/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Gambia/National_Assembly/names.csv",
         "lastmod": "1450787615",
         "person_count": 53,
@@ -3021,7 +3021,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Gambia/National_Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dc53903/data/Gambia/National_Assembly/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/dc53903/data/Gambia/National_Assembly/term-2012.csv"
           }
         ],
         "statement_count": 843
@@ -3039,7 +3039,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Georgia/Parliament/sources",
         "popolo": "data/Georgia/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c8771ea/data/Georgia/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/c8771ea/data/Georgia/Parliament/ep-popolo-v1.0.json",
         "names": "data/Georgia/Parliament/names.csv",
         "lastmod": "1458185473",
         "person_count": 148,
@@ -3052,7 +3052,7 @@
             "start_date": "2012-10-20",
             "slug": "8",
             "csv": "data/Georgia/Parliament/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c8771ea/data/Georgia/Parliament/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c8771ea/data/Georgia/Parliament/term-8.csv"
           }
         ],
         "statement_count": 3436
@@ -3070,7 +3070,7 @@
         "slug": "Bundestag",
         "sources_directory": "data/Germany/Bundestag/sources",
         "popolo": "data/Germany/Bundestag/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/ep-popolo-v1.0.json",
         "names": "data/Germany/Bundestag/names.csv",
         "lastmod": "1458196165",
         "person_count": 3809,
@@ -3083,7 +3083,7 @@
             "wikidata": "Q15081430",
             "slug": "18",
             "csv": "data/Germany/Bundestag/term-18.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-18.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-18.csv"
           },
           {
             "end_date": "2013-10-22",
@@ -3093,7 +3093,7 @@
             "wikidata": "Q15081429",
             "slug": "17",
             "csv": "data/Germany/Bundestag/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-17.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-17.csv"
           },
           {
             "end_date": "2009-10-27",
@@ -3103,7 +3103,7 @@
             "wikidata": "Q15081428",
             "slug": "16",
             "csv": "data/Germany/Bundestag/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-16.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-16.csv"
           },
           {
             "end_date": "2005-10-18",
@@ -3113,7 +3113,7 @@
             "wikidata": "Q15081427",
             "slug": "15",
             "csv": "data/Germany/Bundestag/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-15.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-15.csv"
           },
           {
             "end_date": "2002-10-17",
@@ -3123,7 +3123,7 @@
             "wikidata": "Q15081426",
             "slug": "14",
             "csv": "data/Germany/Bundestag/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-14.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-14.csv"
           },
           {
             "end_date": "1998-10-26",
@@ -3133,7 +3133,7 @@
             "wikidata": "Q15081424",
             "slug": "13",
             "csv": "data/Germany/Bundestag/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-13.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-13.csv"
           },
           {
             "end_date": "1994-11-10",
@@ -3143,7 +3143,7 @@
             "wikidata": "Q15081421",
             "slug": "12",
             "csv": "data/Germany/Bundestag/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-12.csv"
           },
           {
             "end_date": "1990-12-20",
@@ -3153,7 +3153,7 @@
             "wikidata": "Q15741572",
             "slug": "11",
             "csv": "data/Germany/Bundestag/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-11.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-11.csv"
           },
           {
             "end_date": "1987-02-18",
@@ -3163,7 +3163,7 @@
             "wikidata": "Q15741566",
             "slug": "10",
             "csv": "data/Germany/Bundestag/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-10.csv"
           },
           {
             "end_date": "1983-03-29",
@@ -3173,7 +3173,7 @@
             "wikidata": "Q15781093",
             "slug": "9",
             "csv": "data/Germany/Bundestag/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-9.csv"
           },
           {
             "end_date": "1980-11-04",
@@ -3183,7 +3183,7 @@
             "wikidata": "Q15781086",
             "slug": "8",
             "csv": "data/Germany/Bundestag/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-8.csv"
           },
           {
             "end_date": "1976-12-14",
@@ -3193,7 +3193,7 @@
             "wikidata": "Q15781078",
             "slug": "7",
             "csv": "data/Germany/Bundestag/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-7.csv"
           },
           {
             "end_date": "1972-12-13",
@@ -3203,7 +3203,7 @@
             "wikidata": "Q15644627",
             "slug": "6",
             "csv": "data/Germany/Bundestag/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-6.csv"
           },
           {
             "end_date": "1969-10-20",
@@ -3213,7 +3213,7 @@
             "wikidata": "Q15781067",
             "slug": "5",
             "csv": "data/Germany/Bundestag/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-5.csv"
           },
           {
             "end_date": "1965-10-19",
@@ -3223,7 +3223,7 @@
             "wikidata": "Q15781058",
             "slug": "4",
             "csv": "data/Germany/Bundestag/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-4.csv"
           },
           {
             "end_date": "1961-10-17",
@@ -3233,7 +3233,7 @@
             "wikidata": "Q15781041",
             "slug": "3",
             "csv": "data/Germany/Bundestag/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-3.csv"
           },
           {
             "end_date": "1957-10-15",
@@ -3243,7 +3243,7 @@
             "wikidata": "Q7443318",
             "slug": "2",
             "csv": "data/Germany/Bundestag/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-2.csv"
           },
           {
             "end_date": "1953-10-06",
@@ -3253,7 +3253,7 @@
             "wikidata": "Q5453045",
             "slug": "1",
             "csv": "data/Germany/Bundestag/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74d4f01/data/Germany/Bundestag/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74d4f01/data/Germany/Bundestag/term-1.csv"
           }
         ],
         "statement_count": 288955
@@ -3271,7 +3271,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Ghana/Parliament/sources",
         "popolo": "data/Ghana/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c32596a/data/Ghana/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/c32596a/data/Ghana/Parliament/ep-popolo-v1.0.json",
         "names": "data/Ghana/Parliament/names.csv",
         "lastmod": "1457977387",
         "person_count": 272,
@@ -3283,7 +3283,7 @@
             "start_date": "2013-01-07",
             "slug": "6",
             "csv": "data/Ghana/Parliament/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c32596a/data/Ghana/Parliament/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c32596a/data/Ghana/Parliament/term-6.csv"
           }
         ],
         "statement_count": 5253
@@ -3301,7 +3301,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Gibraltar/Parliament/sources",
         "popolo": "data/Gibraltar/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a765d9/data/Gibraltar/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/7a765d9/data/Gibraltar/Parliament/ep-popolo-v1.0.json",
         "names": "data/Gibraltar/Parliament/names.csv",
         "lastmod": "1458277307",
         "person_count": 83,
@@ -3314,7 +3314,7 @@
             "start_date": "2011-12-21",
             "slug": "12",
             "csv": "data/Gibraltar/Parliament/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a765d9/data/Gibraltar/Parliament/term-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7a765d9/data/Gibraltar/Parliament/term-12.csv"
           },
           {
             "end_date": "2011-11-03",
@@ -3323,7 +3323,7 @@
             "start_date": "2007-11-08",
             "slug": "11",
             "csv": "data/Gibraltar/Parliament/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a765d9/data/Gibraltar/Parliament/term-11.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7a765d9/data/Gibraltar/Parliament/term-11.csv"
           },
           {
             "end_date": "2007-09-07",
@@ -3332,7 +3332,7 @@
             "start_date": "2003-12-18",
             "slug": "10",
             "csv": "data/Gibraltar/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a765d9/data/Gibraltar/Parliament/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7a765d9/data/Gibraltar/Parliament/term-10.csv"
           },
           {
             "end_date": "2003-10-24",
@@ -3341,7 +3341,7 @@
             "start_date": "2000-02-23",
             "slug": "9",
             "csv": "data/Gibraltar/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a765d9/data/Gibraltar/Parliament/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7a765d9/data/Gibraltar/Parliament/term-9.csv"
           },
           {
             "end_date": "2000",
@@ -3350,7 +3350,7 @@
             "start_date": "1996",
             "slug": "8",
             "csv": "data/Gibraltar/Parliament/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a765d9/data/Gibraltar/Parliament/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7a765d9/data/Gibraltar/Parliament/term-8.csv"
           },
           {
             "end_date": "1996",
@@ -3359,7 +3359,7 @@
             "start_date": "1992",
             "slug": "7",
             "csv": "data/Gibraltar/Parliament/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a765d9/data/Gibraltar/Parliament/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7a765d9/data/Gibraltar/Parliament/term-7.csv"
           },
           {
             "end_date": "1992",
@@ -3368,7 +3368,7 @@
             "start_date": "1988",
             "slug": "6",
             "csv": "data/Gibraltar/Parliament/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a765d9/data/Gibraltar/Parliament/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7a765d9/data/Gibraltar/Parliament/term-6.csv"
           },
           {
             "end_date": "1988",
@@ -3377,7 +3377,7 @@
             "start_date": "1984",
             "slug": "5",
             "csv": "data/Gibraltar/Parliament/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a765d9/data/Gibraltar/Parliament/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7a765d9/data/Gibraltar/Parliament/term-5.csv"
           },
           {
             "end_date": "1984",
@@ -3386,7 +3386,7 @@
             "start_date": "1980",
             "slug": "4",
             "csv": "data/Gibraltar/Parliament/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a765d9/data/Gibraltar/Parliament/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7a765d9/data/Gibraltar/Parliament/term-4.csv"
           },
           {
             "end_date": "1980",
@@ -3395,7 +3395,7 @@
             "start_date": "1976",
             "slug": "3",
             "csv": "data/Gibraltar/Parliament/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a765d9/data/Gibraltar/Parliament/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7a765d9/data/Gibraltar/Parliament/term-3.csv"
           },
           {
             "end_date": "1976",
@@ -3404,7 +3404,7 @@
             "start_date": "1972",
             "slug": "2",
             "csv": "data/Gibraltar/Parliament/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a765d9/data/Gibraltar/Parliament/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7a765d9/data/Gibraltar/Parliament/term-2.csv"
           },
           {
             "end_date": "1972",
@@ -3413,7 +3413,7 @@
             "start_date": "1969",
             "slug": "1",
             "csv": "data/Gibraltar/Parliament/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a765d9/data/Gibraltar/Parliament/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7a765d9/data/Gibraltar/Parliament/term-1.csv"
           }
         ],
         "statement_count": 2657
@@ -3431,7 +3431,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Greece/Parliament/sources",
         "popolo": "data/Greece/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/ep-popolo-v1.0.json",
         "names": "data/Greece/Parliament/names.csv",
         "lastmod": "1457185473",
         "person_count": 1783,
@@ -3443,7 +3443,7 @@
             "start_date": "2015-09-20",
             "slug": "17",
             "csv": "data/Greece/Parliament/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-17.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-17.csv"
           },
           {
             "end_date": "2015-08-28",
@@ -3452,7 +3452,7 @@
             "start_date": "2015-01-25",
             "slug": "16",
             "csv": "data/Greece/Parliament/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-16.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-16.csv"
           },
           {
             "end_date": "2014-12-31",
@@ -3461,7 +3461,7 @@
             "start_date": "2012-06-17",
             "slug": "15",
             "csv": "data/Greece/Parliament/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-15.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-15.csv"
           },
           {
             "end_date": "2012-05-19",
@@ -3470,7 +3470,7 @@
             "start_date": "2012-05-06",
             "slug": "14",
             "csv": "data/Greece/Parliament/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-14.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-14.csv"
           },
           {
             "end_date": "2012-04-11",
@@ -3479,7 +3479,7 @@
             "start_date": "2009-10-04",
             "slug": "13",
             "csv": "data/Greece/Parliament/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-13.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-13.csv"
           },
           {
             "end_date": "2009-09-07",
@@ -3488,7 +3488,7 @@
             "start_date": "2007-09-16",
             "slug": "12",
             "csv": "data/Greece/Parliament/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-12.csv"
           },
           {
             "end_date": "2007-08-18",
@@ -3497,7 +3497,7 @@
             "start_date": "2004-03-07",
             "slug": "11",
             "csv": "data/Greece/Parliament/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-11.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-11.csv"
           },
           {
             "end_date": "2004-02-11",
@@ -3506,7 +3506,7 @@
             "start_date": "2000-04-09",
             "slug": "10",
             "csv": "data/Greece/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-10.csv"
           },
           {
             "end_date": "2000-03-14",
@@ -3515,7 +3515,7 @@
             "start_date": "1996-09-22",
             "slug": "9",
             "csv": "data/Greece/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-9.csv"
           },
           {
             "end_date": "1996-08-24",
@@ -3524,7 +3524,7 @@
             "start_date": "1993-10-10",
             "slug": "8",
             "csv": "data/Greece/Parliament/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-8.csv"
           },
           {
             "end_date": "1993-09-11",
@@ -3533,7 +3533,7 @@
             "start_date": "1990-04-08",
             "slug": "7",
             "csv": "data/Greece/Parliament/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-7.csv"
           },
           {
             "end_date": "1990-03-12",
@@ -3542,7 +3542,7 @@
             "start_date": "1989-11-05",
             "slug": "6",
             "csv": "data/Greece/Parliament/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-6.csv"
           },
           {
             "end_date": "1989-10-12",
@@ -3551,7 +3551,7 @@
             "start_date": "1989-06-18",
             "slug": "5",
             "csv": "data/Greece/Parliament/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-5.csv"
           },
           {
             "end_date": "1989-06-02",
@@ -3560,7 +3560,7 @@
             "start_date": "1985-06-02",
             "slug": "4",
             "csv": "data/Greece/Parliament/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-4.csv"
           },
           {
             "end_date": "1985-05-07",
@@ -3569,7 +3569,7 @@
             "start_date": "1981-10-18",
             "slug": "3",
             "csv": "data/Greece/Parliament/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-3.csv"
           },
           {
             "end_date": "1981-09-19",
@@ -3578,7 +3578,7 @@
             "start_date": "1977-11-20",
             "slug": "2",
             "csv": "data/Greece/Parliament/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-2.csv"
           },
           {
             "end_date": "1977-10-22",
@@ -3587,7 +3587,7 @@
             "start_date": "1974-11-17",
             "slug": "1",
             "csv": "data/Greece/Parliament/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5637407/data/Greece/Parliament/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5637407/data/Greece/Parliament/term-1.csv"
           }
         ],
         "statement_count": 41730
@@ -3605,7 +3605,7 @@
         "slug": "Inatsisartut",
         "sources_directory": "data/Greenland/Inatsisartut/sources",
         "popolo": "data/Greenland/Inatsisartut/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2df1207/data/Greenland/Inatsisartut/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/2df1207/data/Greenland/Inatsisartut/ep-popolo-v1.0.json",
         "names": "data/Greenland/Inatsisartut/names.csv",
         "lastmod": "1458155997",
         "person_count": 145,
@@ -3617,7 +3617,7 @@
             "start_date": "2014-12-12",
             "slug": "2014-12-12",
             "csv": "data/Greenland/Inatsisartut/term-2014-12-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2df1207/data/Greenland/Inatsisartut/term-2014-12-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2df1207/data/Greenland/Inatsisartut/term-2014-12-12.csv"
           },
           {
             "end_date": "2014-12-11",
@@ -3626,7 +3626,7 @@
             "start_date": "2014-11-28",
             "slug": "2014-11-28",
             "csv": "data/Greenland/Inatsisartut/term-2014-11-28.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2df1207/data/Greenland/Inatsisartut/term-2014-11-28.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2df1207/data/Greenland/Inatsisartut/term-2014-11-28.csv"
           },
           {
             "end_date": "2014-11-27",
@@ -3635,7 +3635,7 @@
             "start_date": "2013-03-12",
             "slug": "2013-03-12",
             "csv": "data/Greenland/Inatsisartut/term-2013-03-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2df1207/data/Greenland/Inatsisartut/term-2013-03-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2df1207/data/Greenland/Inatsisartut/term-2013-03-12.csv"
           },
           {
             "end_date": "2013-03-11",
@@ -3644,7 +3644,7 @@
             "start_date": "2009-06-02",
             "slug": "2009-06-02",
             "csv": "data/Greenland/Inatsisartut/term-2009-06-02.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2df1207/data/Greenland/Inatsisartut/term-2009-06-02.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2df1207/data/Greenland/Inatsisartut/term-2009-06-02.csv"
           },
           {
             "end_date": "2009-06-01",
@@ -3653,7 +3653,7 @@
             "start_date": "2005-11-15",
             "slug": "2005-11-15",
             "csv": "data/Greenland/Inatsisartut/term-2005-11-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2df1207/data/Greenland/Inatsisartut/term-2005-11-15.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2df1207/data/Greenland/Inatsisartut/term-2005-11-15.csv"
           },
           {
             "end_date": "2005-11-14",
@@ -3662,7 +3662,7 @@
             "start_date": "2002-12-03",
             "slug": "2002-12-03",
             "csv": "data/Greenland/Inatsisartut/term-2002-12-03.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2df1207/data/Greenland/Inatsisartut/term-2002-12-03.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2df1207/data/Greenland/Inatsisartut/term-2002-12-03.csv"
           },
           {
             "end_date": "2002-12-02",
@@ -3671,7 +3671,7 @@
             "start_date": "1999-02-16",
             "slug": "1999-02-16",
             "csv": "data/Greenland/Inatsisartut/term-1999-02-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2df1207/data/Greenland/Inatsisartut/term-1999-02-16.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2df1207/data/Greenland/Inatsisartut/term-1999-02-16.csv"
           },
           {
             "end_date": "1999-02-15",
@@ -3680,7 +3680,7 @@
             "start_date": "1995-03-04",
             "slug": "1995-03-04",
             "csv": "data/Greenland/Inatsisartut/term-1995-03-04.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2df1207/data/Greenland/Inatsisartut/term-1995-03-04.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2df1207/data/Greenland/Inatsisartut/term-1995-03-04.csv"
           },
           {
             "end_date": "1995-03-03",
@@ -3689,7 +3689,7 @@
             "start_date": "1991-03-05",
             "slug": "1991-03-05",
             "csv": "data/Greenland/Inatsisartut/term-1991-03-05.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2df1207/data/Greenland/Inatsisartut/term-1991-03-05.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2df1207/data/Greenland/Inatsisartut/term-1991-03-05.csv"
           },
           {
             "end_date": "1991-03-04",
@@ -3698,7 +3698,7 @@
             "start_date": "1987-05-26",
             "slug": "1987-05-26",
             "csv": "data/Greenland/Inatsisartut/term-1987-05-26.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2df1207/data/Greenland/Inatsisartut/term-1987-05-26.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2df1207/data/Greenland/Inatsisartut/term-1987-05-26.csv"
           },
           {
             "end_date": "1987-05-25",
@@ -3707,7 +3707,7 @@
             "start_date": "1984-06-06",
             "slug": "1984-06-06",
             "csv": "data/Greenland/Inatsisartut/term-1984-06-06.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2df1207/data/Greenland/Inatsisartut/term-1984-06-06.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2df1207/data/Greenland/Inatsisartut/term-1984-06-06.csv"
           },
           {
             "end_date": "1984-06-05",
@@ -3716,7 +3716,7 @@
             "start_date": "1983-04-12",
             "slug": "1983-04-12",
             "csv": "data/Greenland/Inatsisartut/term-1983-04-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2df1207/data/Greenland/Inatsisartut/term-1983-04-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2df1207/data/Greenland/Inatsisartut/term-1983-04-12.csv"
           },
           {
             "end_date": "1983-04-11",
@@ -3725,7 +3725,7 @@
             "start_date": "1979-05-01",
             "slug": "1979-05-01",
             "csv": "data/Greenland/Inatsisartut/term-1979-05-01.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2df1207/data/Greenland/Inatsisartut/term-1979-05-01.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2df1207/data/Greenland/Inatsisartut/term-1979-05-01.csv"
           }
         ],
         "statement_count": 4094
@@ -3743,7 +3743,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Grenada/House_of_Representatives/sources",
         "popolo": "data/Grenada/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/681a50e/data/Grenada/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/681a50e/data/Grenada/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Grenada/House_of_Representatives/names.csv",
         "lastmod": "1457185350",
         "person_count": 15,
@@ -3755,7 +3755,7 @@
             "start_date": "2013",
             "slug": "2013",
             "csv": "data/Grenada/House_of_Representatives/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/681a50e/data/Grenada/House_of_Representatives/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/681a50e/data/Grenada/House_of_Representatives/term-2013.csv"
           }
         ],
         "statement_count": 253
@@ -3773,7 +3773,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Guam/Parliament/sources",
         "popolo": "data/Guam/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5fe32a5/data/Guam/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/5fe32a5/data/Guam/Parliament/ep-popolo-v1.0.json",
         "names": "data/Guam/Parliament/names.csv",
         "lastmod": "1457964353",
         "person_count": 28,
@@ -3785,7 +3785,7 @@
             "start_date": "2015-02-16",
             "slug": "33",
             "csv": "data/Guam/Parliament/term-33.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5fe32a5/data/Guam/Parliament/term-33.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5fe32a5/data/Guam/Parliament/term-33.csv"
           },
           {
             "end_date": "2015-01-02",
@@ -3794,7 +3794,7 @@
             "start_date": "2013-01-11",
             "slug": "32",
             "csv": "data/Guam/Parliament/term-32.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5fe32a5/data/Guam/Parliament/term-32.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5fe32a5/data/Guam/Parliament/term-32.csv"
           },
           {
             "end_date": "2013-01-04",
@@ -3803,7 +3803,7 @@
             "start_date": "2011-02-21",
             "slug": "31",
             "csv": "data/Guam/Parliament/term-31.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5fe32a5/data/Guam/Parliament/term-31.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5fe32a5/data/Guam/Parliament/term-31.csv"
           },
           {
             "end_date": "2010-12-22",
@@ -3812,7 +3812,7 @@
             "start_date": "2009-02-16",
             "slug": "30",
             "csv": "data/Guam/Parliament/term-30.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5fe32a5/data/Guam/Parliament/term-30.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5fe32a5/data/Guam/Parliament/term-30.csv"
           }
         ],
         "statement_count": 1007
@@ -3830,7 +3830,7 @@
         "slug": "Congress",
         "sources_directory": "data/Guatemala/Congress/sources",
         "popolo": "data/Guatemala/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7bc4abe/data/Guatemala/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/7bc4abe/data/Guatemala/Congress/ep-popolo-v1.0.json",
         "names": "data/Guatemala/Congress/names.csv",
         "lastmod": "1458163970",
         "person_count": 243,
@@ -3844,7 +3844,7 @@
             "wikidata": "Q23051910",
             "slug": "8",
             "csv": "data/Guatemala/Congress/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7bc4abe/data/Guatemala/Congress/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7bc4abe/data/Guatemala/Congress/term-8.csv"
           },
           {
             "end_date": "2016-01-14",
@@ -3854,7 +3854,7 @@
             "wikidata": "Q16644987",
             "slug": "7",
             "csv": "data/Guatemala/Congress/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7bc4abe/data/Guatemala/Congress/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7bc4abe/data/Guatemala/Congress/term-7.csv"
           }
         ],
         "statement_count": 4662
@@ -3872,7 +3872,7 @@
         "slug": "States",
         "sources_directory": "data/Guernsey/States/sources",
         "popolo": "data/Guernsey/States/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6c6ce2a/data/Guernsey/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/6c6ce2a/data/Guernsey/States/ep-popolo-v1.0.json",
         "names": "data/Guernsey/States/names.csv",
         "lastmod": "1450787974",
         "person_count": 47,
@@ -3884,7 +3884,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Guernsey/States/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6c6ce2a/data/Guernsey/States/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6c6ce2a/data/Guernsey/States/term-2012.csv"
           }
         ],
         "statement_count": 661
@@ -3902,7 +3902,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Guinea-Bissau/Assembly/sources",
         "popolo": "data/Guinea-Bissau/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ec6bc26/data/Guinea-Bissau/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/ec6bc26/data/Guinea-Bissau/Assembly/ep-popolo-v1.0.json",
         "names": "data/Guinea-Bissau/Assembly/names.csv",
         "lastmod": "1450787978",
         "person_count": 100,
@@ -3914,7 +3914,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/Guinea-Bissau/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ec6bc26/data/Guinea-Bissau/Assembly/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ec6bc26/data/Guinea-Bissau/Assembly/term-2014.csv"
           }
         ],
         "statement_count": 1215
@@ -3932,7 +3932,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Guyana/National_Assembly/sources",
         "popolo": "data/Guyana/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e7cdc8a/data/Guyana/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/e7cdc8a/data/Guyana/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Guyana/National_Assembly/names.csv",
         "lastmod": "1457450890",
         "person_count": 55,
@@ -3944,7 +3944,7 @@
             "start_date": "2015-06-10",
             "slug": "11",
             "csv": "data/Guyana/National_Assembly/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e7cdc8a/data/Guyana/National_Assembly/term-11.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/e7cdc8a/data/Guyana/National_Assembly/term-11.csv"
           }
         ],
         "statement_count": 799
@@ -3962,7 +3962,7 @@
         "slug": "Deputies",
         "sources_directory": "data/Haiti/Deputies/sources",
         "popolo": "data/Haiti/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5cdfe84/data/Haiti/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/5cdfe84/data/Haiti/Deputies/ep-popolo-v1.0.json",
         "names": "data/Haiti/Deputies/names.csv",
         "lastmod": "1457185256",
         "person_count": 99,
@@ -3975,7 +3975,7 @@
             "start_date": "2011",
             "slug": "2011",
             "csv": "data/Haiti/Deputies/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5cdfe84/data/Haiti/Deputies/term-2011.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5cdfe84/data/Haiti/Deputies/term-2011.csv"
           }
         ],
         "statement_count": 1451
@@ -3993,7 +3993,7 @@
         "slug": "Congreso-Nacional",
         "sources_directory": "data/Honduras/Congreso_Nacional/sources",
         "popolo": "data/Honduras/Congreso_Nacional/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/483694d/data/Honduras/Congreso_Nacional/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/483694d/data/Honduras/Congreso_Nacional/ep-popolo-v1.0.json",
         "names": "data/Honduras/Congreso_Nacional/names.csv",
         "lastmod": "1458112846",
         "person_count": 128,
@@ -4006,7 +4006,7 @@
             "start_date": "2014",
             "slug": "8",
             "csv": "data/Honduras/Congreso_Nacional/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/483694d/data/Honduras/Congreso_Nacional/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/483694d/data/Honduras/Congreso_Nacional/term-8.csv"
           }
         ],
         "statement_count": 1663
@@ -4024,7 +4024,7 @@
         "slug": "Legislative-Council",
         "sources_directory": "data/Hong_Kong/Legislative_Council/sources",
         "popolo": "data/Hong_Kong/Legislative_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69660d9/data/Hong_Kong/Legislative_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/69660d9/data/Hong_Kong/Legislative_Council/ep-popolo-v1.0.json",
         "names": "data/Hong_Kong/Legislative_Council/names.csv",
         "lastmod": "1458201433",
         "person_count": 71,
@@ -4036,7 +4036,7 @@
             "start_date": "2012-09-12",
             "slug": "5",
             "csv": "data/Hong_Kong/Legislative_Council/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69660d9/data/Hong_Kong/Legislative_Council/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/69660d9/data/Hong_Kong/Legislative_Council/term-5.csv"
           }
         ],
         "statement_count": 4465
@@ -4054,7 +4054,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Hungary/Assembly/sources",
         "popolo": "data/Hungary/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/82b1a29/data/Hungary/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/82b1a29/data/Hungary/Assembly/ep-popolo-v1.0.json",
         "names": "data/Hungary/Assembly/names.csv",
         "lastmod": "1458210839",
         "person_count": 198,
@@ -4066,7 +4066,7 @@
             "start_date": "2014-05-10",
             "slug": "40",
             "csv": "data/Hungary/Assembly/term-40.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/82b1a29/data/Hungary/Assembly/term-40.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/82b1a29/data/Hungary/Assembly/term-40.csv"
           }
         ],
         "statement_count": 8536
@@ -4084,7 +4084,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Iceland/Assembly/sources",
         "popolo": "data/Iceland/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/29c7f47/data/Iceland/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/29c7f47/data/Iceland/Assembly/ep-popolo-v1.0.json",
         "names": "data/Iceland/Assembly/names.csv",
         "lastmod": "1457970046",
         "person_count": 204,
@@ -4096,7 +4096,7 @@
             "start_date": "2013",
             "slug": "2013",
             "csv": "data/Iceland/Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/29c7f47/data/Iceland/Assembly/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/29c7f47/data/Iceland/Assembly/term-2013.csv"
           },
           {
             "end_date": "2013",
@@ -4105,7 +4105,7 @@
             "start_date": "2009",
             "slug": "2009",
             "csv": "data/Iceland/Assembly/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/29c7f47/data/Iceland/Assembly/term-2009.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/29c7f47/data/Iceland/Assembly/term-2009.csv"
           },
           {
             "end_date": "2009",
@@ -4114,7 +4114,7 @@
             "start_date": "2007",
             "slug": "2007",
             "csv": "data/Iceland/Assembly/term-2007.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/29c7f47/data/Iceland/Assembly/term-2007.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/29c7f47/data/Iceland/Assembly/term-2007.csv"
           },
           {
             "end_date": "2007",
@@ -4123,7 +4123,7 @@
             "start_date": "2003",
             "slug": "2003",
             "csv": "data/Iceland/Assembly/term-2003.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/29c7f47/data/Iceland/Assembly/term-2003.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/29c7f47/data/Iceland/Assembly/term-2003.csv"
           },
           {
             "end_date": "2003",
@@ -4132,7 +4132,7 @@
             "start_date": "1999",
             "slug": "1999",
             "csv": "data/Iceland/Assembly/term-1999.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/29c7f47/data/Iceland/Assembly/term-1999.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/29c7f47/data/Iceland/Assembly/term-1999.csv"
           },
           {
             "end_date": "1999",
@@ -4141,7 +4141,7 @@
             "start_date": "1995",
             "slug": "1995",
             "csv": "data/Iceland/Assembly/term-1995.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/29c7f47/data/Iceland/Assembly/term-1995.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/29c7f47/data/Iceland/Assembly/term-1995.csv"
           }
         ],
         "statement_count": 10356
@@ -4159,7 +4159,7 @@
         "slug": "Lok-Sabha",
         "sources_directory": "data/India/Lok_Sabha/sources",
         "popolo": "data/India/Lok_Sabha/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2f42c82/data/India/Lok_Sabha/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/2f42c82/data/India/Lok_Sabha/ep-popolo-v1.0.json",
         "names": "data/India/Lok_Sabha/names.csv",
         "lastmod": "1458171536",
         "person_count": 541,
@@ -4171,7 +4171,7 @@
             "start_date": "2014-05-26",
             "slug": "16",
             "csv": "data/India/Lok_Sabha/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2f42c82/data/India/Lok_Sabha/term-16.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2f42c82/data/India/Lok_Sabha/term-16.csv"
           }
         ],
         "statement_count": 30668
@@ -4189,7 +4189,7 @@
         "slug": "Council",
         "sources_directory": "data/Indonesia/Council/sources",
         "popolo": "data/Indonesia/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6576c99/data/Indonesia/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/6576c99/data/Indonesia/Council/ep-popolo-v1.0.json",
         "names": "data/Indonesia/Council/names.csv",
         "lastmod": "1458165231",
         "person_count": 569,
@@ -4201,7 +4201,7 @@
             "start_date": "2014-10-01",
             "slug": "18",
             "csv": "data/Indonesia/Council/term-18.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6576c99/data/Indonesia/Council/term-18.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6576c99/data/Indonesia/Council/term-18.csv"
           }
         ],
         "statement_count": 10744
@@ -4219,7 +4219,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Iran/Assembly/sources",
         "popolo": "data/Iran/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/16aab1f/data/Iran/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/16aab1f/data/Iran/Assembly/ep-popolo-v1.0.json",
         "names": "data/Iran/Assembly/names.csv",
         "lastmod": "1458167977",
         "person_count": 289,
@@ -4231,7 +4231,7 @@
             "start_date": "2012-05-27",
             "slug": "9",
             "csv": "data/Iran/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/16aab1f/data/Iran/Assembly/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/16aab1f/data/Iran/Assembly/term-9.csv"
           }
         ],
         "statement_count": 4659
@@ -4249,7 +4249,7 @@
         "slug": "Majlis",
         "sources_directory": "data/Iraq/Majlis/sources",
         "popolo": "data/Iraq/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4751ae1/data/Iraq/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/4751ae1/data/Iraq/Majlis/ep-popolo-v1.0.json",
         "names": "data/Iraq/Majlis/names.csv",
         "lastmod": "1450788031",
         "person_count": 328,
@@ -4261,7 +4261,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/Iraq/Majlis/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4751ae1/data/Iraq/Majlis/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/4751ae1/data/Iraq/Majlis/term-2014.csv"
           }
         ],
         "statement_count": 4036
@@ -4279,7 +4279,7 @@
         "slug": "Dail",
         "sources_directory": "data/Ireland/Dail/sources",
         "popolo": "data/Ireland/Dail/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2e0841b/data/Ireland/Dail/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/2e0841b/data/Ireland/Dail/ep-popolo-v1.0.json",
         "names": "data/Ireland/Dail/names.csv",
         "lastmod": "1458190723",
         "person_count": 226,
@@ -4291,7 +4291,7 @@
             "start_date": "2016-03-10",
             "slug": "32",
             "csv": "data/Ireland/Dail/term-32.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2e0841b/data/Ireland/Dail/term-32.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2e0841b/data/Ireland/Dail/term-32.csv"
           },
           {
             "end_date": "2016-03-02",
@@ -4300,7 +4300,7 @@
             "start_date": "2011-03-09",
             "slug": "31",
             "csv": "data/Ireland/Dail/term-31.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2e0841b/data/Ireland/Dail/term-31.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2e0841b/data/Ireland/Dail/term-31.csv"
           }
         ],
         "statement_count": 12148
@@ -4318,7 +4318,7 @@
         "slug": "House-of-Keys",
         "sources_directory": "data/Isle_of_Man/House_of_Keys/sources",
         "popolo": "data/Isle_of_Man/House_of_Keys/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a125e8d/data/Isle_of_Man/House_of_Keys/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/a125e8d/data/Isle_of_Man/House_of_Keys/ep-popolo-v1.0.json",
         "names": "data/Isle_of_Man/House_of_Keys/names.csv",
         "lastmod": "1458228828",
         "person_count": 24,
@@ -4330,7 +4330,7 @@
             "start_date": "2011-10-04",
             "slug": "2011",
             "csv": "data/Isle_of_Man/House_of_Keys/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a125e8d/data/Isle_of_Man/House_of_Keys/term-2011.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a125e8d/data/Isle_of_Man/House_of_Keys/term-2011.csv"
           }
         ],
         "statement_count": 896
@@ -4348,7 +4348,7 @@
         "slug": "Knesset",
         "sources_directory": "data/Israel/Knesset/sources",
         "popolo": "data/Israel/Knesset/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/ep-popolo-v1.0.json",
         "names": "data/Israel/Knesset/names.csv",
         "lastmod": "1457184052",
         "person_count": 926,
@@ -4360,7 +4360,7 @@
             "start_date": "2015-03-31",
             "slug": "20",
             "csv": "data/Israel/Knesset/term-20.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-20.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-20.csv"
           },
           {
             "end_date": "2015-03-31",
@@ -4369,7 +4369,7 @@
             "start_date": "2013-02-05",
             "slug": "19",
             "csv": "data/Israel/Knesset/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-19.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-19.csv"
           },
           {
             "end_date": "2013-02-05",
@@ -4378,7 +4378,7 @@
             "start_date": "2009-02-24",
             "slug": "18",
             "csv": "data/Israel/Knesset/term-18.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-18.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-18.csv"
           },
           {
             "end_date": "2009-02-24",
@@ -4387,7 +4387,7 @@
             "start_date": "2006-04-17",
             "slug": "17",
             "csv": "data/Israel/Knesset/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-17.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-17.csv"
           },
           {
             "end_date": "2006-04-17",
@@ -4396,7 +4396,7 @@
             "start_date": "2003-02-17",
             "slug": "16",
             "csv": "data/Israel/Knesset/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-16.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-16.csv"
           },
           {
             "end_date": "2003-02-17",
@@ -4405,7 +4405,7 @@
             "start_date": "1999-06-07",
             "slug": "15",
             "csv": "data/Israel/Knesset/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-15.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-15.csv"
           },
           {
             "end_date": "1999-06-07",
@@ -4414,7 +4414,7 @@
             "start_date": "1996-06-17",
             "slug": "14",
             "csv": "data/Israel/Knesset/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-14.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-14.csv"
           },
           {
             "end_date": "1996-06-17",
@@ -4423,7 +4423,7 @@
             "start_date": "1992-07-13",
             "slug": "13",
             "csv": "data/Israel/Knesset/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-13.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-13.csv"
           },
           {
             "end_date": "1992-07-13",
@@ -4432,7 +4432,7 @@
             "start_date": "1988-11-21",
             "slug": "12",
             "csv": "data/Israel/Knesset/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-12.csv"
           },
           {
             "end_date": "1988-11-21",
@@ -4441,7 +4441,7 @@
             "start_date": "1984-08-13",
             "slug": "11",
             "csv": "data/Israel/Knesset/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-11.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-11.csv"
           },
           {
             "end_date": "1984-08-13",
@@ -4450,7 +4450,7 @@
             "start_date": "1981-07-20",
             "slug": "10",
             "csv": "data/Israel/Knesset/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-10.csv"
           },
           {
             "end_date": "1981-07-20",
@@ -4459,7 +4459,7 @@
             "start_date": "1977-06-13",
             "slug": "9",
             "csv": "data/Israel/Knesset/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-9.csv"
           },
           {
             "end_date": "1977-06-13",
@@ -4468,7 +4468,7 @@
             "start_date": "1974-01-21",
             "slug": "8",
             "csv": "data/Israel/Knesset/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-8.csv"
           },
           {
             "end_date": "1974-01-21",
@@ -4477,7 +4477,7 @@
             "start_date": "1969-11-17",
             "slug": "7",
             "csv": "data/Israel/Knesset/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-7.csv"
           },
           {
             "end_date": "1969-11-17",
@@ -4486,7 +4486,7 @@
             "start_date": "1965-11-22",
             "slug": "6",
             "csv": "data/Israel/Knesset/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-6.csv"
           },
           {
             "end_date": "1965-11-22",
@@ -4495,7 +4495,7 @@
             "start_date": "1961-09-04",
             "slug": "5",
             "csv": "data/Israel/Knesset/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-5.csv"
           },
           {
             "end_date": "1961-09-04",
@@ -4504,7 +4504,7 @@
             "start_date": "1959-11-30",
             "slug": "4",
             "csv": "data/Israel/Knesset/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-4.csv"
           },
           {
             "end_date": "1959-11-30",
@@ -4513,7 +4513,7 @@
             "start_date": "1955-08-15",
             "slug": "3",
             "csv": "data/Israel/Knesset/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-3.csv"
           },
           {
             "end_date": "1955-08-15",
@@ -4522,7 +4522,7 @@
             "start_date": "1951-08-20",
             "slug": "2",
             "csv": "data/Israel/Knesset/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-2.csv"
           },
           {
             "end_date": "1951-08-20",
@@ -4531,7 +4531,7 @@
             "start_date": "1949-02-14",
             "slug": "1",
             "csv": "data/Israel/Knesset/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6df274/data/Israel/Knesset/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b6df274/data/Israel/Knesset/term-1.csv"
           }
         ],
         "statement_count": 71217
@@ -4549,7 +4549,7 @@
         "slug": "House",
         "sources_directory": "data/Italy/House/sources",
         "popolo": "data/Italy/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2170238/data/Italy/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/2170238/data/Italy/House/ep-popolo-v1.0.json",
         "names": "data/Italy/House/names.csv",
         "lastmod": "1458217268",
         "person_count": 663,
@@ -4561,7 +4561,7 @@
             "start_date": "2013-03-19",
             "slug": "17",
             "csv": "data/Italy/House/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2170238/data/Italy/House/term-17.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2170238/data/Italy/House/term-17.csv"
           }
         ],
         "statement_count": 37916
@@ -4571,7 +4571,7 @@
         "slug": "Senate",
         "sources_directory": "data/Italy/Senate/sources",
         "popolo": "data/Italy/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640fac/data/Italy/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/0640fac/data/Italy/Senate/ep-popolo-v1.0.json",
         "names": "data/Italy/Senate/names.csv",
         "lastmod": "1457387757",
         "person_count": 322,
@@ -4583,7 +4583,7 @@
             "start_date": "2013-03-15",
             "slug": "17",
             "csv": "data/Italy/Senate/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640fac/data/Italy/Senate/term-17.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0640fac/data/Italy/Senate/term-17.csv"
           }
         ],
         "statement_count": 6261
@@ -4601,7 +4601,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Jamaica/House_of_Representatives/sources",
         "popolo": "data/Jamaica/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/44870f9/data/Jamaica/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/44870f9/data/Jamaica/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Jamaica/House_of_Representatives/names.csv",
         "lastmod": "1458165904",
         "person_count": 63,
@@ -4613,7 +4613,7 @@
             "start_date": "2011",
             "slug": "2011",
             "csv": "data/Jamaica/House_of_Representatives/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/44870f9/data/Jamaica/House_of_Representatives/term-2011.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/44870f9/data/Jamaica/House_of_Representatives/term-2011.csv"
           }
         ],
         "statement_count": 2346
@@ -4631,7 +4631,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Japan/House_of_Representatives/sources",
         "popolo": "data/Japan/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb52026/data/Japan/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/cb52026/data/Japan/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Japan/House_of_Representatives/names.csv",
         "lastmod": "1458138132",
         "person_count": 475,
@@ -4643,7 +4643,7 @@
             "start_date": "2014-12-14",
             "slug": "46",
             "csv": "data/Japan/House_of_Representatives/term-46.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb52026/data/Japan/House_of_Representatives/term-46.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/cb52026/data/Japan/House_of_Representatives/term-46.csv"
           }
         ],
         "statement_count": 20735
@@ -4661,7 +4661,7 @@
         "slug": "States",
         "sources_directory": "data/Jersey/States/sources",
         "popolo": "data/Jersey/States/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b4e2c2c/data/Jersey/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/b4e2c2c/data/Jersey/States/ep-popolo-v1.0.json",
         "names": "data/Jersey/States/names.csv",
         "lastmod": "1457183494",
         "person_count": 58,
@@ -4673,7 +4673,7 @@
             "start_date": "2011",
             "slug": "6",
             "csv": "data/Jersey/States/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b4e2c2c/data/Jersey/States/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b4e2c2c/data/Jersey/States/term-6.csv"
           }
         ],
         "statement_count": 1027
@@ -4691,7 +4691,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Jordan/House_of_Representatives/sources",
         "popolo": "data/Jordan/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d38ff4b/data/Jordan/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/d38ff4b/data/Jordan/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Jordan/House_of_Representatives/names.csv",
         "lastmod": "1457261020",
         "person_count": 150,
@@ -4703,7 +4703,7 @@
             "start_date": "2013",
             "slug": "2013",
             "csv": "data/Jordan/House_of_Representatives/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d38ff4b/data/Jordan/House_of_Representatives/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/d38ff4b/data/Jordan/House_of_Representatives/term-2013.csv"
           }
         ],
         "statement_count": 1938
@@ -4721,7 +4721,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Kazakhstan/Assembly/sources",
         "popolo": "data/Kazakhstan/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8c532aa/data/Kazakhstan/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/8c532aa/data/Kazakhstan/Assembly/ep-popolo-v1.0.json",
         "names": "data/Kazakhstan/Assembly/names.csv",
         "lastmod": "1457182152",
         "person_count": 107,
@@ -4733,7 +4733,7 @@
             "start_date": "2012-01-15",
             "slug": "5",
             "csv": "data/Kazakhstan/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8c532aa/data/Kazakhstan/Assembly/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/8c532aa/data/Kazakhstan/Assembly/term-5.csv"
           }
         ],
         "statement_count": 1523
@@ -4751,7 +4751,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Kenya/Assembly/sources",
         "popolo": "data/Kenya/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0f6a1e8/data/Kenya/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/0f6a1e8/data/Kenya/Assembly/ep-popolo-v1.0.json",
         "names": "data/Kenya/Assembly/names.csv",
         "lastmod": "1458118346",
         "person_count": 352,
@@ -4763,7 +4763,7 @@
             "start_date": "2013-03-28",
             "slug": "11",
             "csv": "data/Kenya/Assembly/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0f6a1e8/data/Kenya/Assembly/term-11.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0f6a1e8/data/Kenya/Assembly/term-11.csv"
           }
         ],
         "statement_count": 7978
@@ -4781,7 +4781,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Kiribati/Parliament/sources",
         "popolo": "data/Kiribati/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d489dc5/data/Kiribati/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/d489dc5/data/Kiribati/Parliament/ep-popolo-v1.0.json",
         "names": "data/Kiribati/Parliament/names.csv",
         "lastmod": "1458129481",
         "person_count": 62,
@@ -4794,7 +4794,7 @@
             "start_date": "2010",
             "slug": "10",
             "csv": "data/Kiribati/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d489dc5/data/Kiribati/Parliament/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/d489dc5/data/Kiribati/Parliament/term-10.csv"
           },
           {
             "end_date": "2010",
@@ -4803,7 +4803,7 @@
             "start_date": "2007",
             "slug": "9",
             "csv": "data/Kiribati/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d489dc5/data/Kiribati/Parliament/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/d489dc5/data/Kiribati/Parliament/term-9.csv"
           }
         ],
         "statement_count": 1451
@@ -4821,7 +4821,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Kosovo/Assembly/sources",
         "popolo": "data/Kosovo/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a10c264/data/Kosovo/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/a10c264/data/Kosovo/Assembly/ep-popolo-v1.0.json",
         "names": "data/Kosovo/Assembly/names.csv",
         "lastmod": "1457181025",
         "person_count": 399,
@@ -4833,7 +4833,7 @@
             "start_date": "2014-07-17",
             "slug": "chamber_2014-07-17",
             "csv": "data/Kosovo/Assembly/term-chamber_2014-07-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a10c264/data/Kosovo/Assembly/term-chamber_2014-07-17.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a10c264/data/Kosovo/Assembly/term-chamber_2014-07-17.csv"
           },
           {
             "end_date": "2014-05-07",
@@ -4842,7 +4842,7 @@
             "start_date": "2010-12-12",
             "slug": "chamber_2010-12-12",
             "csv": "data/Kosovo/Assembly/term-chamber_2010-12-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a10c264/data/Kosovo/Assembly/term-chamber_2010-12-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a10c264/data/Kosovo/Assembly/term-chamber_2010-12-12.csv"
           },
           {
             "end_date": "2010-11-03",
@@ -4851,7 +4851,7 @@
             "start_date": "2007-12-13",
             "slug": "chamber_2007-12-13",
             "csv": "data/Kosovo/Assembly/term-chamber_2007-12-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a10c264/data/Kosovo/Assembly/term-chamber_2007-12-13.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a10c264/data/Kosovo/Assembly/term-chamber_2007-12-13.csv"
           },
           {
             "end_date": "2007-12-12",
@@ -4860,7 +4860,7 @@
             "start_date": "2004-11-23",
             "slug": "chamber_2004-11-23",
             "csv": "data/Kosovo/Assembly/term-chamber_2004-11-23.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a10c264/data/Kosovo/Assembly/term-chamber_2004-11-23.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a10c264/data/Kosovo/Assembly/term-chamber_2004-11-23.csv"
           },
           {
             "end_date": "2004-11-23",
@@ -4869,7 +4869,7 @@
             "start_date": "2001-11-17",
             "slug": "chamber_2001-11-17",
             "csv": "data/Kosovo/Assembly/term-chamber_2001-11-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a10c264/data/Kosovo/Assembly/term-chamber_2001-11-17.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a10c264/data/Kosovo/Assembly/term-chamber_2001-11-17.csv"
           }
         ],
         "statement_count": 7263
@@ -4887,7 +4887,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Kuwait/National_Assembly/sources",
         "popolo": "data/Kuwait/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/46da350/data/Kuwait/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/46da350/data/Kuwait/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Kuwait/National_Assembly/names.csv",
         "lastmod": "1457036482",
         "person_count": 45,
@@ -4899,7 +4899,7 @@
             "start_date": "2013-08-06",
             "slug": "14",
             "csv": "data/Kuwait/National_Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/46da350/data/Kuwait/National_Assembly/term-14.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/46da350/data/Kuwait/National_Assembly/term-14.csv"
           }
         ],
         "statement_count": 872
@@ -4917,7 +4917,7 @@
         "slug": "Council",
         "sources_directory": "data/Kyrgyzstan/Council/sources",
         "popolo": "data/Kyrgyzstan/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d3547b/data/Kyrgyzstan/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/4d3547b/data/Kyrgyzstan/Council/ep-popolo-v1.0.json",
         "names": "data/Kyrgyzstan/Council/names.csv",
         "lastmod": "1457983986",
         "person_count": 207,
@@ -4929,7 +4929,7 @@
             "start_date": "2015-10-28",
             "slug": "6",
             "csv": "data/Kyrgyzstan/Council/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d3547b/data/Kyrgyzstan/Council/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/4d3547b/data/Kyrgyzstan/Council/term-6.csv"
           },
           {
             "end_date": "2015-10-15",
@@ -4938,7 +4938,7 @@
             "start_date": "2010",
             "slug": "5",
             "csv": "data/Kyrgyzstan/Council/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d3547b/data/Kyrgyzstan/Council/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/4d3547b/data/Kyrgyzstan/Council/term-5.csv"
           }
         ],
         "statement_count": 3354
@@ -4956,7 +4956,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Laos/Assembly/sources",
         "popolo": "data/Laos/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad63fe4/data/Laos/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/ad63fe4/data/Laos/Assembly/ep-popolo-v1.0.json",
         "names": "data/Laos/Assembly/names.csv",
         "lastmod": "1450788171",
         "person_count": 132,
@@ -4968,7 +4968,7 @@
             "start_date": "2011",
             "slug": "2011",
             "csv": "data/Laos/Assembly/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad63fe4/data/Laos/Assembly/term-2011.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ad63fe4/data/Laos/Assembly/term-2011.csv"
           }
         ],
         "statement_count": 1516
@@ -4986,7 +4986,7 @@
         "slug": "Saeima",
         "sources_directory": "data/Latvia/Saeima/sources",
         "popolo": "data/Latvia/Saeima/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/090fb7d/data/Latvia/Saeima/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/090fb7d/data/Latvia/Saeima/ep-popolo-v1.0.json",
         "names": "data/Latvia/Saeima/names.csv",
         "lastmod": "1457893686",
         "person_count": 104,
@@ -4998,7 +4998,7 @@
             "start_date": "2014-11-04",
             "slug": "12",
             "csv": "data/Latvia/Saeima/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/090fb7d/data/Latvia/Saeima/term-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/090fb7d/data/Latvia/Saeima/term-12.csv"
           }
         ],
         "statement_count": 12060
@@ -5016,7 +5016,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Lebanon/Parliament/sources",
         "popolo": "data/Lebanon/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/06bb267/data/Lebanon/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/06bb267/data/Lebanon/Parliament/ep-popolo-v1.0.json",
         "names": "data/Lebanon/Parliament/names.csv",
         "lastmod": "1458192432",
         "person_count": 129,
@@ -5029,7 +5029,7 @@
             "start_date": "2009",
             "slug": "2009",
             "csv": "data/Lebanon/Parliament/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/06bb267/data/Lebanon/Parliament/term-2009.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/06bb267/data/Lebanon/Parliament/term-2009.csv"
           }
         ],
         "statement_count": 4931
@@ -5047,7 +5047,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Lesotho/Assembly/sources",
         "popolo": "data/Lesotho/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9ee94cc/data/Lesotho/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/9ee94cc/data/Lesotho/Assembly/ep-popolo-v1.0.json",
         "names": "data/Lesotho/Assembly/names.csv",
         "lastmod": "1457180416",
         "person_count": 120,
@@ -5059,7 +5059,7 @@
             "start_date": "2015-03-10",
             "slug": "9",
             "csv": "data/Lesotho/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9ee94cc/data/Lesotho/Assembly/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/9ee94cc/data/Lesotho/Assembly/term-9.csv"
           }
         ],
         "statement_count": 1685
@@ -5077,7 +5077,7 @@
         "slug": "House",
         "sources_directory": "data/Liberia/House/sources",
         "popolo": "data/Liberia/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/525ef15/data/Liberia/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/525ef15/data/Liberia/House/ep-popolo-v1.0.json",
         "names": "data/Liberia/House/names.csv",
         "lastmod": "1457180191",
         "person_count": 73,
@@ -5089,7 +5089,7 @@
             "start_date": "2011",
             "slug": "53",
             "csv": "data/Liberia/House/term-53.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/525ef15/data/Liberia/House/term-53.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/525ef15/data/Liberia/House/term-53.csv"
           }
         ],
         "statement_count": 1483
@@ -5107,7 +5107,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Libya/House_of_Representatives/sources",
         "popolo": "data/Libya/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4efadf/data/Libya/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/a4efadf/data/Libya/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Libya/House_of_Representatives/names.csv",
         "lastmod": "1457180100",
         "person_count": 189,
@@ -5119,7 +5119,7 @@
             "start_date": "2014-08-04",
             "slug": "1",
             "csv": "data/Libya/House_of_Representatives/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4efadf/data/Libya/House_of_Representatives/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a4efadf/data/Libya/House_of_Representatives/term-1.csv"
           }
         ],
         "statement_count": 2694
@@ -5137,7 +5137,7 @@
         "slug": "Landtag",
         "sources_directory": "data/Liechtenstein/Landtag/sources",
         "popolo": "data/Liechtenstein/Landtag/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1cd12ef/data/Liechtenstein/Landtag/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/1cd12ef/data/Liechtenstein/Landtag/ep-popolo-v1.0.json",
         "names": "data/Liechtenstein/Landtag/names.csv",
         "lastmod": "1457748965",
         "person_count": 51,
@@ -5150,7 +5150,7 @@
             "start_date": "2013",
             "slug": "2013",
             "csv": "data/Liechtenstein/Landtag/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1cd12ef/data/Liechtenstein/Landtag/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1cd12ef/data/Liechtenstein/Landtag/term-2013.csv"
           },
           {
             "end_date": "2013",
@@ -5159,7 +5159,7 @@
             "start_date": "2009",
             "slug": "2009",
             "csv": "data/Liechtenstein/Landtag/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1cd12ef/data/Liechtenstein/Landtag/term-2009.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1cd12ef/data/Liechtenstein/Landtag/term-2009.csv"
           },
           {
             "end_date": "2009",
@@ -5168,7 +5168,7 @@
             "start_date": "2005",
             "slug": "2005",
             "csv": "data/Liechtenstein/Landtag/term-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1cd12ef/data/Liechtenstein/Landtag/term-2005.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1cd12ef/data/Liechtenstein/Landtag/term-2005.csv"
           }
         ],
         "statement_count": 2123
@@ -5186,7 +5186,7 @@
         "slug": "Seimas",
         "sources_directory": "data/Lithuania/Seimas/sources",
         "popolo": "data/Lithuania/Seimas/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3495ee0/data/Lithuania/Seimas/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/3495ee0/data/Lithuania/Seimas/ep-popolo-v1.0.json",
         "names": "data/Lithuania/Seimas/names.csv",
         "lastmod": "1457808324",
         "person_count": 150,
@@ -5198,7 +5198,7 @@
             "start_date": "2012-11-17",
             "slug": "11",
             "csv": "data/Lithuania/Seimas/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3495ee0/data/Lithuania/Seimas/term-11.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/3495ee0/data/Lithuania/Seimas/term-11.csv"
           }
         ],
         "statement_count": 14311
@@ -5216,7 +5216,7 @@
         "slug": "Chamber",
         "sources_directory": "data/Luxembourg/Chamber/sources",
         "popolo": "data/Luxembourg/Chamber/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e137f34/data/Luxembourg/Chamber/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/e137f34/data/Luxembourg/Chamber/ep-popolo-v1.0.json",
         "names": "data/Luxembourg/Chamber/names.csv",
         "lastmod": "1457953145",
         "person_count": 60,
@@ -5228,7 +5228,7 @@
             "start_date": "2013-11-13",
             "slug": "2013",
             "csv": "data/Luxembourg/Chamber/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e137f34/data/Luxembourg/Chamber/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/e137f34/data/Luxembourg/Chamber/term-2013.csv"
           }
         ],
         "statement_count": 3422
@@ -5246,7 +5246,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Macao/Assembly/sources",
         "popolo": "data/Macao/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51c1f6b/data/Macao/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/51c1f6b/data/Macao/Assembly/ep-popolo-v1.0.json",
         "names": "data/Macao/Assembly/names.csv",
         "lastmod": "1457875441",
         "person_count": 33,
@@ -5259,7 +5259,7 @@
             "start_date": "2013",
             "slug": "10",
             "csv": "data/Macao/Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51c1f6b/data/Macao/Assembly/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/51c1f6b/data/Macao/Assembly/term-10.csv"
           }
         ],
         "statement_count": 953
@@ -5277,7 +5277,7 @@
         "slug": "Sobranie",
         "sources_directory": "data/Macedonia/Sobranie/sources",
         "popolo": "data/Macedonia/Sobranie/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cd902c4/data/Macedonia/Sobranie/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/cd902c4/data/Macedonia/Sobranie/ep-popolo-v1.0.json",
         "names": "data/Macedonia/Sobranie/names.csv",
         "lastmod": "1457814204",
         "person_count": 92,
@@ -5289,7 +5289,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/Macedonia/Sobranie/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cd902c4/data/Macedonia/Sobranie/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/cd902c4/data/Macedonia/Sobranie/term-2014.csv"
           }
         ],
         "statement_count": 1786
@@ -5307,7 +5307,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Madagascar/Assembly/sources",
         "popolo": "data/Madagascar/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3b67ce8/data/Madagascar/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/3b67ce8/data/Madagascar/Assembly/ep-popolo-v1.0.json",
         "names": "data/Madagascar/Assembly/names.csv",
         "lastmod": "1457176942",
         "person_count": 151,
@@ -5320,7 +5320,7 @@
             "start_date": "2013-12-20",
             "slug": "2013",
             "csv": "data/Madagascar/Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3b67ce8/data/Madagascar/Assembly/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/3b67ce8/data/Madagascar/Assembly/term-2013.csv"
           }
         ],
         "statement_count": 2444
@@ -5338,7 +5338,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Malawi/Assembly/sources",
         "popolo": "data/Malawi/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/96e56da/data/Malawi/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/96e56da/data/Malawi/Assembly/ep-popolo-v1.0.json",
         "names": "data/Malawi/Assembly/names.csv",
         "lastmod": "1457176807",
         "person_count": 193,
@@ -5350,7 +5350,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/Malawi/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/96e56da/data/Malawi/Assembly/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/96e56da/data/Malawi/Assembly/term-2014.csv"
           }
         ],
         "statement_count": 2722
@@ -5368,7 +5368,7 @@
         "slug": "Dewan-Rakyat",
         "sources_directory": "data/Malaysia/Dewan_Rakyat/sources",
         "popolo": "data/Malaysia/Dewan_Rakyat/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db8846f/data/Malaysia/Dewan_Rakyat/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/db8846f/data/Malaysia/Dewan_Rakyat/ep-popolo-v1.0.json",
         "names": "data/Malaysia/Dewan_Rakyat/names.csv",
         "lastmod": "1458116000",
         "person_count": 1148,
@@ -5380,7 +5380,7 @@
             "start_date": "2013-06-24",
             "slug": "13",
             "csv": "data/Malaysia/Dewan_Rakyat/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db8846f/data/Malaysia/Dewan_Rakyat/term-13.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/db8846f/data/Malaysia/Dewan_Rakyat/term-13.csv"
           },
           {
             "end_date": "2013",
@@ -5389,7 +5389,7 @@
             "start_date": "2008",
             "slug": "12",
             "csv": "data/Malaysia/Dewan_Rakyat/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db8846f/data/Malaysia/Dewan_Rakyat/term-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/db8846f/data/Malaysia/Dewan_Rakyat/term-12.csv"
           },
           {
             "end_date": "2008",
@@ -5398,7 +5398,7 @@
             "start_date": "2004",
             "slug": "11",
             "csv": "data/Malaysia/Dewan_Rakyat/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db8846f/data/Malaysia/Dewan_Rakyat/term-11.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/db8846f/data/Malaysia/Dewan_Rakyat/term-11.csv"
           },
           {
             "end_date": "2004",
@@ -5407,7 +5407,7 @@
             "start_date": "1999",
             "slug": "10",
             "csv": "data/Malaysia/Dewan_Rakyat/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db8846f/data/Malaysia/Dewan_Rakyat/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/db8846f/data/Malaysia/Dewan_Rakyat/term-10.csv"
           },
           {
             "end_date": "1999",
@@ -5416,7 +5416,7 @@
             "start_date": "1995",
             "slug": "9",
             "csv": "data/Malaysia/Dewan_Rakyat/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db8846f/data/Malaysia/Dewan_Rakyat/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/db8846f/data/Malaysia/Dewan_Rakyat/term-9.csv"
           },
           {
             "end_date": "1995",
@@ -5425,7 +5425,7 @@
             "start_date": "1990",
             "slug": "8",
             "csv": "data/Malaysia/Dewan_Rakyat/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db8846f/data/Malaysia/Dewan_Rakyat/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/db8846f/data/Malaysia/Dewan_Rakyat/term-8.csv"
           },
           {
             "end_date": "1990",
@@ -5434,7 +5434,7 @@
             "start_date": "1986",
             "slug": "7",
             "csv": "data/Malaysia/Dewan_Rakyat/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db8846f/data/Malaysia/Dewan_Rakyat/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/db8846f/data/Malaysia/Dewan_Rakyat/term-7.csv"
           },
           {
             "end_date": "1986",
@@ -5443,7 +5443,7 @@
             "start_date": "1982",
             "slug": "6",
             "csv": "data/Malaysia/Dewan_Rakyat/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db8846f/data/Malaysia/Dewan_Rakyat/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/db8846f/data/Malaysia/Dewan_Rakyat/term-6.csv"
           },
           {
             "end_date": "1982",
@@ -5452,7 +5452,7 @@
             "start_date": "1978",
             "slug": "5",
             "csv": "data/Malaysia/Dewan_Rakyat/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db8846f/data/Malaysia/Dewan_Rakyat/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/db8846f/data/Malaysia/Dewan_Rakyat/term-5.csv"
           },
           {
             "end_date": "1978",
@@ -5461,7 +5461,7 @@
             "start_date": "1974",
             "slug": "4",
             "csv": "data/Malaysia/Dewan_Rakyat/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db8846f/data/Malaysia/Dewan_Rakyat/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/db8846f/data/Malaysia/Dewan_Rakyat/term-4.csv"
           },
           {
             "end_date": "1974",
@@ -5470,7 +5470,7 @@
             "start_date": "1969",
             "slug": "3",
             "csv": "data/Malaysia/Dewan_Rakyat/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db8846f/data/Malaysia/Dewan_Rakyat/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/db8846f/data/Malaysia/Dewan_Rakyat/term-3.csv"
           },
           {
             "end_date": "1969",
@@ -5479,7 +5479,7 @@
             "start_date": "1964",
             "slug": "2",
             "csv": "data/Malaysia/Dewan_Rakyat/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db8846f/data/Malaysia/Dewan_Rakyat/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/db8846f/data/Malaysia/Dewan_Rakyat/term-2.csv"
           },
           {
             "end_date": "1964",
@@ -5488,7 +5488,7 @@
             "start_date": "1959",
             "slug": "1",
             "csv": "data/Malaysia/Dewan_Rakyat/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db8846f/data/Malaysia/Dewan_Rakyat/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/db8846f/data/Malaysia/Dewan_Rakyat/term-1.csv"
           }
         ],
         "statement_count": 45413
@@ -5506,7 +5506,7 @@
         "slug": "Majlis",
         "sources_directory": "data/Maldives/Majlis/sources",
         "popolo": "data/Maldives/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8ca0508/data/Maldives/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/8ca0508/data/Maldives/Majlis/ep-popolo-v1.0.json",
         "names": "data/Maldives/Majlis/names.csv",
         "lastmod": "1457176655",
         "person_count": 85,
@@ -5518,7 +5518,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/Maldives/Majlis/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8ca0508/data/Maldives/Majlis/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/8ca0508/data/Maldives/Majlis/term-2014.csv"
           }
         ],
         "statement_count": 1127
@@ -5536,7 +5536,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Mali/Assembly/sources",
         "popolo": "data/Mali/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/041f8ff/data/Mali/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/041f8ff/data/Mali/Assembly/ep-popolo-v1.0.json",
         "names": "data/Mali/Assembly/names.csv",
         "lastmod": "1450788264",
         "person_count": 142,
@@ -5548,7 +5548,7 @@
             "start_date": "2014-01-01",
             "slug": "2014",
             "csv": "data/Mali/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/041f8ff/data/Mali/Assembly/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/041f8ff/data/Mali/Assembly/term-2014.csv"
           }
         ],
         "statement_count": 1806
@@ -5566,7 +5566,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Malta/Assembly/sources",
         "popolo": "data/Malta/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6954275/data/Malta/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/6954275/data/Malta/Assembly/ep-popolo-v1.0.json",
         "names": "data/Malta/Assembly/names.csv",
         "lastmod": "1457958970",
         "person_count": 70,
@@ -5578,7 +5578,7 @@
             "start_date": "2013-04-06",
             "slug": "12",
             "csv": "data/Malta/Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6954275/data/Malta/Assembly/term-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6954275/data/Malta/Assembly/term-12.csv"
           }
         ],
         "statement_count": 2230
@@ -5596,7 +5596,7 @@
         "slug": "Nitijela",
         "sources_directory": "data/Marshall_Islands/Nitijela/sources",
         "popolo": "data/Marshall_Islands/Nitijela/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a61d818/data/Marshall_Islands/Nitijela/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/a61d818/data/Marshall_Islands/Nitijela/ep-popolo-v1.0.json",
         "names": "data/Marshall_Islands/Nitijela/names.csv",
         "lastmod": "1457176595",
         "person_count": 33,
@@ -5608,7 +5608,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Marshall_Islands/Nitijela/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a61d818/data/Marshall_Islands/Nitijela/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a61d818/data/Marshall_Islands/Nitijela/term-2012.csv"
           }
         ],
         "statement_count": 507
@@ -5626,7 +5626,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Mauritania/National_Assembly/sources",
         "popolo": "data/Mauritania/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a84bfb0/data/Mauritania/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/a84bfb0/data/Mauritania/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Mauritania/National_Assembly/names.csv",
         "lastmod": "1458185956",
         "person_count": 147,
@@ -5638,7 +5638,7 @@
             "start_date": "2013-12-21",
             "slug": "12",
             "csv": "data/Mauritania/National_Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a84bfb0/data/Mauritania/National_Assembly/term-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a84bfb0/data/Mauritania/National_Assembly/term-12.csv"
           }
         ],
         "statement_count": 1859
@@ -5656,7 +5656,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Mauritius/National_Assembly/sources",
         "popolo": "data/Mauritius/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9f64009/data/Mauritius/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/9f64009/data/Mauritius/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Mauritius/National_Assembly/names.csv",
         "lastmod": "1450788281",
         "person_count": 62,
@@ -5668,7 +5668,7 @@
             "start_date": "2014-12-10",
             "slug": "2014",
             "csv": "data/Mauritius/National_Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9f64009/data/Mauritius/National_Assembly/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/9f64009/data/Mauritius/National_Assembly/term-2014.csv"
           }
         ],
         "statement_count": 888
@@ -5686,7 +5686,7 @@
         "slug": "Deputies",
         "sources_directory": "data/Mexico/Deputies/sources",
         "popolo": "data/Mexico/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/724063c/data/Mexico/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/724063c/data/Mexico/Deputies/ep-popolo-v1.0.json",
         "names": "data/Mexico/Deputies/names.csv",
         "lastmod": "1458187702",
         "person_count": 998,
@@ -5698,7 +5698,7 @@
             "start_date": "2015-09-01",
             "slug": "63",
             "csv": "data/Mexico/Deputies/term-63.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/724063c/data/Mexico/Deputies/term-63.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/724063c/data/Mexico/Deputies/term-63.csv"
           },
           {
             "end_date": "2015-08-31",
@@ -5707,7 +5707,7 @@
             "start_date": "2012-09-01",
             "slug": "62",
             "csv": "data/Mexico/Deputies/term-62.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/724063c/data/Mexico/Deputies/term-62.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/724063c/data/Mexico/Deputies/term-62.csv"
           }
         ],
         "statement_count": 25889
@@ -5725,7 +5725,7 @@
         "slug": "Congress",
         "sources_directory": "data/Micronesia/Congress/sources",
         "popolo": "data/Micronesia/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c2a0905/data/Micronesia/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/c2a0905/data/Micronesia/Congress/ep-popolo-v1.0.json",
         "names": "data/Micronesia/Congress/names.csv",
         "lastmod": "1457338123",
         "person_count": 24,
@@ -5737,7 +5737,7 @@
             "start_date": "2015-05-11",
             "slug": "19",
             "csv": "data/Micronesia/Congress/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c2a0905/data/Micronesia/Congress/term-19.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c2a0905/data/Micronesia/Congress/term-19.csv"
           },
           {
             "end_date": "2015-05-10",
@@ -5746,7 +5746,7 @@
             "start_date": "2013-05-11",
             "slug": "18",
             "csv": "data/Micronesia/Congress/term-18.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c2a0905/data/Micronesia/Congress/term-18.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c2a0905/data/Micronesia/Congress/term-18.csv"
           },
           {
             "end_date": "2013-05-10",
@@ -5755,7 +5755,7 @@
             "start_date": "2011-05-11",
             "slug": "17",
             "csv": "data/Micronesia/Congress/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c2a0905/data/Micronesia/Congress/term-17.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c2a0905/data/Micronesia/Congress/term-17.csv"
           }
         ],
         "statement_count": 436
@@ -5773,7 +5773,7 @@
         "slug": "Parlamentul",
         "sources_directory": "data/Moldova/Parlamentul/sources",
         "popolo": "data/Moldova/Parlamentul/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/57e64a0/data/Moldova/Parlamentul/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/57e64a0/data/Moldova/Parlamentul/ep-popolo-v1.0.json",
         "names": "data/Moldova/Parlamentul/names.csv",
         "lastmod": "1458148357",
         "person_count": 113,
@@ -5785,7 +5785,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/Moldova/Parlamentul/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/57e64a0/data/Moldova/Parlamentul/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/57e64a0/data/Moldova/Parlamentul/term-2014.csv"
           }
         ],
         "statement_count": 5021
@@ -5803,7 +5803,7 @@
         "slug": "Council",
         "sources_directory": "data/Monaco/Council/sources",
         "popolo": "data/Monaco/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b35fa99/data/Monaco/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/b35fa99/data/Monaco/Council/ep-popolo-v1.0.json",
         "names": "data/Monaco/Council/names.csv",
         "lastmod": "1457176429",
         "person_count": 50,
@@ -5816,7 +5816,7 @@
             "start_date": "2013-02-21",
             "slug": "2013",
             "csv": "data/Monaco/Council/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b35fa99/data/Monaco/Council/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b35fa99/data/Monaco/Council/term-2013.csv"
           },
           {
             "end_date": "2013",
@@ -5825,7 +5825,7 @@
             "start_date": "2008",
             "slug": "2008",
             "csv": "data/Monaco/Council/term-2008.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b35fa99/data/Monaco/Council/term-2008.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b35fa99/data/Monaco/Council/term-2008.csv"
           },
           {
             "end_date": "2008",
@@ -5834,7 +5834,7 @@
             "start_date": "2003",
             "slug": "2003",
             "csv": "data/Monaco/Council/term-2003.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b35fa99/data/Monaco/Council/term-2003.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b35fa99/data/Monaco/Council/term-2003.csv"
           }
         ],
         "statement_count": 837
@@ -5852,7 +5852,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Mongolia/Assembly/sources",
         "popolo": "data/Mongolia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2f00453/data/Mongolia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/2f00453/data/Mongolia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Mongolia/Assembly/names.csv",
         "lastmod": "1458291638",
         "person_count": 117,
@@ -5864,7 +5864,7 @@
             "start_date": "2012-06-28",
             "slug": "2012",
             "csv": "data/Mongolia/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2f00453/data/Mongolia/Assembly/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2f00453/data/Mongolia/Assembly/term-2012.csv"
           },
           {
             "end_date": "2012-06-28",
@@ -5873,7 +5873,7 @@
             "start_date": "2008-07-23",
             "slug": "2008",
             "csv": "data/Mongolia/Assembly/term-2008.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2f00453/data/Mongolia/Assembly/term-2008.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2f00453/data/Mongolia/Assembly/term-2008.csv"
           }
         ],
         "statement_count": 4377
@@ -5891,7 +5891,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Montenegro/Assembly/sources",
         "popolo": "data/Montenegro/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b28f5a7/data/Montenegro/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/b28f5a7/data/Montenegro/Assembly/ep-popolo-v1.0.json",
         "names": "data/Montenegro/Assembly/names.csv",
         "lastmod": "1457176108",
         "person_count": 82,
@@ -5904,7 +5904,7 @@
             "start_date": "2012",
             "slug": "25",
             "csv": "data/Montenegro/Assembly/term-25.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b28f5a7/data/Montenegro/Assembly/term-25.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b28f5a7/data/Montenegro/Assembly/term-25.csv"
           }
         ],
         "statement_count": 1482
@@ -5922,7 +5922,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Montserrat/Assembly/sources",
         "popolo": "data/Montserrat/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/13c0ac6/data/Montserrat/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/13c0ac6/data/Montserrat/Assembly/ep-popolo-v1.0.json",
         "names": "data/Montserrat/Assembly/names.csv",
         "lastmod": "1457175881",
         "person_count": 9,
@@ -5934,7 +5934,7 @@
             "start_date": "2014",
             "slug": "1",
             "csv": "data/Montserrat/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/13c0ac6/data/Montserrat/Assembly/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/13c0ac6/data/Montserrat/Assembly/term-1.csv"
           }
         ],
         "statement_count": 124
@@ -5952,7 +5952,7 @@
         "slug": "House",
         "sources_directory": "data/Morocco/House/sources",
         "popolo": "data/Morocco/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af3b18a/data/Morocco/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/af3b18a/data/Morocco/House/ep-popolo-v1.0.json",
         "names": "data/Morocco/House/names.csv",
         "lastmod": "1457175494",
         "person_count": 395,
@@ -5965,7 +5965,7 @@
             "start_date": "2011",
             "slug": "9",
             "csv": "data/Morocco/House/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af3b18a/data/Morocco/House/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/af3b18a/data/Morocco/House/term-9.csv"
           }
         ],
         "statement_count": 4778
@@ -5983,7 +5983,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Mozambique/Assembly/sources",
         "popolo": "data/Mozambique/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7deb361/data/Mozambique/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/7deb361/data/Mozambique/Assembly/ep-popolo-v1.0.json",
         "names": "data/Mozambique/Assembly/names.csv",
         "lastmod": "1457174437",
         "person_count": 250,
@@ -5995,7 +5995,7 @@
             "start_date": "2015-01-12",
             "slug": "8",
             "csv": "data/Mozambique/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7deb361/data/Mozambique/Assembly/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7deb361/data/Mozambique/Assembly/term-8.csv"
           }
         ],
         "statement_count": 3064
@@ -6013,7 +6013,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Myanmar/House_of_Representatives/sources",
         "popolo": "data/Myanmar/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74119ac/data/Myanmar/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/74119ac/data/Myanmar/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Myanmar/House_of_Representatives/names.csv",
         "lastmod": "1450788334",
         "person_count": 314,
@@ -6025,7 +6025,7 @@
             "start_date": "2011-01-31",
             "slug": "1",
             "csv": "data/Myanmar/House_of_Representatives/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74119ac/data/Myanmar/House_of_Representatives/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/74119ac/data/Myanmar/House_of_Representatives/term-1.csv"
           }
         ],
         "statement_count": 5085
@@ -6043,7 +6043,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Nagorno_Karabakh/Assembly/sources",
         "popolo": "data/Nagorno_Karabakh/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ed3bb60/data/Nagorno_Karabakh/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/ed3bb60/data/Nagorno_Karabakh/Assembly/ep-popolo-v1.0.json",
         "names": "data/Nagorno_Karabakh/Assembly/names.csv",
         "lastmod": "1450788337",
         "person_count": 33,
@@ -6055,7 +6055,7 @@
             "start_date": "2015-05-21",
             "slug": "6",
             "csv": "data/Nagorno_Karabakh/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ed3bb60/data/Nagorno_Karabakh/Assembly/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ed3bb60/data/Nagorno_Karabakh/Assembly/term-6.csv"
           }
         ],
         "statement_count": 843
@@ -6073,7 +6073,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Namibia/Assembly/sources",
         "popolo": "data/Namibia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1e777db/data/Namibia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/1e777db/data/Namibia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Namibia/Assembly/names.csv",
         "lastmod": "1458209458",
         "person_count": 270,
@@ -6086,7 +6086,7 @@
             "start_date": "2015",
             "slug": "6",
             "csv": "data/Namibia/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1e777db/data/Namibia/Assembly/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1e777db/data/Namibia/Assembly/term-6.csv"
           },
           {
             "end_date": "2020",
@@ -6095,7 +6095,7 @@
             "start_date": "2015",
             "slug": "5",
             "csv": "data/Namibia/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1e777db/data/Namibia/Assembly/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1e777db/data/Namibia/Assembly/term-5.csv"
           },
           {
             "end_date": "2015",
@@ -6104,7 +6104,7 @@
             "start_date": "2010",
             "slug": "4",
             "csv": "data/Namibia/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1e777db/data/Namibia/Assembly/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1e777db/data/Namibia/Assembly/term-4.csv"
           },
           {
             "end_date": "2010",
@@ -6113,7 +6113,7 @@
             "start_date": "2004",
             "slug": "3",
             "csv": "data/Namibia/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1e777db/data/Namibia/Assembly/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1e777db/data/Namibia/Assembly/term-3.csv"
           },
           {
             "end_date": "2004",
@@ -6122,7 +6122,7 @@
             "start_date": "1998",
             "slug": "2",
             "csv": "data/Namibia/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1e777db/data/Namibia/Assembly/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1e777db/data/Namibia/Assembly/term-2.csv"
           },
           {
             "end_date": "1998",
@@ -6131,7 +6131,7 @@
             "start_date": "1993",
             "slug": "1",
             "csv": "data/Namibia/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1e777db/data/Namibia/Assembly/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1e777db/data/Namibia/Assembly/term-1.csv"
           },
           {
             "end_date": "1990",
@@ -6140,7 +6140,7 @@
             "start_date": "1989",
             "slug": "0",
             "csv": "data/Namibia/Assembly/term-0.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1e777db/data/Namibia/Assembly/term-0.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1e777db/data/Namibia/Assembly/term-0.csv"
           }
         ],
         "statement_count": 9230
@@ -6150,7 +6150,7 @@
         "slug": "Council",
         "sources_directory": "data/Namibia/Council/sources",
         "popolo": "data/Namibia/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9242885/data/Namibia/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/9242885/data/Namibia/Council/ep-popolo-v1.0.json",
         "names": "data/Namibia/Council/names.csv",
         "lastmod": "1450788348",
         "person_count": 81,
@@ -6163,7 +6163,7 @@
             "start_date": "2010",
             "slug": "4",
             "csv": "data/Namibia/Council/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9242885/data/Namibia/Council/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/9242885/data/Namibia/Council/term-4.csv"
           },
           {
             "end_date": "2010",
@@ -6172,7 +6172,7 @@
             "start_date": "2004",
             "slug": "3",
             "csv": "data/Namibia/Council/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9242885/data/Namibia/Council/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/9242885/data/Namibia/Council/term-3.csv"
           },
           {
             "end_date": "2004",
@@ -6181,7 +6181,7 @@
             "start_date": "1998",
             "slug": "2",
             "csv": "data/Namibia/Council/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9242885/data/Namibia/Council/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/9242885/data/Namibia/Council/term-2.csv"
           },
           {
             "end_date": "1998",
@@ -6190,7 +6190,7 @@
             "start_date": "1993",
             "slug": "1",
             "csv": "data/Namibia/Council/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9242885/data/Namibia/Council/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/9242885/data/Namibia/Council/term-1.csv"
           }
         ],
         "statement_count": 1181
@@ -6208,7 +6208,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Nauru/Parliament/sources",
         "popolo": "data/Nauru/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0e07552/data/Nauru/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/0e07552/data/Nauru/Parliament/ep-popolo-v1.0.json",
         "names": "data/Nauru/Parliament/names.csv",
         "lastmod": "1457889297",
         "person_count": 26,
@@ -6220,7 +6220,7 @@
             "start_date": "2013-06-11",
             "slug": "21",
             "csv": "data/Nauru/Parliament/term-21.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0e07552/data/Nauru/Parliament/term-21.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0e07552/data/Nauru/Parliament/term-21.csv"
           },
           {
             "end_date": "2013-05-23",
@@ -6229,7 +6229,7 @@
             "start_date": "2010-06-22",
             "slug": "20",
             "csv": "data/Nauru/Parliament/term-20.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0e07552/data/Nauru/Parliament/term-20.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0e07552/data/Nauru/Parliament/term-20.csv"
           },
           {
             "end_date": "2010-05-23",
@@ -6238,7 +6238,7 @@
             "start_date": "2000-06-19",
             "slug": "19",
             "csv": "data/Nauru/Parliament/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0e07552/data/Nauru/Parliament/term-19.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0e07552/data/Nauru/Parliament/term-19.csv"
           }
         ],
         "statement_count": 1787
@@ -6256,7 +6256,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Nepal/Assembly/sources",
         "popolo": "data/Nepal/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b3d5dd5/data/Nepal/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/b3d5dd5/data/Nepal/Assembly/ep-popolo-v1.0.json",
         "names": "data/Nepal/Assembly/names.csv",
         "lastmod": "1450788357",
         "person_count": 550,
@@ -6268,7 +6268,7 @@
             "start_date": "2014-01-22",
             "slug": "ca2",
             "csv": "data/Nepal/Assembly/term-ca2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b3d5dd5/data/Nepal/Assembly/term-ca2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b3d5dd5/data/Nepal/Assembly/term-ca2.csv"
           }
         ],
         "statement_count": 9392
@@ -6286,7 +6286,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Netherlands/House_of_Representatives/sources",
         "popolo": "data/Netherlands/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4c8e971/data/Netherlands/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/4c8e971/data/Netherlands/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Netherlands/House_of_Representatives/names.csv",
         "lastmod": "1457010597",
         "person_count": 152,
@@ -6298,7 +6298,7 @@
             "start_date": "2012-09-20",
             "slug": "2012",
             "csv": "data/Netherlands/House_of_Representatives/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4c8e971/data/Netherlands/House_of_Representatives/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/4c8e971/data/Netherlands/House_of_Representatives/term-2012.csv"
           }
         ],
         "statement_count": 8842
@@ -6316,7 +6316,7 @@
         "slug": "Congress",
         "sources_directory": "data/New_Caledonia/Congress/sources",
         "popolo": "data/New_Caledonia/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c0e6c0/data/New_Caledonia/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/1c0e6c0/data/New_Caledonia/Congress/ep-popolo-v1.0.json",
         "names": "data/New_Caledonia/Congress/names.csv",
         "lastmod": "1457991326",
         "person_count": 54,
@@ -6328,7 +6328,7 @@
             "start_date": "2014",
             "slug": "4",
             "csv": "data/New_Caledonia/Congress/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c0e6c0/data/New_Caledonia/Congress/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1c0e6c0/data/New_Caledonia/Congress/term-4.csv"
           }
         ],
         "statement_count": 1451
@@ -6346,7 +6346,7 @@
         "slug": "House",
         "sources_directory": "data/New_Zealand/House/sources",
         "popolo": "data/New_Zealand/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ce71e90/data/New_Zealand/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/ce71e90/data/New_Zealand/House/ep-popolo-v1.0.json",
         "names": "data/New_Zealand/House/names.csv",
         "lastmod": "1458155580",
         "person_count": 123,
@@ -6358,7 +6358,7 @@
             "start_date": "2014-10-20",
             "slug": "51",
             "csv": "data/New_Zealand/House/term-51.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ce71e90/data/New_Zealand/House/term-51.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ce71e90/data/New_Zealand/House/term-51.csv"
           }
         ],
         "statement_count": 7112
@@ -6376,7 +6376,7 @@
         "slug": "Asamblea",
         "sources_directory": "data/Nicaragua/Asamblea/sources",
         "popolo": "data/Nicaragua/Asamblea/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/03cf3ee/data/Nicaragua/Asamblea/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/03cf3ee/data/Nicaragua/Asamblea/ep-popolo-v1.0.json",
         "names": "data/Nicaragua/Asamblea/names.csv",
         "lastmod": "1450788386",
         "person_count": 90,
@@ -6388,7 +6388,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Nicaragua/Asamblea/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/03cf3ee/data/Nicaragua/Asamblea/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/03cf3ee/data/Nicaragua/Asamblea/term-2012.csv"
           }
         ],
         "statement_count": 1005
@@ -6406,7 +6406,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Niger/Assembly/sources",
         "popolo": "data/Niger/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cde3086/data/Niger/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/cde3086/data/Niger/Assembly/ep-popolo-v1.0.json",
         "names": "data/Niger/Assembly/names.csv",
         "lastmod": "1457171881",
         "person_count": 113,
@@ -6418,7 +6418,7 @@
             "start_date": "2011-10-06",
             "slug": "7.1",
             "csv": "data/Niger/Assembly/term-7.1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cde3086/data/Niger/Assembly/term-7.1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/cde3086/data/Niger/Assembly/term-7.1.csv"
           }
         ],
         "statement_count": 1268
@@ -6436,7 +6436,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Nigeria/Assembly/sources",
         "popolo": "data/Nigeria/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f8cb6ee/data/Nigeria/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/f8cb6ee/data/Nigeria/Assembly/ep-popolo-v1.0.json",
         "names": "data/Nigeria/Assembly/names.csv",
         "lastmod": "1450788395",
         "person_count": 362,
@@ -6448,7 +6448,7 @@
             "start_date": "2015-06-09",
             "slug": "2015",
             "csv": "data/Nigeria/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f8cb6ee/data/Nigeria/Assembly/term-2015.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/f8cb6ee/data/Nigeria/Assembly/term-2015.csv"
           }
         ],
         "statement_count": 5873
@@ -6466,7 +6466,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Niue/Assembly/sources",
         "popolo": "data/Niue/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d5180f0/data/Niue/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/d5180f0/data/Niue/Assembly/ep-popolo-v1.0.json",
         "names": "data/Niue/Assembly/names.csv",
         "lastmod": "1457038373",
         "person_count": 20,
@@ -6478,7 +6478,7 @@
             "start_date": "2014-04-23",
             "slug": "15",
             "csv": "data/Niue/Assembly/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d5180f0/data/Niue/Assembly/term-15.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/d5180f0/data/Niue/Assembly/term-15.csv"
           }
         ],
         "statement_count": 518
@@ -6496,7 +6496,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Norfolk_Island/Assembly/sources",
         "popolo": "data/Norfolk_Island/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1eb4c7/data/Norfolk_Island/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/d1eb4c7/data/Norfolk_Island/Assembly/ep-popolo-v1.0.json",
         "names": "data/Norfolk_Island/Assembly/names.csv",
         "lastmod": "1450788403",
         "person_count": 9,
@@ -6509,7 +6509,7 @@
             "start_date": "2013-03-20",
             "slug": "14",
             "csv": "data/Norfolk_Island/Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1eb4c7/data/Norfolk_Island/Assembly/term-14.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/d1eb4c7/data/Norfolk_Island/Assembly/term-14.csv"
           }
         ],
         "statement_count": 104
@@ -6527,7 +6527,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/North_Korea/National_Assembly/sources",
         "popolo": "data/North_Korea/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7c1c1fa/data/North_Korea/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/7c1c1fa/data/North_Korea/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/North_Korea/National_Assembly/names.csv",
         "lastmod": "1457253818",
         "person_count": 687,
@@ -6539,7 +6539,7 @@
             "start_date": "2014-03-09",
             "slug": "13",
             "csv": "data/North_Korea/National_Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7c1c1fa/data/North_Korea/National_Assembly/term-13.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7c1c1fa/data/North_Korea/National_Assembly/term-13.csv"
           }
         ],
         "statement_count": 12434
@@ -6557,7 +6557,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Northern_Cyprus/Assembly/sources",
         "popolo": "data/Northern_Cyprus/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fe0ffd4/data/Northern_Cyprus/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/fe0ffd4/data/Northern_Cyprus/Assembly/ep-popolo-v1.0.json",
         "names": "data/Northern_Cyprus/Assembly/names.csv",
         "lastmod": "1457331932",
         "person_count": 50,
@@ -6569,7 +6569,7 @@
             "start_date": "2013",
             "slug": "14",
             "csv": "data/Northern_Cyprus/Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fe0ffd4/data/Northern_Cyprus/Assembly/term-14.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fe0ffd4/data/Northern_Cyprus/Assembly/term-14.csv"
           }
         ],
         "statement_count": 1269
@@ -6587,7 +6587,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Northern_Ireland/Assembly/sources",
         "popolo": "data/Northern_Ireland/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e083214/data/Northern_Ireland/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/e083214/data/Northern_Ireland/Assembly/ep-popolo-v1.0.json",
         "names": "data/Northern_Ireland/Assembly/names.csv",
         "lastmod": "1458270920",
         "person_count": 242,
@@ -6600,7 +6600,7 @@
             "wikidata": "Q21124329",
             "slug": "4",
             "csv": "data/Northern_Ireland/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e083214/data/Northern_Ireland/Assembly/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/e083214/data/Northern_Ireland/Assembly/term-4.csv"
           },
           {
             "end_date": "2011-03-24",
@@ -6610,7 +6610,7 @@
             "wikidata": "Q21128152",
             "slug": "3",
             "csv": "data/Northern_Ireland/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e083214/data/Northern_Ireland/Assembly/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/e083214/data/Northern_Ireland/Assembly/term-3.csv"
           },
           {
             "end_date": "2007-01-30",
@@ -6620,7 +6620,7 @@
             "wikidata": "Q21128144",
             "slug": "2",
             "csv": "data/Northern_Ireland/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e083214/data/Northern_Ireland/Assembly/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/e083214/data/Northern_Ireland/Assembly/term-2.csv"
           },
           {
             "end_date": "2003-04-28",
@@ -6630,7 +6630,7 @@
             "wikidata": "Q21128140",
             "slug": "1",
             "csv": "data/Northern_Ireland/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e083214/data/Northern_Ireland/Assembly/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/e083214/data/Northern_Ireland/Assembly/term-1.csv"
           }
         ],
         "statement_count": 13388
@@ -6648,7 +6648,7 @@
         "slug": "House",
         "sources_directory": "data/Northern_Mariana_Islands/House/sources",
         "popolo": "data/Northern_Mariana_Islands/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ea59c4d/data/Northern_Mariana_Islands/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/ea59c4d/data/Northern_Mariana_Islands/House/ep-popolo-v1.0.json",
         "names": "data/Northern_Mariana_Islands/House/names.csv",
         "lastmod": "1450788429",
         "person_count": 20,
@@ -6660,7 +6660,7 @@
             "start_date": "2014",
             "slug": "19",
             "csv": "data/Northern_Mariana_Islands/House/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ea59c4d/data/Northern_Mariana_Islands/House/term-19.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ea59c4d/data/Northern_Mariana_Islands/House/term-19.csv"
           }
         ],
         "statement_count": 377
@@ -6678,7 +6678,7 @@
         "slug": "Storting",
         "sources_directory": "data/Norway/Storting/sources",
         "popolo": "data/Norway/Storting/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/ep-popolo-v1.0.json",
         "names": "data/Norway/Storting/names.csv",
         "lastmod": "1458123773",
         "person_count": 1141,
@@ -6691,7 +6691,7 @@
             "start_date": "2013-10-01",
             "slug": "2013-2017",
             "csv": "data/Norway/Storting/term-2013-2017.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-2013-2017.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-2013-2017.csv"
           },
           {
             "end_date": "2013-09-30",
@@ -6700,7 +6700,7 @@
             "start_date": "2009-10-01",
             "slug": "2009-2013",
             "csv": "data/Norway/Storting/term-2009-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-2009-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-2009-2013.csv"
           },
           {
             "end_date": "2009-09-30",
@@ -6709,7 +6709,7 @@
             "start_date": "2005-10-01",
             "slug": "2005-2009",
             "csv": "data/Norway/Storting/term-2005-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-2005-2009.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-2005-2009.csv"
           },
           {
             "end_date": "2005-09-30",
@@ -6718,7 +6718,7 @@
             "start_date": "2001-10-01",
             "slug": "2001-2005",
             "csv": "data/Norway/Storting/term-2001-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-2001-2005.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-2001-2005.csv"
           },
           {
             "end_date": "2001-09-30",
@@ -6727,7 +6727,7 @@
             "start_date": "1997-10-01",
             "slug": "1997-2001",
             "csv": "data/Norway/Storting/term-1997-2001.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-1997-2001.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-1997-2001.csv"
           },
           {
             "end_date": "1997-09-30",
@@ -6736,7 +6736,7 @@
             "start_date": "1993-10-01",
             "slug": "1993-97",
             "csv": "data/Norway/Storting/term-1993-97.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-1993-97.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-1993-97.csv"
           },
           {
             "end_date": "1993-09-30",
@@ -6745,7 +6745,7 @@
             "start_date": "1989-10-01",
             "slug": "1989-93",
             "csv": "data/Norway/Storting/term-1989-93.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-1989-93.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-1989-93.csv"
           },
           {
             "end_date": "1989-09-30",
@@ -6754,7 +6754,7 @@
             "start_date": "1985-10-01",
             "slug": "1985-89",
             "csv": "data/Norway/Storting/term-1985-89.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-1985-89.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-1985-89.csv"
           },
           {
             "end_date": "1985-09-30",
@@ -6763,7 +6763,7 @@
             "start_date": "1981-10-01",
             "slug": "1981-85",
             "csv": "data/Norway/Storting/term-1981-85.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-1981-85.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-1981-85.csv"
           },
           {
             "end_date": "1981-09-30",
@@ -6772,7 +6772,7 @@
             "start_date": "1977-10-01",
             "slug": "1977-81",
             "csv": "data/Norway/Storting/term-1977-81.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-1977-81.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-1977-81.csv"
           },
           {
             "end_date": "1977-09-30",
@@ -6781,7 +6781,7 @@
             "start_date": "1973-10-01",
             "slug": "1973-77",
             "csv": "data/Norway/Storting/term-1973-77.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-1973-77.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-1973-77.csv"
           },
           {
             "end_date": "1973-09-30",
@@ -6790,7 +6790,7 @@
             "start_date": "1969-10-01",
             "slug": "1969-73",
             "csv": "data/Norway/Storting/term-1969-73.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-1969-73.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-1969-73.csv"
           },
           {
             "end_date": "1969-09-30",
@@ -6799,7 +6799,7 @@
             "start_date": "1965-10-01",
             "slug": "1965-69",
             "csv": "data/Norway/Storting/term-1965-69.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-1965-69.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-1965-69.csv"
           },
           {
             "end_date": "1965-09-30",
@@ -6808,7 +6808,7 @@
             "start_date": "1961-10-01",
             "slug": "1961-65",
             "csv": "data/Norway/Storting/term-1961-65.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-1961-65.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-1961-65.csv"
           },
           {
             "end_date": "1961-09-30",
@@ -6817,7 +6817,7 @@
             "start_date": "1958-01-11",
             "slug": "1958-61",
             "csv": "data/Norway/Storting/term-1958-61.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-1958-61.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-1958-61.csv"
           },
           {
             "end_date": "1958-01-10",
@@ -6826,7 +6826,7 @@
             "start_date": "1954-01-11",
             "slug": "1954-57",
             "csv": "data/Norway/Storting/term-1954-57.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-1954-57.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-1954-57.csv"
           },
           {
             "end_date": "1954-01-10",
@@ -6835,7 +6835,7 @@
             "start_date": "1950-01-11",
             "slug": "1950-53",
             "csv": "data/Norway/Storting/term-1950-53.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-1950-53.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-1950-53.csv"
           },
           {
             "end_date": "1950-01-10",
@@ -6844,7 +6844,7 @@
             "start_date": "1945-12-04",
             "slug": "1945-49",
             "csv": "data/Norway/Storting/term-1945-49.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ca402b0/data/Norway/Storting/term-1945-49.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ca402b0/data/Norway/Storting/term-1945-49.csv"
           }
         ],
         "statement_count": 71568
@@ -6862,7 +6862,7 @@
         "slug": "Majlis",
         "sources_directory": "data/Oman/Majlis/sources",
         "popolo": "data/Oman/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1026e93/data/Oman/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/1026e93/data/Oman/Majlis/ep-popolo-v1.0.json",
         "names": "data/Oman/Majlis/names.csv",
         "lastmod": "1457171820",
         "person_count": 84,
@@ -6874,7 +6874,7 @@
             "start_date": "2011",
             "slug": "7",
             "csv": "data/Oman/Majlis/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1026e93/data/Oman/Majlis/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1026e93/data/Oman/Majlis/term-7.csv"
           }
         ],
         "statement_count": 1120
@@ -6892,7 +6892,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Pakistan/Assembly/sources",
         "popolo": "data/Pakistan/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c646af4/data/Pakistan/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/c646af4/data/Pakistan/Assembly/ep-popolo-v1.0.json",
         "names": "data/Pakistan/Assembly/names.csv",
         "lastmod": "1457171768",
         "person_count": 345,
@@ -6904,7 +6904,7 @@
             "start_date": "2013-06-01",
             "slug": "14",
             "csv": "data/Pakistan/Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c646af4/data/Pakistan/Assembly/term-14.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c646af4/data/Pakistan/Assembly/term-14.csv"
           }
         ],
         "statement_count": 11858
@@ -6922,7 +6922,7 @@
         "slug": "House-of-Delegates",
         "sources_directory": "data/Palau/House_of_Delegates/sources",
         "popolo": "data/Palau/House_of_Delegates/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cca32b2/data/Palau/House_of_Delegates/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/cca32b2/data/Palau/House_of_Delegates/ep-popolo-v1.0.json",
         "names": "data/Palau/House_of_Delegates/names.csv",
         "lastmod": "1450788542",
         "person_count": 16,
@@ -6934,7 +6934,7 @@
             "start_date": "2013",
             "slug": "2012",
             "csv": "data/Palau/House_of_Delegates/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cca32b2/data/Palau/House_of_Delegates/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/cca32b2/data/Palau/House_of_Delegates/term-2012.csv"
           }
         ],
         "statement_count": 221
@@ -6952,7 +6952,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Panama/Assembly/sources",
         "popolo": "data/Panama/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4b2e187/data/Panama/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/4b2e187/data/Panama/Assembly/ep-popolo-v1.0.json",
         "names": "data/Panama/Assembly/names.csv",
         "lastmod": "1452784767",
         "person_count": 71,
@@ -6964,7 +6964,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/Panama/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4b2e187/data/Panama/Assembly/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/4b2e187/data/Panama/Assembly/term-2014.csv"
           }
         ],
         "statement_count": 1355
@@ -6982,7 +6982,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Papua_New_Guinea/Parliament/sources",
         "popolo": "data/Papua_New_Guinea/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/107e2a2/data/Papua_New_Guinea/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/107e2a2/data/Papua_New_Guinea/Parliament/ep-popolo-v1.0.json",
         "names": "data/Papua_New_Guinea/Parliament/names.csv",
         "lastmod": "1457171435",
         "person_count": 108,
@@ -6995,7 +6995,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Papua_New_Guinea/Parliament/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/107e2a2/data/Papua_New_Guinea/Parliament/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/107e2a2/data/Papua_New_Guinea/Parliament/term-2012.csv"
           }
         ],
         "statement_count": 2126
@@ -7013,7 +7013,7 @@
         "slug": "Deputies",
         "sources_directory": "data/Paraguay/Deputies/sources",
         "popolo": "data/Paraguay/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aac2850/data/Paraguay/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/aac2850/data/Paraguay/Deputies/ep-popolo-v1.0.json",
         "names": "data/Paraguay/Deputies/names.csv",
         "lastmod": "1457171342",
         "person_count": 80,
@@ -7025,7 +7025,7 @@
             "start_date": "2013-04-21",
             "slug": "2013",
             "csv": "data/Paraguay/Deputies/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aac2850/data/Paraguay/Deputies/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/aac2850/data/Paraguay/Deputies/term-2013.csv"
           }
         ],
         "statement_count": 1704
@@ -7043,7 +7043,7 @@
         "slug": "Congreso",
         "sources_directory": "data/Peru/Congreso/sources",
         "popolo": "data/Peru/Congreso/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/782725a/data/Peru/Congreso/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/782725a/data/Peru/Congreso/ep-popolo-v1.0.json",
         "names": "data/Peru/Congreso/names.csv",
         "lastmod": "1458106858",
         "person_count": 127,
@@ -7056,7 +7056,7 @@
             "start_date": "2011-07-27",
             "slug": "2011",
             "csv": "data/Peru/Congreso/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/782725a/data/Peru/Congreso/term-2011.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/782725a/data/Peru/Congreso/term-2011.csv"
           }
         ],
         "statement_count": 4886
@@ -7074,7 +7074,7 @@
         "slug": "House",
         "sources_directory": "data/Philippines/House/sources",
         "popolo": "data/Philippines/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/285db69/data/Philippines/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/285db69/data/Philippines/House/ep-popolo-v1.0.json",
         "names": "data/Philippines/House/names.csv",
         "lastmod": "1458143624",
         "person_count": 291,
@@ -7087,7 +7087,7 @@
             "start_date": "2013-06-30",
             "slug": "16",
             "csv": "data/Philippines/House/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/285db69/data/Philippines/House/term-16.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/285db69/data/Philippines/House/term-16.csv"
           }
         ],
         "statement_count": 6782
@@ -7105,7 +7105,7 @@
         "slug": "Island-Council",
         "sources_directory": "data/Pitcairn/Island_Council/sources",
         "popolo": "data/Pitcairn/Island_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/812add4/data/Pitcairn/Island_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/812add4/data/Pitcairn/Island_Council/ep-popolo-v1.0.json",
         "names": "data/Pitcairn/Island_Council/names.csv",
         "lastmod": "1450788632",
         "person_count": 12,
@@ -7117,7 +7117,7 @@
             "start_date": "2013-11-12",
             "slug": "2013",
             "csv": "data/Pitcairn/Island_Council/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/812add4/data/Pitcairn/Island_Council/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/812add4/data/Pitcairn/Island_Council/term-2013.csv"
           },
           {
             "end_date": "2013-11-11",
@@ -7126,7 +7126,7 @@
             "start_date": "2011-12-12",
             "slug": "2011",
             "csv": "data/Pitcairn/Island_Council/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/812add4/data/Pitcairn/Island_Council/term-2011.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/812add4/data/Pitcairn/Island_Council/term-2011.csv"
           },
           {
             "end_date": "2011-12-11",
@@ -7135,7 +7135,7 @@
             "start_date": "2009-12-11",
             "slug": "2009",
             "csv": "data/Pitcairn/Island_Council/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/812add4/data/Pitcairn/Island_Council/term-2009.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/812add4/data/Pitcairn/Island_Council/term-2009.csv"
           }
         ],
         "statement_count": 155
@@ -7153,7 +7153,7 @@
         "slug": "Sejm",
         "sources_directory": "data/Poland/Sejm/sources",
         "popolo": "data/Poland/Sejm/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296bc3f/data/Poland/Sejm/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/296bc3f/data/Poland/Sejm/ep-popolo-v1.0.json",
         "names": "data/Poland/Sejm/names.csv",
         "lastmod": "1457254438",
         "person_count": 2187,
@@ -7165,7 +7165,7 @@
             "start_date": "2015-11-12",
             "slug": "8",
             "csv": "data/Poland/Sejm/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296bc3f/data/Poland/Sejm/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/296bc3f/data/Poland/Sejm/term-8.csv"
           },
           {
             "end_date": "2015-11-11",
@@ -7174,7 +7174,7 @@
             "start_date": "2011-11-08",
             "slug": "7",
             "csv": "data/Poland/Sejm/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296bc3f/data/Poland/Sejm/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/296bc3f/data/Poland/Sejm/term-7.csv"
           },
           {
             "end_date": "2011-11-07",
@@ -7183,7 +7183,7 @@
             "start_date": "2007-11-05",
             "slug": "6",
             "csv": "data/Poland/Sejm/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296bc3f/data/Poland/Sejm/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/296bc3f/data/Poland/Sejm/term-6.csv"
           },
           {
             "end_date": "2007-11-04",
@@ -7192,7 +7192,7 @@
             "start_date": "2005-10-19",
             "slug": "5",
             "csv": "data/Poland/Sejm/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296bc3f/data/Poland/Sejm/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/296bc3f/data/Poland/Sejm/term-5.csv"
           },
           {
             "end_date": "2005-10-18",
@@ -7201,7 +7201,7 @@
             "start_date": "2001-10-19",
             "slug": "4",
             "csv": "data/Poland/Sejm/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296bc3f/data/Poland/Sejm/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/296bc3f/data/Poland/Sejm/term-4.csv"
           },
           {
             "end_date": "2001-10-18",
@@ -7210,7 +7210,7 @@
             "start_date": "1997-10-20",
             "slug": "3",
             "csv": "data/Poland/Sejm/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296bc3f/data/Poland/Sejm/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/296bc3f/data/Poland/Sejm/term-3.csv"
           },
           {
             "end_date": "1997-10-19",
@@ -7219,7 +7219,7 @@
             "start_date": "1993-09-19",
             "slug": "2",
             "csv": "data/Poland/Sejm/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296bc3f/data/Poland/Sejm/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/296bc3f/data/Poland/Sejm/term-2.csv"
           },
           {
             "end_date": "1993-09-18",
@@ -7228,7 +7228,7 @@
             "start_date": "1991-11-25",
             "slug": "1",
             "csv": "data/Poland/Sejm/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296bc3f/data/Poland/Sejm/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/296bc3f/data/Poland/Sejm/term-1.csv"
           }
         ],
         "statement_count": 111024
@@ -7246,7 +7246,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Portugal/Assembly/sources",
         "popolo": "data/Portugal/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e3d12c/data/Portugal/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/6e3d12c/data/Portugal/Assembly/ep-popolo-v1.0.json",
         "names": "data/Portugal/Assembly/names.csv",
         "lastmod": "1458282183",
         "person_count": 230,
@@ -7259,7 +7259,7 @@
             "start_date": "2011",
             "slug": "12",
             "csv": "data/Portugal/Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e3d12c/data/Portugal/Assembly/term-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6e3d12c/data/Portugal/Assembly/term-12.csv"
           },
           {
             "end_date": "2011",
@@ -7268,7 +7268,7 @@
             "start_date": "2009",
             "slug": "11",
             "csv": "data/Portugal/Assembly/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e3d12c/data/Portugal/Assembly/term-11.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6e3d12c/data/Portugal/Assembly/term-11.csv"
           },
           {
             "end_date": "2009",
@@ -7277,7 +7277,7 @@
             "start_date": "2005",
             "slug": "10",
             "csv": "data/Portugal/Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e3d12c/data/Portugal/Assembly/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6e3d12c/data/Portugal/Assembly/term-10.csv"
           },
           {
             "end_date": "2005",
@@ -7286,7 +7286,7 @@
             "start_date": "2002",
             "slug": "9",
             "csv": "data/Portugal/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e3d12c/data/Portugal/Assembly/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6e3d12c/data/Portugal/Assembly/term-9.csv"
           },
           {
             "end_date": "2002",
@@ -7295,7 +7295,7 @@
             "start_date": "1999",
             "slug": "8",
             "csv": "data/Portugal/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e3d12c/data/Portugal/Assembly/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6e3d12c/data/Portugal/Assembly/term-8.csv"
           },
           {
             "end_date": "1999",
@@ -7304,7 +7304,7 @@
             "start_date": "1995",
             "slug": "7",
             "csv": "data/Portugal/Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e3d12c/data/Portugal/Assembly/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6e3d12c/data/Portugal/Assembly/term-7.csv"
           },
           {
             "end_date": "1995",
@@ -7313,7 +7313,7 @@
             "start_date": "1991",
             "slug": "6",
             "csv": "data/Portugal/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e3d12c/data/Portugal/Assembly/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6e3d12c/data/Portugal/Assembly/term-6.csv"
           }
         ],
         "statement_count": 7142
@@ -7331,7 +7331,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Puerto_Rico/House_of_Representatives/sources",
         "popolo": "data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d526379/data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/d526379/data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Puerto_Rico/House_of_Representatives/names.csv",
         "lastmod": "1457881784",
         "person_count": 51,
@@ -7344,7 +7344,7 @@
             "start_date": "2013-01-14",
             "slug": "29",
             "csv": "data/Puerto_Rico/House_of_Representatives/term-29.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d526379/data/Puerto_Rico/House_of_Representatives/term-29.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/d526379/data/Puerto_Rico/House_of_Representatives/term-29.csv"
           }
         ],
         "statement_count": 2818
@@ -7362,7 +7362,7 @@
         "slug": "Deputies",
         "sources_directory": "data/Romania/Deputies/sources",
         "popolo": "data/Romania/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/172eb10/data/Romania/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/172eb10/data/Romania/Deputies/ep-popolo-v1.0.json",
         "names": "data/Romania/Deputies/names.csv",
         "lastmod": "1458218887",
         "person_count": 417,
@@ -7374,7 +7374,7 @@
             "start_date": "2012-12-12",
             "slug": "2012",
             "csv": "data/Romania/Deputies/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/172eb10/data/Romania/Deputies/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/172eb10/data/Romania/Deputies/term-2012.csv"
           }
         ],
         "statement_count": 20095
@@ -7392,7 +7392,7 @@
         "slug": "Duma",
         "sources_directory": "data/Russia/Duma/sources",
         "popolo": "data/Russia/Duma/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/84315b0/data/Russia/Duma/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/84315b0/data/Russia/Duma/ep-popolo-v1.0.json",
         "names": "data/Russia/Duma/names.csv",
         "lastmod": "1458189916",
         "person_count": 461,
@@ -7404,7 +7404,7 @@
             "start_date": "2011-12-04",
             "slug": "6",
             "csv": "data/Russia/Duma/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/84315b0/data/Russia/Duma/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/84315b0/data/Russia/Duma/term-6.csv"
           }
         ],
         "statement_count": 17192
@@ -7422,7 +7422,7 @@
         "slug": "Deputies",
         "sources_directory": "data/Rwanda/Deputies/sources",
         "popolo": "data/Rwanda/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/84b6c9d/data/Rwanda/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/84b6c9d/data/Rwanda/Deputies/ep-popolo-v1.0.json",
         "names": "data/Rwanda/Deputies/names.csv",
         "lastmod": "1457171035",
         "person_count": 77,
@@ -7434,7 +7434,7 @@
             "start_date": "2013",
             "slug": "3",
             "csv": "data/Rwanda/Deputies/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/84b6c9d/data/Rwanda/Deputies/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/84b6c9d/data/Rwanda/Deputies/term-3.csv"
           }
         ],
         "statement_count": 1380
@@ -7452,7 +7452,7 @@
         "slug": "Council",
         "sources_directory": "data/Saint_Barthelemy/Council/sources",
         "popolo": "data/Saint_Barthelemy/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6896529/data/Saint_Barthelemy/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/6896529/data/Saint_Barthelemy/Council/ep-popolo-v1.0.json",
         "names": "data/Saint_Barthelemy/Council/names.csv",
         "lastmod": "1457789692",
         "person_count": 19,
@@ -7464,7 +7464,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Saint_Barthelemy/Council/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6896529/data/Saint_Barthelemy/Council/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6896529/data/Saint_Barthelemy/Council/term-2012.csv"
           }
         ],
         "statement_count": 302
@@ -7482,7 +7482,7 @@
         "slug": "Legislative-Council",
         "sources_directory": "data/Saint_Helena/Legislative_Council/sources",
         "popolo": "data/Saint_Helena/Legislative_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/381d8d9/data/Saint_Helena/Legislative_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/381d8d9/data/Saint_Helena/Legislative_Council/ep-popolo-v1.0.json",
         "names": "data/Saint_Helena/Legislative_Council/names.csv",
         "lastmod": "1450788778",
         "person_count": 12,
@@ -7494,7 +7494,7 @@
             "start_date": "2013-07-17",
             "slug": "2013",
             "csv": "data/Saint_Helena/Legislative_Council/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/381d8d9/data/Saint_Helena/Legislative_Council/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/381d8d9/data/Saint_Helena/Legislative_Council/term-2013.csv"
           }
         ],
         "statement_count": 166
@@ -7512,7 +7512,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Saint_Kitts_and_Nevis/Assembly/sources",
         "popolo": "data/Saint_Kitts_and_Nevis/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/ep-popolo-v1.0.json",
         "names": "data/Saint_Kitts_and_Nevis/Assembly/names.csv",
         "lastmod": "1457962354",
         "person_count": 30,
@@ -7524,7 +7524,7 @@
             "start_date": "2015",
             "slug": "2015",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/term-2015.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/term-2015.csv"
           },
           {
             "end_date": "2015",
@@ -7533,7 +7533,7 @@
             "start_date": "2010",
             "slug": "2010",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/term-2010.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/term-2010.csv"
           },
           {
             "end_date": "2010",
@@ -7542,7 +7542,7 @@
             "start_date": "2004",
             "slug": "2004",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-2004.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/term-2004.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/term-2004.csv"
           },
           {
             "end_date": "2004",
@@ -7551,7 +7551,7 @@
             "start_date": "2000",
             "slug": "2000",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-2000.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/term-2000.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/term-2000.csv"
           },
           {
             "end_date": "2000",
@@ -7560,7 +7560,7 @@
             "start_date": "1995",
             "slug": "1995",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-1995.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/term-1995.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/term-1995.csv"
           },
           {
             "end_date": "1995",
@@ -7569,7 +7569,7 @@
             "start_date": "1993",
             "slug": "1993",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-1993.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/term-1993.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/term-1993.csv"
           },
           {
             "end_date": "1993",
@@ -7578,7 +7578,7 @@
             "start_date": "1989",
             "slug": "1989",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-1989.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/term-1989.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/term-1989.csv"
           },
           {
             "end_date": "1989",
@@ -7587,7 +7587,7 @@
             "start_date": "1984",
             "slug": "1984",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-1984.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/term-1984.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a854f6d/data/Saint_Kitts_and_Nevis/Assembly/term-1984.csv"
           }
         ],
         "statement_count": 1448
@@ -7605,7 +7605,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Saint_Lucia/Assembly/sources",
         "popolo": "data/Saint_Lucia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ffe63d8/data/Saint_Lucia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/ffe63d8/data/Saint_Lucia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Saint_Lucia/Assembly/names.csv",
         "lastmod": "1457985207",
         "person_count": 23,
@@ -7617,7 +7617,7 @@
             "start_date": "2011",
             "slug": "9",
             "csv": "data/Saint_Lucia/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ffe63d8/data/Saint_Lucia/Assembly/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ffe63d8/data/Saint_Lucia/Assembly/term-9.csv"
           },
           {
             "end_date": "2011",
@@ -7626,7 +7626,7 @@
             "start_date": "2007",
             "slug": "8",
             "csv": "data/Saint_Lucia/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ffe63d8/data/Saint_Lucia/Assembly/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ffe63d8/data/Saint_Lucia/Assembly/term-8.csv"
           }
         ],
         "statement_count": 1150
@@ -7644,7 +7644,7 @@
         "slug": "Council",
         "sources_directory": "data/Saint_Martin/Council/sources",
         "popolo": "data/Saint_Martin/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5e13138/data/Saint_Martin/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/5e13138/data/Saint_Martin/Council/ep-popolo-v1.0.json",
         "names": "data/Saint_Martin/Council/names.csv",
         "lastmod": "1458212186",
         "person_count": 23,
@@ -7656,7 +7656,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Saint_Martin/Council/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5e13138/data/Saint_Martin/Council/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5e13138/data/Saint_Martin/Council/term-2012.csv"
           }
         ],
         "statement_count": 341
@@ -7674,7 +7674,7 @@
         "slug": "Territorial-Council",
         "sources_directory": "data/Saint_Pierre_and_Miquelon/Territorial_Council/sources",
         "popolo": "data/Saint_Pierre_and_Miquelon/Territorial_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2436aac/data/Saint_Pierre_and_Miquelon/Territorial_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/2436aac/data/Saint_Pierre_and_Miquelon/Territorial_Council/ep-popolo-v1.0.json",
         "names": "data/Saint_Pierre_and_Miquelon/Territorial_Council/names.csv",
         "lastmod": "1457815140",
         "person_count": 31,
@@ -7687,7 +7687,7 @@
             "start_date": "2012-03",
             "slug": "2012",
             "csv": "data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2436aac/data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2436aac/data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2012.csv"
           },
           {
             "end_date": "2012-03",
@@ -7696,7 +7696,7 @@
             "start_date": "2006-03",
             "slug": "2006",
             "csv": "data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2006.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2436aac/data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2006.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2436aac/data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2006.csv"
           }
         ],
         "statement_count": 554
@@ -7714,7 +7714,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Saint_Vincent_and_the_Grenadines/Assembly/sources",
         "popolo": "data/Saint_Vincent_and_the_Grenadines/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/98d6caf/data/Saint_Vincent_and_the_Grenadines/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/98d6caf/data/Saint_Vincent_and_the_Grenadines/Assembly/ep-popolo-v1.0.json",
         "names": "data/Saint_Vincent_and_the_Grenadines/Assembly/names.csv",
         "lastmod": "1456519029",
         "person_count": 15,
@@ -7726,7 +7726,7 @@
             "start_date": "2010",
             "slug": "8",
             "csv": "data/Saint_Vincent_and_the_Grenadines/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/98d6caf/data/Saint_Vincent_and_the_Grenadines/Assembly/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/98d6caf/data/Saint_Vincent_and_the_Grenadines/Assembly/term-8.csv"
           }
         ],
         "statement_count": 256
@@ -7744,7 +7744,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Samoa/Parliament/sources",
         "popolo": "data/Samoa/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/26496a2/data/Samoa/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/26496a2/data/Samoa/Parliament/ep-popolo-v1.0.json",
         "names": "data/Samoa/Parliament/names.csv",
         "lastmod": "1457786245",
         "person_count": 49,
@@ -7756,7 +7756,7 @@
             "start_date": "2011",
             "slug": "15",
             "csv": "data/Samoa/Parliament/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/26496a2/data/Samoa/Parliament/term-15.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/26496a2/data/Samoa/Parliament/term-15.csv"
           }
         ],
         "statement_count": 1183
@@ -7774,7 +7774,7 @@
         "slug": "Council",
         "sources_directory": "data/San_Marino/Council/sources",
         "popolo": "data/San_Marino/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/405e2cd/data/San_Marino/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/405e2cd/data/San_Marino/Council/ep-popolo-v1.0.json",
         "names": "data/San_Marino/Council/names.csv",
         "lastmod": "1458236043",
         "person_count": 60,
@@ -7786,7 +7786,7 @@
             "start_date": "2012-12-26",
             "slug": "2012",
             "csv": "data/San_Marino/Council/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/405e2cd/data/San_Marino/Council/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/405e2cd/data/San_Marino/Council/term-2012.csv"
           }
         ],
         "statement_count": 2605
@@ -7804,7 +7804,7 @@
         "slug": "Chief-Pleas",
         "sources_directory": "data/Sark/Chief_Pleas/sources",
         "popolo": "data/Sark/Chief_Pleas/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a345ad/data/Sark/Chief_Pleas/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/7a345ad/data/Sark/Chief_Pleas/ep-popolo-v1.0.json",
         "names": "data/Sark/Chief_Pleas/names.csv",
         "lastmod": "1450788811",
         "person_count": 46,
@@ -7817,7 +7817,7 @@
             "start_date": "2015",
             "slug": "2015",
             "csv": "data/Sark/Chief_Pleas/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a345ad/data/Sark/Chief_Pleas/term-2015.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7a345ad/data/Sark/Chief_Pleas/term-2015.csv"
           },
           {
             "end_date": "2015",
@@ -7826,7 +7826,7 @@
             "start_date": "2013",
             "slug": "2013",
             "csv": "data/Sark/Chief_Pleas/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a345ad/data/Sark/Chief_Pleas/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7a345ad/data/Sark/Chief_Pleas/term-2013.csv"
           },
           {
             "end_date": "2013",
@@ -7835,7 +7835,7 @@
             "start_date": "2011",
             "slug": "2011",
             "csv": "data/Sark/Chief_Pleas/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a345ad/data/Sark/Chief_Pleas/term-2011.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7a345ad/data/Sark/Chief_Pleas/term-2011.csv"
           },
           {
             "end_date": "2011",
@@ -7844,7 +7844,7 @@
             "start_date": "2009",
             "slug": "2009",
             "csv": "data/Sark/Chief_Pleas/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a345ad/data/Sark/Chief_Pleas/term-2009.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7a345ad/data/Sark/Chief_Pleas/term-2009.csv"
           }
         ],
         "statement_count": 822
@@ -7862,7 +7862,7 @@
         "slug": "Shura",
         "sources_directory": "data/Saudi_Arabia/Shura/sources",
         "popolo": "data/Saudi_Arabia/Shura/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aabb322/data/Saudi_Arabia/Shura/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/aabb322/data/Saudi_Arabia/Shura/ep-popolo-v1.0.json",
         "names": "data/Saudi_Arabia/Shura/names.csv",
         "lastmod": "1450788816",
         "person_count": 148,
@@ -7874,7 +7874,7 @@
             "start_date": "2013-02-24",
             "slug": "6",
             "csv": "data/Saudi_Arabia/Shura/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aabb322/data/Saudi_Arabia/Shura/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/aabb322/data/Saudi_Arabia/Shura/term-6.csv"
           }
         ],
         "statement_count": 1696
@@ -7892,7 +7892,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Scotland/Parliament/sources",
         "popolo": "data/Scotland/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c26800c/data/Scotland/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/c26800c/data/Scotland/Parliament/ep-popolo-v1.0.json",
         "names": "data/Scotland/Parliament/names.csv",
         "lastmod": "1458194523",
         "person_count": 254,
@@ -7904,7 +7904,7 @@
             "start_date": "2011-05-06",
             "slug": "4",
             "csv": "data/Scotland/Parliament/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c26800c/data/Scotland/Parliament/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c26800c/data/Scotland/Parliament/term-4.csv"
           },
           {
             "end_date": "2011-05-04",
@@ -7913,7 +7913,7 @@
             "start_date": "2007-05-03",
             "slug": "3",
             "csv": "data/Scotland/Parliament/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c26800c/data/Scotland/Parliament/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c26800c/data/Scotland/Parliament/term-3.csv"
           },
           {
             "end_date": "2007-04-02",
@@ -7922,7 +7922,7 @@
             "start_date": "2003-05-01",
             "slug": "2",
             "csv": "data/Scotland/Parliament/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c26800c/data/Scotland/Parliament/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c26800c/data/Scotland/Parliament/term-2.csv"
           },
           {
             "end_date": "2003-03-31",
@@ -7931,7 +7931,7 @@
             "start_date": "1999-05-06",
             "slug": "1",
             "csv": "data/Scotland/Parliament/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c26800c/data/Scotland/Parliament/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c26800c/data/Scotland/Parliament/term-1.csv"
           }
         ],
         "statement_count": 15586
@@ -7949,7 +7949,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Senegal/Assembly/sources",
         "popolo": "data/Senegal/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1059eda/data/Senegal/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/1059eda/data/Senegal/Assembly/ep-popolo-v1.0.json",
         "names": "data/Senegal/Assembly/names.csv",
         "lastmod": "1457790861",
         "person_count": 149,
@@ -7961,7 +7961,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Senegal/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1059eda/data/Senegal/Assembly/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1059eda/data/Senegal/Assembly/term-2012.csv"
           }
         ],
         "statement_count": 2046
@@ -7979,7 +7979,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Serbia/National_Assembly/sources",
         "popolo": "data/Serbia/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640fac/data/Serbia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/0640fac/data/Serbia/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Serbia/National_Assembly/names.csv",
         "lastmod": "1457387757",
         "person_count": 251,
@@ -7991,7 +7991,7 @@
             "start_date": "2014-04-16",
             "slug": "10",
             "csv": "data/Serbia/National_Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640fac/data/Serbia/National_Assembly/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0640fac/data/Serbia/National_Assembly/term-10.csv"
           }
         ],
         "statement_count": 4707
@@ -8009,7 +8009,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Seychelles/Assembly/sources",
         "popolo": "data/Seychelles/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6814a15/data/Seychelles/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/6814a15/data/Seychelles/Assembly/ep-popolo-v1.0.json",
         "names": "data/Seychelles/Assembly/names.csv",
         "lastmod": "1457170324",
         "person_count": 32,
@@ -8021,7 +8021,7 @@
             "start_date": "2011",
             "slug": "2011",
             "csv": "data/Seychelles/Assembly/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6814a15/data/Seychelles/Assembly/term-2011.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6814a15/data/Seychelles/Assembly/term-2011.csv"
           }
         ],
         "statement_count": 574
@@ -8039,7 +8039,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Sierra_Leone/Parliament/sources",
         "popolo": "data/Sierra_Leone/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c74eb2f/data/Sierra_Leone/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/c74eb2f/data/Sierra_Leone/Parliament/ep-popolo-v1.0.json",
         "names": "data/Sierra_Leone/Parliament/names.csv",
         "lastmod": "1457170183",
         "person_count": 124,
@@ -8051,7 +8051,7 @@
             "start_date": "2012",
             "slug": "2-4",
             "csv": "data/Sierra_Leone/Parliament/term-2-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c74eb2f/data/Sierra_Leone/Parliament/term-2-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c74eb2f/data/Sierra_Leone/Parliament/term-2-4.csv"
           }
         ],
         "statement_count": 1579
@@ -8069,7 +8069,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Singapore/Parliament/sources",
         "popolo": "data/Singapore/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef2848c/data/Singapore/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/ef2848c/data/Singapore/Parliament/ep-popolo-v1.0.json",
         "names": "data/Singapore/Parliament/names.csv",
         "lastmod": "1458279337",
         "person_count": 397,
@@ -8081,7 +8081,7 @@
             "start_date": "2016 --01-15",
             "slug": "13",
             "csv": "data/Singapore/Parliament/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef2848c/data/Singapore/Parliament/term-13.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ef2848c/data/Singapore/Parliament/term-13.csv"
           },
           {
             "end_date": "2015-08-25",
@@ -8090,7 +8090,7 @@
             "start_date": "2011-10-10",
             "slug": "12",
             "csv": "data/Singapore/Parliament/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef2848c/data/Singapore/Parliament/term-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ef2848c/data/Singapore/Parliament/term-12.csv"
           },
           {
             "end_date": "2011-04-19",
@@ -8099,7 +8099,7 @@
             "start_date": "2006-11-02",
             "slug": "11",
             "csv": "data/Singapore/Parliament/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef2848c/data/Singapore/Parliament/term-11.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ef2848c/data/Singapore/Parliament/term-11.csv"
           },
           {
             "end_date": "2006-04-19",
@@ -8108,7 +8108,7 @@
             "start_date": "2002-03-25",
             "slug": "10",
             "csv": "data/Singapore/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef2848c/data/Singapore/Parliament/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ef2848c/data/Singapore/Parliament/term-10.csv"
           },
           {
             "end_date": "2001-10-17",
@@ -8117,7 +8117,7 @@
             "start_date": "1997-05-26",
             "slug": "9",
             "csv": "data/Singapore/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef2848c/data/Singapore/Parliament/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ef2848c/data/Singapore/Parliament/term-9.csv"
           },
           {
             "end_date": "1996-12-15",
@@ -8126,7 +8126,7 @@
             "start_date": "1992-01-06",
             "slug": "8",
             "csv": "data/Singapore/Parliament/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef2848c/data/Singapore/Parliament/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ef2848c/data/Singapore/Parliament/term-8.csv"
           },
           {
             "end_date": "1991-08-13",
@@ -8135,7 +8135,7 @@
             "start_date": "1989-01-09",
             "slug": "7",
             "csv": "data/Singapore/Parliament/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef2848c/data/Singapore/Parliament/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ef2848c/data/Singapore/Parliament/term-7.csv"
           },
           {
             "end_date": "1988-08-16",
@@ -8144,7 +8144,7 @@
             "start_date": "1985-02-25",
             "slug": "6",
             "csv": "data/Singapore/Parliament/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef2848c/data/Singapore/Parliament/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ef2848c/data/Singapore/Parliament/term-6.csv"
           },
           {
             "end_date": "1984-12-03",
@@ -8153,7 +8153,7 @@
             "start_date": "1981-02-03",
             "slug": "5",
             "csv": "data/Singapore/Parliament/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef2848c/data/Singapore/Parliament/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ef2848c/data/Singapore/Parliament/term-5.csv"
           },
           {
             "end_date": "1980-12-04",
@@ -8162,7 +8162,7 @@
             "start_date": "1977-02-07",
             "slug": "4",
             "csv": "data/Singapore/Parliament/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef2848c/data/Singapore/Parliament/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ef2848c/data/Singapore/Parliament/term-4.csv"
           },
           {
             "end_date": "1976-12-06",
@@ -8171,7 +8171,7 @@
             "start_date": "1972-10-12",
             "slug": "3",
             "csv": "data/Singapore/Parliament/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef2848c/data/Singapore/Parliament/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ef2848c/data/Singapore/Parliament/term-3.csv"
           },
           {
             "end_date": "1972-08-16",
@@ -8180,7 +8180,7 @@
             "start_date": "1968-05-06",
             "slug": "2",
             "csv": "data/Singapore/Parliament/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef2848c/data/Singapore/Parliament/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ef2848c/data/Singapore/Parliament/term-2.csv"
           },
           {
             "end_date": "1968-02-08",
@@ -8189,7 +8189,7 @@
             "start_date": "1965-12-08",
             "slug": "1",
             "csv": "data/Singapore/Parliament/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef2848c/data/Singapore/Parliament/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ef2848c/data/Singapore/Parliament/term-1.csv"
           }
         ],
         "statement_count": 14618
@@ -8207,7 +8207,7 @@
         "slug": "Estates",
         "sources_directory": "data/Sint_Maarten/Estates/sources",
         "popolo": "data/Sint_Maarten/Estates/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b66ac25/data/Sint_Maarten/Estates/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/b66ac25/data/Sint_Maarten/Estates/ep-popolo-v1.0.json",
         "names": "data/Sint_Maarten/Estates/names.csv",
         "lastmod": "1450788856",
         "person_count": 15,
@@ -8219,7 +8219,7 @@
             "start_date": "2014",
             "slug": "2",
             "csv": "data/Sint_Maarten/Estates/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b66ac25/data/Sint_Maarten/Estates/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b66ac25/data/Sint_Maarten/Estates/term-2.csv"
           }
         ],
         "statement_count": 205
@@ -8237,7 +8237,7 @@
         "slug": "National-Council",
         "sources_directory": "data/Slovakia/National_Council/sources",
         "popolo": "data/Slovakia/National_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/199fe12/data/Slovakia/National_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/199fe12/data/Slovakia/National_Council/ep-popolo-v1.0.json",
         "names": "data/Slovakia/National_Council/names.csv",
         "lastmod": "1458261321",
         "person_count": 526,
@@ -8249,7 +8249,7 @@
             "start_date": "2012-03-11",
             "slug": "6",
             "csv": "data/Slovakia/National_Council/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/199fe12/data/Slovakia/National_Council/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/199fe12/data/Slovakia/National_Council/term-6.csv"
           },
           {
             "end_date": "2012-03-10",
@@ -8258,7 +8258,7 @@
             "start_date": "2010-06-13",
             "slug": "5",
             "csv": "data/Slovakia/National_Council/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/199fe12/data/Slovakia/National_Council/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/199fe12/data/Slovakia/National_Council/term-5.csv"
           },
           {
             "end_date": "2010-06-12",
@@ -8267,7 +8267,7 @@
             "start_date": "2006-06-17",
             "slug": "4",
             "csv": "data/Slovakia/National_Council/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/199fe12/data/Slovakia/National_Council/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/199fe12/data/Slovakia/National_Council/term-4.csv"
           },
           {
             "end_date": "2006-06-16",
@@ -8276,7 +8276,7 @@
             "start_date": "2002-09-22",
             "slug": "3",
             "csv": "data/Slovakia/National_Council/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/199fe12/data/Slovakia/National_Council/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/199fe12/data/Slovakia/National_Council/term-3.csv"
           },
           {
             "end_date": "2002-09-21",
@@ -8285,7 +8285,7 @@
             "start_date": "1998-09-26",
             "slug": "2",
             "csv": "data/Slovakia/National_Council/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/199fe12/data/Slovakia/National_Council/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/199fe12/data/Slovakia/National_Council/term-2.csv"
           }
         ],
         "statement_count": 28087
@@ -8303,7 +8303,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Slovenia/National_Assembly/sources",
         "popolo": "data/Slovenia/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/815e4a0/data/Slovenia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/815e4a0/data/Slovenia/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Slovenia/National_Assembly/names.csv",
         "lastmod": "1458120209",
         "person_count": 90,
@@ -8315,7 +8315,7 @@
             "start_date": "2014-08-01",
             "slug": "7",
             "csv": "data/Slovenia/National_Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/815e4a0/data/Slovenia/National_Assembly/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/815e4a0/data/Slovenia/National_Assembly/term-7.csv"
           }
         ],
         "statement_count": 6667
@@ -8333,7 +8333,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Solomon_Islands/Parliament/sources",
         "popolo": "data/Solomon_Islands/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2465285/data/Solomon_Islands/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/2465285/data/Solomon_Islands/Parliament/ep-popolo-v1.0.json",
         "names": "data/Solomon_Islands/Parliament/names.csv",
         "lastmod": "1457033126",
         "person_count": 50,
@@ -8345,7 +8345,7 @@
             "start_date": "2014",
             "slug": "10",
             "csv": "data/Solomon_Islands/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2465285/data/Solomon_Islands/Parliament/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2465285/data/Solomon_Islands/Parliament/term-10.csv"
           }
         ],
         "statement_count": 1848
@@ -8363,7 +8363,7 @@
         "slug": "Lower",
         "sources_directory": "data/Somalia/Lower/sources",
         "popolo": "data/Somalia/Lower/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/271117a/data/Somalia/Lower/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/271117a/data/Somalia/Lower/ep-popolo-v1.0.json",
         "names": "data/Somalia/Lower/names.csv",
         "lastmod": "1450788879",
         "person_count": 204,
@@ -8375,7 +8375,7 @@
             "start_date": "2012-08-20",
             "slug": "2012",
             "csv": "data/Somalia/Lower/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/271117a/data/Somalia/Lower/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/271117a/data/Somalia/Lower/term-2012.csv"
           }
         ],
         "statement_count": 2065
@@ -8393,7 +8393,7 @@
         "slug": "Representatives",
         "sources_directory": "data/Somaliland/Representatives/sources",
         "popolo": "data/Somaliland/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b029acf/data/Somaliland/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/b029acf/data/Somaliland/Representatives/ep-popolo-v1.0.json",
         "names": "data/Somaliland/Representatives/names.csv",
         "lastmod": "1450788884",
         "person_count": 82,
@@ -8405,7 +8405,7 @@
             "start_date": "2005-09-29",
             "slug": "2005",
             "csv": "data/Somaliland/Representatives/term-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b029acf/data/Somaliland/Representatives/term-2005.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b029acf/data/Somaliland/Representatives/term-2005.csv"
           }
         ],
         "statement_count": 936
@@ -8423,7 +8423,7 @@
         "slug": "Assembly",
         "sources_directory": "data/South_Africa/Assembly/sources",
         "popolo": "data/South_Africa/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ac2cfb1/data/South_Africa/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/ac2cfb1/data/South_Africa/Assembly/ep-popolo-v1.0.json",
         "names": "data/South_Africa/Assembly/names.csv",
         "lastmod": "1457875190",
         "person_count": 397,
@@ -8435,7 +8435,7 @@
             "start_date": "2014",
             "slug": "26",
             "csv": "data/South_Africa/Assembly/term-26.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ac2cfb1/data/South_Africa/Assembly/term-26.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ac2cfb1/data/South_Africa/Assembly/term-26.csv"
           }
         ],
         "statement_count": 10015
@@ -8453,7 +8453,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/South_Korea/National_Assembly/sources",
         "popolo": "data/South_Korea/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3e336c9/data/South_Korea/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/3e336c9/data/South_Korea/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/South_Korea/National_Assembly/names.csv",
         "lastmod": "1458284182",
         "person_count": 297,
@@ -8465,7 +8465,7 @@
             "start_date": "2012-05-30",
             "slug": "19",
             "csv": "data/South_Korea/National_Assembly/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3e336c9/data/South_Korea/National_Assembly/term-19.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/3e336c9/data/South_Korea/National_Assembly/term-19.csv"
           }
         ],
         "statement_count": 13764
@@ -8483,7 +8483,7 @@
         "slug": "Parliament",
         "sources_directory": "data/South_Ossetia/Parliament/sources",
         "popolo": "data/South_Ossetia/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a33f60f/data/South_Ossetia/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/a33f60f/data/South_Ossetia/Parliament/ep-popolo-v1.0.json",
         "names": "data/South_Ossetia/Parliament/names.csv",
         "lastmod": "1450788907",
         "person_count": 34,
@@ -8495,7 +8495,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/South_Ossetia/Parliament/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a33f60f/data/South_Ossetia/Parliament/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/a33f60f/data/South_Ossetia/Parliament/term-2014.csv"
           }
         ],
         "statement_count": 362
@@ -8513,7 +8513,7 @@
         "slug": "Assembly",
         "sources_directory": "data/South_Sudan/Assembly/sources",
         "popolo": "data/South_Sudan/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e35a65d/data/South_Sudan/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/e35a65d/data/South_Sudan/Assembly/ep-popolo-v1.0.json",
         "names": "data/South_Sudan/Assembly/names.csv",
         "lastmod": "1457168530",
         "person_count": 167,
@@ -8525,7 +8525,7 @@
             "start_date": "2011-07-09",
             "slug": "1",
             "csv": "data/South_Sudan/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e35a65d/data/South_Sudan/Assembly/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/e35a65d/data/South_Sudan/Assembly/term-1.csv"
           }
         ],
         "statement_count": 1889
@@ -8543,7 +8543,7 @@
         "slug": "Congress",
         "sources_directory": "data/Spain/Congress/sources",
         "popolo": "data/Spain/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6dbc327/data/Spain/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/6dbc327/data/Spain/Congress/ep-popolo-v1.0.json",
         "names": "data/Spain/Congress/names.csv",
         "lastmod": "1458279212",
         "person_count": 621,
@@ -8555,7 +8555,7 @@
             "start_date": "2016-01-13",
             "slug": "11",
             "csv": "data/Spain/Congress/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6dbc327/data/Spain/Congress/term-11.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6dbc327/data/Spain/Congress/term-11.csv"
           },
           {
             "end_date": "2015-10-27",
@@ -8564,7 +8564,7 @@
             "start_date": "2011-11-28",
             "slug": "10",
             "csv": "data/Spain/Congress/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6dbc327/data/Spain/Congress/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6dbc327/data/Spain/Congress/term-10.csv"
           }
         ],
         "statement_count": 27156
@@ -8582,7 +8582,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Sri_Lanka/Parliament/sources",
         "popolo": "data/Sri_Lanka/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cc57005/data/Sri_Lanka/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/cc57005/data/Sri_Lanka/Parliament/ep-popolo-v1.0.json",
         "names": "data/Sri_Lanka/Parliament/names.csv",
         "lastmod": "1458121116",
         "person_count": 228,
@@ -8594,7 +8594,7 @@
             "start_date": "2015-09-01",
             "slug": "15",
             "csv": "data/Sri_Lanka/Parliament/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cc57005/data/Sri_Lanka/Parliament/term-15.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/cc57005/data/Sri_Lanka/Parliament/term-15.csv"
           }
         ],
         "statement_count": 7990
@@ -8612,7 +8612,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Suriname/Assembly/sources",
         "popolo": "data/Suriname/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f7e61a0/data/Suriname/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/f7e61a0/data/Suriname/Assembly/ep-popolo-v1.0.json",
         "names": "data/Suriname/Assembly/names.csv",
         "lastmod": "1450788937",
         "person_count": 102,
@@ -8624,7 +8624,7 @@
             "start_date": "2015",
             "slug": "2015",
             "csv": "data/Suriname/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f7e61a0/data/Suriname/Assembly/term-2015.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/f7e61a0/data/Suriname/Assembly/term-2015.csv"
           },
           {
             "end_date": "2015",
@@ -8633,7 +8633,7 @@
             "start_date": "2010",
             "slug": "2010",
             "csv": "data/Suriname/Assembly/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f7e61a0/data/Suriname/Assembly/term-2010.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/f7e61a0/data/Suriname/Assembly/term-2010.csv"
           }
         ],
         "statement_count": 1954
@@ -8651,7 +8651,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Swaziland/Assembly/sources",
         "popolo": "data/Swaziland/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/44c58bd/data/Swaziland/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/44c58bd/data/Swaziland/Assembly/ep-popolo-v1.0.json",
         "names": "data/Swaziland/Assembly/names.csv",
         "lastmod": "1450788941",
         "person_count": 93,
@@ -8663,7 +8663,7 @@
             "start_date": "2013",
             "slug": "10",
             "csv": "data/Swaziland/Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/44c58bd/data/Swaziland/Assembly/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/44c58bd/data/Swaziland/Assembly/term-10.csv"
           },
           {
             "end_date": "2013",
@@ -8672,7 +8672,7 @@
             "start_date": "2008",
             "slug": "9",
             "csv": "data/Swaziland/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/44c58bd/data/Swaziland/Assembly/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/44c58bd/data/Swaziland/Assembly/term-9.csv"
           }
         ],
         "statement_count": 1195
@@ -8690,7 +8690,7 @@
         "slug": "Riksdag",
         "sources_directory": "data/Sweden/Riksdag/sources",
         "popolo": "data/Sweden/Riksdag/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c9eba8b/data/Sweden/Riksdag/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/c9eba8b/data/Sweden/Riksdag/ep-popolo-v1.0.json",
         "names": "data/Sweden/Riksdag/names.csv",
         "lastmod": "1457815638",
         "person_count": 1248,
@@ -8703,7 +8703,7 @@
             "start_date": "2014-09-29",
             "slug": "2014",
             "csv": "data/Sweden/Riksdag/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c9eba8b/data/Sweden/Riksdag/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c9eba8b/data/Sweden/Riksdag/term-2014.csv"
           },
           {
             "end_date": "2014-09-29",
@@ -8712,7 +8712,7 @@
             "start_date": "2010-10-04",
             "slug": "2010",
             "csv": "data/Sweden/Riksdag/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c9eba8b/data/Sweden/Riksdag/term-2010.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c9eba8b/data/Sweden/Riksdag/term-2010.csv"
           },
           {
             "end_date": "2010-10-04",
@@ -8721,7 +8721,7 @@
             "start_date": "2006-10-02",
             "slug": "2006",
             "csv": "data/Sweden/Riksdag/term-2006.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c9eba8b/data/Sweden/Riksdag/term-2006.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c9eba8b/data/Sweden/Riksdag/term-2006.csv"
           },
           {
             "end_date": "2006-10-02",
@@ -8730,7 +8730,7 @@
             "start_date": "2002-09-30",
             "slug": "2002",
             "csv": "data/Sweden/Riksdag/term-2002.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c9eba8b/data/Sweden/Riksdag/term-2002.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c9eba8b/data/Sweden/Riksdag/term-2002.csv"
           },
           {
             "end_date": "2002-09-30",
@@ -8739,7 +8739,7 @@
             "start_date": "1998-10-05",
             "slug": "1998",
             "csv": "data/Sweden/Riksdag/term-1998.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c9eba8b/data/Sweden/Riksdag/term-1998.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c9eba8b/data/Sweden/Riksdag/term-1998.csv"
           },
           {
             "end_date": "1998-10-05",
@@ -8748,7 +8748,7 @@
             "start_date": "1994-10-03",
             "slug": "1994",
             "csv": "data/Sweden/Riksdag/term-1994.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c9eba8b/data/Sweden/Riksdag/term-1994.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c9eba8b/data/Sweden/Riksdag/term-1994.csv"
           }
         ],
         "statement_count": 70131
@@ -8766,7 +8766,7 @@
         "slug": "National-Council",
         "sources_directory": "data/Switzerland/National_Council/sources",
         "popolo": "data/Switzerland/National_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcf495c/data/Switzerland/National_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/fcf495c/data/Switzerland/National_Council/ep-popolo-v1.0.json",
         "names": "data/Switzerland/National_Council/names.csv",
         "lastmod": "1457958377",
         "person_count": 1216,
@@ -8779,7 +8779,7 @@
             "start_date": "2015-11-30",
             "slug": "50",
             "csv": "data/Switzerland/National_Council/term-50.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcf495c/data/Switzerland/National_Council/term-50.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fcf495c/data/Switzerland/National_Council/term-50.csv"
           },
           {
             "end_date": "2015-11-29",
@@ -8788,7 +8788,7 @@
             "start_date": "2011-12-05",
             "slug": "49",
             "csv": "data/Switzerland/National_Council/term-49.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcf495c/data/Switzerland/National_Council/term-49.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fcf495c/data/Switzerland/National_Council/term-49.csv"
           },
           {
             "end_date": "2011-12-02",
@@ -8797,7 +8797,7 @@
             "start_date": "2007-12-03",
             "slug": "48",
             "csv": "data/Switzerland/National_Council/term-48.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcf495c/data/Switzerland/National_Council/term-48.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fcf495c/data/Switzerland/National_Council/term-48.csv"
           },
           {
             "end_date": "2007-11-30",
@@ -8806,7 +8806,7 @@
             "start_date": "2003-12-01",
             "slug": "47",
             "csv": "data/Switzerland/National_Council/term-47.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcf495c/data/Switzerland/National_Council/term-47.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fcf495c/data/Switzerland/National_Council/term-47.csv"
           },
           {
             "end_date": "2003-11-30",
@@ -8815,7 +8815,7 @@
             "start_date": "1999-12-06",
             "slug": "46",
             "csv": "data/Switzerland/National_Council/term-46.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcf495c/data/Switzerland/National_Council/term-46.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fcf495c/data/Switzerland/National_Council/term-46.csv"
           },
           {
             "end_date": "1999-11-30",
@@ -8824,7 +8824,7 @@
             "start_date": "1995-12-04",
             "slug": "45",
             "csv": "data/Switzerland/National_Council/term-45.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcf495c/data/Switzerland/National_Council/term-45.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fcf495c/data/Switzerland/National_Council/term-45.csv"
           },
           {
             "end_date": "1995-12-03",
@@ -8833,7 +8833,7 @@
             "start_date": "1991-11-25",
             "slug": "44",
             "csv": "data/Switzerland/National_Council/term-44.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcf495c/data/Switzerland/National_Council/term-44.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fcf495c/data/Switzerland/National_Council/term-44.csv"
           },
           {
             "end_date": "1991-11-24",
@@ -8842,7 +8842,7 @@
             "start_date": "1987-11-30",
             "slug": "43",
             "csv": "data/Switzerland/National_Council/term-43.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcf495c/data/Switzerland/National_Council/term-43.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fcf495c/data/Switzerland/National_Council/term-43.csv"
           },
           {
             "end_date": "1987-11-29",
@@ -8851,7 +8851,7 @@
             "start_date": "1983-11-28",
             "slug": "42",
             "csv": "data/Switzerland/National_Council/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcf495c/data/Switzerland/National_Council/term-42.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fcf495c/data/Switzerland/National_Council/term-42.csv"
           },
           {
             "end_date": "1983-11-27",
@@ -8860,7 +8860,7 @@
             "start_date": "1979-11-26",
             "slug": "41",
             "csv": "data/Switzerland/National_Council/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcf495c/data/Switzerland/National_Council/term-41.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fcf495c/data/Switzerland/National_Council/term-41.csv"
           },
           {
             "end_date": "1979-11-25",
@@ -8869,7 +8869,7 @@
             "start_date": "1975-12-01",
             "slug": "40",
             "csv": "data/Switzerland/National_Council/term-40.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcf495c/data/Switzerland/National_Council/term-40.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fcf495c/data/Switzerland/National_Council/term-40.csv"
           },
           {
             "end_date": "1975-11-30",
@@ -8878,7 +8878,7 @@
             "start_date": "1971-11-29",
             "slug": "39",
             "csv": "data/Switzerland/National_Council/term-39.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcf495c/data/Switzerland/National_Council/term-39.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fcf495c/data/Switzerland/National_Council/term-39.csv"
           },
           {
             "end_date": "1971-11-28",
@@ -8887,7 +8887,7 @@
             "start_date": "1967-12-04",
             "slug": "38",
             "csv": "data/Switzerland/National_Council/term-38.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcf495c/data/Switzerland/National_Council/term-38.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fcf495c/data/Switzerland/National_Council/term-38.csv"
           },
           {
             "end_date": "1967-12-03",
@@ -8896,7 +8896,7 @@
             "start_date": "1963-12-02",
             "slug": "37",
             "csv": "data/Switzerland/National_Council/term-37.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcf495c/data/Switzerland/National_Council/term-37.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fcf495c/data/Switzerland/National_Council/term-37.csv"
           }
         ],
         "statement_count": 42768
@@ -8914,7 +8914,7 @@
         "slug": "Majlis",
         "sources_directory": "data/Syria/Majlis/sources",
         "popolo": "data/Syria/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/585eef9/data/Syria/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/585eef9/data/Syria/Majlis/ep-popolo-v1.0.json",
         "names": "data/Syria/Majlis/names.csv",
         "lastmod": "1450788979",
         "person_count": 274,
@@ -8926,7 +8926,7 @@
             "start_date": "2012-05-24",
             "slug": "2012",
             "csv": "data/Syria/Majlis/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/585eef9/data/Syria/Majlis/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/585eef9/data/Syria/Majlis/term-2012.csv"
           }
         ],
         "statement_count": 3967
@@ -8944,7 +8944,7 @@
         "slug": "Legislative-Yuan",
         "sources_directory": "data/Taiwan/Legislative_Yuan/sources",
         "popolo": "data/Taiwan/Legislative_Yuan/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dec5b79/data/Taiwan/Legislative_Yuan/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/dec5b79/data/Taiwan/Legislative_Yuan/ep-popolo-v1.0.json",
         "names": "data/Taiwan/Legislative_Yuan/names.csv",
         "lastmod": "1457965277",
         "person_count": 166,
@@ -8956,7 +8956,7 @@
             "start_date": "2016-01-16",
             "slug": "9",
             "csv": "data/Taiwan/Legislative_Yuan/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dec5b79/data/Taiwan/Legislative_Yuan/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/dec5b79/data/Taiwan/Legislative_Yuan/term-9.csv"
           },
           {
             "end_date": "2016-01-16",
@@ -8965,7 +8965,7 @@
             "start_date": "2012-02-01",
             "slug": "8",
             "csv": "data/Taiwan/Legislative_Yuan/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dec5b79/data/Taiwan/Legislative_Yuan/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/dec5b79/data/Taiwan/Legislative_Yuan/term-8.csv"
           }
         ],
         "statement_count": 6436
@@ -8983,7 +8983,7 @@
         "slug": "Representatives",
         "sources_directory": "data/Tajikistan/Representatives/sources",
         "popolo": "data/Tajikistan/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5516776/data/Tajikistan/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/5516776/data/Tajikistan/Representatives/ep-popolo-v1.0.json",
         "names": "data/Tajikistan/Representatives/names.csv",
         "lastmod": "1450788987",
         "person_count": 62,
@@ -8995,7 +8995,7 @@
             "start_date": "2015",
             "slug": "2015",
             "csv": "data/Tajikistan/Representatives/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5516776/data/Tajikistan/Representatives/term-2015.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/5516776/data/Tajikistan/Representatives/term-2015.csv"
           }
         ],
         "statement_count": 943
@@ -9013,7 +9013,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Tanzania/Assembly/sources",
         "popolo": "data/Tanzania/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6134705/data/Tanzania/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/6134705/data/Tanzania/Assembly/ep-popolo-v1.0.json",
         "names": "data/Tanzania/Assembly/names.csv",
         "lastmod": "1458178830",
         "person_count": 672,
@@ -9025,7 +9025,7 @@
             "start_date": "2010-10-31",
             "slug": "4",
             "csv": "data/Tanzania/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6134705/data/Tanzania/Assembly/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6134705/data/Tanzania/Assembly/term-4.csv"
           },
           {
             "end_date": "2010-10-30",
@@ -9034,7 +9034,7 @@
             "start_date": "2005-10-30",
             "slug": "3",
             "csv": "data/Tanzania/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6134705/data/Tanzania/Assembly/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6134705/data/Tanzania/Assembly/term-3.csv"
           },
           {
             "end_date": "2005-10-29",
@@ -9043,7 +9043,7 @@
             "start_date": "2000-10-29",
             "slug": "2",
             "csv": "data/Tanzania/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6134705/data/Tanzania/Assembly/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/6134705/data/Tanzania/Assembly/term-2.csv"
           }
         ],
         "statement_count": 19733
@@ -9061,7 +9061,7 @@
         "slug": "National-Legislative-Assembly",
         "sources_directory": "data/Thailand/National_Legislative_Assembly/sources",
         "popolo": "data/Thailand/National_Legislative_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c13a2d1/data/Thailand/National_Legislative_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/c13a2d1/data/Thailand/National_Legislative_Assembly/ep-popolo-v1.0.json",
         "names": "data/Thailand/National_Legislative_Assembly/names.csv",
         "lastmod": "1457032902",
         "person_count": 218,
@@ -9073,7 +9073,7 @@
             "start_date": "2014",
             "slug": "2557",
             "csv": "data/Thailand/National_Legislative_Assembly/term-2557.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c13a2d1/data/Thailand/National_Legislative_Assembly/term-2557.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/c13a2d1/data/Thailand/National_Legislative_Assembly/term-2557.csv"
           }
         ],
         "statement_count": 3018
@@ -9091,7 +9091,7 @@
         "slug": "Parlamento",
         "sources_directory": "data/Timor_Leste/Parlamento/sources",
         "popolo": "data/Timor_Leste/Parlamento/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1cce9eb/data/Timor_Leste/Parlamento/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/1cce9eb/data/Timor_Leste/Parlamento/ep-popolo-v1.0.json",
         "names": "data/Timor_Leste/Parlamento/names.csv",
         "lastmod": "1450789005",
         "person_count": 65,
@@ -9103,7 +9103,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Timor_Leste/Parlamento/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1cce9eb/data/Timor_Leste/Parlamento/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1cce9eb/data/Timor_Leste/Parlamento/term-2012.csv"
           }
         ],
         "statement_count": 896
@@ -9121,7 +9121,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Togo/Assembly/sources",
         "popolo": "data/Togo/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9aeb8d6/data/Togo/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/9aeb8d6/data/Togo/Assembly/ep-popolo-v1.0.json",
         "names": "data/Togo/Assembly/names.csv",
         "lastmod": "1458171196",
         "person_count": 92,
@@ -9133,7 +9133,7 @@
             "start_date": "2013",
             "slug": "2013",
             "csv": "data/Togo/Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9aeb8d6/data/Togo/Assembly/term-2013.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/9aeb8d6/data/Togo/Assembly/term-2013.csv"
           }
         ],
         "statement_count": 1329
@@ -9151,7 +9151,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Tonga/Assembly/sources",
         "popolo": "data/Tonga/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0b5af3c/data/Tonga/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/0b5af3c/data/Tonga/Assembly/ep-popolo-v1.0.json",
         "names": "data/Tonga/Assembly/names.csv",
         "lastmod": "1457167981",
         "person_count": 26,
@@ -9164,7 +9164,7 @@
             "start_date": "2015",
             "slug": "2015",
             "csv": "data/Tonga/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0b5af3c/data/Tonga/Assembly/term-2015.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0b5af3c/data/Tonga/Assembly/term-2015.csv"
           }
         ],
         "statement_count": 451
@@ -9182,7 +9182,7 @@
         "slug": "Supreme-Council",
         "sources_directory": "data/Transnistria/Supreme_Council/sources",
         "popolo": "data/Transnistria/Supreme_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c624d7/data/Transnistria/Supreme_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/1c624d7/data/Transnistria/Supreme_Council/ep-popolo-v1.0.json",
         "names": "data/Transnistria/Supreme_Council/names.csv",
         "lastmod": "1457994376",
         "person_count": 65,
@@ -9194,7 +9194,7 @@
             "start_date": "2015-12-23",
             "slug": "6",
             "csv": "data/Transnistria/Supreme_Council/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c624d7/data/Transnistria/Supreme_Council/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1c624d7/data/Transnistria/Supreme_Council/term-6.csv"
           },
           {
             "end_date": "2015",
@@ -9203,7 +9203,7 @@
             "start_date": "2010",
             "slug": "5",
             "csv": "data/Transnistria/Supreme_Council/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c624d7/data/Transnistria/Supreme_Council/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/1c624d7/data/Transnistria/Supreme_Council/term-5.csv"
           }
         ],
         "statement_count": 1061
@@ -9221,7 +9221,7 @@
         "slug": "Representatives",
         "sources_directory": "data/Trinidad_and_Tobago/Representatives/sources",
         "popolo": "data/Trinidad_and_Tobago/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/557e3fb/data/Trinidad_and_Tobago/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/557e3fb/data/Trinidad_and_Tobago/Representatives/ep-popolo-v1.0.json",
         "names": "data/Trinidad_and_Tobago/Representatives/names.csv",
         "lastmod": "1450789019",
         "person_count": 42,
@@ -9233,7 +9233,7 @@
             "start_date": "2015-09-23",
             "slug": "11",
             "csv": "data/Trinidad_and_Tobago/Representatives/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/557e3fb/data/Trinidad_and_Tobago/Representatives/term-11.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/557e3fb/data/Trinidad_and_Tobago/Representatives/term-11.csv"
           }
         ],
         "statement_count": 826
@@ -9243,7 +9243,7 @@
         "slug": "Senate",
         "sources_directory": "data/Trinidad_and_Tobago/Senate/sources",
         "popolo": "data/Trinidad_and_Tobago/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d1653f/data/Trinidad_and_Tobago/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/2d1653f/data/Trinidad_and_Tobago/Senate/ep-popolo-v1.0.json",
         "names": "data/Trinidad_and_Tobago/Senate/names.csv",
         "lastmod": "1450789023",
         "person_count": 31,
@@ -9255,7 +9255,7 @@
             "start_date": "2015-09-23",
             "slug": "11",
             "csv": "data/Trinidad_and_Tobago/Senate/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d1653f/data/Trinidad_and_Tobago/Senate/term-11.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/2d1653f/data/Trinidad_and_Tobago/Senate/term-11.csv"
           }
         ],
         "statement_count": 511
@@ -9273,7 +9273,7 @@
         "slug": "Majlis",
         "sources_directory": "data/Tunisia/Majlis/sources",
         "popolo": "data/Tunisia/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b5c811e/data/Tunisia/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/b5c811e/data/Tunisia/Majlis/ep-popolo-v1.0.json",
         "names": "data/Tunisia/Majlis/names.csv",
         "lastmod": "1457167850",
         "person_count": 217,
@@ -9285,7 +9285,7 @@
             "start_date": "2014-12-02",
             "slug": "1",
             "csv": "data/Tunisia/Majlis/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b5c811e/data/Tunisia/Majlis/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/b5c811e/data/Tunisia/Majlis/term-1.csv"
           }
         ],
         "statement_count": 3386
@@ -9303,7 +9303,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Turkey/Assembly/sources",
         "popolo": "data/Turkey/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/ep-popolo-v1.0.json",
         "names": "data/Turkey/Assembly/names.csv",
         "lastmod": "1458280627",
         "person_count": 6912,
@@ -9315,7 +9315,7 @@
             "start_date": "2015-11-17",
             "slug": "26",
             "csv": "data/Turkey/Assembly/term-26.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-26.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-26.csv"
           },
           {
             "end_date": "2015-11-01",
@@ -9324,7 +9324,7 @@
             "start_date": "2015-06-23",
             "slug": "25",
             "csv": "data/Turkey/Assembly/term-25.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-25.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-25.csv"
           },
           {
             "end_date": "2015-06-07",
@@ -9333,7 +9333,7 @@
             "start_date": "2011-06-28",
             "slug": "24",
             "csv": "data/Turkey/Assembly/term-24.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-24.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-24.csv"
           },
           {
             "end_date": "2011-06-28",
@@ -9342,7 +9342,7 @@
             "start_date": "2007-07-23",
             "slug": "23",
             "csv": "data/Turkey/Assembly/term-23.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-23.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-23.csv"
           },
           {
             "end_date": "2007-07-23",
@@ -9351,7 +9351,7 @@
             "start_date": "2002-11-14",
             "slug": "22",
             "csv": "data/Turkey/Assembly/term-22.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-22.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-22.csv"
           },
           {
             "end_date": "2002-11-14",
@@ -9360,7 +9360,7 @@
             "start_date": "1999-04-18",
             "slug": "21",
             "csv": "data/Turkey/Assembly/term-21.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-21.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-21.csv"
           },
           {
             "end_date": "1999-04-18",
@@ -9369,7 +9369,7 @@
             "start_date": "1996-01-08",
             "slug": "20",
             "csv": "data/Turkey/Assembly/term-20.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-20.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-20.csv"
           },
           {
             "end_date": "1995-12-24",
@@ -9378,7 +9378,7 @@
             "start_date": "1991-11-06",
             "slug": "19",
             "csv": "data/Turkey/Assembly/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-19.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-19.csv"
           },
           {
             "end_date": "1991-10-20",
@@ -9387,7 +9387,7 @@
             "start_date": "1987-12-14",
             "slug": "18",
             "csv": "data/Turkey/Assembly/term-18.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-18.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-18.csv"
           },
           {
             "end_date": "1987-11-29",
@@ -9396,7 +9396,7 @@
             "start_date": "1983-11-24",
             "slug": "17",
             "csv": "data/Turkey/Assembly/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-17.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-17.csv"
           },
           {
             "end_date": "1980-09-12",
@@ -9405,7 +9405,7 @@
             "start_date": "1977-06-13",
             "slug": "16",
             "csv": "data/Turkey/Assembly/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-16.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-16.csv"
           },
           {
             "end_date": "1977-06-05",
@@ -9414,7 +9414,7 @@
             "start_date": "1973-10-24",
             "slug": "15",
             "csv": "data/Turkey/Assembly/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-15.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-15.csv"
           },
           {
             "end_date": "1973-10-14",
@@ -9423,7 +9423,7 @@
             "start_date": "1969-10-22",
             "slug": "14",
             "csv": "data/Turkey/Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-14.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-14.csv"
           },
           {
             "end_date": "1973-10-14",
@@ -9432,7 +9432,7 @@
             "start_date": "1965-10-22",
             "slug": "13",
             "csv": "data/Turkey/Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-13.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-13.csv"
           },
           {
             "end_date": "1973-10-14",
@@ -9441,7 +9441,7 @@
             "start_date": "1961-10-25",
             "slug": "12",
             "csv": "data/Turkey/Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-12.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-12.csv"
           },
           {
             "end_date": "1960-05-27",
@@ -9450,7 +9450,7 @@
             "start_date": "1957-11-01",
             "slug": "11",
             "csv": "data/Turkey/Assembly/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-11.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-11.csv"
           },
           {
             "end_date": "1957-11-01",
@@ -9459,7 +9459,7 @@
             "start_date": "1954-05-14",
             "slug": "10",
             "csv": "data/Turkey/Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-10.csv"
           },
           {
             "end_date": "1954-05-14",
@@ -9468,7 +9468,7 @@
             "start_date": "1950-05-22",
             "slug": "9",
             "csv": "data/Turkey/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-9.csv"
           },
           {
             "end_date": "1950-05-22",
@@ -9477,7 +9477,7 @@
             "start_date": "1946-08-05",
             "slug": "8",
             "csv": "data/Turkey/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-8.csv"
           },
           {
             "end_date": "1946-08-05",
@@ -9486,7 +9486,7 @@
             "start_date": "1943-03-08",
             "slug": "7",
             "csv": "data/Turkey/Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-7.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-7.csv"
           },
           {
             "end_date": "1943-03-08",
@@ -9495,7 +9495,7 @@
             "start_date": "1939-04-03",
             "slug": "6",
             "csv": "data/Turkey/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-6.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-6.csv"
           },
           {
             "end_date": "1939-04-03",
@@ -9504,7 +9504,7 @@
             "start_date": "1935-03-01",
             "slug": "5",
             "csv": "data/Turkey/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-5.csv"
           },
           {
             "end_date": "1935-03-01",
@@ -9513,7 +9513,7 @@
             "start_date": "1931-05-04",
             "slug": "4",
             "csv": "data/Turkey/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-4.csv"
           },
           {
             "end_date": "1931-05-04",
@@ -9522,7 +9522,7 @@
             "start_date": "1927-05-01",
             "slug": "3",
             "csv": "data/Turkey/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-3.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-3.csv"
           },
           {
             "end_date": "1927-11-01",
@@ -9531,7 +9531,7 @@
             "start_date": "1923-08-11",
             "slug": "2",
             "csv": "data/Turkey/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-2.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-2.csv"
           },
           {
             "end_date": "1923-08-11",
@@ -9540,7 +9540,7 @@
             "start_date": "1920-04-23",
             "slug": "1",
             "csv": "data/Turkey/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/27bd888/data/Turkey/Assembly/term-1.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/27bd888/data/Turkey/Assembly/term-1.csv"
           }
         ],
         "statement_count": 205347
@@ -9558,7 +9558,7 @@
         "slug": "Mejlis",
         "sources_directory": "data/Turkmenistan/Mejlis/sources",
         "popolo": "data/Turkmenistan/Mejlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad50ea7/data/Turkmenistan/Mejlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/ad50ea7/data/Turkmenistan/Mejlis/ep-popolo-v1.0.json",
         "names": "data/Turkmenistan/Mejlis/names.csv",
         "lastmod": "1450789527",
         "person_count": 237,
@@ -9570,7 +9570,7 @@
             "start_date": "2013",
             "slug": "5",
             "csv": "data/Turkmenistan/Mejlis/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad50ea7/data/Turkmenistan/Mejlis/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ad50ea7/data/Turkmenistan/Mejlis/term-5.csv"
           },
           {
             "end_date": "2013",
@@ -9579,7 +9579,7 @@
             "start_date": "2009",
             "slug": "4",
             "csv": "data/Turkmenistan/Mejlis/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad50ea7/data/Turkmenistan/Mejlis/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/ad50ea7/data/Turkmenistan/Mejlis/term-4.csv"
           }
         ],
         "statement_count": 3991
@@ -9597,7 +9597,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Turks_and_Caicos_Islands/Assembly/sources",
         "popolo": "data/Turks_and_Caicos_Islands/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/701b4b6/data/Turks_and_Caicos_Islands/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/701b4b6/data/Turks_and_Caicos_Islands/Assembly/ep-popolo-v1.0.json",
         "names": "data/Turks_and_Caicos_Islands/Assembly/names.csv",
         "lastmod": "1457256084",
         "person_count": 18,
@@ -9609,7 +9609,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Turks_and_Caicos_Islands/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/701b4b6/data/Turks_and_Caicos_Islands/Assembly/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/701b4b6/data/Turks_and_Caicos_Islands/Assembly/term-2012.csv"
           }
         ],
         "statement_count": 476
@@ -9627,7 +9627,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Tuvalu/Parliament/sources",
         "popolo": "data/Tuvalu/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d2b79c1/data/Tuvalu/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/d2b79c1/data/Tuvalu/Parliament/ep-popolo-v1.0.json",
         "names": "data/Tuvalu/Parliament/names.csv",
         "lastmod": "1457820049",
         "person_count": 27,
@@ -9639,7 +9639,7 @@
             "start_date": "2015-03-31",
             "slug": "11",
             "csv": "data/Tuvalu/Parliament/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d2b79c1/data/Tuvalu/Parliament/term-11.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/d2b79c1/data/Tuvalu/Parliament/term-11.csv"
           },
           {
             "end_date": "2015-03-30",
@@ -9648,7 +9648,7 @@
             "start_date": "2010-09-16",
             "slug": "10",
             "csv": "data/Tuvalu/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d2b79c1/data/Tuvalu/Parliament/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/d2b79c1/data/Tuvalu/Parliament/term-10.csv"
           },
           {
             "end_date": "2010-09-16",
@@ -9657,7 +9657,7 @@
             "start_date": "2006-08-03",
             "slug": "9",
             "csv": "data/Tuvalu/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d2b79c1/data/Tuvalu/Parliament/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/d2b79c1/data/Tuvalu/Parliament/term-9.csv"
           }
         ],
         "statement_count": 1385
@@ -9675,7 +9675,7 @@
         "slug": "Legislature",
         "sources_directory": "data/US_Virgin_Islands/Legislature/sources",
         "popolo": "data/US_Virgin_Islands/Legislature/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20f8a5e/data/US_Virgin_Islands/Legislature/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/20f8a5e/data/US_Virgin_Islands/Legislature/ep-popolo-v1.0.json",
         "names": "data/US_Virgin_Islands/Legislature/names.csv",
         "lastmod": "1457166568",
         "person_count": 15,
@@ -9687,7 +9687,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/US_Virgin_Islands/Legislature/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20f8a5e/data/US_Virgin_Islands/Legislature/term-2014.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/20f8a5e/data/US_Virgin_Islands/Legislature/term-2014.csv"
           }
         ],
         "statement_count": 245
@@ -9705,7 +9705,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Uganda/Parliament/sources",
         "popolo": "data/Uganda/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d707cb4/data/Uganda/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/d707cb4/data/Uganda/Parliament/ep-popolo-v1.0.json",
         "names": "data/Uganda/Parliament/names.csv",
         "lastmod": "1450789624",
         "person_count": 385,
@@ -9717,7 +9717,7 @@
             "start_date": "2011",
             "slug": "9",
             "csv": "data/Uganda/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d707cb4/data/Uganda/Parliament/term-9.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/d707cb4/data/Uganda/Parliament/term-9.csv"
           }
         ],
         "statement_count": 7993
@@ -9735,7 +9735,7 @@
         "slug": "Verkhovna-Rada",
         "sources_directory": "data/Ukraine/Verkhovna_Rada/sources",
         "popolo": "data/Ukraine/Verkhovna_Rada/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/428f40f/data/Ukraine/Verkhovna_Rada/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/428f40f/data/Ukraine/Verkhovna_Rada/ep-popolo-v1.0.json",
         "names": "data/Ukraine/Verkhovna_Rada/names.csv",
         "lastmod": "1458258849",
         "person_count": 443,
@@ -9747,7 +9747,7 @@
             "start_date": "2014-11-27",
             "slug": "8",
             "csv": "data/Ukraine/Verkhovna_Rada/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/428f40f/data/Ukraine/Verkhovna_Rada/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/428f40f/data/Ukraine/Verkhovna_Rada/term-8.csv"
           }
         ],
         "statement_count": 19771
@@ -9765,7 +9765,7 @@
         "slug": "Federal-National-Council",
         "sources_directory": "data/United_Arab_Emirates/Federal_National_Council/sources",
         "popolo": "data/United_Arab_Emirates/Federal_National_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0b0664c/data/United_Arab_Emirates/Federal_National_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/0b0664c/data/United_Arab_Emirates/Federal_National_Council/ep-popolo-v1.0.json",
         "names": "data/United_Arab_Emirates/Federal_National_Council/names.csv",
         "lastmod": "1450789633",
         "person_count": 40,
@@ -9778,7 +9778,7 @@
             "start_date": "2011",
             "slug": "2011",
             "csv": "data/United_Arab_Emirates/Federal_National_Council/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0b0664c/data/United_Arab_Emirates/Federal_National_Council/term-2011.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0b0664c/data/United_Arab_Emirates/Federal_National_Council/term-2011.csv"
           }
         ],
         "statement_count": 614
@@ -9796,7 +9796,7 @@
         "slug": "Commons",
         "sources_directory": "data/UK/Commons/sources",
         "popolo": "data/UK/Commons/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/19d075a/data/UK/Commons/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/19d075a/data/UK/Commons/ep-popolo-v1.0.json",
         "names": "data/UK/Commons/names.csv",
         "lastmod": "1458282440",
         "person_count": 1338,
@@ -9809,7 +9809,7 @@
             "wikidata": "Q21084473",
             "slug": "56",
             "csv": "data/UK/Commons/term-56.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/19d075a/data/UK/Commons/term-56.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/19d075a/data/UK/Commons/term-56.csv"
           },
           {
             "end_date": "2015-03-30",
@@ -9819,7 +9819,7 @@
             "wikidata": "Q21084472",
             "slug": "55",
             "csv": "data/UK/Commons/term-55.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/19d075a/data/UK/Commons/term-55.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/19d075a/data/UK/Commons/term-55.csv"
           },
           {
             "end_date": "2010-04-12",
@@ -9829,7 +9829,7 @@
             "wikidata": "Q21084471",
             "slug": "54",
             "csv": "data/UK/Commons/term-54.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/19d075a/data/UK/Commons/term-54.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/19d075a/data/UK/Commons/term-54.csv"
           },
           {
             "end_date": "2005-04-11",
@@ -9839,7 +9839,7 @@
             "wikidata": "Q21084470",
             "slug": "53",
             "csv": "data/UK/Commons/term-53.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/19d075a/data/UK/Commons/term-53.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/19d075a/data/UK/Commons/term-53.csv"
           },
           {
             "end_date": "2001-05-14",
@@ -9849,7 +9849,7 @@
             "wikidata": "Q21084469",
             "slug": "52",
             "csv": "data/UK/Commons/term-52.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/19d075a/data/UK/Commons/term-52.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/19d075a/data/UK/Commons/term-52.csv"
           }
         ],
         "statement_count": 117994
@@ -9867,7 +9867,7 @@
         "slug": "House",
         "sources_directory": "data/United_States_of_America/House/sources",
         "popolo": "data/United_States_of_America/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/ep-popolo-v1.0.json",
         "names": "data/United_States_of_America/House/names.csv",
         "lastmod": "1458183768",
         "person_count": 1584,
@@ -9880,7 +9880,7 @@
             "wikidata": "Q16146771",
             "slug": "114",
             "csv": "data/United_States_of_America/House/term-114.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-114.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-114.csv"
           },
           {
             "end_date": "2015-01-03",
@@ -9890,7 +9890,7 @@
             "wikidata": "Q71871",
             "slug": "113",
             "csv": "data/United_States_of_America/House/term-113.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-113.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-113.csv"
           },
           {
             "end_date": "2013-01-03",
@@ -9900,7 +9900,7 @@
             "wikidata": "Q170447",
             "slug": "112",
             "csv": "data/United_States_of_America/House/term-112.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-112.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-112.csv"
           },
           {
             "end_date": "2011-01-03",
@@ -9910,7 +9910,7 @@
             "wikidata": "Q170375",
             "slug": "111",
             "csv": "data/United_States_of_America/House/term-111.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-111.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-111.csv"
           },
           {
             "end_date": "2009-01-03",
@@ -9920,7 +9920,7 @@
             "wikidata": "Q170018",
             "slug": "110",
             "csv": "data/United_States_of_America/House/term-110.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-110.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-110.csv"
           },
           {
             "end_date": "2007-01-03",
@@ -9930,7 +9930,7 @@
             "wikidata": "Q168778",
             "slug": "109",
             "csv": "data/United_States_of_America/House/term-109.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-109.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-109.csv"
           },
           {
             "end_date": "2005-01-03",
@@ -9940,7 +9940,7 @@
             "wikidata": "Q168504",
             "slug": "108",
             "csv": "data/United_States_of_America/House/term-108.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-108.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-108.csv"
           },
           {
             "end_date": "2003-01-03",
@@ -9950,7 +9950,7 @@
             "wikidata": "Q2057259",
             "slug": "107",
             "csv": "data/United_States_of_America/House/term-107.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-107.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-107.csv"
           },
           {
             "end_date": "2001-01-03",
@@ -9960,7 +9960,7 @@
             "wikidata": "Q3596897",
             "slug": "106",
             "csv": "data/United_States_of_America/House/term-106.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-106.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-106.csv"
           },
           {
             "end_date": "1999-01-03",
@@ -9970,7 +9970,7 @@
             "wikidata": "Q3596884",
             "slug": "105",
             "csv": "data/United_States_of_America/House/term-105.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-105.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-105.csv"
           },
           {
             "end_date": "1997-01-03",
@@ -9980,7 +9980,7 @@
             "wikidata": "Q3596857",
             "slug": "104",
             "csv": "data/United_States_of_America/House/term-104.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-104.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-104.csv"
           },
           {
             "end_date": "1995-01-03",
@@ -9990,7 +9990,7 @@
             "wikidata": "Q3556780",
             "slug": "103",
             "csv": "data/United_States_of_America/House/term-103.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-103.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-103.csv"
           },
           {
             "end_date": "1993-01-03",
@@ -10000,7 +10000,7 @@
             "wikidata": "Q347346",
             "slug": "102",
             "csv": "data/United_States_of_America/House/term-102.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-102.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-102.csv"
           },
           {
             "end_date": "1991-01-03",
@@ -10010,7 +10010,7 @@
             "wikidata": "Q4546373",
             "slug": "101",
             "csv": "data/United_States_of_America/House/term-101.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-101.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-101.csv"
           },
           {
             "end_date": "1989-01-03",
@@ -10020,7 +10020,7 @@
             "wikidata": "Q4546248",
             "slug": "100",
             "csv": "data/United_States_of_America/House/term-100.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-100.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-100.csv"
           },
           {
             "end_date": "1987-01-03",
@@ -10030,7 +10030,7 @@
             "wikidata": "Q4646349",
             "slug": "99",
             "csv": "data/United_States_of_America/House/term-99.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-99.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-99.csv"
           },
           {
             "end_date": "1983-01-03",
@@ -10040,7 +10040,7 @@
             "wikidata": "Q4646254",
             "slug": "98",
             "csv": "data/United_States_of_America/House/term-98.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-98.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-98.csv"
           },
           {
             "end_date": "1983-01-03",
@@ -10050,7 +10050,7 @@
             "wikidata": "Q4646187",
             "slug": "97",
             "csv": "data/United_States_of_America/House/term-97.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd0ed68/data/United_States_of_America/House/term-97.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fd0ed68/data/United_States_of_America/House/term-97.csv"
           }
         ],
         "statement_count": 192189
@@ -10060,7 +10060,7 @@
         "slug": "Senate",
         "sources_directory": "data/United_States_of_America/Senate/sources",
         "popolo": "data/United_States_of_America/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/ep-popolo-v1.0.json",
         "names": "data/United_States_of_America/Senate/names.csv",
         "lastmod": "1458274036",
         "person_count": 310,
@@ -10073,7 +10073,7 @@
             "wikidata": "Q16146771",
             "slug": "114",
             "csv": "data/United_States_of_America/Senate/term-114.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-114.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-114.csv"
           },
           {
             "end_date": "2015-01-03",
@@ -10083,7 +10083,7 @@
             "wikidata": "Q71871",
             "slug": "113",
             "csv": "data/United_States_of_America/Senate/term-113.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-113.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-113.csv"
           },
           {
             "end_date": "2013-01-03",
@@ -10093,7 +10093,7 @@
             "wikidata": "Q170447",
             "slug": "112",
             "csv": "data/United_States_of_America/Senate/term-112.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-112.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-112.csv"
           },
           {
             "end_date": "2011-01-03",
@@ -10103,7 +10103,7 @@
             "wikidata": "Q170375",
             "slug": "111",
             "csv": "data/United_States_of_America/Senate/term-111.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-111.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-111.csv"
           },
           {
             "end_date": "2009-01-03",
@@ -10113,7 +10113,7 @@
             "wikidata": "Q170018",
             "slug": "110",
             "csv": "data/United_States_of_America/Senate/term-110.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-110.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-110.csv"
           },
           {
             "end_date": "2007-01-03",
@@ -10123,7 +10123,7 @@
             "wikidata": "Q168778",
             "slug": "109",
             "csv": "data/United_States_of_America/Senate/term-109.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-109.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-109.csv"
           },
           {
             "end_date": "2005-01-03",
@@ -10133,7 +10133,7 @@
             "wikidata": "Q168504",
             "slug": "108",
             "csv": "data/United_States_of_America/Senate/term-108.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-108.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-108.csv"
           },
           {
             "end_date": "2003-01-03",
@@ -10143,7 +10143,7 @@
             "wikidata": "Q2057259",
             "slug": "107",
             "csv": "data/United_States_of_America/Senate/term-107.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-107.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-107.csv"
           },
           {
             "end_date": "2001-01-03",
@@ -10153,7 +10153,7 @@
             "wikidata": "Q3596897",
             "slug": "106",
             "csv": "data/United_States_of_America/Senate/term-106.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-106.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-106.csv"
           },
           {
             "end_date": "1999-01-03",
@@ -10163,7 +10163,7 @@
             "wikidata": "Q3596884",
             "slug": "105",
             "csv": "data/United_States_of_America/Senate/term-105.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-105.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-105.csv"
           },
           {
             "end_date": "1997-01-03",
@@ -10173,7 +10173,7 @@
             "wikidata": "Q3596857",
             "slug": "104",
             "csv": "data/United_States_of_America/Senate/term-104.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-104.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-104.csv"
           },
           {
             "end_date": "1995-01-03",
@@ -10183,7 +10183,7 @@
             "wikidata": "Q3556780",
             "slug": "103",
             "csv": "data/United_States_of_America/Senate/term-103.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-103.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-103.csv"
           },
           {
             "end_date": "1993-01-03",
@@ -10193,7 +10193,7 @@
             "wikidata": "Q347346",
             "slug": "102",
             "csv": "data/United_States_of_America/Senate/term-102.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-102.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-102.csv"
           },
           {
             "end_date": "1991-01-03",
@@ -10203,7 +10203,7 @@
             "wikidata": "Q4546373",
             "slug": "101",
             "csv": "data/United_States_of_America/Senate/term-101.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-101.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-101.csv"
           },
           {
             "end_date": "1989-01-03",
@@ -10213,7 +10213,7 @@
             "wikidata": "Q4546248",
             "slug": "100",
             "csv": "data/United_States_of_America/Senate/term-100.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-100.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-100.csv"
           },
           {
             "end_date": "1987-01-03",
@@ -10223,7 +10223,7 @@
             "wikidata": "Q4646349",
             "slug": "99",
             "csv": "data/United_States_of_America/Senate/term-99.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-99.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-99.csv"
           },
           {
             "end_date": "1983-01-03",
@@ -10233,7 +10233,7 @@
             "wikidata": "Q4646254",
             "slug": "98",
             "csv": "data/United_States_of_America/Senate/term-98.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-98.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-98.csv"
           },
           {
             "end_date": "1983-01-03",
@@ -10243,7 +10243,7 @@
             "wikidata": "Q4646187",
             "slug": "97",
             "csv": "data/United_States_of_America/Senate/term-97.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf540ae/data/United_States_of_America/Senate/term-97.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bf540ae/data/United_States_of_America/Senate/term-97.csv"
           }
         ],
         "statement_count": 53776
@@ -10261,7 +10261,7 @@
         "slug": "Deputies",
         "sources_directory": "data/Uruguay/Deputies/sources",
         "popolo": "data/Uruguay/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7ced540/data/Uruguay/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/7ced540/data/Uruguay/Deputies/ep-popolo-v1.0.json",
         "names": "data/Uruguay/Deputies/names.csv",
         "lastmod": "1450789813",
         "person_count": 106,
@@ -10273,7 +10273,7 @@
             "start_date": "2015-02-15",
             "slug": "48",
             "csv": "data/Uruguay/Deputies/term-48.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7ced540/data/Uruguay/Deputies/term-48.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/7ced540/data/Uruguay/Deputies/term-48.csv"
           }
         ],
         "statement_count": 1816
@@ -10291,7 +10291,7 @@
         "slug": "Legislative-Chamber",
         "sources_directory": "data/Uzbekistan/Legislative_Chamber/sources",
         "popolo": "data/Uzbekistan/Legislative_Chamber/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cc97604/data/Uzbekistan/Legislative_Chamber/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/cc97604/data/Uzbekistan/Legislative_Chamber/ep-popolo-v1.0.json",
         "names": "data/Uzbekistan/Legislative_Chamber/names.csv",
         "lastmod": "1450789817",
         "person_count": 147,
@@ -10303,7 +10303,7 @@
             "start_date": "2015",
             "slug": "5",
             "csv": "data/Uzbekistan/Legislative_Chamber/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cc97604/data/Uzbekistan/Legislative_Chamber/term-5.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/cc97604/data/Uzbekistan/Legislative_Chamber/term-5.csv"
           }
         ],
         "statement_count": 2417
@@ -10321,7 +10321,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Vanuatu/Parliament/sources",
         "popolo": "data/Vanuatu/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cfce748/data/Vanuatu/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/cfce748/data/Vanuatu/Parliament/ep-popolo-v1.0.json",
         "names": "data/Vanuatu/Parliament/names.csv",
         "lastmod": "1450789821",
         "person_count": 52,
@@ -10333,7 +10333,7 @@
             "start_date": "2012",
             "slug": "10",
             "csv": "data/Vanuatu/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cfce748/data/Vanuatu/Parliament/term-10.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/cfce748/data/Vanuatu/Parliament/term-10.csv"
           }
         ],
         "statement_count": 763
@@ -10351,7 +10351,7 @@
         "slug": "Pontifical-Commission",
         "sources_directory": "data/Vatican_City/Pontifical_Commission/sources",
         "popolo": "data/Vatican_City/Pontifical_Commission/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/61539aa/data/Vatican_City/Pontifical_Commission/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/61539aa/data/Vatican_City/Pontifical_Commission/ep-popolo-v1.0.json",
         "names": "data/Vatican_City/Pontifical_Commission/names.csv",
         "lastmod": "1457035207",
         "person_count": 7,
@@ -10363,7 +10363,7 @@
             "start_date": "2011-10-01",
             "slug": "2011",
             "csv": "data/Vatican_City/Pontifical_Commission/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/61539aa/data/Vatican_City/Pontifical_Commission/term-2011.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/61539aa/data/Vatican_City/Pontifical_Commission/term-2011.csv"
           }
         ],
         "statement_count": 913
@@ -10381,7 +10381,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Venezuela/Assembly/sources",
         "popolo": "data/Venezuela/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8a33117/data/Venezuela/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/8a33117/data/Venezuela/Assembly/ep-popolo-v1.0.json",
         "names": "data/Venezuela/Assembly/names.csv",
         "lastmod": "1458004110",
         "person_count": 279,
@@ -10393,7 +10393,7 @@
             "start_date": "2016-01-05",
             "slug": "2016",
             "csv": "data/Venezuela/Assembly/term-2016.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8a33117/data/Venezuela/Assembly/term-2016.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/8a33117/data/Venezuela/Assembly/term-2016.csv"
           },
           {
             "end_date": "2016-01-04",
@@ -10402,7 +10402,7 @@
             "start_date": "2011-01-05",
             "slug": "2011",
             "csv": "data/Venezuela/Assembly/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8a33117/data/Venezuela/Assembly/term-2011.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/8a33117/data/Venezuela/Assembly/term-2011.csv"
           }
         ],
         "statement_count": 5185
@@ -10420,7 +10420,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Vietnam/National_Assembly/sources",
         "popolo": "data/Vietnam/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0b1ecbb/data/Vietnam/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/0b1ecbb/data/Vietnam/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Vietnam/National_Assembly/names.csv",
         "lastmod": "1458184265",
         "person_count": 492,
@@ -10433,7 +10433,7 @@
             "start_date": "2011",
             "slug": "13",
             "csv": "data/Vietnam/National_Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0b1ecbb/data/Vietnam/National_Assembly/term-13.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/0b1ecbb/data/Vietnam/National_Assembly/term-13.csv"
           }
         ],
         "statement_count": 11800
@@ -10451,7 +10451,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Wales/Assembly/sources",
         "popolo": "data/Wales/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/36614ee/data/Wales/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/36614ee/data/Wales/Assembly/ep-popolo-v1.0.json",
         "names": "data/Wales/Assembly/names.csv",
         "lastmod": "1458281922",
         "person_count": 63,
@@ -10463,7 +10463,7 @@
             "start_date": "2011-09-15",
             "slug": "4",
             "csv": "data/Wales/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/36614ee/data/Wales/Assembly/term-4.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/36614ee/data/Wales/Assembly/term-4.csv"
           }
         ],
         "statement_count": 3929
@@ -10481,7 +10481,7 @@
         "slug": "Territorial-Assembly",
         "sources_directory": "data/Wallis_and_Futuna/Territorial_Assembly/sources",
         "popolo": "data/Wallis_and_Futuna/Territorial_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/59116d6/data/Wallis_and_Futuna/Territorial_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/59116d6/data/Wallis_and_Futuna/Territorial_Assembly/ep-popolo-v1.0.json",
         "names": "data/Wallis_and_Futuna/Territorial_Assembly/names.csv",
         "lastmod": "1457256271",
         "person_count": 20,
@@ -10493,7 +10493,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Wallis_and_Futuna/Territorial_Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/59116d6/data/Wallis_and_Futuna/Territorial_Assembly/term-2012.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/59116d6/data/Wallis_and_Futuna/Territorial_Assembly/term-2012.csv"
           }
         ],
         "statement_count": 327
@@ -10511,7 +10511,7 @@
         "slug": "Majlis",
         "sources_directory": "data/Yemen/Majlis/sources",
         "popolo": "data/Yemen/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bfcadfe/data/Yemen/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/bfcadfe/data/Yemen/Majlis/ep-popolo-v1.0.json",
         "names": "data/Yemen/Majlis/names.csv",
         "lastmod": "1450789844",
         "person_count": 302,
@@ -10523,7 +10523,7 @@
             "start_date": "2003",
             "slug": "2003",
             "csv": "data/Yemen/Majlis/term-2003.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bfcadfe/data/Yemen/Majlis/term-2003.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/bfcadfe/data/Yemen/Majlis/term-2003.csv"
           }
         ],
         "statement_count": 5165
@@ -10541,7 +10541,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Zambia/Assembly/sources",
         "popolo": "data/Zambia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d423189/data/Zambia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/d423189/data/Zambia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Zambia/Assembly/names.csv",
         "lastmod": "1457166401",
         "person_count": 148,
@@ -10553,7 +10553,7 @@
             "start_date": "2011-10-06",
             "slug": "2011",
             "csv": "data/Zambia/Assembly/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d423189/data/Zambia/Assembly/term-2011.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/d423189/data/Zambia/Assembly/term-2011.csv"
           }
         ],
         "statement_count": 2959
@@ -10571,7 +10571,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Zimbabwe/Assembly/sources",
         "popolo": "data/Zimbabwe/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fb9382f/data/Zimbabwe/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/fb9382f/data/Zimbabwe/Assembly/ep-popolo-v1.0.json",
         "names": "data/Zimbabwe/Assembly/names.csv",
         "lastmod": "1458108910",
         "person_count": 219,
@@ -10583,7 +10583,7 @@
             "start_date": "2013",
             "slug": "8",
             "csv": "data/Zimbabwe/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fb9382f/data/Zimbabwe/Assembly/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/fb9382f/data/Zimbabwe/Assembly/term-8.csv"
           }
         ],
         "statement_count": 5321
@@ -10593,7 +10593,7 @@
         "slug": "Senate",
         "sources_directory": "data/Zimbabwe/Senate/sources",
         "popolo": "data/Zimbabwe/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cd53360/data/Zimbabwe/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/cd53360/data/Zimbabwe/Senate/ep-popolo-v1.0.json",
         "names": "data/Zimbabwe/Senate/names.csv",
         "lastmod": "1452158936",
         "person_count": 67,
@@ -10605,7 +10605,7 @@
             "start_date": "2013",
             "slug": "8",
             "csv": "data/Zimbabwe/Senate/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cd53360/data/Zimbabwe/Senate/term-8.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/cd53360/data/Zimbabwe/Senate/term-8.csv"
           }
         ],
         "statement_count": 1237
@@ -10623,7 +10623,7 @@
         "slug": "Lagting",
         "sources_directory": "data/Aland/Lagting/sources",
         "popolo": "data/Aland/Lagting/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/22acfeb/data/Aland/Lagting/ep-popolo-v1.0.json",
+        "popolo_url": "https://github.com/everypolitician/everypolitician-data/raw/22acfeb/data/Aland/Lagting/ep-popolo-v1.0.json",
         "names": "data/Aland/Lagting/names.csv",
         "lastmod": "1458095291",
         "person_count": 47,
@@ -10635,7 +10635,7 @@
             "start_date": "2011",
             "slug": "2011",
             "csv": "data/Aland/Lagting/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/22acfeb/data/Aland/Lagting/term-2011.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/22acfeb/data/Aland/Lagting/term-2011.csv"
           },
           {
             "end_date": "2011",
@@ -10644,7 +10644,7 @@
             "start_date": "2007",
             "slug": "2007",
             "csv": "data/Aland/Lagting/term-2007.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/22acfeb/data/Aland/Lagting/term-2007.csv"
+            "csv_url": "https://github.com/everypolitician/everypolitician-data/raw/22acfeb/data/Aland/Lagting/term-2007.csv"
           }
         ],
         "statement_count": 1994


### PR DESCRIPTION
RawGit has been down a couple of times lately, so instead of pointing to
that this changes things to point directly to GitHub. This does mean
that all JSON and CSV urls will have the content type text/plain (as
that's what GitHub serves them up with) but we can document that and
tell people to use RawGit if they need the correct content type.