### PR TITLE
Ensure gender header is added to merged CSV

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -110,11 +110,11 @@
         "slug": "States",
         "sources_directory": "data/Alderney/States/sources",
         "popolo": "data/Alderney/States/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/99d752b/data/Alderney/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5eea8c9/data/Alderney/States/ep-popolo-v1.0.json",
         "names": "data/Alderney/States/names.csv",
-        "lastmod": "1453735005",
+        "lastmod": "1458566386",
         "person_count": 10,
-        "sha": "99d752b",
+        "sha": "5eea8c9",
         "legislative_periods": [
           {
             "end_date": "2015",
@@ -123,10 +123,10 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/Alderney/States/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/99d752b/data/Alderney/States/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5eea8c9/data/Alderney/States/term-2014.csv"
           }
         ],
-        "statement_count": 145
+        "statement_count": 153
       }
     ]
   },

--- a/data/Alderney/States/ep-popolo-v1.0.json
+++ b/data/Alderney/States/ep-popolo-v1.0.json
@@ -1,6 +1,7 @@
 {
   "persons": [
     {
+      "gender": "male",
       "id": "6baacce2-655a-493f-883a-29feea8a799d",
       "identifiers": [
         {
@@ -22,6 +23,7 @@
       ]
     },
     {
+      "gender": "male",
       "id": "4703e873-67fd-4322-9659-39f6d47b8eab",
       "identifiers": [
         {
@@ -43,16 +45,12 @@
       ]
     },
     {
+      "gender": "male",
       "id": "b9a6c59e-a3cf-406e-88b8-9bba70ffbb30",
       "identifiers": [
         {
           "identifier": "4387",
           "scheme": "everypolitician_legacy"
-        }
-      ],
-      "images": [
-        {
-          "url": ""
         }
       ],
       "name": "Graham McKinley",
@@ -63,6 +61,7 @@
       ]
     },
     {
+      "gender": "male",
       "id": "48723cfe-9970-4ce7-92da-ff6b91dfa2b5",
       "identifiers": [
         {
@@ -84,6 +83,7 @@
       ]
     },
     {
+      "gender": "male",
       "id": "a3833a8a-61b0-415a-a459-b6726d916f7b",
       "identifiers": [
         {
@@ -105,6 +105,7 @@
       ]
     },
     {
+      "gender": "male",
       "id": "77f036f7-c8ca-4388-be74-74aea27b7652",
       "identifiers": [
         {
@@ -126,6 +127,7 @@
       ]
     },
     {
+      "gender": "male",
       "id": "66d1f769-3e52-40cb-9ddb-1e5ffbec8456",
       "identifiers": [
         {
@@ -147,16 +149,12 @@
       ]
     },
     {
+      "gender": "female",
       "id": "70b26d38-ae65-4e90-9a99-15b948b9784b",
       "identifiers": [
         {
           "identifier": "112088",
           "scheme": "everypolitician_legacy"
-        }
-      ],
-      "images": [
-        {
-          "url": ""
         }
       ],
       "name": "Norma Paris",
@@ -167,6 +165,7 @@
       ]
     },
     {
+      "gender": "male",
       "id": "061ae887-8e7f-45be-9ef2-84a18fd4dd45",
       "identifiers": [
         {
@@ -188,6 +187,7 @@
       ]
     },
     {
+      "gender": "male",
       "id": "a11887ce-2c42-4555-bfd9-0843f3a9ced0",
       "identifiers": [
         {

--- a/data/Alderney/States/term-2014.csv
+++ b/data/Alderney/States/term-2014.csv
@@ -1,11 +1,11 @@
 id,name,sort_name,email,twitter,facebook,group,group_id,area_id,area,chamber,term,start_date,end_date,image,gender
-6baacce2-655a-493f-883a-29feea8a799d,Chris Rowley,Chris Rowley,,,,Independent,independent,area/alderney,Alderney,States,2014,,,http://www.alderney.gov.gg/media/image/9/i/140913_Alderney-868.jpg,
-4703e873-67fd-4322-9659-39f6d47b8eab,Francis Simonet,Francis Simonet,,,,Independent,independent,area/alderney,Alderney,States,2014,,,http://www.alderney.gov.gg/media/image/a/i/140913_Alderney-982.jpg,
-b9a6c59e-a3cf-406e-88b8-9bba70ffbb30,Graham McKinley,Graham McKinley,,,,Independent,independent,area/alderney,Alderney,States,2014,,,,
-48723cfe-9970-4ce7-92da-ff6b91dfa2b5,Ian Tugby,Ian Tugby,,,,Independent,independent,area/alderney,Alderney,States,2014,,,http://www.alderney.gov.gg/media/image/6/o/140913_Alderney-801.jpg,
-a3833a8a-61b0-415a-a459-b6726d916f7b,Louis Jean,Louis Jean,,,,Independent,independent,area/alderney,Alderney,States,2014,,,http://www.alderney.gov.gg/media/image/7/2/140913_Alderney-731.jpg,
-77f036f7-c8ca-4388-be74-74aea27b7652,Matthew Birmingham,Matthew Birmingham,,,,Independent,independent,area/alderney,Alderney,States,2014,,,http://www.alderney.gov.gg/media/image/9/c/140913_Alderney-913.jpg,
-66d1f769-3e52-40cb-9ddb-1e5ffbec8456,Neil Harvey,Neil Harvey,,,,Independent,independent,area/alderney,Alderney,States,2014,,,http://www.alderney.gov.gg/media/image/7/g/140913_Alderney-673.jpg,
-70b26d38-ae65-4e90-9a99-15b948b9784b,Norma Paris,Norma Paris,,,,Independent,independent,area/alderney,Alderney,States,2014,,,,
-061ae887-8e7f-45be-9ef2-84a18fd4dd45,Robert McDowall,Robert McDowall,,,,Independent,independent,area/alderney,Alderney,States,2014,,,http://www.alderney.gov.gg/media/image/8/9/140913_Alderney-822.jpg,
-a11887ce-2c42-4555-bfd9-0843f3a9ced0,Steve Roberts,Steve Roberts,,,,Independent,independent,area/alderney,Alderney,States,2014,,,http://www.alderney.gov.gg/media/image/8/e/140913_Alderney-779.jpg,
+6baacce2-655a-493f-883a-29feea8a799d,Chris Rowley,Chris Rowley,,,,Independent,independent,area/alderney,Alderney,States,2014,,,http://www.alderney.gov.gg/media/image/9/i/140913_Alderney-868.jpg,male
+4703e873-67fd-4322-9659-39f6d47b8eab,Francis Simonet,Francis Simonet,,,,Independent,independent,area/alderney,Alderney,States,2014,,,http://www.alderney.gov.gg/media/image/a/i/140913_Alderney-982.jpg,male
+b9a6c59e-a3cf-406e-88b8-9bba70ffbb30,Graham McKinley,Graham McKinley,,,,Independent,independent,area/alderney,Alderney,States,2014,,,,male
+48723cfe-9970-4ce7-92da-ff6b91dfa2b5,Ian Tugby,Ian Tugby,,,,Independent,independent,area/alderney,Alderney,States,2014,,,http://www.alderney.gov.gg/media/image/6/o/140913_Alderney-801.jpg,male
+a3833a8a-61b0-415a-a459-b6726d916f7b,Louis Jean,Louis Jean,,,,Independent,independent,area/alderney,Alderney,States,2014,,,http://www.alderney.gov.gg/media/image/7/2/140913_Alderney-731.jpg,male
+77f036f7-c8ca-4388-be74-74aea27b7652,Matthew Birmingham,Matthew Birmingham,,,,Independent,independent,area/alderney,Alderney,States,2014,,,http://www.alderney.gov.gg/media/image/9/c/140913_Alderney-913.jpg,male
+66d1f769-3e52-40cb-9ddb-1e5ffbec8456,Neil Harvey,Neil Harvey,,,,Independent,independent,area/alderney,Alderney,States,2014,,,http://www.alderney.gov.gg/media/image/7/g/140913_Alderney-673.jpg,male
+70b26d38-ae65-4e90-9a99-15b948b9784b,Norma Paris,Norma Paris,,,,Independent,independent,area/alderney,Alderney,States,2014,,,,female
+061ae887-8e7f-45be-9ef2-84a18fd4dd45,Robert McDowall,Robert McDowall,,,,Independent,independent,area/alderney,Alderney,States,2014,,,http://www.alderney.gov.gg/media/image/8/9/140913_Alderney-822.jpg,male
+a11887ce-2c42-4555-bfd9-0843f3a9ced0,Steve Roberts,Steve Roberts,,,,Independent,independent,area/alderney,Alderney,States,2014,,,http://www.alderney.gov.gg/media/image/8/e/140913_Alderney-779.jpg,male

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -109,8 +109,8 @@ namespace :merge_sources do
     end
 
     # Build the master list of columns
-    all_headers = instructions(:sources).find_all { |src|
-      src[:type] != 'term'
+    all_headers = instructions(:sources).reject { |src|
+      %w(term gender).include? src[:type] 
     }. map { |src| src[:file] }.reduce([]) do |all_headers, file|
       header_line = File.open(file, &:gets) or abort "#{file} is empty!".red
       all_headers | CSV.parse_line(header_line).map { |h| remap(h.downcase) } 
@@ -322,6 +322,7 @@ namespace :merge_sources do
         r[:gender] = winner.first.to_s 
         gb_votes += 1
       end
+      all_headers |= [:gender]
       warn "⚥ #{gb_votes}".cyan 
     end
 


### PR DESCRIPTION
When we're constructing the merged CSV file to be given to CSV-to-Popolo,
ensure that we add a gender header when reading data from GenderBalance,
rather than the headers from the Gender-Balance API file.

Without this, we end up with (usually blank) columns for 'male', 'female', etc,
and none for 'gender' itself, ensuring that the data is never recognised.