### PR TITLE
combine_sources: Rename 'Fetcher' as 'RemoteSource'

### DIFF
--- a/lib/remotesource.rb
+++ b/lib/remotesource.rb
@@ -2,7 +2,7 @@ require_relative './wikidata_lookup'
 require 'json'
 require 'csv'
 
-class Fetcher
+class RemoteSource
   def self.regenerate(i)
     new(i).fetch
   end
@@ -34,14 +34,14 @@ class Fetcher
   end
 end
 
-class Fetcher::GenderBalance < Fetcher
+class RemoteSource::GenderBalance < RemoteSource
   def write
     remote = "http://www.gender-balance.org/export/#{source}"
     copy_url(remote)
   end
 end
 
-class Fetcher::Morph < Fetcher
+class RemoteSource::Morph < RemoteSource
   def morph_select(src, qs)
     morph_api_key = ENV['MORPH_API_KEY'] or fail 'Need a Morph API key'
     key = ERB::Util.url_encode(morph_api_key)
@@ -56,14 +56,14 @@ class Fetcher::Morph < Fetcher
   end
 end
 
-class Fetcher::OCD < Fetcher
+class RemoteSource::OCD < RemoteSource
   def write
     remote = 'https://raw.githubusercontent.com/opencivicdata/ocd-division-ids/master/identifiers/' + source
     copy_url(remote)
   end
 end
 
-class Fetcher::Parlparse < Fetcher
+class RemoteSource::Parlparse < RemoteSource
   def write
     gh_url = 'https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/data/'
     term_file_url = gh_url + '%s/sources/manual/terms.csv'
@@ -79,13 +79,13 @@ class Fetcher::Parlparse < Fetcher
   end
 end
 
-class Fetcher::URL < Fetcher
+class RemoteSource::URL < RemoteSource
   def write
     copy_url(c(:url))
   end
 end
 
-class Fetcher::Wikidata < Fetcher
+class RemoteSource::Wikidata < RemoteSource
   def lookup_class
     WikidataLookup
   end
@@ -111,16 +111,16 @@ class Fetcher::Wikidata < Fetcher
   end
 end
 
-class Fetcher::Wikidata::Area < Fetcher::Wikidata
+class RemoteSource::Wikidata::Area < RemoteSource::Wikidata
 end
 
-class Fetcher::Wikidata::Group < Fetcher::Wikidata
+class RemoteSource::Wikidata::Group < RemoteSource::Wikidata
   def lookup_class
     GroupLookup
   end
 end
 
-class Fetcher::Wikidata::Raw < Fetcher::Wikidata
+class RemoteSource::Wikidata::Raw < RemoteSource::Wikidata
   def lookup_class
     P39sLookup
   end

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -2,7 +2,7 @@ require 'sass'
 require_relative '../lib/wikidata_lookup'
 require_relative '../lib/matcher'
 require_relative '../lib/reconciliation'
-require_relative '../lib/fetcher'
+require_relative '../lib/remotesource'
 
 class String
   def tidy
@@ -37,21 +37,21 @@ namespace :merge_sources do
       if _should_refetch(i[:file])
         c = i[:create]
         if c.key? :url
-          Fetcher::URL.regenerate(i)
+          RemoteSource::URL.regenerate(i)
         elsif c[:type] == 'morph'
-          Fetcher::Morph.regenerate(i)
+          RemoteSource::Morph.regenerate(i)
         elsif c[:type] == 'parlparse'
-          Fetcher::Parlparse.regenerate(i)
+          RemoteSource::Parlparse.regenerate(i)
         elsif c[:type] == 'ocd'
-          Fetcher::OCD.regenerate(i)
+          RemoteSource::OCD.regenerate(i)
         elsif c[:type] == 'group-wikidata'
-          Fetcher::Wikidata::Group.regenerate(i)
+          RemoteSource::Wikidata::Group.regenerate(i)
         elsif c[:type] == 'area-wikidata'
-          Fetcher::Wikidata::Area.regenerate(i)
+          RemoteSource::Wikidata::Area.regenerate(i)
         elsif c[:type] == 'wikidata-raw'
-          Fetcher::Wikidata::Raw.regenerate(i)
+          RemoteSource::Wikidata::Raw.regenerate(i)
         elsif c[:type] == 'gender-balance'
-          Fetcher::GenderBalance.regenerate(i)
+          RemoteSource::GenderBalance.regenerate(i)
         else
           raise "Don't know how to fetch #{i[:file]}" unless c[:type] == 'morph'
         end

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -26,6 +26,8 @@ namespace :merge_sources do
 
   CLEAN.include 'sources/merged.csv'
 
+  # We re-fetch any file that is missing, or, if REBUILD_SOURCE is set,
+  # any file that matches that.
   def _should_refetch(file)
     return true unless File.exist?(file)
     return false unless ENV['REBUILD_SOURCE']
@@ -34,28 +36,7 @@ namespace :merge_sources do
 
   def fetch_missing
     @recreatable.each do |i|
-      if _should_refetch(i[:file])
-        c = i[:create]
-        if c.key? :url
-          RemoteSource::URL.regenerate(i)
-        elsif c[:type] == 'morph'
-          RemoteSource::Morph.regenerate(i)
-        elsif c[:type] == 'parlparse'
-          RemoteSource::Parlparse.regenerate(i)
-        elsif c[:type] == 'ocd'
-          RemoteSource::OCD.regenerate(i)
-        elsif c[:type] == 'group-wikidata'
-          RemoteSource::Wikidata::Group.regenerate(i)
-        elsif c[:type] == 'area-wikidata'
-          RemoteSource::Wikidata::Area.regenerate(i)
-        elsif c[:type] == 'wikidata-raw'
-          RemoteSource::Wikidata::Raw.regenerate(i)
-        elsif c[:type] == 'gender-balance'
-          RemoteSource::GenderBalance.regenerate(i)
-        else
-          raise "Don't know how to fetch #{i[:file]}" unless c[:type] == 'morph'
-        end
-      end
+      RemoteSource.instantiate(i).regenerate if _should_refetch(i[:file])
     end
   end
 


### PR DESCRIPTION
Name this after what each thing _is_, rather than what this _does_. Then
move the instantiation code out of the Rakefile, and into the class.