### PR TITLE
combine_sources: explicitly name 'OCD' type

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -548,11 +548,11 @@
         "slug": "Representatives",
         "sources_directory": "data/Australia/Representatives/sources",
         "popolo": "data/Australia/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5bd76e7/data/Australia/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/Australia/Representatives/ep-popolo-v1.0.json",
         "names": "data/Australia/Representatives/names.csv",
-        "lastmod": "1459024749",
+        "lastmod": "1459088499",
         "person_count": 475,
-        "sha": "5bd76e7",
+        "sha": "a4a56c3",
         "legislative_periods": [
           {
             "id": "term/44",
@@ -560,7 +560,7 @@
             "start_date": "2013-09-07",
             "slug": "44",
             "csv": "data/Australia/Representatives/term-44.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5bd76e7/data/Australia/Representatives/term-44.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/Australia/Representatives/term-44.csv"
           },
           {
             "end_date": "2013-09-07",
@@ -569,7 +569,7 @@
             "start_date": "2010-08-21",
             "slug": "43",
             "csv": "data/Australia/Representatives/term-43.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5bd76e7/data/Australia/Representatives/term-43.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/Australia/Representatives/term-43.csv"
           },
           {
             "end_date": "2010-08-21",
@@ -578,7 +578,7 @@
             "start_date": "2007-11-24",
             "slug": "42",
             "csv": "data/Australia/Representatives/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5bd76e7/data/Australia/Representatives/term-42.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/Australia/Representatives/term-42.csv"
           },
           {
             "end_date": "2007-11-24",
@@ -587,7 +587,7 @@
             "start_date": "2004-10-09",
             "slug": "41",
             "csv": "data/Australia/Representatives/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5bd76e7/data/Australia/Representatives/term-41.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/Australia/Representatives/term-41.csv"
           },
           {
             "end_date": "2004-10-09",
@@ -596,7 +596,7 @@
             "start_date": "2001-11-10",
             "slug": "40",
             "csv": "data/Australia/Representatives/term-40.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5bd76e7/data/Australia/Representatives/term-40.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/Australia/Representatives/term-40.csv"
           },
           {
             "end_date": "2001-11-10",
@@ -605,7 +605,7 @@
             "start_date": "1998-10-03",
             "slug": "39",
             "csv": "data/Australia/Representatives/term-39.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5bd76e7/data/Australia/Representatives/term-39.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/Australia/Representatives/term-39.csv"
           },
           {
             "end_date": "1998-10-03",
@@ -614,7 +614,7 @@
             "start_date": "1996-03-02",
             "slug": "38",
             "csv": "data/Australia/Representatives/term-38.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5bd76e7/data/Australia/Representatives/term-38.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/Australia/Representatives/term-38.csv"
           },
           {
             "end_date": "1996-03-02",
@@ -623,7 +623,7 @@
             "start_date": "1993-03-13",
             "slug": "37",
             "csv": "data/Australia/Representatives/term-37.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5bd76e7/data/Australia/Representatives/term-37.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/Australia/Representatives/term-37.csv"
           },
           {
             "end_date": "1993-03-13",
@@ -632,7 +632,7 @@
             "start_date": "1990-03-24",
             "slug": "36",
             "csv": "data/Australia/Representatives/term-36.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5bd76e7/data/Australia/Representatives/term-36.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/Australia/Representatives/term-36.csv"
           },
           {
             "end_date": "1990-03-24",
@@ -641,7 +641,7 @@
             "start_date": "1987-07-11",
             "slug": "35",
             "csv": "data/Australia/Representatives/term-35.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5bd76e7/data/Australia/Representatives/term-35.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/Australia/Representatives/term-35.csv"
           }
         ],
         "statement_count": 34845
@@ -9991,11 +9991,11 @@
         "slug": "House",
         "sources_directory": "data/United_States_of_America/House/sources",
         "popolo": "data/United_States_of_America/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/ep-popolo-v1.0.json",
         "names": "data/United_States_of_America/House/names.csv",
-        "lastmod": "1458944160",
+        "lastmod": "1459088499",
         "person_count": 1584,
-        "sha": "9fc3791",
+        "sha": "a4a56c3",
         "legislative_periods": [
           {
             "id": "term/114",
@@ -10004,7 +10004,7 @@
             "wikidata": "Q16146771",
             "slug": "114",
             "csv": "data/United_States_of_America/House/term-114.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-114.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-114.csv"
           },
           {
             "end_date": "2015-01-03",
@@ -10014,7 +10014,7 @@
             "wikidata": "Q71871",
             "slug": "113",
             "csv": "data/United_States_of_America/House/term-113.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-113.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-113.csv"
           },
           {
             "end_date": "2013-01-03",
@@ -10024,7 +10024,7 @@
             "wikidata": "Q170447",
             "slug": "112",
             "csv": "data/United_States_of_America/House/term-112.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-112.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-112.csv"
           },
           {
             "end_date": "2011-01-03",
@@ -10034,7 +10034,7 @@
             "wikidata": "Q170375",
             "slug": "111",
             "csv": "data/United_States_of_America/House/term-111.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-111.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-111.csv"
           },
           {
             "end_date": "2009-01-03",
@@ -10044,7 +10044,7 @@
             "wikidata": "Q170018",
             "slug": "110",
             "csv": "data/United_States_of_America/House/term-110.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-110.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-110.csv"
           },
           {
             "end_date": "2007-01-03",
@@ -10054,7 +10054,7 @@
             "wikidata": "Q168778",
             "slug": "109",
             "csv": "data/United_States_of_America/House/term-109.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-109.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-109.csv"
           },
           {
             "end_date": "2005-01-03",
@@ -10064,7 +10064,7 @@
             "wikidata": "Q168504",
             "slug": "108",
             "csv": "data/United_States_of_America/House/term-108.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-108.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-108.csv"
           },
           {
             "end_date": "2003-01-03",
@@ -10074,7 +10074,7 @@
             "wikidata": "Q2057259",
             "slug": "107",
             "csv": "data/United_States_of_America/House/term-107.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-107.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-107.csv"
           },
           {
             "end_date": "2001-01-03",
@@ -10084,7 +10084,7 @@
             "wikidata": "Q3596897",
             "slug": "106",
             "csv": "data/United_States_of_America/House/term-106.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-106.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-106.csv"
           },
           {
             "end_date": "1999-01-03",
@@ -10094,7 +10094,7 @@
             "wikidata": "Q3596884",
             "slug": "105",
             "csv": "data/United_States_of_America/House/term-105.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-105.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-105.csv"
           },
           {
             "end_date": "1997-01-03",
@@ -10104,7 +10104,7 @@
             "wikidata": "Q3596857",
             "slug": "104",
             "csv": "data/United_States_of_America/House/term-104.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-104.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-104.csv"
           },
           {
             "end_date": "1995-01-03",
@@ -10114,7 +10114,7 @@
             "wikidata": "Q3556780",
             "slug": "103",
             "csv": "data/United_States_of_America/House/term-103.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-103.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-103.csv"
           },
           {
             "end_date": "1993-01-03",
@@ -10124,7 +10124,7 @@
             "wikidata": "Q347346",
             "slug": "102",
             "csv": "data/United_States_of_America/House/term-102.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-102.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-102.csv"
           },
           {
             "end_date": "1991-01-03",
@@ -10134,7 +10134,7 @@
             "wikidata": "Q4546373",
             "slug": "101",
             "csv": "data/United_States_of_America/House/term-101.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-101.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-101.csv"
           },
           {
             "end_date": "1989-01-03",
@@ -10144,7 +10144,7 @@
             "wikidata": "Q4546248",
             "slug": "100",
             "csv": "data/United_States_of_America/House/term-100.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-100.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-100.csv"
           },
           {
             "end_date": "1987-01-03",
@@ -10154,7 +10154,7 @@
             "wikidata": "Q4646349",
             "slug": "99",
             "csv": "data/United_States_of_America/House/term-99.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-99.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-99.csv"
           },
           {
             "end_date": "1983-01-03",
@@ -10164,7 +10164,7 @@
             "wikidata": "Q4646254",
             "slug": "98",
             "csv": "data/United_States_of_America/House/term-98.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-98.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-98.csv"
           },
           {
             "end_date": "1983-01-03",
@@ -10174,7 +10174,7 @@
             "wikidata": "Q4646187",
             "slug": "97",
             "csv": "data/United_States_of_America/House/term-97.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc3791/data/United_States_of_America/House/term-97.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/House/term-97.csv"
           }
         ],
         "statement_count": 193149
@@ -10184,11 +10184,11 @@
         "slug": "Senate",
         "sources_directory": "data/United_States_of_America/Senate/sources",
         "popolo": "data/United_States_of_America/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/ep-popolo-v1.0.json",
         "names": "data/United_States_of_America/Senate/names.csv",
-        "lastmod": "1459057951",
+        "lastmod": "1459088499",
         "person_count": 310,
-        "sha": "369fa05",
+        "sha": "a4a56c3",
         "legislative_periods": [
           {
             "id": "term/114",
@@ -10197,7 +10197,7 @@
             "wikidata": "Q16146771",
             "slug": "114",
             "csv": "data/United_States_of_America/Senate/term-114.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-114.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-114.csv"
           },
           {
             "end_date": "2015-01-03",
@@ -10207,7 +10207,7 @@
             "wikidata": "Q71871",
             "slug": "113",
             "csv": "data/United_States_of_America/Senate/term-113.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-113.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-113.csv"
           },
           {
             "end_date": "2013-01-03",
@@ -10217,7 +10217,7 @@
             "wikidata": "Q170447",
             "slug": "112",
             "csv": "data/United_States_of_America/Senate/term-112.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-112.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-112.csv"
           },
           {
             "end_date": "2011-01-03",
@@ -10227,7 +10227,7 @@
             "wikidata": "Q170375",
             "slug": "111",
             "csv": "data/United_States_of_America/Senate/term-111.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-111.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-111.csv"
           },
           {
             "end_date": "2009-01-03",
@@ -10237,7 +10237,7 @@
             "wikidata": "Q170018",
             "slug": "110",
             "csv": "data/United_States_of_America/Senate/term-110.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-110.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-110.csv"
           },
           {
             "end_date": "2007-01-03",
@@ -10247,7 +10247,7 @@
             "wikidata": "Q168778",
             "slug": "109",
             "csv": "data/United_States_of_America/Senate/term-109.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-109.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-109.csv"
           },
           {
             "end_date": "2005-01-03",
@@ -10257,7 +10257,7 @@
             "wikidata": "Q168504",
             "slug": "108",
             "csv": "data/United_States_of_America/Senate/term-108.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-108.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-108.csv"
           },
           {
             "end_date": "2003-01-03",
@@ -10267,7 +10267,7 @@
             "wikidata": "Q2057259",
             "slug": "107",
             "csv": "data/United_States_of_America/Senate/term-107.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-107.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-107.csv"
           },
           {
             "end_date": "2001-01-03",
@@ -10277,7 +10277,7 @@
             "wikidata": "Q3596897",
             "slug": "106",
             "csv": "data/United_States_of_America/Senate/term-106.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-106.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-106.csv"
           },
           {
             "end_date": "1999-01-03",
@@ -10287,7 +10287,7 @@
             "wikidata": "Q3596884",
             "slug": "105",
             "csv": "data/United_States_of_America/Senate/term-105.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-105.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-105.csv"
           },
           {
             "end_date": "1997-01-03",
@@ -10297,7 +10297,7 @@
             "wikidata": "Q3596857",
             "slug": "104",
             "csv": "data/United_States_of_America/Senate/term-104.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-104.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-104.csv"
           },
           {
             "end_date": "1995-01-03",
@@ -10307,7 +10307,7 @@
             "wikidata": "Q3556780",
             "slug": "103",
             "csv": "data/United_States_of_America/Senate/term-103.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-103.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-103.csv"
           },
           {
             "end_date": "1993-01-03",
@@ -10317,7 +10317,7 @@
             "wikidata": "Q347346",
             "slug": "102",
             "csv": "data/United_States_of_America/Senate/term-102.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-102.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-102.csv"
           },
           {
             "end_date": "1991-01-03",
@@ -10327,7 +10327,7 @@
             "wikidata": "Q4546373",
             "slug": "101",
             "csv": "data/United_States_of_America/Senate/term-101.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-101.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-101.csv"
           },
           {
             "end_date": "1989-01-03",
@@ -10337,7 +10337,7 @@
             "wikidata": "Q4546248",
             "slug": "100",
             "csv": "data/United_States_of_America/Senate/term-100.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-100.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-100.csv"
           },
           {
             "end_date": "1987-01-03",
@@ -10347,7 +10347,7 @@
             "wikidata": "Q4646349",
             "slug": "99",
             "csv": "data/United_States_of_America/Senate/term-99.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-99.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-99.csv"
           },
           {
             "end_date": "1983-01-03",
@@ -10357,7 +10357,7 @@
             "wikidata": "Q4646254",
             "slug": "98",
             "csv": "data/United_States_of_America/Senate/term-98.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-98.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-98.csv"
           },
           {
             "end_date": "1983-01-03",
@@ -10367,7 +10367,7 @@
             "wikidata": "Q4646187",
             "slug": "97",
             "csv": "data/United_States_of_America/Senate/term-97.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/369fa05/data/United_States_of_America/Senate/term-97.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4a56c3/data/United_States_of_America/Senate/term-97.csv"
           }
         ],
         "statement_count": 63409

--- a/data/Australia/Representatives/sources/instructions.json
+++ b/data/Australia/Representatives/sources/instructions.json
@@ -67,7 +67,7 @@
           "Northern Territory": ""
         }
       },
-      "type": "area"
+      "type": "ocd"
     },
     {
       "file": "morph/terms.csv",

--- a/data/United_States_of_America/House/sources/instructions.json
+++ b/data/United_States_of_America/House/sources/instructions.json
@@ -54,7 +54,7 @@
         "type": "ocd",
         "source": "country-us.csv"
       },
-      "type": "area",
+      "type": "ocd",
       "generate": "area"
     },
     {

--- a/data/United_States_of_America/Senate/sources/instructions.json
+++ b/data/United_States_of_America/Senate/sources/instructions.json
@@ -54,7 +54,7 @@
         "type": "ocd",
         "source": "country-us.csv"
       },
-      "type": "area",
+      "type": "ocd",
       "generate": "area"
     },
     {

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -308,7 +308,7 @@ namespace :merge_sources do
     end
 
     # Map Areas
-    if area = instructions(:sources).find { |src| src[:type].to_s.downcase == 'area' }
+    if area = instructions(:sources).find { |src| src[:type].to_s.downcase == 'ocd' }
       ocds = CSV.table(area[:file], converters: nil).group_by { |r| r[:id] }
 
       all_headers |= [:area, :area_id]


### PR DESCRIPTION
We also have other area data, so explicitly name the OCD instructions.