### PR TITLE
Reconciler: Some refactoring

### DIFF
--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -58,7 +58,61 @@
         </div>
     </script>
 
-    <script type="text/html" id="person">
+    <script type="text/html" id="incomingPerson">
+      {% if(person.uuid){ %}
+        <div class="person" data-uuid="{{ person.uuid }}">
+      {% } else if(person.id){ %}
+        <div class="person" data-id="{{ person.id }}">
+        {% if(person.id.startsWith('Q')) { %}
+          <div style="float:right">
+            <a target="_blank" href="https://tools.wmflabs.org/reasonator/?&q={{ person.id }}">{{ person.id }}</a>
+          </div>
+        {% } %}
+      {% } %}
+          {% if (person.matchStrength) { %}
+            <header class="person__meta">
+              <h1>{{ h1_name }}
+                <span class="person__match-strength">{{ person.matchStrength }}% match</span>
+              </h1>
+              <div class="progress-bar"><div style="width: {{ person.matchStrength }}%"></div></div>
+            </header>
+          {% } else { %}
+            <h1>{{ h1_name }}</h1>
+          {% } %}
+
+            <dl>
+            {% if(!person.uuid) { %}
+              <dt title="Names">Names:</dt>
+              {% names.forEach(function(name) { %}
+                <dd>{{ name }}</dd>
+              {% }) %}
+            {% } %}
+
+              {% fields.forEach(function(field) { %}
+                {% if(field !== 'id' && field !== 'name' && person[field]){ %}
+                  <dt title="{{ field }}">{{ field }}:</dt>
+                  <dd>
+                  {% if (field == 'image') { %}
+                    <img src="{{ person[field] }}" width="150">
+                  {% } else { %}
+                    {% if (comparison) { %} 
+                      {% if (comparison[field] == person[field]) { %} 
+                        <span class="match">{{ person[field] }}</span>
+                      {% } else { %}
+                        <span class="nomatch">{{ person[field] }}</span>
+                      {% } %}
+                    {% } else { %}
+                      {{ person[field] }} 
+                    {% } %}
+                  {% } %}
+                  </dd>
+                {% } %}
+              {% }) %}
+            </dl>
+        </div>
+    </script>
+
+    <script type="text/html" id="existingPerson">
       {% if(person.uuid){ %}
         <div class="person" data-uuid="{{ person.uuid }}">
       {% } else if(person.id){ %}

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -108,7 +108,7 @@
                   {% if (field == 'image') { %}
                     <img src="{{ person[field] }}" width="150">
                   {% } else { %}
-                    {% if (comparison[field] == person[field]) { %} 
+                    {% if (compare_with[field] == person[field]) { %} 
                       <span class="match">{{ person[field] }}</span>
                     {% } else { %}
                       <span class="nomatch">{{ person[field] }}</span>

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -95,15 +95,7 @@
                   {% if (field == 'image') { %}
                     <img src="{{ person[field] }}" width="150">
                   {% } else { %}
-                    {% if (comparison) { %} 
-                      {% if (comparison[field] == person[field]) { %} 
-                        <span class="match">{{ person[field] }}</span>
-                      {% } else { %}
-                        <span class="nomatch">{{ person[field] }}</span>
-                      {% } %}
-                    {% } else { %}
-                      {{ person[field] }} 
-                    {% } %}
+                    {{ person[field] }} 
                   {% } %}
                   </dd>
                 {% } %}
@@ -149,14 +141,10 @@
                   {% if (field == 'image') { %}
                     <img src="{{ person[field] }}" width="150">
                   {% } else { %}
-                    {% if (comparison) { %} 
-                      {% if (comparison[field] == person[field]) { %} 
-                        <span class="match">{{ person[field] }}</span>
-                      {% } else { %}
-                        <span class="nomatch">{{ person[field] }}</span>
-                      {% } %}
+                    {% if (comparison[field] == person[field]) { %} 
+                      <span class="match">{{ person[field] }}</span>
                     {% } else { %}
-                      {{ person[field] }} 
+                      <span class="nomatch">{{ person[field] }}</span>
                     {% } %}
                   {% } %}
                   </dd>

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -69,12 +69,10 @@
             <h1>{{ h1_name }}</h1>
 
             <dl>
-            {% if(!person.uuid) { %}
               <dt title="Names">Names:</dt>
               {% names.forEach(function(name) { %}
                 <dd>{{ name }}</dd>
               {% }) %}
-            {% } %}
 
               {% fields.forEach(function(field) { %}
                 {% if(field !== 'id' && field !== 'name' && person[field]){ %}
@@ -102,12 +100,6 @@
             </header>
 
             <dl>
-            {% if(!person.uuid) { %}
-              <dt title="Names">Names:</dt>
-              {% names.forEach(function(name) { %}
-                <dd>{{ name }}</dd>
-              {% }) %}
-            {% } %}
 
               {% fields.forEach(function(field) { %}
                 {% if(field !== 'id' && field !== 'name' && person[field]){ %}

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -66,16 +66,7 @@
           </div>
         {% } %}
 
-          {% if (person.matchStrength) { %}
-            <header class="person__meta">
-              <h1>{{ h1_name }}
-                <span class="person__match-strength">{{ person.matchStrength }}% match</span>
-              </h1>
-              <div class="progress-bar"><div style="width: {{ person.matchStrength }}%"></div></div>
-            </header>
-          {% } else { %}
             <h1>{{ h1_name }}</h1>
-          {% } %}
 
             <dl>
             {% if(!person.uuid) { %}
@@ -103,16 +94,12 @@
 
     <script type="text/html" id="existingPerson">
         <div class="person" data-uuid="{{ person.uuid }}">
-          {% if (person.matchStrength) { %}
             <header class="person__meta">
               <h1>{{ h1_name }}
                 <span class="person__match-strength">{{ person.matchStrength }}% match</span>
               </h1>
               <div class="progress-bar"><div style="width: {{ person.matchStrength }}%"></div></div>
             </header>
-          {% } else { %}
-            <h1>{{ h1_name }}</h1>
-          {% } %}
 
             <dl>
             {% if(!person.uuid) { %}

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -59,16 +59,13 @@
     </script>
 
     <script type="text/html" id="incomingPerson">
-      {% if(person.uuid){ %}
-        <div class="person" data-uuid="{{ person.uuid }}">
-      {% } else if(person.id){ %}
         <div class="person" data-id="{{ person.id }}">
         {% if(person.id.startsWith('Q')) { %}
           <div style="float:right">
             <a target="_blank" href="https://tools.wmflabs.org/reasonator/?&q={{ person.id }}">{{ person.id }}</a>
           </div>
         {% } %}
-      {% } %}
+
           {% if (person.matchStrength) { %}
             <header class="person__meta">
               <h1>{{ h1_name }}
@@ -105,16 +102,7 @@
     </script>
 
     <script type="text/html" id="existingPerson">
-      {% if(person.uuid){ %}
         <div class="person" data-uuid="{{ person.uuid }}">
-      {% } else if(person.id){ %}
-        <div class="person" data-id="{{ person.id }}">
-        {% if(person.id.startsWith('Q')) { %}
-          <div style="float:right">
-            <a target="_blank" href="https://tools.wmflabs.org/reasonator/?&q={{ person.id }}">{{ person.id }}</a>
-          </div>
-        {% } %}
-      {% } %}
           {% if (person.matchStrength) { %}
             <header class="person__meta">
               <h1>{{ h1_name }}

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -285,11 +285,13 @@ jQuery(function($) {
       });
     });
 
-    var html = renderTemplate('pairing', {
-      incomingPersonHTML: incomingPersonHTML,
-      existingPersonHTML: existingPersonHTML.join("\n"),
-    });
-    $('.pairings').append(html);
+    $('.pairings').append(
+      renderTemplate('pairing', {
+        incomingPersonHTML: incomingPersonHTML,
+        existingPersonHTML: existingPersonHTML.join("\n")
+      })
+    );
+
   });
 
   $(document).on('click', '.pairing__choices > div', function(){

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -265,7 +265,7 @@ jQuery(function($) {
         }
       }).join(" ");
 
-      return renderTemplate('person', {
+      return renderTemplate('existingPerson', {
         person: person,
         h1_name: markedName,
         comparison: incomingPerson,
@@ -282,7 +282,7 @@ jQuery(function($) {
 
     var html = renderTemplate('pairing', {
       existingPersonHTML: existingPersonHTML.join("\n"),
-      incomingPersonHTML: renderTemplate('person', {
+      incomingPersonHTML: renderTemplate('incomingPerson', {
         person: incomingPerson,
         h1_name: incomingPerson[window.incomingField],
         comparison: null,

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -280,14 +280,16 @@ jQuery(function($) {
 
     var commonFields = _.intersection(incomingPersonFields, _.uniq(_.flatten(fields)));
 
+    var incomingPersonHTML = renderTemplate('incomingPerson', {
+      person: incomingPerson,
+      h1_name: incomingPerson[window.incomingField],
+      fields: commonFields,
+      names: _.uniq(_.map(_.filter(incomingPersonFields, function(f) { return f.includes('name__') }), function(f) { return incomingPerson[f] })).sort()
+    });
+
     var html = renderTemplate('pairing', {
+      incomingPersonHTML: incomingPersonHTML,
       existingPersonHTML: existingPersonHTML.join("\n"),
-      incomingPersonHTML: renderTemplate('incomingPerson', {
-        person: incomingPerson,
-        h1_name: incomingPerson[window.incomingField],
-        fields: commonFields,
-        names: _.uniq(_.map(_.filter(incomingPersonFields, function(f) { return f.includes('name__') }), function(f) { return incomingPerson[f] })).sort()
-      })
     });
     $('.pairings').append(html);
   });

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -268,7 +268,7 @@ jQuery(function($) {
       return renderTemplate('existingPerson', {
         person: person,
         h1_name: markedName,
-        comparison: incomingPerson,
+        compare_with: incomingPerson,
         fields: fields
       });
     });
@@ -285,7 +285,6 @@ jQuery(function($) {
       incomingPersonHTML: renderTemplate('incomingPerson', {
         person: incomingPerson,
         h1_name: incomingPerson[window.incomingField],
-        comparison: null,
         fields: commonFields,
         names: _.uniq(_.map(_.filter(incomingPersonFields, function(f) { return f.includes('name__') }), function(f) { return incomingPerson[f] })).sort()
       })

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -250,6 +250,18 @@ jQuery(function($) {
     var incomingPersonFields = _.filter(Object.keys(incomingPerson), function(field) {
       return incomingPerson[field];
     });
+    var existingPeopleFields = _.uniq(_.flatten(match.existing.map(function(existing) {
+      var person = existing[0];
+      return Object.keys(person);
+    })));
+    var commonFields = _.intersection(incomingPersonFields, existingPeopleFields);
+
+    var incomingPersonHTML = renderTemplate('incomingPerson', {
+      person: incomingPerson,
+      h1_name: incomingPerson[window.incomingField],
+      fields: commonFields,
+      names: _.uniq(_.map(_.filter(incomingPersonFields, function(f) { return f.includes('name__') }), function(f) { return incomingPerson[f] })).sort()
+    });
 
     var existingPersonHTML = _.map(match.existing, function(existing) {
       var person = existing[0];
@@ -271,20 +283,6 @@ jQuery(function($) {
         compare_with: incomingPerson,
         fields: fields
       });
-    });
-
-    var fields = match.existing.map(function(existing) {
-      var person = existing[0];
-      return Object.keys(person);
-    });
-
-    var commonFields = _.intersection(incomingPersonFields, _.uniq(_.flatten(fields)));
-
-    var incomingPersonHTML = renderTemplate('incomingPerson', {
-      person: incomingPerson,
-      h1_name: incomingPerson[window.incomingField],
-      fields: commonFields,
-      names: _.uniq(_.map(_.filter(incomingPersonFields, function(f) { return f.includes('name__') }), function(f) { return incomingPerson[f] })).sort()
     });
 
     var html = renderTemplate('pairing', {


### PR DESCRIPTION
The logic for showing the cards on the left and right side (incoming vs
existing people) was getting a little hard to follow, as they were both
using the same template, even though they were conceptually quite
different things, and almost every section of the card had to be wrapped
in a check to see which type it was.

Split these out so that it's easier to follow (even though there’s now a
small amount of duplication between them), but also harmonise some of
the other code that was needlessly different.