### PR TITLE
Standardise `group_id`s, if possible

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -10750,11 +10750,11 @@
         "slug": "Lagting",
         "sources_directory": "data/Aland/Lagting/sources",
         "popolo": "data/Aland/Lagting/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5aec946/data/Aland/Lagting/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/351d0c8/data/Aland/Lagting/ep-popolo-v1.0.json",
         "names": "data/Aland/Lagting/names.csv",
-        "lastmod": "1459517419",
+        "lastmod": "1459524485",
         "person_count": 47,
-        "sha": "5aec946",
+        "sha": "351d0c8",
         "legislative_periods": [
           {
             "id": "term/2011",
@@ -10762,7 +10762,7 @@
             "start_date": "2011",
             "slug": "2011",
             "csv": "data/Aland/Lagting/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5aec946/data/Aland/Lagting/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/351d0c8/data/Aland/Lagting/term-2011.csv"
           },
           {
             "end_date": "2011",
@@ -10771,10 +10771,10 @@
             "start_date": "2007",
             "slug": "2007",
             "csv": "data/Aland/Lagting/term-2007.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5aec946/data/Aland/Lagting/term-2007.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/351d0c8/data/Aland/Lagting/term-2007.csv"
           }
         ],
-        "statement_count": 2372
+        "statement_count": 2317
       }
     ]
   }

--- a/data/Aland/Lagting/ep-popolo-v1.0.json
+++ b/data/Aland/Lagting/ep-popolo-v1.0.json
@@ -3441,6 +3441,11 @@
           "note": "multilingual"
         },
         {
+          "lang": "fi",
+          "name": "Liberalerna",
+          "note": "multilingual"
+        },
+        {
           "lang": "sv",
           "name": "Mittenliberalerna",
           "note": "multilingual"
@@ -3535,6 +3540,11 @@
           "note": "multilingual"
         },
         {
+          "lang": "sv",
+          "name": "Moderat Samling",
+          "note": "multilingual"
+        },
+        {
           "lang": "nb",
           "name": "Frisinnad Samverkan",
           "note": "multilingual"
@@ -3611,6 +3621,11 @@
         {
           "lang": "fi",
           "name": "Obunden samling",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sv",
+          "name": "Obunden Samling på Åland",
           "note": "multilingual"
         }
       ]

--- a/data/Aland/Lagting/ep-popolo-v1.0.json
+++ b/data/Aland/Lagting/ep-popolo-v1.0.json
@@ -3370,7 +3370,7 @@
     },
     {
       "classification": "party",
-      "id": "party/liberalerna",
+      "id": "liberalerna",
       "identifiers": [
         {
           "identifier": "Q923843",
@@ -3454,17 +3454,7 @@
     },
     {
       "classification": "party",
-      "id": "party/moderat_samling",
-      "name": "Moderat Samling"
-    },
-    {
-      "classification": "party",
-      "id": "party/moderat_samling",
-      "name": "Moderat samling"
-    },
-    {
-      "classification": "party",
-      "id": "party/moderaterna_på_Åland",
+      "id": "moderaterna_på_Åland",
       "identifiers": [
         {
           "identifier": "Q2113965",
@@ -3553,7 +3543,7 @@
     },
     {
       "classification": "party",
-      "id": "party/obunden_samling_på_Åland",
+      "id": "obunden_samling_på_Åland",
       "identifiers": [
         {
           "identifier": "Q2113701",
@@ -3632,7 +3622,7 @@
     },
     {
       "classification": "party",
-      "id": "party/Ålands_framtid",
+      "id": "Ålands_framtid",
       "identifiers": [
         {
           "identifier": "Q2113751",
@@ -3786,7 +3776,7 @@
     },
     {
       "classification": "party",
-      "id": "party/Ålands_socialdemokrater",
+      "id": "Ålands_socialdemokrater",
       "identifiers": [
         {
           "identifier": "Q270982",
@@ -3865,111 +3855,7 @@
     },
     {
       "classification": "party",
-      "id": "party/Åländsk_center",
-      "identifiers": [
-        {
-          "identifier": "Q2113706",
-          "scheme": "wikidata"
-        }
-      ],
-      "links": [
-        {
-          "note": "website",
-          "url": "http://www.centern.ax/"
-        }
-      ],
-      "name": "Åländsk Center",
-      "other_names": [
-        {
-          "lang": "nn",
-          "name": "Centern på Åland",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Åland Centre",
-          "note": "multilingual"
-        },
-        {
-          "lang": "ru",
-          "name": "Аландский центр",
-          "note": "multilingual"
-        },
-        {
-          "lang": "fr",
-          "name": "Ålandsk Center",
-          "note": "multilingual"
-        },
-        {
-          "lang": "en",
-          "name": "Åland Centre",
-          "note": "multilingual"
-        },
-        {
-          "lang": "ca",
-          "name": "Centre d'Åland",
-          "note": "multilingual"
-        },
-        {
-          "lang": "fi",
-          "name": "Ahvenanmaan keskusta",
-          "note": "multilingual"
-        },
-        {
-          "lang": "sv",
-          "name": "Åländsk Center",
-          "note": "multilingual"
-        },
-        {
-          "lang": "it",
-          "name": "Centro delle Åland",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Åländsk Center",
-          "note": "multilingual"
-        },
-        {
-          "lang": "de",
-          "name": "Åländisches Zentrum",
-          "note": "multilingual"
-        },
-        {
-          "lang": "da",
-          "name": "Åländsk Center",
-          "note": "multilingual"
-        },
-        {
-          "lang": "az",
-          "name": "Aland mərkəzi",
-          "note": "multilingual"
-        },
-        {
-          "lang": "ja",
-          "name": "オーランド中央党",
-          "note": "multilingual"
-        },
-        {
-          "lang": "ca",
-          "name": "Centre d’Åland",
-          "note": "multilingual"
-        },
-        {
-          "lang": "fi",
-          "name": "Åländsk center",
-          "note": "multilingual"
-        },
-        {
-          "lang": "it",
-          "name": "Åländsk Center",
-          "note": "multilingual"
-        }
-      ]
-    },
-    {
-      "classification": "party",
-      "id": "party/Åländsk_center",
+      "id": "Åländsk_center",
       "identifiers": [
         {
           "identifier": "Q2113706",
@@ -4081,420 +3967,420 @@
   "memberships": [
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/Ålands_framtid",
+      "on_behalf_of_id": "Ålands_framtid",
       "organization_id": "legislature",
       "person_id": "069c61d9-e17f-46aa-aba9-1b255e3166e5",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/Ålands_framtid",
+      "on_behalf_of_id": "Ålands_framtid",
       "organization_id": "legislature",
       "person_id": "069c61d9-e17f-46aa-aba9-1b255e3166e5",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/liberalerna",
+      "on_behalf_of_id": "liberalerna",
       "organization_id": "legislature",
       "person_id": "10995076-8cb9-43a8-b1e0-ed1af900ed70",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/moderat_samling",
+      "on_behalf_of_id": "moderaterna_på_Åland",
       "organization_id": "legislature",
       "person_id": "1ab91134-5837-430d-855d-6acfdce78d86",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/moderat_samling",
+      "on_behalf_of_id": "moderaterna_på_Åland",
       "organization_id": "legislature",
       "person_id": "1ab91134-5837-430d-855d-6acfdce78d86",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/moderat_samling",
+      "on_behalf_of_id": "moderaterna_på_Åland",
       "organization_id": "legislature",
       "person_id": "212c44f3-e91d-48ad-9476-ad3ea8998ab6",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/Åländsk_center",
+      "on_behalf_of_id": "Åländsk_center",
       "organization_id": "legislature",
       "person_id": "25ac9df5-73ca-446b-8bc3-d91b80b7909b",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/Åländsk_center",
+      "on_behalf_of_id": "Åländsk_center",
       "organization_id": "legislature",
       "person_id": "25ac9df5-73ca-446b-8bc3-d91b80b7909b",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/moderat_samling",
+      "on_behalf_of_id": "moderaterna_på_Åland",
       "organization_id": "legislature",
       "person_id": "294b101b-1db4-469e-9684-f3124f9cd061",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/moderat_samling",
+      "on_behalf_of_id": "moderaterna_på_Åland",
       "organization_id": "legislature",
       "person_id": "2d97597a-4313-4ee9-a5bc-762c2608b4f9",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/Ålands_socialdemokrater",
+      "on_behalf_of_id": "Ålands_socialdemokrater",
       "organization_id": "legislature",
       "person_id": "3392297b-d394-4b04-a858-3738b2931335",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/Ålands_socialdemokrater",
+      "on_behalf_of_id": "Ålands_socialdemokrater",
       "organization_id": "legislature",
       "person_id": "3392297b-d394-4b04-a858-3738b2931335",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/Åländsk_center",
+      "on_behalf_of_id": "Åländsk_center",
       "organization_id": "legislature",
       "person_id": "36915827-7b54-4f98-8f0a-a54db2a41136",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/Åländsk_center",
+      "on_behalf_of_id": "Åländsk_center",
       "organization_id": "legislature",
       "person_id": "3fdb5680-ddd6-4c06-a199-6a3a76327ece",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/Ålands_framtid",
+      "on_behalf_of_id": "Ålands_framtid",
       "organization_id": "legislature",
       "person_id": "4116682f-f3c3-4514-a891-b9fe8afa245f",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/moderat_samling",
+      "on_behalf_of_id": "moderaterna_på_Åland",
       "organization_id": "legislature",
       "person_id": "4519dd08-5c45-4324-a257-591aaa03c3e8",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/moderat_samling",
+      "on_behalf_of_id": "moderaterna_på_Åland",
       "organization_id": "legislature",
       "person_id": "4519dd08-5c45-4324-a257-591aaa03c3e8",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/Åländsk_center",
+      "on_behalf_of_id": "Åländsk_center",
       "organization_id": "legislature",
       "person_id": "5049236d-df09-43ab-a843-b9c910603479",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/Ålands_socialdemokrater",
+      "on_behalf_of_id": "Ålands_socialdemokrater",
       "organization_id": "legislature",
       "person_id": "58467ee7-696f-4c46-91c8-7ac4110e9d32",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/Ålands_socialdemokrater",
+      "on_behalf_of_id": "Ålands_socialdemokrater",
       "organization_id": "legislature",
       "person_id": "58aff53c-e322-40e3-a8d2-49b672ae500c",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/Åländsk_center",
+      "on_behalf_of_id": "Åländsk_center",
       "organization_id": "legislature",
       "person_id": "5b06a945-d7f3-4290-8794-9372273aa22c",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/liberalerna",
+      "on_behalf_of_id": "liberalerna",
       "organization_id": "legislature",
       "person_id": "6338f4dd-223b-4900-8cf7-d632eaabdb0e",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/liberalerna",
+      "on_behalf_of_id": "liberalerna",
       "organization_id": "legislature",
       "person_id": "73c20499-0d12-4409-b430-1ae222d6bc4c",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/liberalerna",
+      "on_behalf_of_id": "liberalerna",
       "organization_id": "legislature",
       "person_id": "74f795c8-c159-4c18-b2e5-bfbf58502c29",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/Ålands_framtid",
+      "on_behalf_of_id": "Ålands_framtid",
       "organization_id": "legislature",
       "person_id": "7877e36d-a18b-4e99-b6bb-74aac77286d3",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/liberalerna",
+      "on_behalf_of_id": "liberalerna",
       "organization_id": "legislature",
       "person_id": "7bcba90d-f015-4ea3-9243-eb1619719f61",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/Åländsk_center",
+      "on_behalf_of_id": "Åländsk_center",
       "organization_id": "legislature",
       "person_id": "7e3b4661-2fe0-4f15-9970-86b98701dee1",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/moderaterna_på_Åland",
+      "on_behalf_of_id": "moderaterna_på_Åland",
       "organization_id": "legislature",
       "person_id": "7efe27f8-e3a4-4ac2-8daf-f49bdca45ab9",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/Ålands_socialdemokrater",
+      "on_behalf_of_id": "Ålands_socialdemokrater",
       "organization_id": "legislature",
       "person_id": "88204fba-8f58-4add-9e16-2c9aba3ad44c",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/liberalerna",
+      "on_behalf_of_id": "liberalerna",
       "organization_id": "legislature",
       "person_id": "884b6d85-564f-4f43-9e37-d5306e241cc5",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/Åländsk_center",
+      "on_behalf_of_id": "Åländsk_center",
       "organization_id": "legislature",
       "person_id": "9969d9d7-ab81-4ab0-bd80-35e4c21d5b22",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/Åländsk_center",
+      "on_behalf_of_id": "Åländsk_center",
       "organization_id": "legislature",
       "person_id": "9969d9d7-ab81-4ab0-bd80-35e4c21d5b22",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/liberalerna",
+      "on_behalf_of_id": "liberalerna",
       "organization_id": "legislature",
       "person_id": "9dbf37cd-1a94-47f5-93ac-b7de0e34083b",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/liberalerna",
+      "on_behalf_of_id": "liberalerna",
       "organization_id": "legislature",
       "person_id": "9dbf37cd-1a94-47f5-93ac-b7de0e34083b",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/liberalerna",
+      "on_behalf_of_id": "liberalerna",
       "organization_id": "legislature",
       "person_id": "9fbcb798-95de-44a8-ae21-b8c42eb21f27",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/obunden_samling_på_Åland",
+      "on_behalf_of_id": "obunden_samling_på_Åland",
       "organization_id": "legislature",
       "person_id": "a4194905-b544-441b-a58f-7d92681398cf",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/moderat_samling",
+      "on_behalf_of_id": "moderaterna_på_Åland",
       "organization_id": "legislature",
       "person_id": "a41f0372-a0b2-422a-b9f5-a04698a8205e",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/moderat_samling",
+      "on_behalf_of_id": "moderaterna_på_Åland",
       "organization_id": "legislature",
       "person_id": "a41f0372-a0b2-422a-b9f5-a04698a8205e",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/moderaterna_på_Åland",
+      "on_behalf_of_id": "moderaterna_på_Åland",
       "organization_id": "legislature",
       "person_id": "a539ff7e-cc05-4dfe-b068-a5969a0d9538",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/Åländsk_center",
+      "on_behalf_of_id": "Åländsk_center",
       "organization_id": "legislature",
       "person_id": "acdcf89a-6477-4afd-a65e-9989bd2a1af4",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/Åländsk_center",
+      "on_behalf_of_id": "Åländsk_center",
       "organization_id": "legislature",
       "person_id": "b7892b68-4297-47ca-a4fa-00f343925655",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/Åländsk_center",
+      "on_behalf_of_id": "Åländsk_center",
       "organization_id": "legislature",
       "person_id": "b7892b68-4297-47ca-a4fa-00f343925655",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/Ålands_socialdemokrater",
+      "on_behalf_of_id": "Ålands_socialdemokrater",
       "organization_id": "legislature",
       "person_id": "b7fae283-e2ae-4f24-b071-473db127ed2b",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/moderat_samling",
+      "on_behalf_of_id": "moderaterna_på_Åland",
       "organization_id": "legislature",
       "person_id": "c074f156-4e82-43ea-a999-2333b7b0f75c",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/moderat_samling",
+      "on_behalf_of_id": "moderaterna_på_Åland",
       "organization_id": "legislature",
       "person_id": "c074f156-4e82-43ea-a999-2333b7b0f75c",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/moderat_samling",
+      "on_behalf_of_id": "moderaterna_på_Åland",
       "organization_id": "legislature",
       "person_id": "c1735663-4615-4bd7-bac6-68f206835bf3",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/moderat_samling",
+      "on_behalf_of_id": "moderaterna_på_Åland",
       "organization_id": "legislature",
       "person_id": "c1735663-4615-4bd7-bac6-68f206835bf3",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/Åländsk_center",
+      "on_behalf_of_id": "Åländsk_center",
       "organization_id": "legislature",
       "person_id": "c2e677f9-7320-45b6-88a4-32ef42ff1acc",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/Ålands_socialdemokrater",
+      "on_behalf_of_id": "Ålands_socialdemokrater",
       "organization_id": "legislature",
       "person_id": "d65f8266-9315-47be-9c64-0f54625c6ddf",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/liberalerna",
+      "on_behalf_of_id": "liberalerna",
       "organization_id": "legislature",
       "person_id": "d7a8d7c9-9019-4db4-8039-0941b7ab9e1a",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/Åländsk_center",
+      "on_behalf_of_id": "Åländsk_center",
       "organization_id": "legislature",
       "person_id": "dd1cba32-c84c-4563-88a0-cb724a62ffce",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/Åländsk_center",
+      "on_behalf_of_id": "Åländsk_center",
       "organization_id": "legislature",
       "person_id": "dd1cba32-c84c-4563-88a0-cb724a62ffce",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/Ålands_socialdemokrater",
+      "on_behalf_of_id": "Ålands_socialdemokrater",
       "organization_id": "legislature",
       "person_id": "e3aab23e-a883-4763-be0d-92e5936024e2",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/Ålands_socialdemokrater",
+      "on_behalf_of_id": "Ålands_socialdemokrater",
       "organization_id": "legislature",
       "person_id": "e3c01d19-cdd8-407c-b52f-95eea87f2307",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/liberalerna",
+      "on_behalf_of_id": "liberalerna",
       "organization_id": "legislature",
       "person_id": "e57828f1-e51a-41ea-a61b-7fc1b92e2b37",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/Åländsk_center",
+      "on_behalf_of_id": "Åländsk_center",
       "organization_id": "legislature",
       "person_id": "e6f6e01b-bcb0-4374-8912-7e1eaf492f10",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/liberalerna",
+      "on_behalf_of_id": "liberalerna",
       "organization_id": "legislature",
       "person_id": "ed4838aa-19f8-493c-b8c4-58780b5b0d84",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/liberalerna",
+      "on_behalf_of_id": "liberalerna",
       "organization_id": "legislature",
       "person_id": "f4f995ae-126c-468f-8f26-deec1e26adc2",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2007",
-      "on_behalf_of_id": "party/liberalerna",
+      "on_behalf_of_id": "liberalerna",
       "organization_id": "legislature",
       "person_id": "fe40bb08-5025-473d-af52-bf1e30ecc5e6",
       "role": "member"
     },
     {
       "legislative_period_id": "term/2011",
-      "on_behalf_of_id": "party/liberalerna",
+      "on_behalf_of_id": "liberalerna",
       "organization_id": "legislature",
       "person_id": "fe40bb08-5025-473d-af52-bf1e30ecc5e6",
       "role": "member"

--- a/data/Aland/Lagting/sources/wikidata/groups.json
+++ b/data/Aland/Lagting/sources/wikidata/groups.json
@@ -164,6 +164,11 @@
         "note": "multilingual"
       },
       {
+        "lang": "fi",
+        "name": "Liberalerna",
+        "note": "multilingual"
+      },
+      {
         "lang": "sv",
         "name": "Mittenliberalerna",
         "note": "multilingual"
@@ -242,6 +247,11 @@
       {
         "lang": "sv",
         "name": "Frisinnad Samverkan",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sv",
+        "name": "Moderat Samling",
         "note": "multilingual"
       },
       {
@@ -545,6 +555,11 @@
       {
         "lang": "fi",
         "name": "Obunden samling",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sv",
+        "name": "Obunden Samling på Åland",
         "note": "multilingual"
       }
     ],

--- a/data/Aland/Lagting/term-2007.csv
+++ b/data/Aland/Lagting/term-2007.csv
@@ -1,31 +1,31 @@
 id,name,sort_name,email,twitter,facebook,group,group_id,area_id,area,chamber,term,start_date,end_date,image,gender
 e3aab23e-a883-4763-be0d-92e5936024e2,Aaltonen Carina,Aaltonen Carina,carina.aaltonen@lagtinget.ax,,,Ålands socialdemokrater,Ålands_socialdemokrater,,,Lagting,2007,,,http://www.lagtinget.ax/files/aaltonen_carina.jpg,female
-3fdb5680-ddd6-4c06-a199-6a3a76327ece,Carlson Gun,Carlson Gun,gun.carlson@lagtinget.ax,,,Åländsk Center,Åländsk_center,,,Lagting,2007,,,http://www.lagtinget.ax/files/carlson_gun.jpg,female
+3fdb5680-ddd6-4c06-a199-6a3a76327ece,Carlson Gun,Carlson Gun,gun.carlson@lagtinget.ax,,,Åländsk center,Åländsk_center,,,Lagting,2007,,,http://www.lagtinget.ax/files/carlson_gun.jpg,female
 e57828f1-e51a-41ea-a61b-7fc1b92e2b37,Dahl Ulla-Britt,Dahl Ulla-Britt,ulla-britt.dahl@lagtinget.ax,,,Liberalerna,liberalerna,,,Lagting,2007,,,http://www.lagtinget.ax/files/dahl_ulla_britt.jpg,female
 a539ff7e-cc05-4dfe-b068-a5969a0d9538,Ehn Johan,Ehn Johan,johan.ehn@lagtinget.ax,,,Moderaterna på Åland,moderaterna_på_Åland,,,Lagting,2007,,,http://www.lagtinget.ax/files/ehn_johan.jpg,male
 7bcba90d-f015-4ea3-9243-eb1619719f61,Eklöw Raija-Liisa,Eklöw Raija-Liisa,raija-liisa.eklow@lagtinget.ax,,,Liberalerna,liberalerna,,,Lagting,2007,,,http://www.lagtinget.ax/files/eklow_raija_liisa.jpg,female
-dd1cba32-c84c-4563-88a0-cb724a62ffce,Englund Anders,Englund Anders,anders.englund@agtinget.ax,,,Åländsk Center,Åländsk_center,,,Lagting,2007,,,,male
+dd1cba32-c84c-4563-88a0-cb724a62ffce,Englund Anders,Englund Anders,anders.englund@agtinget.ax,,,Åländsk center,Åländsk_center,,,Lagting,2007,,,,male
 069c61d9-e17f-46aa-aba9-1b255e3166e5,Eriksson Anders,Eriksson Anders,anders.eriksson@lagtinget.ax,,,Ålands framtid,Ålands_framtid,,,Lagting,2007,,,http://www.lagtinget.ax/files/AndersEriksson.jpg,male
 9fbcb798-95de-44a8-ae21-b8c42eb21f27,Eriksson Sirpa,Eriksson Sirpa,sirpa.eriksson@lagtinget.ax.,,,Liberalerna,liberalerna,,,Lagting,2007,,,http://www.lagtinget.ax/files/eriksson_sirpa.jpg,female
 d7a8d7c9-9019-4db4-8039-0941b7ab9e1a,Erland Olof,Erland Olof,olof.erland@lagtinget.ax,,,Liberalerna,liberalerna,,,Lagting,2007,,,http://www.lagtinget.ax/files/erland_olof.jpg,male
 b7fae283-e2ae-4f24-b071-473db127ed2b,Gunell Camilla,Gunell Camilla,camilla.gunell@lagtinget.ax,,,Ålands socialdemokrater,Ålands_socialdemokrater,,,Lagting,2007,,,http://www.lagtinget.ax/files/gunell_camilla.jpg,female
 9dbf37cd-1a94-47f5-93ac-b7de0e34083b,Jansson Gunnar,Jansson Gunnar,gunnar.jansson@lagtinget.ax,,,Liberalerna,liberalerna,,,Lagting,2007,,,http://www.lagtinget.ax/files/jansson_gunnar.jpg,male
-9969d9d7-ab81-4ab0-bd80-35e4c21d5b22,Jansson Harry,Jansson Harry,harry.jansson@lagtinget.ax,,,Åländsk Center,Åländsk_center,,,Lagting,2007,,,http://www.lagtinget.ax/files/jansson_harry.jpg,male
-1ab91134-5837-430d-855d-6acfdce78d86,Jansson Roger,Jansson Roger,roger.jansson@lagtinget.ax,,,Moderat Samling,moderat_samling,,,Lagting,2007,,,http://www.lagtinget.ax/files/jansson_roger.jpg,male
-b7892b68-4297-47ca-a4fa-00f343925655,Karlsson Runar,Karlsson Runar,runar.karlsson@lagtinget.ax,,,Åländsk Center,Åländsk_center,,,Lagting,2007,,,http://www.lagtinget.ax/files/karlsson_runar.jpg,male
+9969d9d7-ab81-4ab0-bd80-35e4c21d5b22,Jansson Harry,Jansson Harry,harry.jansson@lagtinget.ax,,,Åländsk center,Åländsk_center,,,Lagting,2007,,,http://www.lagtinget.ax/files/jansson_harry.jpg,male
+1ab91134-5837-430d-855d-6acfdce78d86,Jansson Roger,Jansson Roger,roger.jansson@lagtinget.ax,,,Moderaterna på Åland,moderaterna_på_Åland,,,Lagting,2007,,,http://www.lagtinget.ax/files/jansson_roger.jpg,male
+b7892b68-4297-47ca-a4fa-00f343925655,Karlsson Runar,Karlsson Runar,runar.karlsson@lagtinget.ax,,,Åländsk center,Åländsk_center,,,Lagting,2007,,,http://www.lagtinget.ax/files/karlsson_runar.jpg,male
 a4194905-b544-441b-a58f-7d92681398cf,Karlström Fredrik,Karlström Fredrik,fredrik.karlstrom@lagtinget.ax,,,Obunden Samling på Åland,obunden_samling_på_Åland,,,Lagting,2007,,,http://www.lagtinget.ax/files/karlstrom_fredrik.jpg,male
-c1735663-4615-4bd7-bac6-68f206835bf3,Lindholm Gun-Mari,Lindholm Gun-Mari,gun-mari.lindholm@lagtinget.ax,,,Moderat Samling,moderat_samling,,,Lagting,2007,,,http://www.lagtinget.ax/files/lindholm_gun_mari.jpg,female
-e6f6e01b-bcb0-4374-8912-7e1eaf492f10,Lindström Henry,Lindström Henry,henry.lindstrom@lagtinget.ax,,,Åländsk Center,Åländsk_center,,,Lagting,2007,,,http://www.lagtinget.ax/files/lindfors_henry.jpg,male
+c1735663-4615-4bd7-bac6-68f206835bf3,Lindholm Gun-Mari,Lindholm Gun-Mari,gun-mari.lindholm@lagtinget.ax,,,Moderaterna på Åland,moderaterna_på_Åland,,,Lagting,2007,,,http://www.lagtinget.ax/files/lindholm_gun_mari.jpg,female
+e6f6e01b-bcb0-4374-8912-7e1eaf492f10,Lindström Henry,Lindström Henry,henry.lindstrom@lagtinget.ax,,,Åländsk center,Åländsk_center,,,Lagting,2007,,,http://www.lagtinget.ax/files/lindfors_henry.jpg,male
 73c20499-0d12-4409-b430-1ae222d6bc4c,Lundberg Margaret,Lundberg Margaret,margaret.lundberg@lagtinget.ax,,,Liberalerna,liberalerna,,,Lagting,2007,,,http://www.lagtinget.ax/files/lundberg_margaret.jpg,female
-c2e677f9-7320-45b6-88a4-32ef42ff1acc,Mattsson Jan-Erik,Mattsson Jan-Erik,jan-erik.mattsson@lagtinget.ax,,,Åländsk Center,Åländsk_center,,,Lagting,2007,,,http://www.lagtinget.ax/files/mattsson_jan_erik.jpg,male
-c074f156-4e82-43ea-a999-2333b7b0f75c,Mattsson Åke,Mattsson Åke,ake.mattson@lagtinget.ax,,,Moderat Samling,moderat_samling,,,Lagting,2007,,,http://www.lagtinget.ax/files/mattsson_ake.jpg,male
-a41f0372-a0b2-422a-b9f5-a04698a8205e,Nordberg Mika,Nordberg Mika,mika.nordberg@lagtinget.ax,,,Moderat Samling,moderat_samling,,,Lagting,2007,,,http://www.lagtinget.ax/files/nordberg_mika.jpg,male
-7e3b4661-2fe0-4f15-9970-86b98701dee1,Nordlund Roger,Nordlund Roger,roger.nordlund@lagtinget.ax,,,Åländsk Center,Åländsk_center,,,Lagting,2007,,,http://www.lagtinget.ax/files/nordlund_roger.jpg,male
-5049236d-df09-43ab-a843-b9c910603479,Salmén Jan,Salmén Jan,jan.salmen@lagtinget.ax,,,Åländsk Center,Åländsk_center,,,Lagting,2007,,,http://www.lagtinget.ax/files/salmen_jan.jpg,male
+c2e677f9-7320-45b6-88a4-32ef42ff1acc,Mattsson Jan-Erik,Mattsson Jan-Erik,jan-erik.mattsson@lagtinget.ax,,,Åländsk center,Åländsk_center,,,Lagting,2007,,,http://www.lagtinget.ax/files/mattsson_jan_erik.jpg,male
+c074f156-4e82-43ea-a999-2333b7b0f75c,Mattsson Åke,Mattsson Åke,ake.mattson@lagtinget.ax,,,Moderaterna på Åland,moderaterna_på_Åland,,,Lagting,2007,,,http://www.lagtinget.ax/files/mattsson_ake.jpg,male
+a41f0372-a0b2-422a-b9f5-a04698a8205e,Nordberg Mika,Nordberg Mika,mika.nordberg@lagtinget.ax,,,Moderaterna på Åland,moderaterna_på_Åland,,,Lagting,2007,,,http://www.lagtinget.ax/files/nordberg_mika.jpg,male
+7e3b4661-2fe0-4f15-9970-86b98701dee1,Nordlund Roger,Nordlund Roger,roger.nordlund@lagtinget.ax,,,Åländsk center,Åländsk_center,,,Lagting,2007,,,http://www.lagtinget.ax/files/nordlund_roger.jpg,male
+5049236d-df09-43ab-a843-b9c910603479,Salmén Jan,Salmén Jan,jan.salmen@lagtinget.ax,,,Åländsk center,Åländsk_center,,,Lagting,2007,,,http://www.lagtinget.ax/files/salmen_jan.jpg,male
 ed4838aa-19f8-493c-b8c4-58780b5b0d84,Sjölund Folke,Sjölund Folke,folke.sjolund@lagtinget.ax,,,Liberalerna,liberalerna,,,Lagting,2007,,,http://www.lagtinget.ax/files/sjolund_folke.jpg,male
 74f795c8-c159-4c18-b2e5-bfbf58502c29,Sjöstrand Leo,Sjöstrand Leo,leo.sjostrand@lagtinget.ax,,,Liberalerna,liberalerna,,,Lagting,2007,,,http://www.lagtinget.ax/files/sjostrand_leo.jpg,male
-25ac9df5-73ca-446b-8bc3-d91b80b7909b,Slotte Roger,Slotte Roger,roger.slotte@lagtinget.ax,,,Åländsk Center,Åländsk_center,,,Lagting,2007,,,http://www.lagtinget.ax/files/slotte_roger.jpg,male
+25ac9df5-73ca-446b-8bc3-d91b80b7909b,Slotte Roger,Slotte Roger,roger.slotte@lagtinget.ax,,,Åländsk center,Åländsk_center,,,Lagting,2007,,,http://www.lagtinget.ax/files/slotte_roger.jpg,male
 7efe27f8-e3a4-4ac2-8daf-f49bdca45ab9,Strand Jörgen,Strand Jörgen,jorgen.strand@lagtinget.ax,,,Moderaterna på Åland,moderaterna_på_Åland,,,Lagting,2007,,,http://www.lagtinget.ax/files/strand_jorgen.jpg,male
 3392297b-d394-4b04-a858-3738b2931335,Sundback Barbro,Sundback Barbro,barbro.sundback@lagtinget.ax,,,Ålands socialdemokrater,Ålands_socialdemokrater,,,Lagting,2007,,,http://www.lagtinget.ax/files/sundback_barbro.jpg,female
 fe40bb08-5025-473d-af52-bf1e30ecc5e6,Sundblom Torsten,Sundblom Torsten,torsten.sundblom@lagtinget.ax,,,Liberalerna,liberalerna,,,Lagting,2007,,,http://www.lagtinget.ax/files/sundblom_torsten.jpg,male
-4519dd08-5c45-4324-a257-591aaa03c3e8,Sundman Danne,Sundman Danne,danne.sundman@lagtinget.ax,,,Moderat Samling,moderat_samling,,,Lagting,2007,,,http://www.lagtinget.ax/files/sundman_danne.jpg,male
+4519dd08-5c45-4324-a257-591aaa03c3e8,Sundman Danne,Sundman Danne,danne.sundman@lagtinget.ax,,,Moderaterna på Åland,moderaterna_på_Åland,,,Lagting,2007,,,http://www.lagtinget.ax/files/sundman_danne.jpg,male

--- a/data/Aland/Lagting/term-2011.csv
+++ b/data/Aland/Lagting/term-2011.csv
@@ -1,31 +1,31 @@
 id,name,sort_name,email,twitter,facebook,group,group_id,area_id,area,chamber,term,start_date,end_date,image,gender
 f4f995ae-126c-468f-8f26-deec1e26adc2,Asumaa Tony,Asumaa Tony,tony.asumaa@lagtinget.ax,,,Liberalerna,liberalerna,,,Lagting,2011,,,http://www.lagtinget.ax/files/asumaa_tony.jpg,male
 58aff53c-e322-40e3-a8d2-49b672ae500c,Beijar Christian,Beijar Christian,christian.beijar@lagtinget.ax,,,Ålands socialdemokrater,Ålands_socialdemokrater,,,Lagting,2011,,,http://www.lagtinget.ax/files/beijar_christian.jpg,male
-2d97597a-4313-4ee9-a5bc-762c2608b4f9,Carlsson Petri,Carlsson Petri,petri.carlsson@lagtinget.ax,,,Moderat Samling,moderat_samling,,,Lagting,2011,,,http://www.lagtinget.ax/files/petri_carlsson.jpg,male
+2d97597a-4313-4ee9-a5bc-762c2608b4f9,Carlsson Petri,Carlsson Petri,petri.carlsson@lagtinget.ax,,,Moderaterna på Åland,moderaterna_på_Åland,,,Lagting,2011,,,http://www.lagtinget.ax/files/petri_carlsson.jpg,male
 7877e36d-a18b-4e99-b6bb-74aac77286d3,Eklund Brage,Eklund Brage,brage.eklund@lagtinget.ax,,,Ålands framtid,Ålands_framtid,,,Lagting,2011,,,http://www.lagtinget.ax/files/eklund_brage.jpg,male
-5b06a945-d7f3-4290-8794-9372273aa22c,Eliasson Torbjörn,Eliasson Torbjörn,torbjorn.eliasson@lagtinget.ax,,,Åländsk Center,Åländsk_center,,,Lagting,2011,,,http://www.lagtinget.ax/files/eliasson_torbjorn.jpg,male
-dd1cba32-c84c-4563-88a0-cb724a62ffce,Englund Anders,Englund Anders,anders.englund@agtinget.ax,,,Åländsk Center,Åländsk_center,,,Lagting,2011,,,,male
+5b06a945-d7f3-4290-8794-9372273aa22c,Eliasson Torbjörn,Eliasson Torbjörn,torbjorn.eliasson@lagtinget.ax,,,Åländsk center,Åländsk_center,,,Lagting,2011,,,http://www.lagtinget.ax/files/eliasson_torbjorn.jpg,male
+dd1cba32-c84c-4563-88a0-cb724a62ffce,Englund Anders,Englund Anders,anders.englund@agtinget.ax,,,Åländsk center,Åländsk_center,,,Lagting,2011,,,,male
 069c61d9-e17f-46aa-aba9-1b255e3166e5,Eriksson Anders,Eriksson Anders,anders.eriksson@lagtinget.ax,,,Ålands framtid,Ålands_framtid,,,Lagting,2011,,,http://www.lagtinget.ax/files/AndersEriksson.jpg,male
 6338f4dd-223b-4900-8cf7-d632eaabdb0e,Eriksson Viveka,Eriksson Viveka,viveka.eriksson@lagtinget.ax,,,Liberalerna,liberalerna,,,Lagting,2011,,,http://www.lagtinget.ax/files/eriksson_viveka.jpg,female
 88204fba-8f58-4add-9e16-2c9aba3ad44c,Fogelström Karl-Johan,Fogelström Karl-Johan,karl-johan.fogelstrom@lagtinget.ax,,,Ålands socialdemokrater,Ålands_socialdemokrater,,,Lagting,2011,,,http://www.lagtinget.ax/files/fogelstom_karljohan.jpg,male
-294b101b-1db4-469e-9684-f3124f9cd061,Hilander John,Hilander John,john.hilander@lagtinget.ax,,,Moderat Samling,moderat_samling,,,Lagting,2011,,,http://www.lagtinget.ax/files/hillander_copy2.jpg,male
+294b101b-1db4-469e-9684-f3124f9cd061,Hilander John,Hilander John,john.hilander@lagtinget.ax,,,Moderaterna på Åland,moderaterna_på_Åland,,,Lagting,2011,,,http://www.lagtinget.ax/files/hillander_copy2.jpg,male
 d65f8266-9315-47be-9c64-0f54625c6ddf,Holmberg Igge,Holmberg Igge,igge.holmberg@lagtinget.ax,,,Ålands socialdemokrater,Ålands_socialdemokrater,,,Lagting,2011,,,http://www.lagtinget.ax/files/holmberg_mikael.jpg,male
-212c44f3-e91d-48ad-9476-ad3ea8998ab6,Holmberg-Jansson Annette,Holmberg-Jansson Annette,annette.holmberg-jansson@lagtinget.ax,,,Moderat Samling,moderat_samling,,,Lagting,2011,,,,
+212c44f3-e91d-48ad-9476-ad3ea8998ab6,Holmberg-Jansson Annette,Holmberg-Jansson Annette,annette.holmberg-jansson@lagtinget.ax,,,Moderaterna på Åland,moderaterna_på_Åland,,,Lagting,2011,,,,
 9dbf37cd-1a94-47f5-93ac-b7de0e34083b,Jansson Gunnar,Jansson Gunnar,gunnar.jansson@lagtinget.ax,,,Liberalerna,liberalerna,,,Lagting,2011,,,http://www.lagtinget.ax/files/jansson_gunnar.jpg,male
-9969d9d7-ab81-4ab0-bd80-35e4c21d5b22,Jansson Harry,Jansson Harry,harry.jansson@lagtinget.ax,,,Åländsk Center,Åländsk_center,,,Lagting,2011,,,http://www.lagtinget.ax/files/jansson_harry.jpg,male
-1ab91134-5837-430d-855d-6acfdce78d86,Jansson Roger,Jansson Roger,roger.jansson@lagtinget.ax,,,Moderat Samling,moderat_samling,,,Lagting,2011,,,http://www.lagtinget.ax/files/jansson_roger.jpg,male
+9969d9d7-ab81-4ab0-bd80-35e4c21d5b22,Jansson Harry,Jansson Harry,harry.jansson@lagtinget.ax,,,Åländsk center,Åländsk_center,,,Lagting,2011,,,http://www.lagtinget.ax/files/jansson_harry.jpg,male
+1ab91134-5837-430d-855d-6acfdce78d86,Jansson Roger,Jansson Roger,roger.jansson@lagtinget.ax,,,Moderaterna på Åland,moderaterna_på_Åland,,,Lagting,2011,,,http://www.lagtinget.ax/files/jansson_roger.jpg,male
 4116682f-f3c3-4514-a891-b9fe8afa245f,Jonsson Axel,Jonsson Axel,axel.jonsson@lagtinget.ax,,,Ålands framtid,Ålands_framtid,,,Lagting,2011,,,http://www.lagtinget.ax/files/jonsson_axel.jpg,male
-b7892b68-4297-47ca-a4fa-00f343925655,Karlsson Runar,Karlsson Runar,runar.karlsson@lagtinget.ax,,,Åländsk Center,Åländsk_center,,,Lagting,2011,,,http://www.lagtinget.ax/files/karlsson_runar.jpg,male
+b7892b68-4297-47ca-a4fa-00f343925655,Karlsson Runar,Karlsson Runar,runar.karlsson@lagtinget.ax,,,Åländsk center,Åländsk_center,,,Lagting,2011,,,http://www.lagtinget.ax/files/karlsson_runar.jpg,male
 e3c01d19-cdd8-407c-b52f-95eea87f2307,Kemetter Sara,Kemetter Sara,sara.kemetter@lagtinget.ax,,,Ålands socialdemokrater,Ålands_socialdemokrater,,,Lagting,2011,,,http://www.lagtinget.ax/files/kemetter_sara.jpg,female
-c1735663-4615-4bd7-bac6-68f206835bf3,Lindholm Gun-Mari,Lindholm Gun-Mari,gun-mari.lindholm@lagtinget.ax,,,Moderat Samling,moderat_samling,,,Lagting,2011,,,http://www.lagtinget.ax/files/lindholm_gun_mari.jpg,female
-36915827-7b54-4f98-8f0a-a54db2a41136,Lundberg Britt,Lundberg Britt,britt.lundberg@lagtinget.ax,,,Åländsk Center,Åländsk_center,,,Lagting,2011,,,,female
-c074f156-4e82-43ea-a999-2333b7b0f75c,Mattsson Åke,Mattsson Åke,ake.mattson@lagtinget.ax,,,Moderat Samling,moderat_samling,,,Lagting,2011,,,http://www.lagtinget.ax/files/mattsson_ake.jpg,male
-a41f0372-a0b2-422a-b9f5-a04698a8205e,Nordberg Mika,Nordberg Mika,mika.nordberg@lagtinget.ax,,,Moderat Samling,moderat_samling,,,Lagting,2011,,,http://www.lagtinget.ax/files/nordberg_mika.jpg,male
+c1735663-4615-4bd7-bac6-68f206835bf3,Lindholm Gun-Mari,Lindholm Gun-Mari,gun-mari.lindholm@lagtinget.ax,,,Moderaterna på Åland,moderaterna_på_Åland,,,Lagting,2011,,,http://www.lagtinget.ax/files/lindholm_gun_mari.jpg,female
+36915827-7b54-4f98-8f0a-a54db2a41136,Lundberg Britt,Lundberg Britt,britt.lundberg@lagtinget.ax,,,Åländsk center,Åländsk_center,,,Lagting,2011,,,,female
+c074f156-4e82-43ea-a999-2333b7b0f75c,Mattsson Åke,Mattsson Åke,ake.mattson@lagtinget.ax,,,Moderaterna på Åland,moderaterna_på_Åland,,,Lagting,2011,,,http://www.lagtinget.ax/files/mattsson_ake.jpg,male
+a41f0372-a0b2-422a-b9f5-a04698a8205e,Nordberg Mika,Nordberg Mika,mika.nordberg@lagtinget.ax,,,Moderaterna på Åland,moderaterna_på_Åland,,,Lagting,2011,,,http://www.lagtinget.ax/files/nordberg_mika.jpg,male
 884b6d85-564f-4f43-9e37-d5306e241cc5,Perämaa Mats,Perämaa Mats,mats.peramaa@lagtinget.ax,,,Liberalerna,liberalerna,,,Lagting,2011,,,http://www.lagtinget.ax/files/peramaa_mats.jpg,male
-acdcf89a-6477-4afd-a65e-9989bd2a1af4,Pettersson Jörgen,Pettersson Jörgen,jorgen.pettersson@lagtinget.ax,,,Åländsk Center,Åländsk_center,,,Lagting,2011,,,http://www.lagtinget.ax/files/pettersson_gorgen.jpg,male
+acdcf89a-6477-4afd-a65e-9989bd2a1af4,Pettersson Jörgen,Pettersson Jörgen,jorgen.pettersson@lagtinget.ax,,,Åländsk center,Åländsk_center,,,Lagting,2011,,,http://www.lagtinget.ax/files/pettersson_gorgen.jpg,male
 10995076-8cb9-43a8-b1e0-ed1af900ed70,Sjögren Katrin,Sjögren Katrin,katrin.sjogrenoch@lagtinget.ax,,,Liberalerna,liberalerna,,,Lagting,2011,,,http://www.lagtinget.ax/files/sjogren_katrin.jpg,female
-25ac9df5-73ca-446b-8bc3-d91b80b7909b,Slotte Roger,Slotte Roger,roger.slotte@lagtinget.ax,,,Åländsk Center,Åländsk_center,,,Lagting,2011,,,http://www.lagtinget.ax/files/slotte_roger.jpg,male
+25ac9df5-73ca-446b-8bc3-d91b80b7909b,Slotte Roger,Slotte Roger,roger.slotte@lagtinget.ax,,,Åländsk center,Åländsk_center,,,Lagting,2011,,,http://www.lagtinget.ax/files/slotte_roger.jpg,male
 3392297b-d394-4b04-a858-3738b2931335,Sundback Barbro,Sundback Barbro,barbro.sundback@lagtinget.ax,,,Ålands socialdemokrater,Ålands_socialdemokrater,,,Lagting,2011,,,http://www.lagtinget.ax/files/sundback_barbro.jpg,female
 fe40bb08-5025-473d-af52-bf1e30ecc5e6,Sundblom Torsten,Sundblom Torsten,torsten.sundblom@lagtinget.ax,,,Liberalerna,liberalerna,,,Lagting,2011,,,http://www.lagtinget.ax/files/sundblom_torsten.jpg,male
-4519dd08-5c45-4324-a257-591aaa03c3e8,Sundman Danne,Sundman Danne,danne.sundman@lagtinget.ax,,,Moderat Samling,moderat_samling,,,Lagting,2011,,,http://www.lagtinget.ax/files/sundman_danne.jpg,male
+4519dd08-5c45-4324-a257-591aaa03c3e8,Sundman Danne,Sundman Danne,danne.sundman@lagtinget.ax,,,Moderaterna på Åland,moderaterna_på_Åland,,,Lagting,2011,,,http://www.lagtinget.ax/files/sundman_danne.jpg,male
 58467ee7-696f-4c46-91c8-7ac4110e9d32,Winé Göte,Winé Göte,gote.wine@lagtinget.ax,,,Ålands socialdemokrater,Ålands_socialdemokrater,,,Lagting,2011,,,http://www.lagtinget.ax/files/GteWin.jpg,male

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -104,7 +104,7 @@ namespace :merge_sources do
         row[:uuid] = id_map[row[:id]] ||= SecureRandom.uuid
 
         # If we don't have a `group_id`, can we generate one from the `group`?
-        if group_names and not row[:group_id]
+        if group_names and row[:group] and not row[:group_id]
           found = group_names.select { |id, ns| ns.include? row[:group].downcase }
           warn_once "  Unknown group: #{row[:group]}" if found.empty?
           warn_once "  Ambiguous group: #{row[:group]}" if found.count > 1


### PR DESCRIPTION
If the incoming source only has a `group` column (remapped from party,
faction, etc.), and no `group_id`, standardise the IDs by looking them up
in the Groups file (generated from Wikidata). This will help us map parties
that changed name etc over time into the same thing.
