### PR TITLE
Turks and Caicos Islands (Assembly) — add Group information

### DIFF
--- a/data/Turks_and_Caicos_Islands/Assembly/ep-popolo-v1.0.json
+++ b/data/Turks_and_Caicos_Islands/Assembly/ep-popolo-v1.0.json
@@ -765,12 +765,38 @@
     {
       "classification": "party",
       "id": "party/pdm",
-      "name": "PDM"
+      "identifiers": [
+        {
+          "identifier": "Q7165523",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "PDM",
+      "other_names": [
+        {
+          "lang": "en",
+          "name": "People's Democratic Movement",
+          "note": "multilingual"
+        }
+      ]
     },
     {
       "classification": "party",
       "id": "party/pnp",
-      "name": "PNP"
+      "identifiers": [
+        {
+          "identifier": "Q7248774",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "PNP",
+      "other_names": [
+        {
+          "lang": "en",
+          "name": "Progressive National Party",
+          "note": "multilingual"
+        }
+      ]
     },
     {
       "classification": "party",

--- a/data/Turks_and_Caicos_Islands/Assembly/sources/instructions.json
+++ b/data/Turks_and_Caicos_Islands/Assembly/sources/instructions.json
@@ -55,6 +55,14 @@
         "type": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "create": {
+        "type": "group-wikidata",
+        "source": "manual/group_wikidata.csv"
+      }
     }
   ]
 }

--- a/data/Turks_and_Caicos_Islands/Assembly/sources/manual/group_wikidata.csv
+++ b/data/Turks_and_Caicos_Islands/Assembly/sources/manual/group_wikidata.csv
@@ -1,0 +1,3 @@
+id,wikidata
+pnp,Q7248774
+pdm,Q7165523

--- a/data/Turks_and_Caicos_Islands/Assembly/sources/wikidata/groups.json
+++ b/data/Turks_and_Caicos_Islands/Assembly/sources/wikidata/groups.json
@@ -1,0 +1,32 @@
+{
+  "pnp": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q7248774"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "en",
+        "name": "Progressive National Party",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "pdm": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q7165523"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "en",
+        "name": "People's Democratic Movement",
+        "note": "multilingual"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add Wikidata information about each of the political groups.