### PR TITLE
Botswana (Assembly) — add Group information

### DIFF
--- a/data/Botswana/Assembly/ep-popolo-v1.0.json
+++ b/data/Botswana/Assembly/ep-popolo-v1.0.json
@@ -2253,12 +2253,155 @@
     {
       "classification": "party",
       "id": "party/bcp",
-      "name": "BCP"
+      "identifiers": [
+        {
+          "identifier": "Q4894021",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "BCP",
+      "other_names": [
+        {
+          "lang": "ja",
+          "name": "ボツワナ会議党",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Botswana Congress Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ca",
+          "name": "Partit del Congrés de Botswana",
+          "note": "multilingual"
+        }
+      ]
     },
     {
       "classification": "party",
       "id": "party/bdp",
-      "name": "BDP"
+      "identifiers": [
+        {
+          "identifier": "Q859825",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "https://upload.wikimedia.org/wikipedia/commons/8/8a/Flag_of_the_Botswana_Democratic_Party.svg",
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.bdp.org.bw/"
+        }
+      ],
+      "name": "BDP",
+      "other_names": [
+        {
+          "lang": "zh-hans",
+          "name": "博茨瓦纳民主党",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh-hant",
+          "name": "博茨瓦納民主黨",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh-hk",
+          "name": "博茨瓦納民主黨",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh-tw",
+          "name": "波札那民主黨",
+          "note": "multilingual"
+        },
+        {
+          "lang": "de",
+          "name": "Botswana Democratic Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "tn",
+          "name": "Phathi ya Tomokoraga",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ja",
+          "name": "ボツワナ民主党",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ru",
+          "name": "Демократическая партия Ботсваны",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Partido Democrático de Botsuana",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Botswana Democratic Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hr",
+          "name": "Demokratska stranka Bocvane",
+          "note": "multilingual"
+        },
+        {
+          "lang": "uk",
+          "name": "Демократична партія Ботсвани",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Botswana Democratische Partij",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Botswana Democratic Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "he",
+          "name": "המפלגה הדמוקרטית הבוטסואנית",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh",
+          "name": "博茨瓦纳民主党",
+          "note": "multilingual"
+        },
+        {
+          "lang": "id",
+          "name": "Partai Demokratik Botswana",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ko",
+          "name": "보츠와나 민주당",
+          "note": "multilingual"
+        },
+        {
+          "lang": "pt",
+          "name": "Partido Democrático do Botswana",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nb",
+          "name": "Botswana Democratic Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Partido Democratico de Botsuana",
+          "note": "multilingual"
+        }
+      ]
     },
     {
       "classification": "legislature",
@@ -2275,7 +2418,30 @@
     {
       "classification": "party",
       "id": "party/udc",
-      "name": "UDC"
+      "identifiers": [
+        {
+          "identifier": "Q18347306",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "UDC",
+      "other_names": [
+        {
+          "lang": "en",
+          "name": "Umbrella for Democratic Change",
+          "note": "multilingual"
+        },
+        {
+          "lang": "id",
+          "name": "Payung untuk Perubahan Demokratik",
+          "note": "multilingual"
+        },
+        {
+          "lang": "de",
+          "name": "Umbrella for Democratic Change",
+          "note": "multilingual"
+        }
+      ]
     },
     {
       "classification": "party",

--- a/data/Botswana/Assembly/sources/instructions.json
+++ b/data/Botswana/Assembly/sources/instructions.json
@@ -59,6 +59,14 @@
         "type": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "create": {
+        "type": "group-wikidata",
+        "source": "manual/group_wikidata.csv"
+      }
     }
   ]
 }

--- a/data/Botswana/Assembly/sources/manual/group_wikidata.csv
+++ b/data/Botswana/Assembly/sources/manual/group_wikidata.csv
@@ -1,0 +1,4 @@
+id,wikidata
+bdp,Q859825
+udc,Q18347306
+bcp,Q4894021

--- a/data/Botswana/Assembly/sources/wikidata/groups.json
+++ b/data/Botswana/Assembly/sources/wikidata/groups.json
@@ -1,0 +1,174 @@
+{
+  "bdp": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q859825"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "zh-hans",
+        "name": "博茨瓦纳民主党",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh-hant",
+        "name": "博茨瓦納民主黨",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh-hk",
+        "name": "博茨瓦納民主黨",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh-tw",
+        "name": "波札那民主黨",
+        "note": "multilingual"
+      },
+      {
+        "lang": "de",
+        "name": "Botswana Democratic Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "tn",
+        "name": "Phathi ya Tomokoraga",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ja",
+        "name": "ボツワナ民主党",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ru",
+        "name": "Демократическая партия Ботсваны",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Partido Democrático de Botsuana",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Botswana Democratic Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "hr",
+        "name": "Demokratska stranka Bocvane",
+        "note": "multilingual"
+      },
+      {
+        "lang": "uk",
+        "name": "Демократична партія Ботсвани",
+        "note": "multilingual"
+      },
+      {
+        "lang": "nl",
+        "name": "Botswana Democratische Partij",
+        "note": "multilingual"
+      },
+      {
+        "lang": "fr",
+        "name": "Botswana Democratic Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "he",
+        "name": "המפלגה הדמוקרטית הבוטסואנית",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh",
+        "name": "博茨瓦纳民主党",
+        "note": "multilingual"
+      },
+      {
+        "lang": "id",
+        "name": "Partai Demokratik Botswana",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ko",
+        "name": "보츠와나 민주당",
+        "note": "multilingual"
+      },
+      {
+        "lang": "pt",
+        "name": "Partido Democrático do Botswana",
+        "note": "multilingual"
+      },
+      {
+        "lang": "nb",
+        "name": "Botswana Democratic Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Partido Democratico de Botsuana",
+        "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.bdp.org.bw/",
+        "note": "website"
+      }
+    ],
+    "image": "https://upload.wikimedia.org/wikipedia/commons/8/8a/Flag_of_the_Botswana_Democratic_Party.svg"
+  },
+  "udc": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q18347306"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "en",
+        "name": "Umbrella for Democratic Change",
+        "note": "multilingual"
+      },
+      {
+        "lang": "id",
+        "name": "Payung untuk Perubahan Demokratik",
+        "note": "multilingual"
+      },
+      {
+        "lang": "de",
+        "name": "Umbrella for Democratic Change",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "bcp": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q4894021"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "ja",
+        "name": "ボツワナ会議党",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Botswana Congress Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ca",
+        "name": "Partit del Congrés de Botswana",
+        "note": "multilingual"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add Wikidata information about each of the political groups.