### PR TITLE
Rename creation 'type' to 'from'

### DIFF
--- a/data/Abkhazia/Assembly/sources/instructions.json
+++ b/data/Abkhazia/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/abkhazia-peoples-assmebly",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/abkhazia-peoples-assmebly-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Abkhazia/Assembly"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Afghanistan/Wolesi_Jirga/sources/instructions.json
+++ b/data/Afghanistan/Wolesi_Jirga/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/afghanistan-assembly",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/afghanistan-assembly-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Afghanistan/Wolesi-Jirga"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Aland/Lagting/sources/instructions.json
+++ b/data/Aland/Lagting/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/a-lands-lagting",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/aland-lagting-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -29,7 +29,7 @@
       "file": "morph/terms.csv",
       "type": "term",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/a-lands-lagting",
         "query": "SELECT * FROM terms"
       }
@@ -38,7 +38,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -46,7 +46,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Aland/Lagting"
       }
     },
@@ -54,7 +54,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Albania/Assembly/sources/instructions.json
+++ b/data/Albania/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/albania-kuvendi-wikipedia",
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id, NULL AS source FROM data WHERE term = '8' ORDER BY name"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikipedia-7.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/albania-kuvendi-wikipedia",
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id, NULL AS source FROM data WHERE term = '7' ORDER BY name"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/official-8.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/albania-kuvendi",
         "query": "SELECT id,name,email,image,birth_date,birth_place,source,id AS identifier__kuvendi FROM data ORDER BY id"
       },
@@ -43,7 +43,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/albania-assembly-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -63,7 +63,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Albania/Assembly"
       }
     },
@@ -71,7 +71,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Alderney/States/sources/instructions.json
+++ b/data/Alderney/States/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/Alderney",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Alderney/States"
       }
     }

--- a/data/Algeria/Majlis/sources/instructions.json
+++ b/data/Algeria/Majlis/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/algeria-assemblee",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Algeria/Majlis"
       }
     },
@@ -26,7 +26,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/American_Samoa/House/sources/instructions.json
+++ b/data/American_Samoa/House/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/american-samoa-elections",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/american-samoa-representatives",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "American-Samoa/House"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Andorra/General_Council/sources/instructions.json
+++ b/data/Andorra/General_Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/andorra-consell-general",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/andorra-consell-general-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Andorra/General-Council"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Angola/National_Assembly/sources/instructions.json
+++ b/data/Angola/National_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/angola-national-assembly",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -26,7 +26,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Angola/National-Assembly"
       }
     }

--- a/data/Anguilla/Assembly/sources/instructions.json
+++ b/data/Anguilla/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "lizconlan/anguilla-election-centre",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "lizconlan/anguilla-election-centre",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -32,7 +32,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Anguilla/Assembly"
       }
     }

--- a/data/Antigua_and_Barbuda/Representatives/sources/instructions.json
+++ b/data/Antigua_and_Barbuda/Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/antigua-barbuda-election-centre",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/antigua-barbuda-representatives-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/antigua-barbuda-election-centre",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Antigua-and-Barbuda/Representatives"
       }
     },
@@ -47,7 +47,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Argentina/Diputados/sources/instructions.json
+++ b/data/Argentina/Diputados/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/argentina-diputados",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/argentina-diputados-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Argentina/Diputados"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Armenia/Assembly/sources/instructions.json
+++ b/data/Armenia/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/armenia-assembly",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/armenia-assembly-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -41,7 +41,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Armenia/Assembly"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Aruba/Estates/sources/instructions.json
+++ b/data/Aruba/Estates/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/aruba-parlamento",
         "query": "SELECT *, other_name AS name, name AS other_name FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/aruba-parlamento",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Aruba/Estates"
       }
     },
@@ -32,7 +32,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Australia/Representatives/sources/instructions.json
+++ b/data/Australia/Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/openaustralia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/australia-openaustralia",
         "query": "SELECT *, id AS identifier__openaustralia FROM data ORDER BY id"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "openaustralia/aus_mp_contact_details",
         "query": "SELECT aph_id, photo_url AS photo, email, facebook, website FROM data WHERE house = 'representatives' ORDER BY aph_id"
       },
@@ -27,7 +27,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/australia-house-of-representatives-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -58,7 +58,7 @@
     {
       "file": "ocd/divisions.csv",
       "create": {
-        "type": "ocd",
+        "from": "ocd",
         "source": "country-au/federal_electorates.csv"
       },
       "merge": {
@@ -72,7 +72,7 @@
     {
       "file": "morph/terms.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/australia-openaustralia",
         "query": "SELECT * FROM terms"
       },
@@ -82,7 +82,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -90,7 +90,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Australia/Representatives"
       }
     },
@@ -98,7 +98,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Australia/Senate/sources/instructions.json
+++ b/data/Australia/Senate/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "openaustralia/aus_mp_contact_details",
         "query": "SELECT aph_id AS id, full_name AS name, electorate AS constituency, photo_url AS photo, REPLACE(LOWER(party),' ','_') AS party_id, 44 AS term, *, null AS chamber FROM data WHERE house = 'senate'"
       },
@@ -18,7 +18,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -26,7 +26,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Australia/Senate"
       }
     }

--- a/data/Austria/Nationalrat/sources/instructions.json
+++ b/data/Austria/Nationalrat/sources/instructions.json
@@ -8,7 +8,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/austria-nationalrat-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -28,7 +28,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Austria/Nationalrat"
       }
     },
@@ -36,7 +36,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Azerbaijan/National_Assembly/sources/instructions.json
+++ b/data/Azerbaijan/National_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/members.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/azerbaijan-national-assembly-wikipedia",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/azerbaijan-national-assembly-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Azerbaijan/National-Assembly"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Bahamas/House_of_Assembly/sources/instructions.json
+++ b/data/Bahamas/House_of_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/bahamas-assembly-wikipedia",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/bahamas-assembly-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -32,7 +32,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Bahamas/House-of-Assembly"
       }
     },
@@ -40,7 +40,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -48,7 +48,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Bahrain/Council_of_Representatives/sources/instructions.json
+++ b/data/Bahrain/Council_of_Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/bahrain-council-of-representatives",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Bahrain/Council-of-Representatives"
       }
     }

--- a/data/Bangladesh/House/sources/instructions.json
+++ b/data/Bangladesh/House/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/bangladesh-parliament-scraper",
         "query": "SELECT * FROM data ORDER BY term DESC, id"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Bangladesh/House"
       }
     }

--- a/data/Barbados/House_of_Assembly/sources/instructions.json
+++ b/data/Barbados/House_of_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/barbados-parliament",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Barbados/House-of-Assembly"
       }
     },
@@ -26,7 +26,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Belarus/Chamber/sources/instructions.json
+++ b/data/Belarus/Chamber/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/belarus-house-of-representatives",
         "query": "SELECT *, 'unknown' as party_id FROM data"
       },
@@ -21,7 +21,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/belarus-house-of-representatives-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -41,7 +41,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Belarus/Chamber"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     },
@@ -57,7 +57,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Belgium/Representatives/sources/instructions.json
+++ b/data/Belgium/Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/belgium-represenatives-wikipedia",
         "query": "SELECT *, null as source FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/belgium-lachambre",
         "query": "SELECT * FROM data"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/belgium-represenatives-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -42,7 +42,7 @@
     {
       "file": "morph/terms.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/belgium-lachambre",
         "query": "SELECT * FROM terms"
       },
@@ -52,7 +52,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Belgium/Representatives"
       }
     },
@@ -60,7 +60,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Belize/Representatives/sources/instructions.json
+++ b/data/Belize/Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/belize-national-assembly",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/belize-national-assembly-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Belize/Representatives"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Benin/National_Assembly/sources/instructions.json
+++ b/data/Benin/National_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/benin-assemblee-nationale",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/benin-assemblee-nationale",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Benin/National-Assembly"
       }
     }

--- a/data/Bermuda/Assembly/sources/instructions.json
+++ b/data/Bermuda/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/bermuda_parliament",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/bermuda_parliament",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Bermuda/Assembly"
       }
     },
@@ -32,7 +32,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Bhutan/Assembly/sources/instructions.json
+++ b/data/Bhutan/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/bhutan-national-assembly",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Bhutan/Assembly"
       }
     },
@@ -26,7 +26,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Bolivia/Deputies/sources/instructions.json
+++ b/data/Bolivia/Deputies/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/bolivia-diputados",
         "query": "SELECT * FROM data WHERE type = 'Titular'"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/bolivia-diputados-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Bolivia/Deputies"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Bosnia_and_Herzegovina/House_of_Representatives/sources/instructions.json
+++ b/data/Bosnia_and_Herzegovina/House_of_Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/BiH-assembly",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/BiH-assembly",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Bosnia-and-Herzegovina/House-of-Representatives"
       }
     }

--- a/data/Botswana/Assembly/sources/instructions.json
+++ b/data/Botswana/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/botswana-national-assembly-wp",
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/official.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/botswana-national-assembly",
         "query": "SELECT name, email, REPLACE(LOWER(name),' ','-') AS id FROM data"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/botswana-national-assembly-wikidata",
         "query": "SELECT *, id AS identifier__wikidata FROM data"
       },
@@ -48,7 +48,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Botswana/Assembly"
       }
     },
@@ -56,7 +56,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     },
@@ -64,7 +64,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Brazil/Deputies/sources/instructions.json
+++ b/data/Brazil/Deputies/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/brasil-deputados-scraper",
         "query": "SELECT * FROM data WHERE term = 55"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/brasil-deputados-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Brazil/Deputies"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/British_Virgin_Islands/Assembly/sources/instructions.json
+++ b/data/British_Virgin_Islands/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/members.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/british-virgin-islands-assembly-wikipedia",
         "query": "SELECT * FROM data WHERE term >= 2007"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/british-virgin-islands-assembly-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -41,7 +41,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "British-Virgin-Islands/Assembly"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/British_Virgin_Islands/Council/sources/instructions.json
+++ b/data/British_Virgin_Islands/Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/members.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/british-virgin-islands-assembly-wikipedia",
         "query": "SELECT * FROM data WHERE term < 2007"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/british-virgin-islands-assembly-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "British-Virgin-Islands/Council"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Brunei/Legislative_Council/sources/instructions.json
+++ b/data/Brunei/Legislative_Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "chrismytton/brunei-legislative-council",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "chrismytton/brunei-legislative-council",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Brunei/Legislative-Council"
       }
     }

--- a/data/Bulgaria/National_Assembly/sources/instructions.json
+++ b/data/Bulgaria/National_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/bulgaria-parliament",
         "query": "SELECT *, id AS identifier__parliament_bg FROM data ORDER BY id"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/bulgaria-parliament-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -41,7 +41,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Bulgaria/National-Assembly"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Burkina_Faso/Assembly/sources/instructions.json
+++ b/data/Burkina_Faso/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/burkina-faso-national-assembly",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/burkina-faso-national-assembly",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Burkina-Faso/Assembly"
       }
     }

--- a/data/Burundi/Assembly/sources/instructions.json
+++ b/data/Burundi/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/members-2010.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/burundi-assemblee",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/members-2015.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "duncanfwalker/burundi-national-assembly",
         "query": "SELECT * FROM data"
       },
@@ -28,7 +28,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Burundi/Assembly"
       }
     }

--- a/data/Cabo_Verde/Assembly/sources/instructions.json
+++ b/data/Cabo_Verde/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/cabo-verde-assembleia-nacionale",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/cabo-verde-assembleia-nacionale",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Cabo-Verde/Assembly"
       }
     },
@@ -32,7 +32,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Cambodia/National_Assembly/sources/instructions.json
+++ b/data/Cambodia/National_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/cambodia-national-assembly-wikipedia",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/cambodia-national-assembly-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Cambodia/National-Assembly"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Cameroon/Assembly/sources/instructions.json
+++ b/data/Cameroon/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/cameroon-assembly",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Cameroon/Assembly"
       }
     },
@@ -26,7 +26,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Cameroon/Senate/sources/instructions.json
+++ b/data/Cameroon/Senate/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/cameroon-senate",
         "query": "SELECT *, 9 AS term FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Cameroon/Senate"
       }
     }

--- a/data/Canada/Commons/sources/instructions.json
+++ b/data/Canada/Commons/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/canada-house-of-commons-wikipedia",
         "query": "SELECT *, LOWER(REPLACE(name, ' ', '-')) AS id FROM data ORDER BY name"
       },
@@ -23,7 +23,7 @@
     {
       "file": "morph/data-42.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/represent-ca",
         "query": "SELECT *, id AS identifier__represent FROM data ORDER BY id"
       },
@@ -44,7 +44,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/canada-house-of-commons-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -72,7 +72,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -80,7 +80,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Canada/Commons"
       }
     },
@@ -88,7 +88,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Cayman_Islands/Legislative_Assembly/sources/instructions.json
+++ b/data/Cayman_Islands/Legislative_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/cayman-islands-assembly",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Cayman-Islands/Legislative-Assembly"
       }
     },
@@ -26,7 +26,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Chad/Assembly/sources/instructions.json
+++ b/data/Chad/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/chad-national-assembly",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/chad-national-assembly",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Chad/Assembly"
       }
     }

--- a/data/Chile/Deputies/sources/instructions.json
+++ b/data/Chile/Deputies/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/chile-opendata",
         "query": "SELECT *, CASE district WHEN '0' THEN '' ELSE district END AS area FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/chile-congress-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -41,7 +41,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Chile/Deputies"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/China/Congress/sources/instructions.json
+++ b/data/China/Congress/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/china-national-peoples-congress",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "China/Congress"
       }
     }

--- a/data/Colombia/Representatives/sources/instructions.json
+++ b/data/Colombia/Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/colombia-representantes",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/colombia-representantes-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Colombia/Representatives"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Comoros/Assembly/sources/instructions.json
+++ b/data/Comoros/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/comoros-legislative-election-2015",
         "query": "SELECT *, 2015 as TERM FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Comoros/Assembly"
       }
     }

--- a/data/Congo-Brazzaville/Assembly/sources/instructions.json
+++ b/data/Congo-Brazzaville/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/congo-assemblee",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Congo-Brazzaville/Assembly"
       }
     }

--- a/data/Congo-Kinshasa/Assembly/sources/instructions.json
+++ b/data/Congo-Kinshasa/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/drc-assemblee-members",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Congo-Kinshasa/Assembly"
       }
     }

--- a/data/Cook_Islands/Parliament/sources/instructions.json
+++ b/data/Cook_Islands/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/2014.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/cook-islands-elections-wikipedia",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/cook-islands-representatives-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Cook-Islands/Parliament"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Costa_Rica/Assembly/sources/instructions.json
+++ b/data/Costa_Rica/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/costa-rica-asamblea",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/emails.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/costa-rica-asamblea-emails",
         "query": "SELECT * FROM data"
       },
@@ -26,7 +26,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/costa-rica-election-2014",
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data"
       },
@@ -40,7 +40,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/costa-rica-asamblea-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -59,7 +59,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Costa-Rica/Assembly"
       }
     },
@@ -67,7 +67,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -75,7 +75,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Croatia/Sabor/sources/instructions.json
+++ b/data/Croatia/Sabor/sources/instructions.json
@@ -8,7 +8,7 @@
     {
       "file": "morph/sabor-8.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/croatia-parliament",
         "query": "SELECT id, name, sortname, image, party, birth_date, constituency, term, start_date, source FROM data"
       },
@@ -23,7 +23,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/croatian-parliament-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -43,7 +43,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Croatia/Sabor"
       }
     },
@@ -51,7 +51,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Curacao/Estates/sources/instructions.json
+++ b/data/Curacao/Estates/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/curacao-parliament",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/curacao-parliament",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -32,7 +32,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Curacao/Estates"
       }
     }

--- a/data/Cyprus/House_of_Representatives/sources/instructions.json
+++ b/data/Cyprus/House_of_Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/cyprus-openpatata",
         "query": "SELECT *, NULL as wikipedia FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/cyprus-parliament-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -29,7 +29,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -37,7 +37,7 @@
       "file": "morph/terms.csv",
       "type": "term",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/cyprus-openpatata",
         "query": "SELECT * FROM terms"
       }
@@ -46,7 +46,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Cyprus/House-of-Representatives"
       }
     },
@@ -54,7 +54,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Czech_Republic/Deputies/sources/instructions.json
+++ b/data/Czech_Republic/Deputies/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/czech-chamber-of-deputies",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/czech-chamber-of-deputies-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/czech-chamber-of-deputies",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Czech-Republic/Deputies"
       }
     },
@@ -47,7 +47,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     },
@@ -55,7 +55,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Denmark/Folketing/sources/instructions.json
+++ b/data/Denmark/Folketing/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/denmark-folketing",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikipedia-historic.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/denmark-folketing-wp",
         "query": "SELECT * FROM data"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/denmark-folketing-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -48,7 +48,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Denmark/Folketing"
       }
     },
@@ -56,7 +56,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Djibouti/Assembly/sources/instructions.json
+++ b/data/Djibouti/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/djibouti-election-2013",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/djibouti-election-2013",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Djibouti/Assembly"
       }
     },
@@ -32,7 +32,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Dominica/House_of_Assembly/sources/instructions.json
+++ b/data/Dominica/House_of_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/dominica-election-2014",
         "query": "SELECT * FROM data WHERE winner = 'yes'"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Dominica/House-of-Assembly"
       }
     },
@@ -26,7 +26,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Dominican_Republic/Diputados/sources/instructions.json
+++ b/data/Dominican_Republic/Diputados/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/dominican-republic-deputies",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/dominican-republic-deputies-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/dominican-republic-deputies",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Dominican-Republic/Diputados"
       }
     },
@@ -47,7 +47,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Ecuador/Asamblea/sources/instructions.json
+++ b/data/Ecuador/Asamblea/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "struan/ecuador_national_assembly_members",
         "query": "SELECT *, 2013 AS term FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/ecuador_national_assembly_wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Ecuador/Asamblea"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Egypt/Parliament/sources/instructions.json
+++ b/data/Egypt/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "struan/egypt_parliament_members",
         "query": "SELECT *, cons AS area, 2015 AS term, NULL as source FROM data ORDER BY id"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Egypt/Parliament"
       }
     }

--- a/data/El_Salvador/Legislative_Assembly/sources/instructions.json
+++ b/data/El_Salvador/Legislative_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "jennahowe/El_Salvador_Legislative_Assembly",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "El-Salvador/Legislative-Assembly"
       }
     },
@@ -26,7 +26,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Estonia/Riigikogu/sources/instructions.json
+++ b/data/Estonia/Riigikogu/sources/instructions.json
@@ -24,7 +24,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/estonia-riigikogu",
         "query": "SELECT id,name,image,phone,email,source,id AS identifier__riigikogu FROM data ORDER BY id"
       },
@@ -38,7 +38,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/estonia-riigikogu-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -53,7 +53,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -61,7 +61,7 @@
       "file": "wikidata/areas.json",
       "type": "area-wikidata",
       "create": {
-        "type": "area-wikidata",
+        "from": "area-wikidata",
         "source": "manual/area_wikidata.csv"
       }
     },
@@ -69,7 +69,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Estonia/Riigikogu"
       }
     },
@@ -77,7 +77,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Falkland_Islands/Assembly/sources/instructions.json
+++ b/data/Falkland_Islands/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "dracos/falkland-islands",
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/official.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/falkland-islands-assembly",
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/falkland-islands-representatives-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -42,7 +42,7 @@
     {
       "file": "morph/terms.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "dracos/falkland-islands",
         "query": "SELECT *, ID as start_date, ID + 4 AS end_date FROM terms"
       },
@@ -52,7 +52,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Falkland-Islands/Assembly"
       }
     },
@@ -60,7 +60,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Faroe_Islands/Logting/sources/instructions.json
+++ b/data/Faroe_Islands/Logting/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/members.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/faroes-logting-wikipedia",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/faroes-logting-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/terms.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/faroes-logting-wikipedia",
         "query": "SELECT * FROM terms"
       },
@@ -38,7 +38,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Faroe-Islands/Logting"
       }
     },
@@ -46,7 +46,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Fiji/Parliament/sources/instructions.json
+++ b/data/Fiji/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/fiji-parliament",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/fiji-parliament-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Fiji/Parliament"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Finland/Eduskunta/sources/instructions.json
+++ b/data/Finland/Eduskunta/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/members.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/finland-eduskunta-kansanmuisti",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/members-2015.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/finland-eduskunta-2015-wikipedia",
         "query": "SELECT * FROM data ORDER BY name"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/finland-eduskunta-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -49,7 +49,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Finland/Eduskunta"
       }
     },
@@ -57,7 +57,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -65,7 +65,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/France/National_Assembly/sources/instructions.json
+++ b/data/France/National_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/nos_deputes_france",
         "query": "SELECT *, identifier_assemblee_nationale AS identifier__assemblee_nationale, 'http://www2.assemblee-nationale.fr/static/tribun/14/photos/' || identifier_assemblee_nationale || '.jpg' AS image FROM data ORDER BY id"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/france-chamber-of-deputies-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -30,7 +30,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "France/National-Assembly"
       }
     },
@@ -38,7 +38,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -46,7 +46,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/French_Polynesia/Assembly/sources/instructions.json
+++ b/data/French_Polynesia/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/french-polynesia-assembly",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/french-polynesia-assembly",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "French-Polynesia/Assembly"
       }
     },
@@ -32,7 +32,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Gabon/Assembly/sources/instructions.json
+++ b/data/Gabon/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/gabon-deputes",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/gabon-deputes-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/gabon-deputes",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Gabon/Assembly"
       }
     },
@@ -47,7 +47,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -55,7 +55,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Gambia/National_Assembly/sources/instructions.json
+++ b/data/Gambia/National_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/gambia-parliament",
         "query": "SELECT * FROM data"
       },
@@ -14,7 +14,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Gambia/National-Assembly"
       }
     },
@@ -22,7 +22,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Georgia/Parliament/sources/instructions.json
+++ b/data/Georgia/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/members.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/georgia-chemiparlamenti",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/georgia-parliament-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Georgia/Parliament"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Germany/Bundestag/sources/instructions.json
+++ b/data/Germany/Bundestag/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/germany-bundestag-members-wikipedia",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/germany-bundestag-members-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Germany/Bundestag"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Ghana/Parliament/sources/instructions.json
+++ b/data/Ghana/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/ghana-parliament",
         "query": "SELECT *, REPLACE(name, 'Hon. ', '') AS name FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/ghana-parliament-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/ghana-parliament",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -47,7 +47,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Ghana/Parliament"
       }
     },
@@ -55,7 +55,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Gibraltar/Parliament/sources/instructions.json
+++ b/data/Gibraltar/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "andylolz/gibraltar-parliament",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "andylolz/gibraltar-wikipedia",
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data"
       },
@@ -29,7 +29,7 @@
     {
       "file": "morph/terms.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "andylolz/gibraltar-parliament",
         "query": "SELECT * FROM terms"
       },
@@ -39,7 +39,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/gibraltar-parliament-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -55,7 +55,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Gibraltar/Parliament"
       }
     },
@@ -63,7 +63,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Greece/Parliament/sources/instructions.json
+++ b/data/Greece/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/hellenic-parliament",
         "query": "SELECT *, name_el AS name__el FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/official-bios.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/hellenic-parliament-bio",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -29,7 +29,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/hellenic-parliament",
         "query": "SELECT * FROM terms"
       }
@@ -38,7 +38,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Greece/Parliament"
       }
     }

--- a/data/Greenland/Inatsisartut/sources/instructions.json
+++ b/data/Greenland/Inatsisartut/sources/instructions.json
@@ -9,7 +9,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/greenland-inatsisartut-members-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -29,7 +29,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Greenland/Inatsisartut"
       }
     },
@@ -37,7 +37,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Grenada/House_of_Representatives/sources/instructions.json
+++ b/data/Grenada/House_of_Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/grenada-parliament",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Grenada/House-of-Representatives"
       }
     }

--- a/data/Guam/Parliament/sources/instructions.json
+++ b/data/Guam/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/guam-parliament",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/guam-legislature-members",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -41,7 +41,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Guam/Parliament"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Guatemala/Congress/sources/instructions.json
+++ b/data/Guatemala/Congress/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/guatemala-congreso",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -26,7 +26,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Guatemala/Congress"
       }
     }

--- a/data/Guernsey/States/sources/instructions.json
+++ b/data/Guernsey/States/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/guernsey-states",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Guernsey/States"
       }
     }

--- a/data/Guinea-Bissau/Assembly/sources/instructions.json
+++ b/data/Guinea-Bissau/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "chrismytton/guinea-bissau-national-peoples-assembly",
         "query": "SELECT *, 2014 AS term FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Guinea-Bissau/Assembly"
       }
     }

--- a/data/Guyana/National_Assembly/sources/instructions.json
+++ b/data/Guyana/National_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/guyana-parliament",
         "query": "SELECT * FROM data"
       },
@@ -23,7 +23,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Guyana/National-Assembly"
       }
     },
@@ -31,7 +31,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Haiti/Deputies/sources/instructions.json
+++ b/data/Haiti/Deputies/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/haiti-deputies-2011",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Haiti/Deputies"
       }
     }

--- a/data/Honduras/Congreso_Nacional/sources/instructions.json
+++ b/data/Honduras/Congreso_Nacional/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/honduras-national-congress-wikipedia",
         "query": "SELECT *, 8 AS term FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/honduras-national-congress-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -29,7 +29,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Honduras/Congreso-Nacional"
       }
     },
@@ -37,7 +37,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Hong_Kong/Legislative_Council/sources/instructions.json
+++ b/data/Hong_Kong/Legislative_Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "struan/hong_kong_legislative_council_members",
         "query": "SELECT *, REPLACE(id,'yr12-16/','') AS id FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/hong-kong-legislative-council-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "struan/hong_kong_legislative_council_members",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Hong-Kong/Legislative-Council"
       }
     },
@@ -47,7 +47,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Hungary/Assembly/sources/instructions.json
+++ b/data/Hungary/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/hungary-parliament",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/hungary-parliament-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Hungary/Assembly"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Iceland/Assembly/sources/instructions.json
+++ b/data/Iceland/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/iceland-althing-wp",
         "query": "SELECT REPLACE(LOWER(name),' ','_') AS id, REPLACE(LOWER(party),' ','_') AS party_id, * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/iceland-althingismenn-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Iceland/Assembly"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/India/Lok_Sabha/sources/instructions.json
+++ b/data/India/Lok_Sabha/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/india-lok-sabha",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/india-lok-sabha-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/india-lok-sabha",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "India/Lok-Sabha"
       }
     },
@@ -47,7 +47,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Indonesia/Council/sources/instructions.json
+++ b/data/Indonesia/Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "struan/indonesia",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/indonesian-mps",
         "query": "SELECT * FROM data"
       },
@@ -29,7 +29,7 @@
       "file": "morph/terms.csv",
       "type": "term",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "struan/indonesia",
         "query": "SELECT * FROM terms"
       }
@@ -38,7 +38,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Indonesia/Council"
       }
     },
@@ -46,7 +46,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Iran/Assembly/sources/instructions.json
+++ b/data/Iran/Assembly/sources/instructions.json
@@ -8,7 +8,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/iran-assembly-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -28,7 +28,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Iran/Assembly"
       }
     },
@@ -36,7 +36,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Iraq/Majlis/sources/instructions.json
+++ b/data/Iraq/Majlis/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/iraq-majilis",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Iraq/Majlis"
       }
     }

--- a/data/Ireland/Dail/sources/instructions.json
+++ b/data/Ireland/Dail/sources/instructions.json
@@ -8,7 +8,7 @@
     {
       "file": "morph/kildare32.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/ireland-kildarestreet",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -23,7 +23,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/ireland-dail-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -43,7 +43,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -51,7 +51,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Ireland/Dail"
       }
     },
@@ -59,7 +59,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Isle_of_Man/House_of_Keys/sources/instructions.json
+++ b/data/Isle_of_Man/House_of_Keys/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/members.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/isle-of-man-house-of-keys-wikipedia",
         "query": "SELECT *, null AS source FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/images.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/isle-of-man-house-of-keys",
         "query": "SELECT * FROM data"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/isle-of-man-house-of-keys-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -44,7 +44,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Isle-of-Man/House-of-Keys"
       }
     },
@@ -52,7 +52,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     },
@@ -60,7 +60,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Israel/Knesset/sources/instructions.json
+++ b/data/Israel/Knesset/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/israel-knesset-members",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/israel-knesset-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/israel-knesset-members",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Israel/Knesset"
       }
     },
@@ -47,7 +47,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Italy/House/sources/instructions.json
+++ b/data/Italy/House/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/camera.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "andylolz/italy-camera",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/openpolis-scraper",
         "query": "SELECT * FROM data WHERE house = 'Chamber of Deputies' ORDER BY id"
       },
@@ -29,7 +29,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/italy-legislature-XVII-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -49,7 +49,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Italy/House"
       }
     },
@@ -57,7 +57,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Italy/Senate/sources/instructions.json
+++ b/data/Italy/Senate/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/openpolis-scraper",
         "query": "SELECT * FROM data WHERE house = 'Senate'"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Italy/Senate"
       }
     }

--- a/data/Ivory_Coast/Assembly/sources/instructions.json
+++ b/data/Ivory_Coast/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/ivory-coast-election-results-2011",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/ivory-coast-election-results-2011",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Ivory-Coast/Assembly"
       }
     }

--- a/data/Jamaica/House_of_Representatives/sources/instructions.json
+++ b/data/Jamaica/House_of_Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/jamaica-representatives-wikipedia",
         "query": "SELECT *, NULL as source FROM data ORDER BY name, term"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/jamaica-representatives-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -29,7 +29,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -37,7 +37,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Jamaica/House-of-Representatives"
       }
     },
@@ -45,7 +45,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Japan/House_of_Representatives/sources/instructions.json
+++ b/data/Japan/House_of_Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "struan/japan",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/japan-house-of-representatives-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -29,7 +29,7 @@
       "file": "morph/terms.csv",
       "type": "term",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "struan/japan",
         "query": "SELECT * FROM terms"
       }
@@ -38,7 +38,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Japan/House-of-Representatives"
       }
     },
@@ -46,7 +46,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Jersey/States/sources/instructions.json
+++ b/data/Jersey/States/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/jersey-assembly",
         "query": "SELECT *, parish AS area, 6 as term FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/jersey-assembly",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Jersey/States"
       }
     }

--- a/data/Jordan/House_of_Representatives/sources/instructions.json
+++ b/data/Jordan/House_of_Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/jordan-house-of-representatives-wikipedia",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/jordan-house-of-representatives-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -29,7 +29,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Jordan/House-of-Representatives"
       }
     },
@@ -37,7 +37,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Kazakhstan/Assembly/sources/instructions.json
+++ b/data/Kazakhstan/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/kazakh-mazhilis",
         "query": "SELECT *, 5 AS term FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Kazakhstan/Assembly"
       }
     }

--- a/data/Kenya/Assembly/sources/instructions.json
+++ b/data/Kenya/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/kenya-mzalendo",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/official.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/kenya-national-assembly",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/kenya-house-of-representatives-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -45,7 +45,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/kenya-mzalendo",
         "query": "SELECT * FROM terms"
       }
@@ -54,7 +54,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Kenya/Assembly"
       }
     },
@@ -62,7 +62,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -70,7 +70,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Kiribati/Parliament/sources/instructions.json
+++ b/data/Kiribati/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/kiribati-parliament",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikipedia-9.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/kiribati-parliament-wikipedia",
         "query": "SELECT *, 9 AS term FROM data ORDER BY name"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/kiribati-parliament-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -44,7 +44,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Kiribati/Parliament"
       }
     },
@@ -52,7 +52,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Kosovo/Assembly/sources/instructions.json
+++ b/data/Kosovo/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/kosovo-parldata",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/kosovo-parldata",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Kosovo/Assembly"
       }
     }

--- a/data/Kuwait/National_Assembly/sources/instructions.json
+++ b/data/Kuwait/National_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/kuwait-national-assembly",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/kuwait-national-assembly-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -29,7 +29,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Kuwait/National-Assembly"
       }
     },
@@ -37,7 +37,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Kyrgyzstan/Council/sources/instructions.json
+++ b/data/Kyrgyzstan/Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/official5.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/kyrgyzstan-deputies",
         "query": "SELECT id, name, name_ru AS name__ru, party, party_ru AS party__ru, image, term, source FROM data WHERE term = '5'"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/official6.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/kyrgyzstan-deputies",
         "query": "SELECT id, name, name_ru AS name__ru, party, party_ru AS party__ru, image, term, source FROM data WHERE term = '6'"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/kyrgyzstan-supreme-council-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -48,7 +48,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Kyrgyzstan/Council"
       }
     },
@@ -56,7 +56,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -64,7 +64,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Laos/Assembly/sources/instructions.json
+++ b/data/Laos/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/laos-national-assembly",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Laos/Assembly"
       }
     }

--- a/data/Latvia/Saeima/sources/instructions.json
+++ b/data/Latvia/Saeima/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/lativa-saeima",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/latvia-saeima-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -41,7 +41,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Latvia/Saeima"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Lebanon/Parliament/sources/instructions.json
+++ b/data/Lebanon/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/lebanese-parliament-2009",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/lebanese-parliament-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -29,7 +29,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Lebanon/Parliament"
       }
     },
@@ -37,7 +37,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Lesotho/Assembly/sources/instructions.json
+++ b/data/Lesotho/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/lesotho-assembly",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/lesotho-assembly",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Lesotho/Assembly"
       }
     }

--- a/data/Liberia/House/sources/instructions.json
+++ b/data/Liberia/House/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/liberia-representatives",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/liberia-representatives",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -32,7 +32,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Liberia/House"
       }
     }

--- a/data/Libya/House_of_Representatives/sources/instructions.json
+++ b/data/Libya/House_of_Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/libya-house-of-representatives",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/libya-house-of-representatives",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Libya/House-of-Representatives"
       }
     }

--- a/data/Liechtenstein/Landtag/sources/instructions.json
+++ b/data/Liechtenstein/Landtag/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/liechtenstein-landtag",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/liechtenstein-landtag-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/liechtenstein-landtag",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Liechtenstein/Landtag"
       }
     },
@@ -47,7 +47,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     },
@@ -55,7 +55,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Lithuania/Seimas/sources/instructions.json
+++ b/data/Lithuania/Seimas/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "mhl/lithuania-politician-scraper",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/lithuania-manoseimas-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -41,7 +41,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Lithuania/Seimas"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Luxembourg/Chamber/sources/instructions.json
+++ b/data/Luxembourg/Chamber/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/luxembourg-chamber-of-deputies",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/luxembourg-chamber-of-deputies-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/terms.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/luxembourg-chamber-of-deputies",
         "query": "SELECT * FROM terms"
       },
@@ -38,7 +38,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Luxembourg/Chamber"
       }
     },
@@ -46,7 +46,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -54,7 +54,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Macao/Assembly/sources/instructions.json
+++ b/data/Macao/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/official.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/macau-legislative-assembly",
         "query": "SELECT *, name__en as name FROM data ORDER BY id"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/macau-legislative-assembly-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Macao/Assembly"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Macedonia/Sobranie/sources/instructions.json
+++ b/data/Macedonia/Sobranie/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/macedonia-sobranie",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/macedonia-sobranie-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -41,7 +41,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Macedonia/Sobranie"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Madagascar/Assembly/sources/instructions.json
+++ b/data/Madagascar/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "duncanparkes/madagascar",
         "query": "SELECT *, term_id AS term, null AS term_id FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/madagascar-national-assembly-members-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "duncanparkes/madagascar",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Madagascar/Assembly"
       }
     },
@@ -47,7 +47,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Malawi/Assembly/sources/instructions.json
+++ b/data/Malawi/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/malawi-parliament",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/malawi-parliament",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Malawi/Assembly"
       }
     },
@@ -32,7 +32,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Malaysia/Dewan_Rakyat/sources/instructions.json
+++ b/data/Malaysia/Dewan_Rakyat/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/malaysian_parliament-wp",
         "query": "SELECT *, null AS source FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/malaysian_parliament-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -29,7 +29,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Malaysia/Dewan-Rakyat"
       }
     },
@@ -37,7 +37,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Maldives/Majlis/sources/instructions.json
+++ b/data/Maldives/Majlis/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/maldives-psephos",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Maldives/Majlis"
       }
     }

--- a/data/Mali/Assembly/sources/instructions.json
+++ b/data/Mali/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/mali-psephos",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Mali/Assembly"
       }
     }

--- a/data/Malta/Assembly/sources/instructions.json
+++ b/data/Malta/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/malta-parliament",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/malta-parliament-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Malta/Assembly"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Marshall_Islands/Nitijela/sources/instructions.json
+++ b/data/Marshall_Islands/Nitijela/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/marshall-islands-nitijela",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -26,7 +26,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Marshall-Islands/Nitijela"
       }
     }

--- a/data/Mauritania/National_Assembly/sources/instructions.json
+++ b/data/Mauritania/National_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/mauritania-assembly",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/mauritania-assembly",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Mauritania/National-Assembly"
       }
     }

--- a/data/Mauritius/National_Assembly/sources/instructions.json
+++ b/data/Mauritius/National_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/mauritius-election-2014",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Mauritius/National-Assembly"
       }
     },
@@ -26,7 +26,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Mexico/Deputies/sources/instructions.json
+++ b/data/Mexico/Deputies/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/official-LXII.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/mexico-diputados",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/official-LXIII.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/mexico-diputados-2015",
         "query": "SELECT *, '2015-' || id AS id FROM data"
       },
@@ -23,7 +23,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/mexico-deputies-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -43,7 +43,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Mexico/Deputies"
       }
     },
@@ -51,7 +51,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -59,7 +59,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Micronesia/Congress/sources/instructions.json
+++ b/data/Micronesia/Congress/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/micronesia-congress",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Micronesia/Congress"
       }
     }

--- a/data/Moldova/Parlamentul/sources/instructions.json
+++ b/data/Moldova/Parlamentul/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/moldova_parlament",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -18,7 +18,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/moldova-parlament-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -35,7 +35,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/moldova_parlament",
         "query": "SELECT * FROM terms"
       }
@@ -44,7 +44,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Moldova/Parlamentul"
       }
     },
@@ -52,7 +52,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -60,7 +60,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Monaco/Council/sources/instructions.json
+++ b/data/Monaco/Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "duncanparkes/monaco",
         "query": "SELECT id, name, party, area, image, email, term_id AS term, details_url AS source FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "duncanparkes/monaco",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -32,7 +32,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Monaco/Council"
       }
     }

--- a/data/Mongolia/Assembly/sources/instructions.json
+++ b/data/Mongolia/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/mongolia-khurai-wp",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/official.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/mongolia-khurai-official",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/mongolia-khurai-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -48,7 +48,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Mongolia/Assembly"
       }
     },
@@ -56,7 +56,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -64,7 +64,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Montenegro/Assembly/sources/instructions.json
+++ b/data/Montenegro/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/montenegro-parldata",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/montenegro-politicians-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/montenegro-parldata",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Montenegro/Assembly"
       }
     },
@@ -47,7 +47,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -55,7 +55,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Montserrat/Assembly/sources/instructions.json
+++ b/data/Montserrat/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/montseratt-election-2014",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/montseratt-election-2014",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Montserrat/Assembly"
       }
     },
@@ -32,7 +32,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Morocco/House/sources/instructions.json
+++ b/data/Morocco/House/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/morocco-house-of-representatives",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Morocco/House"
       }
     }

--- a/data/Mozambique/Assembly/sources/instructions.json
+++ b/data/Mozambique/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/mozambique-assembleia",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/mozambique-assembleia",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Mozambique/Assembly"
       }
     },
@@ -32,7 +32,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Myanmar/House_of_Representatives/sources/instructions.json
+++ b/data/Myanmar/House_of_Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/myanmar-house-of-representatives",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Myanmar/House-of-Representatives"
       }
     }

--- a/data/Nagorno_Karabakh/Assembly/sources/instructions.json
+++ b/data/Nagorno_Karabakh/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/nagorno-karabakh-national-assembly",
         "query": "SELECT id, name, faction, faction, * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Nagorno-Karabakh/Assembly"
       }
     }

--- a/data/Namibia/Assembly/sources/instructions.json
+++ b/data/Namibia/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "duncanparkes/namibia",
         "query": "SELECT data.id, data.name, data.image, data.party, data.party AS party_id, terms.term_number AS term, data.email, data.area, data.details_url AS source from data JOIN terms ON data.term_id = terms.id WHERE chamber = 'National Assembly' ORDER BY data.id, term DESC"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/namibia-national-assembly-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "duncanparkes/namibia",
         "query": "SELECT *, term_number AS id FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Namibia/Assembly"
       }
     },
@@ -47,7 +47,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -55,7 +55,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Namibia/Council/sources/instructions.json
+++ b/data/Namibia/Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "duncanparkes/namibia",
         "query": "SELECT data.id, data.name, data.image, data.party, data.party AS party_id, terms.term_number AS term, data.email, data.area, data.details_url AS source from data JOIN terms ON data.term_id = terms.id WHERE chamber = 'National Council'"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "duncanparkes/namibia",
         "query": "SELECT *, term_number AS id FROM terms WHERE id LIKE '%Council%'"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Namibia/Council"
       }
     }

--- a/data/Nauru/Parliament/sources/instructions.json
+++ b/data/Nauru/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/nauru-parliament",
         "query": "SELECT *, party as faction FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/nauru-parliament-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Nauru/Parliament"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Nepal/Assembly/sources/instructions.json
+++ b/data/Nepal/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/members.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/nepal-ca-members",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Nepal/Assembly"
       }
     }

--- a/data/Netherlands/House_of_Representatives/sources/instructions.json
+++ b/data/Netherlands/House_of_Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "struan/netherlands",
         "query": "SELECT *, '2012' AS term FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "chrismytton/netherlands-tweede-kamer-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Netherlands/House-of-Representatives"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/New_Caledonia/Congress/sources/instructions.json
+++ b/data/New_Caledonia/Congress/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/members.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/new-caledonia-assemblee",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/new-caledonia-mps-wp",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "New-Caledonia/Congress"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/New_Zealand/House/sources/instructions.json
+++ b/data/New_Zealand/House/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/new-zealand-parliament",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/new-zealand-parliament-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -41,7 +41,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "New-Zealand/House"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Nicaragua/Asamblea/sources/instructions.json
+++ b/data/Nicaragua/Asamblea/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/nicaragua-asamblea",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Nicaragua/Asamblea"
       }
     },
@@ -26,7 +26,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Niger/Assembly/sources/instructions.json
+++ b/data/Niger/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/niger-assemblee",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Niger/Assembly"
       }
     }

--- a/data/Nigeria/Assembly/sources/instructions.json
+++ b/data/Nigeria/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/nigeria-national-assembly",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -26,7 +26,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Nigeria/Assembly"
       }
     }

--- a/data/Niue/Assembly/sources/instructions.json
+++ b/data/Niue/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/gov.nu.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/niue-assembly",
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/niue-election-2014",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -29,7 +29,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Niue/Assembly"
       }
     },
@@ -37,7 +37,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Norfolk_Island/Assembly/sources/instructions.json
+++ b/data/Norfolk_Island/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/norfolk-island-assembly",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/terms.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/norfolk-island-assembly",
         "query": "SELECT * FROM terms"
       },
@@ -23,7 +23,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Norfolk-Island/Assembly"
       }
     }

--- a/data/North_Korea/National_Assembly/sources/instructions.json
+++ b/data/North_Korea/National_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/north-korea-assembly-wikipedia",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/north-korea-assembly-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -32,7 +32,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "North-Korea/National-Assembly"
       }
     },
@@ -40,7 +40,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Northern_Cyprus/Assembly/sources/instructions.json
+++ b/data/Northern_Cyprus/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/northern_cyprus_parliament_wikipedia",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/northern_cyprus_parliament_wikidata",
         "query": "SELECT * FROM data"
       },
@@ -32,7 +32,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -40,7 +40,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Northern-Cyprus/Assembly"
       }
     },
@@ -48,7 +48,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Northern_Ireland/Assembly/sources/instructions.json
+++ b/data/Northern_Ireland/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "parlparse/data.csv",
       "create": {
-        "type": "parlparse",
+        "from": "parlparse",
         "instructions": "parlparse/instructions.json"
       },
       "source": "http://theyworkforyou.com/",
@@ -12,7 +12,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/ni-assembly-wikidata",
         "query": "SELECT *, REPLACE(SUBSTR(REPLACE(identifier__parliamentDOTuk,'/','-------'), -6), '-', '') AS parlid FROM data"
       },
@@ -32,7 +32,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -40,7 +40,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Northern-Ireland/Assembly"
       }
     },
@@ -48,7 +48,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Northern_Mariana_Islands/House/sources/instructions.json
+++ b/data/Northern_Mariana_Islands/House/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/members.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/northern-marianas-legislature",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Northern-Mariana-Islands/House"
       }
     },
@@ -26,7 +26,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Norway/Storting/sources/instructions.json
+++ b/data/Norway/Storting/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/members.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/norway-stortinget",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/norway-stortingsrepresentanter-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/terms.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/norway-stortinget",
         "query": "SELECT * FROM terms"
       },
@@ -38,7 +38,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -46,7 +46,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Norway/Storting"
       }
     },
@@ -54,7 +54,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Oman/Majlis/sources/instructions.json
+++ b/data/Oman/Majlis/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/oman-majlis",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/oman-majlis",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Oman/Majlis"
       }
     }

--- a/data/Pakistan/Assembly/sources/instructions.json
+++ b/data/Pakistan/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/pakistan-national-assembly",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/pakistan-national-assembly-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/pakistan-national-assembly",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -47,7 +47,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Pakistan/Assembly"
       }
     },
@@ -55,7 +55,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Palau/House_of_Delegates/sources/instructions.json
+++ b/data/Palau/House_of_Delegates/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/palau-2012-election",
         "query": "SELECT * FROM data WHERE won = 'yes'"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Palau/House-of-Delegates"
       }
     }

--- a/data/Panama/Assembly/sources/instructions.json
+++ b/data/Panama/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/panama-asamblea",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Panama/Assembly"
       }
     },
@@ -26,7 +26,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Papua_New_Guinea/Parliament/sources/instructions.json
+++ b/data/Papua_New_Guinea/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "duncanparkes/papuanewguinea",
         "query": "SELECT *, province as area__province, region as area__region, area AS constituency, term_id AS term, null AS term_id FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "duncanparkes/papuanewguinea",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Papua-New-Guinea/Parliament"
       }
     }

--- a/data/Paraguay/Deputies/sources/instructions.json
+++ b/data/Paraguay/Deputies/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/paraguay-diputados",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/paraguay-diputados",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Paraguay/Deputies"
       }
     },
@@ -32,7 +32,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Peru/Congreso/sources/instructions.json
+++ b/data/Peru/Congreso/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/peru-congreso",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/peru-congreso-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Peru/Congreso"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Philippines/House/sources/instructions.json
+++ b/data/Philippines/House/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/philippines-house-of-representatives",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/philippines-house-of-representatives-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/philippines-house-of-representatives",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Philippines/House"
       }
     },
@@ -47,7 +47,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Pitcairn/Island_Council/sources/instructions.json
+++ b/data/Pitcairn/Island_Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/pitcairn-island-council",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Pitcairn/Island-Council"
       }
     }

--- a/data/Poland/Sejm/sources/instructions.json
+++ b/data/Poland/Sejm/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/members.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/poland-sejm-wikipedia",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/poland-sejm-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Poland/Sejm"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Portugal/Assembly/sources/instructions.json
+++ b/data/Portugal/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/centraldedados.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/portugal-centraldedados",
         "query": "SELECT * FROM data ORDER BY id, term"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/portugal-democratica-scraper",
         "query": "SELECT id, name, photo, email, twitter, identifier__parlamento FROM data GROUP BY id"
       },
@@ -27,7 +27,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/portugal-deputados-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -47,7 +47,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -55,7 +55,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Portugal/Assembly"
       }
     },
@@ -63,7 +63,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Puerto_Rico/House_of_Representatives/sources/instructions.json
+++ b/data/Puerto_Rico/House_of_Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/puerto-rico-representantes",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/puerto-rico-house-of-representatives-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -41,7 +41,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Puerto-Rico/House-of-Representatives"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Romania/Deputies/sources/instructions.json
+++ b/data/Romania/Deputies/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/romanian-parliament",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/romanian-parliament-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Romania/Deputies"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Russia/Duma/sources/instructions.json
+++ b/data/Russia/Duma/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/russia-duma",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/russian-duma-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -41,7 +41,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Russia/Duma"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Rwanda/Deputies/sources/instructions.json
+++ b/data/Rwanda/Deputies/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/rwanda-chamber-of-deputies",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Rwanda/Deputies"
       }
     }

--- a/data/Saint_Barthelemy/Council/sources/instructions.json
+++ b/data/Saint_Barthelemy/Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-barthelemy-council",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-barthelemy-council-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -32,7 +32,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Saint-Barthelemy/Council"
       }
     },
@@ -40,7 +40,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     },
@@ -48,7 +48,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Saint_Helena/Legislative_Council/sources/instructions.json
+++ b/data/Saint_Helena/Legislative_Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-helena-election-2013",
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/official.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-helena-legislative-council",
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data"
       },
@@ -29,7 +29,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Saint-Helena/Legislative-Council"
       }
     }

--- a/data/Saint_Kitts_and_Nevis/Assembly/sources/instructions.json
+++ b/data/Saint_Kitts_and_Nevis/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/electionpassport.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-kitts-and-nevis-electionpassort",
         "query": "SELECT *, election AS term FROM data WHERE election = '2015' ORDER BY id"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/electionpassport-2010.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-kitts-and-nevis-electionpassort",
         "query": "SELECT *, election AS term FROM data WHERE election = '2010' ORDER BY id"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/electionpassport-2004.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-kitts-and-nevis-electionpassort",
         "query": "SELECT *, election AS term FROM data WHERE election = '2004' ORDER BY id"
       },
@@ -43,7 +43,7 @@
     {
       "file": "morph/electionpassport-2000.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-kitts-and-nevis-electionpassort",
         "query": "SELECT *, election AS term FROM data WHERE election = '2000' ORDER BY id"
       },
@@ -58,7 +58,7 @@
     {
       "file": "morph/electionpassport-1995.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-kitts-and-nevis-electionpassort",
         "query": "SELECT *, election AS term FROM data WHERE election = '1995' ORDER BY id"
       },
@@ -73,7 +73,7 @@
     {
       "file": "morph/electionpassport-1993.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-kitts-and-nevis-electionpassort",
         "query": "SELECT *, election AS term FROM data WHERE election = '1993' ORDER BY id"
       },
@@ -88,7 +88,7 @@
     {
       "file": "morph/electionpassport-1989.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-kitts-and-nevis-electionpassort",
         "query": "SELECT *, election AS term FROM data WHERE election = '1989' ORDER BY id"
       },
@@ -103,7 +103,7 @@
     {
       "file": "morph/electionpassport-1984.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-kitts-and-nevis-electionpassort",
         "query": "SELECT *, election AS term FROM data WHERE election = '1984' ORDER BY id"
       },
@@ -118,7 +118,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-kitts-and-nevis-elections-wikipedia",
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data"
       },
@@ -133,7 +133,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-kitts-and-nevis-elections-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -149,7 +149,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Saint-Kitts-and-Nevis/Assembly"
       }
     },
@@ -157,7 +157,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -165,7 +165,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Saint_Lucia/Assembly/sources/instructions.json
+++ b/data/Saint_Lucia/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/members.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-lucia-assembly-wikipedia",
         "query": "SELECT *, REPLACE(LOWER(name),' ','-') AS id, null AS source FROM data ORDER BY id"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/images.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-lucia-assembly",
         "query": "SELECT *, REPLACE(LOWER(name),' ','-') AS id FROM data ORDER BY id"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-lucia-assembly-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -44,7 +44,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Saint-Lucia/Assembly"
       }
     },
@@ -52,7 +52,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     },
@@ -60,7 +60,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Saint_Martin/Council/sources/instructions.json
+++ b/data/Saint_Martin/Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-martin-territorial-council",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-martin-territorial-council-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -32,7 +32,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Saint-Martin/Council"
       }
     },
@@ -40,7 +40,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     },
@@ -48,7 +48,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Saint_Pierre_and_Miquelon/Territorial_Council/sources/instructions.json
+++ b/data/Saint_Pierre_and_Miquelon/Territorial_Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-pierre-and-miquelon-territorial-council",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saint-pierre-and-miquelon-territorial-council-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Saint-Pierre-and-Miquelon/Territorial-Council"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Saint_Vincent_and_the_Grenadines/Assembly/sources/instructions.json
+++ b/data/Saint_Vincent_and_the_Grenadines/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/st-vincent-and-grenadines-elections",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/terms.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/st-vincent-and-grenadines-elections",
         "query": "SELECT * FROM terms"
       },
@@ -23,7 +23,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Saint-Vincent-and-the-Grenadines/Assembly"
       }
     },
@@ -31,7 +31,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Samoa/Parliament/sources/instructions.json
+++ b/data/Samoa/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/samoa-parliament-wikipedia",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/samoa-parliament",
         "query": "SELECT * FROM data"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/samoa-parliament-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -44,7 +44,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Samoa/Parliament"
       }
     },
@@ -52,7 +52,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     },
@@ -60,7 +60,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/San_Marino/Council/sources/instructions.json
+++ b/data/San_Marino/Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/san_marino_council",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/san_marino_council-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/san_marino_council",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "San-Marino/Council"
       }
     },
@@ -47,7 +47,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Sark/Chief_Pleas/sources/instructions.json
+++ b/data/Sark/Chief_Pleas/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/sark-chief-pleas-wikipedia",
         "query": "SELECT *, 'None' AS party FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/sark-chief-pleas-wikipedia",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Sark/Chief-Pleas"
       }
     }

--- a/data/Saudi_Arabia/Shura/sources/instructions.json
+++ b/data/Saudi_Arabia/Shura/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/saudi-arabia-shura",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Saudi-Arabia/Shura"
       }
     }

--- a/data/Scotland/Parliament/sources/instructions.json
+++ b/data/Scotland/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "parlparse/data.csv",
       "create": {
-        "type": "parlparse",
+        "from": "parlparse",
         "instructions": "parlparse/instructions.json"
       },
       "source": "http://theyworkforyou.com/",
@@ -12,7 +12,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/scottish-parliament-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -32,7 +32,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -40,7 +40,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Scotland/Parliament"
       }
     },
@@ -48,7 +48,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Senegal/Assembly/sources/instructions.json
+++ b/data/Senegal/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/senegal-national-assembly",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/senegal-national-assembly-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -32,7 +32,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Senegal/Assembly"
       }
     },
@@ -40,7 +40,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Serbia/National_Assembly/sources/instructions.json
+++ b/data/Serbia/National_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "struan/serbia_national_assembly_members",
         "query": "SELECT id, name, party, faction, *, 10 AS term FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/serbia-national-assembly-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Serbia/National-Assembly"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Seychelles/Assembly/sources/instructions.json
+++ b/data/Seychelles/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/seychelles_national_assembly",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/seychelles_national_assembly",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Seychelles/Assembly"
       }
     },
@@ -32,7 +32,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Sierra_Leone/Parliament/sources/instructions.json
+++ b/data/Sierra_Leone/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/sierra-leone-parliament",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/sierra-leone-parliament",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Sierra-Leone/Parliament"
       }
     },
@@ -32,7 +32,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Singapore/Parliament/sources/instructions.json
+++ b/data/Singapore/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/singapore-parliament",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/singapore-parliament-2016-wikipedia",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/terms.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/singapore-parliament",
         "query": "SELECT * FROM terms"
       },
@@ -38,7 +38,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -46,7 +46,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Singapore/Parliament"
       }
     },
@@ -54,7 +54,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Sint_Maarten/Estates/sources/instructions.json
+++ b/data/Sint_Maarten/Estates/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/members.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/sint-maarten-parliament",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Sint-Maarten/Estates"
       }
     }

--- a/data/Slovakia/National_Council/sources/instructions.json
+++ b/data/Slovakia/National_Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/slovakia-national-council",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/slovakia-national-council-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/slovakia-national-council",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Slovakia/National-Council"
       }
     },
@@ -47,7 +47,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Slovenia/National_Assembly/sources/instructions.json
+++ b/data/Slovenia/National_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/slovenia-drzhavni-zbor",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "chrismytton/slovenia-national-assembly-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/slovenia-drzhavni-zbor",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Slovenia/National-Assembly"
       }
     },
@@ -47,7 +47,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -55,7 +55,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Solomon_Islands/Parliament/sources/instructions.json
+++ b/data/Solomon_Islands/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/election.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/solomon-islands-election-results",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/gov.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/solomon-islands-parliament",
         "query": "SELECT * FROM data"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/solomon-islands-parliament-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -43,7 +43,7 @@
     {
       "file": "morph/terms.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/solomon-islands-parliament",
         "query": "SELECT * FROM terms"
       },
@@ -53,7 +53,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Solomon-Islands/Parliament"
       }
     },
@@ -61,7 +61,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Somalia/Lower/sources/instructions.json
+++ b/data/Somalia/Lower/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/somalia-parliament",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Somalia/Lower"
       }
     }

--- a/data/Somaliland/Representatives/sources/instructions.json
+++ b/data/Somaliland/Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/somaliland-parliament",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Somaliland/Representatives"
       }
     }

--- a/data/South_Africa/Assembly/sources/instructions.json
+++ b/data/South_Africa/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/south-africa-national-assembly",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/south-african-national-assembly-members-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -29,7 +29,7 @@
       "file": "wikidata/parties.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/parties_wikidata.csv"
       }
     },
@@ -38,7 +38,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/south-africa-national-assembly",
         "query": "SELECT * FROM terms"
       }
@@ -47,7 +47,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "South-Africa/Assembly"
       }
     },
@@ -55,7 +55,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/South_Korea/National_Assembly/sources/instructions.json
+++ b/data/South_Korea/National_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/korea-popong-data",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/korean-assembly-members-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -41,7 +41,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "South-Korea/National-Assembly"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/South_Ossetia/Parliament/sources/instructions.json
+++ b/data/South_Ossetia/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/south-ossetia-parliament",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "South-Ossetia/Parliament"
       }
     },
@@ -26,7 +26,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/South_Sudan/Assembly/sources/instructions.json
+++ b/data/South_Sudan/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/south-sudan-legislative-assembly",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/south-sudan-legislative-assembly",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "South-Sudan/Assembly"
       }
     },
@@ -32,7 +32,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Spain/Congress/sources/instructions.json
+++ b/data/Spain/Congress/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/spain-proyectocolibri",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/official-2015.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "struan/spain_congreso_es",
         "query": "SELECT * FROM data WHERE term = 11"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/spain-diputados-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -48,7 +48,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -56,7 +56,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Spain/Congress"
       }
     },
@@ -64,7 +64,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Sri_Lanka/Parliament/sources/instructions.json
+++ b/data/Sri_Lanka/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "Abbie2020/sri_lanka_members_of_parliament",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/sri-lanka-parliament-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Sri-Lanka/Parliament"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Suriname/Assembly/sources/instructions.json
+++ b/data/Suriname/Assembly/sources/instructions.json
@@ -9,7 +9,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/suriname-nationale-assemblee",
         "query": "SELECT * FROM data"
       },
@@ -20,7 +20,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Suriname/Assembly"
       }
     }

--- a/data/Swaziland/Assembly/sources/instructions.json
+++ b/data/Swaziland/Assembly/sources/instructions.json
@@ -13,7 +13,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Swaziland/Assembly"
       }
     }

--- a/data/Sweden/Riksdag/sources/instructions.json
+++ b/data/Sweden/Riksdag/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/sweden-parliament-api",
         "query": "SELECT *, id AS identifier__riksdagen FROM data WHERE term IN ('1990', '1994', '1998', '2002', '2006', '2010', '2014')"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/sweden-riksdag-members-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -29,7 +29,7 @@
       "file": "morph/terms.csv",
       "type": "term",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/sweden-parliament-api",
         "query": "SELECT * FROM terms"
       }
@@ -38,7 +38,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -46,7 +46,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Sweden/Riksdag"
       }
     },
@@ -54,7 +54,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Switzerland/National_Council/sources/instructions.json
+++ b/data/Switzerland/National_Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/switzerland-parlament",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/switzerland-national-assembly-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/terms.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/switzerland-parlament",
         "query": "SELECT * FROM terms"
       },
@@ -38,7 +38,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Switzerland/National-Council"
       }
     },
@@ -46,7 +46,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Syria/Majlis/sources/instructions.json
+++ b/data/Syria/Majlis/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/syria-peoples-council",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Syria/Majlis"
       }
     }

--- a/data/Taiwan/Legislative_Yuan/sources/instructions.json
+++ b/data/Taiwan/Legislative_Yuan/sources/instructions.json
@@ -8,7 +8,7 @@
     {
       "file": "morph/official9.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/taiwan-legislative-yuan",
         "query": "SELECT * FROM data"
       },
@@ -23,7 +23,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/taiwan-legislative-yuan-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -43,7 +43,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -51,7 +51,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Taiwan/Legislative-Yuan"
       }
     },
@@ -59,7 +59,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Tajikistan/Representatives/sources/instructions.json
+++ b/data/Tajikistan/Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/tajikistan-parlament",
         "query": "SELECT *, 'Unknown' AS party, 2015 AS term FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Tajikistan/Representatives"
       }
     }

--- a/data/Tanzania/Assembly/sources/instructions.json
+++ b/data/Tanzania/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/tanzania-parliament",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/tanzania-parliament-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Tanzania/Assembly"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Thailand/National_Legislative_Assembly/sources/instructions.json
+++ b/data/Thailand/National_Legislative_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "davewhiteland/thailand-national-assembly",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/thailand-national-assembly-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -29,7 +29,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Thailand/National-Legislative-Assembly"
       }
     },
@@ -37,7 +37,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Timor_Leste/Parlamento/sources/instructions.json
+++ b/data/Timor_Leste/Parlamento/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/timor-leste-parlamento",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Timor-Leste/Parlamento"
       }
     }

--- a/data/Togo/Assembly/sources/instructions.json
+++ b/data/Togo/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/togo-national-assembly",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/togo-national-assembly-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -30,7 +30,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/togo-national-assembly",
         "query": "SELECT * FROM terms"
       }
@@ -39,7 +39,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Togo/Assembly"
       }
     },
@@ -47,7 +47,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Tonga/Assembly/sources/instructions.json
+++ b/data/Tonga/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "duncanparkes/tonga",
         "query": "SELECT id, name, constituency, 'unknown' AS party, term_id AS term, image, email, phone, cell, details_url AS source FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "duncanparkes/tonga",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Tonga/Assembly"
       }
     }

--- a/data/Transnistria/Supreme_Council/sources/instructions.json
+++ b/data/Transnistria/Supreme_Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/transnistrian-supreme-council",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Transnistria/Supreme-Council"
       }
     }

--- a/data/Trinidad_and_Tobago/Representatives/sources/instructions.json
+++ b/data/Trinidad_and_Tobago/Representatives/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "jennahowe/trinidad_and_tobago",
         "query": "SELECT *, 11 AS term FROM house_of_representatives"
       },
@@ -18,7 +18,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -26,7 +26,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Trinidad-and-Tobago/Representatives"
       }
     }

--- a/data/Trinidad_and_Tobago/Senate/sources/instructions.json
+++ b/data/Trinidad_and_Tobago/Senate/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "jennahowe/trinidad_and_tobago",
         "query": "SELECT *, 11 AS term FROM senate"
       },
@@ -18,7 +18,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -26,7 +26,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Trinidad-and-Tobago/Senate"
       }
     }

--- a/data/Tunisia/Majlis/sources/instructions.json
+++ b/data/Tunisia/Majlis/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/tunisia-marsad",
         "query": "SELECT *, '1' as term FROM data WHERE term = '2014'"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/tunisia-marsad-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Tunisia/Majlis"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Turkey/Assembly/sources/instructions.json
+++ b/data/Turkey/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/turkey-tbmm-wikipedia",
         "query": "SELECT *, NULL AS source FROM data ORDER by term, name, party, area"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/turkey-tbmm-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Turkey/Assembly"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Turkmenistan/Mejlis/sources/instructions.json
+++ b/data/Turkmenistan/Mejlis/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/turkmenistan-majilis",
         "query": "SELECT * FROM data"
       },
@@ -15,7 +15,7 @@
       "type": "term",
       "create": {
         "file": "morph/terms.csv",
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/turkmenistan-majilis",
         "query": "SELECT * FROM terms"
       }
@@ -24,7 +24,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Turkmenistan/Mejlis"
       }
     }

--- a/data/Turks_and_Caicos_Islands/Assembly/sources/instructions.json
+++ b/data/Turks_and_Caicos_Islands/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/turks-and-caicos-assembly",
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/turks-and-caicos-assembly-wikipedia",
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/turks-and-caicos-assembly-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -44,7 +44,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Turks-and-Caicos-Islands/Assembly"
       }
     },
@@ -52,7 +52,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     },
@@ -60,7 +60,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Tuvalu/Parliament/sources/instructions.json
+++ b/data/Tuvalu/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/tuvalu-parliament-wikipedia",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/tuvalu-parliament-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -27,7 +27,7 @@
     {
       "file": "morph/terms.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/tuvalu-parliament-wikipedia",
         "query": "SELECT * FROM terms"
       },
@@ -37,7 +37,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Tuvalu/Parliament"
       }
     },
@@ -45,7 +45,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/UK/Commons/sources/instructions.json
+++ b/data/UK/Commons/sources/instructions.json
@@ -4,7 +4,7 @@
       "file": "parlparse/data.csv",
       "type": "membership",
       "create": {
-        "type": "parlparse",
+        "from": "parlparse",
         "instructions": "parlparse/instructions.json"
       },
       "source": "http://parser.theyworkforyou.com/"
@@ -12,7 +12,7 @@
     {
       "file": "morph/parliament.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/uk-parliament-members",
         "query": "SELECT * FROM data"
       },
@@ -35,7 +35,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/uk-house-of-commons-wikidata",
         "query": "SELECT *, REPLACE(SUBSTR(REPLACE(identifier__parliamentDOTuk,'/','-------'), -6), '-', '') AS parlid FROM data"
       },
@@ -59,7 +59,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -67,7 +67,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "UK/Commons"
       }
     },
@@ -75,7 +75,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/US_Virgin_Islands/Legislature/sources/instructions.json
+++ b/data/US_Virgin_Islands/Legislature/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/us-virgin-islands-legislature-wikipedia",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/official.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/us-virgin-islands-legislature",
         "query": "SELECT * FROM data"
       },
@@ -28,7 +28,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "US-Virgin-Islands/Legislature"
       }
     },
@@ -36,7 +36,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     }

--- a/data/Uganda/Parliament/sources/instructions.json
+++ b/data/Uganda/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "duncanfwalker/uganda-parliament-scraper",
         "query": "SELECT *, 9 AS term FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Uganda/Parliament"
       }
     }

--- a/data/Ukraine/Verkhovna_Rada/sources/instructions.json
+++ b/data/Ukraine/Verkhovna_Rada/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "openaustralia/ukraine_verkhovna_rada_deputies",
         "query": "SELECT *, COALESCE(faction, 'Позафракційні') AS faction, id AS identifier__rada FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/ukraine-deputies-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Ukraine/Verkhovna-Rada"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/United_Arab_Emirates/Federal_National_Council/sources/instructions.json
+++ b/data/United_Arab_Emirates/Federal_National_Council/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "chrismytton/united-arab-emirates-federal-national-council",
         "query": "SELECT id, name, name_ar AS name__ar, email, photo, 2011 AS term FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "United-Arab-Emirates/Federal-National-Council"
       }
     }

--- a/data/United_States_of_America/House/sources/instructions.json
+++ b/data/United_States_of_America/House/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/us-congress-members",
         "query": "SELECT *, CASE WHEN end_date > date('now') THEN '' ELSE end_date END AS end_date FROM data WHERE house = 'rep' ORDER BY id"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/socialmedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/us-congress-members-social-media",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/us-representatives-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -44,14 +44,14 @@
       "file": "wikidata/parties.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/parties_wikidata.csv"
       }
     },
     {
       "file": "ocd/divisions.csv",
       "create": {
-        "type": "ocd",
+        "from": "ocd",
         "source": "country-us.csv"
       },
       "type": "ocd",
@@ -65,7 +65,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "United-States-of-America/House"
       }
     },
@@ -73,7 +73,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/United_States_of_America/Senate/sources/instructions.json
+++ b/data/United_States_of_America/Senate/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/us-congress-members",
         "query": "SELECT *, CASE WHEN end_date > date('now') THEN '' ELSE end_date END AS end_date FROM data WHERE house = 'sen' ORDER BY id"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/socialmedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/us-congress-members-social-media",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/us-senators-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -44,14 +44,14 @@
       "file": "wikidata/parties.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/parties_wikidata.csv"
       }
     },
     {
       "file": "ocd/divisions.csv",
       "create": {
-        "type": "ocd",
+        "from": "ocd",
         "source": "country-us.csv"
       },
       "type": "ocd",
@@ -65,7 +65,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "United-States-of-America/Senate"
       }
     },
@@ -73,7 +73,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Uruguay/Deputies/sources/instructions.json
+++ b/data/Uruguay/Deputies/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/uruguay-parlamento",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/uruguay-parlamento-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -41,7 +41,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Uruguay/Deputies"
       }
     }

--- a/data/Uzbekistan/Legislative_Chamber/sources/instructions.json
+++ b/data/Uzbekistan/Legislative_Chamber/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/uzbekistan-majlis",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Uzbekistan/Legislative-Chamber"
       }
     }

--- a/data/Vanuatu/Parliament/sources/instructions.json
+++ b/data/Vanuatu/Parliament/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/vanuatu-parliament",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Vanuatu/Parliament"
       }
     }

--- a/data/Vatican_City/Pontifical_Commission/sources/instructions.json
+++ b/data/Vatican_City/Pontifical_Commission/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/pontifical-commission-for-vatican-state-wikipedia",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/pontifical-commission-for-vatican-state-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Vatican-City/Pontifical-Commission"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Venezuela/Assembly/sources/instructions.json
+++ b/data/Venezuela/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/official2011.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/venezuela-asamblea",
         "query": "SELECT *, 2011 AS term FROM data WHERE term = 2015 ORDER BY id"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/official2016.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/venezuela-asamblea",
         "query": "SELECT * FROM data WHERE term = 2016 ORDER BY id"
       },
@@ -28,7 +28,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/venezuela-asamblea-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -48,7 +48,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Venezuela/Assembly"
       }
     },
@@ -56,7 +56,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Vietnam/National_Assembly/sources/instructions.json
+++ b/data/Vietnam/National_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/vietnam-national-assembly-members",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/vietnam-national-assembly-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Vietnam/National-Assembly"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Wales/Assembly/sources/instructions.json
+++ b/data/Wales/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/welsh-assembly",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/wales-AMs-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -29,7 +29,7 @@
       "file": "wikidata/parties.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/parties_wikidata.csv"
       }
     },
@@ -41,7 +41,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Wales/Assembly"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Wallis_and_Futuna/Territorial_Assembly/sources/instructions.json
+++ b/data/Wallis_and_Futuna/Territorial_Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/wikipedia.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/wallis-and-futuna-territorial-assembly",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/wallis-and-futuna-territorial-assembly-wikidata",
         "query": "SELECT * FROM data"
       },
@@ -29,7 +29,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Wallis-and-Futuna/Territorial-Assembly"
       }
     },
@@ -37,7 +37,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Yemen/Majlis/sources/instructions.json
+++ b/data/Yemen/Majlis/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/yemen-ypwatch",
         "query": "SELECT * FROM data"
       },
@@ -18,7 +18,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Yemen/Majlis"
       }
     }

--- a/data/Zambia/Assembly/sources/instructions.json
+++ b/data/Zambia/Assembly/sources/instructions.json
@@ -3,7 +3,7 @@
     {
       "file": "morph/data.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/zambia-na-scraper",
         "query": "SELECT * FROM data"
       },
@@ -13,7 +13,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/zambia-national-assembly-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -33,7 +33,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Zambia/Assembly"
       }
     },
@@ -41,7 +41,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -49,7 +49,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Zimbabwe/Assembly/sources/instructions.json
+++ b/data/Zimbabwe/Assembly/sources/instructions.json
@@ -28,7 +28,7 @@
     {
       "file": "morph/official.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/zimbabwe-parliament",
         "query": "SELECT * FROM data WHERE house = 'assembly' ORDER BY id"
       },
@@ -42,7 +42,7 @@
     {
       "file": "morph/wikidata.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/zimbabwe-representatives-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
@@ -62,7 +62,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -70,7 +70,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Zimbabwe/Assembly"
       }
     },
@@ -78,7 +78,7 @@
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
       "create": {
-        "type": "wikidata-raw",
+        "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
     }

--- a/data/Zimbabwe/Senate/sources/instructions.json
+++ b/data/Zimbabwe/Senate/sources/instructions.json
@@ -28,7 +28,7 @@
     {
       "file": "morph/official.csv",
       "create": {
-        "type": "morph",
+        "from": "morph",
         "scraper": "tmtmtmtm/zimbabwe-parliament",
         "query": "SELECT * FROM data WHERE house = 'senate' ORDER BY id"
       },
@@ -47,7 +47,7 @@
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {
-        "type": "group-wikidata",
+        "from": "group-wikidata",
         "source": "manual/group_wikidata.csv"
       }
     },
@@ -55,7 +55,7 @@
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {
-        "type": "gender-balance",
+        "from": "gender-balance",
         "source": "Zimbabwe/Senate"
       }
     }

--- a/lib/remotesource.rb
+++ b/lib/remotesource.rb
@@ -8,13 +8,13 @@ class RemoteSource
   def self.instantiate(i)
     c = i[:create]
     return RemoteSource::URL.new(i)             if c.key? :url
-    return RemoteSource::Morph.new(i)           if c[:type] == 'morph'
-    return RemoteSource::Parlparse.new(i)       if c[:type] == 'parlparse'
-    return RemoteSource::OCD.new(i)             if c[:type] == 'ocd'
-    return RemoteSource::Wikidata::Group.new(i) if c[:type] == 'group-wikidata'
-    return RemoteSource::Wikidata::Area.new(i)  if c[:type] == 'area-wikidata'
-    return RemoteSource::Wikidata::Raw.new(i)   if c[:type] == 'wikidata-raw'
-    return RemoteSource::GenderBalance.new(i)   if c[:type] == 'gender-balance'
+    return RemoteSource::Morph.new(i)           if c[:from] == 'morph'
+    return RemoteSource::Parlparse.new(i)       if c[:from] == 'parlparse'
+    return RemoteSource::OCD.new(i)             if c[:from] == 'ocd'
+    return RemoteSource::Wikidata::Group.new(i) if c[:from] == 'group-wikidata'
+    return RemoteSource::Wikidata::Area.new(i)  if c[:from] == 'area-wikidata'
+    return RemoteSource::Wikidata::Raw.new(i)   if c[:from] == 'wikidata-raw'
+    return RemoteSource::GenderBalance.new(i)   if c[:from] == 'gender-balance'
     raise "Don't know how to fetch #{i[:file]}" 
   end
 

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -98,7 +98,7 @@ task :add_gender_balance do
     file: "gender-balance/results.csv",
     type: "gender",
     create: {
-      type: "gender-balance",
+      from: "gender-balance",
       source: pwd.split("/").last(2).join("/").gsub("_", "-"),
     },
   } 
@@ -124,7 +124,7 @@ task :build_parties do
     file: "wikidata/groups.json",
     type: "group",
     create: {
-      type: "group-wikidata",
+      from: "group-wikidata",
       source: "manual/group_wikidata.csv"
     },
   } 
@@ -144,7 +144,7 @@ task :build_p39s do
     file: "wikidata/positions.json",
     type: "wikidata-positions",
     create: {
-      type: "wikidata-raw",
+      from: "wikidata-raw",
       source: reconciliation[:reconciliation_file],
     },
   } 


### PR DESCRIPTION
We currently have two different uses of 'type' in the instructions files.
One is what sort of data we read from the file, and one is how the file is
created. Rename the second one to `from`.

part of https://github.com/everypolitician/everypolitician/issues/325