### PR TITLE
Make the build output quieter and more consistent

### DIFF
--- a/lib/source.rb
+++ b/lib/source.rb
@@ -96,6 +96,16 @@ module Source
     end
   end
 
+  class PlainCSV < Base
+    def fields 
+      []
+    end
+
+    def as_table
+      ::CSV.table(filename, converters: nil)
+    end
+  end
+
   class JSON < Base
     def fields 
       []
@@ -157,18 +167,25 @@ module Source
     def fields 
       %i(area area_id)
     end
+
+    def overrides
+      return {} unless i(:merge) 
+      return {} unless i(:merge).key? :overrides
+      return i(:merge)[:overrides]
+    end
+
+    def generate
+      i(:generate)
+    end
   end
 
-  class Gender < CSV
+  class Gender < PlainCSV
     def fields 
       %i(gender)
     end
   end
 
-  class Term < CSV
-    def fields 
-      []
-    end
+  class Term < PlainCSV
   end
 
   class Group < JSON

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -191,7 +191,7 @@ namespace :merge_sources do
           end
         end
 
-        warn "* %d of %d unmatched".magenta % [unmatched.count, incoming_data.count]
+        warn "* %d of %d unmatched".magenta % [unmatched.count, incoming_data.count] if unmatched.any?
         unmatched.sample(10).each do |r|
           warn "\t#{r.to_hash.reject { |k,v| v.to_s.empty? }.select { |k, v| %i(id name).include? k } }"
         end 

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -271,8 +271,10 @@ namespace :merge_sources do
     end
 
     # Any local corrections in manual/corrections.csv
+    # TODO add this as a Source
     corrections_file = 'sources/manual/corrections.csv'
     if File.exist? corrections_file
+      warn "Applying local corrections from #{corrections_file}".magenta
       CSV.table(corrections_file, converters: nil).each do |correction|
         rows = merged_rows.select { |r| r[:uuid] == correction[:uuid] } 
         if rows.empty?
@@ -292,6 +294,7 @@ namespace :merge_sources do
     end
 
 
+    # TODO add this as a Source
     legacy_id_file = 'sources/manual/legacy-ids.csv'
     if File.exist? legacy_id_file
       legacy = CSV.table(legacy_id_file, converters: nil).reject { |r| r[:legacy].to_s.empty? }.group_by { |r| r[:id] }

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -66,7 +66,7 @@ namespace :merge_sources do
 
     # First get all the `membership` rows, and either merge or concat
     sources.select(&:is_memberships?).each do |src|
-      warn "Add memberships from #{src.filename}".magenta
+      warn "Add memberships from #{src.filename}".green
       
       incoming_data = src.filtered_table
       id_map = src.id_map
@@ -104,7 +104,7 @@ namespace :merge_sources do
     # Then merge with Biographical data files
 
     sources.select(&:is_bios?).each do |pd|
-      warn "Merging with #{pd.filename}".magenta
+      warn "Merging with #{pd.filename}".green
 
       incoming_data = pd.as_table
 
@@ -202,7 +202,7 @@ namespace :merge_sources do
 
     # Gender information from Gender-Balance.org
     if gb = sources.find { |src| src.type.downcase == 'gender' }
-      warn "Adding GenderBalance results from #{gb.filename}".magenta 
+      warn "Adding GenderBalance results from #{gb.filename}".green 
 
       min_selections = 5   # accept gender if at least this many votes
       vote_threshold = 0.8 # and at least this ratio of votes were for it
@@ -228,7 +228,7 @@ namespace :merge_sources do
 
     # Map Areas
     if area = sources.find { |src| src.type.downcase == 'ocd' }
-      warn "Adding OCD areas from #{area.filename}".magenta
+      warn "Adding OCD areas from #{area.filename}".green
       ocds = area.as_table.group_by { |r| r[:id] }
 
       if area.generate == 'area'
@@ -274,7 +274,7 @@ namespace :merge_sources do
     # TODO add this as a Source
     corrections_file = 'sources/manual/corrections.csv'
     if File.exist? corrections_file
-      warn "Applying local corrections from #{corrections_file}".magenta
+      warn "Applying local corrections from #{corrections_file}".green
       CSV.table(corrections_file, converters: nil).each do |correction|
         rows = merged_rows.select { |r| r[:uuid] == correction[:uuid] } 
         if rows.empty?

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -112,8 +112,6 @@ namespace :merge_sources do
       approaches.each_with_index do |merge_instructions, i|
         reconciler = Reconciler.new(merge_instructions)
 
-        warn "  Match incoming #{reconciler.incoming_field} to #{reconciler.existing_field}"
-
         if reconciler.filename
           if ENV['GENERATE_RECONCILIATION_INTERFACE'] && reconciler.triggered_by?(ENV['GENERATE_RECONCILIATION_INTERFACE'])
             filename = reconciler.generate_interface!(merged_rows, incoming_data.uniq { |r| r[:id] })

--- a/rake_helpers/generate_final_csvs.rb
+++ b/rake_helpers/generate_final_csvs.rb
@@ -73,7 +73,7 @@ namespace :term_csvs do
       map { |i, is| [i, is.count] }
 
     if top_identifiers.any?
-      warn "Top identifiers:"
+      warn "\nTop identifiers:"
       top_identifiers.each do |i, c|
         warn "  #{c} x #{i}"
       end

--- a/rake_helpers/generate_final_csvs.rb
+++ b/rake_helpers/generate_final_csvs.rb
@@ -55,12 +55,13 @@ namespace :term_csvs do
         gender: person.gender,
       }
     end
-    data.group_by { |r| r[:term] }.each do |t, rs|
+    terms = data.group_by { |r| r[:term] }
+    warn "Creating #{terms.count} term file#{terms.count > 1 ? 's' : ''}"
+    terms.each do |t, rs|
       filename = "term-#{t}.csv"
       header = rs.first.keys.to_csv
       rows   = rs.sort_by { |r| [r[:name], r[:id], r[:start_date].to_s, r[:area].to_s ] }.map { |r| r.values.to_csv }
       csv    = [header, rows].compact.join
-      warn "Creating #{filename}"
       File.write(filename, csv)
     end
   end

--- a/rake_helpers/generate_final_csvs.rb
+++ b/rake_helpers/generate_final_csvs.rb
@@ -101,10 +101,13 @@ namespace :term_csvs do
     wikidata_parties = @json[:organizations].select { |o| o[:classification] == 'party' }.partition { |p| 
       p[:name].downcase == 'unknown' || (p[:identifiers] || []).find { |i| i[:scheme] == 'wikidata' } 
     }
-    warn "Wikidata Persons matched: #{wikidata_persons.first.count} ✓ | #{wikidata_persons.last.count} ✘"
-    wikidata_persons.last.shuffle.take(10).each { |p| warn "  Missing: #{ p[:name] }" } if wikidata_persons.first.count > 0 
-    warn "Wikidata Parties matched: #{wikidata_parties.first.count} ✓ | #{wikidata_parties.last.count} ✘"
-    wikidata_parties.last.each { |p| warn "  Missing: #{p[:name]} (#{p[:id]})" } if wikidata_parties.first.count > 0 && wikidata_parties.last.count <= 5
+    matched, unmatched = wikidata_persons.map(&:count)
+    warn "Wikidata Persons matched: #{matched} ✓ #{unmatched.zero? ? '' : "| #{unmatched} ✘"}"
+    wikidata_persons.last.shuffle.take(10).each { |p| warn "  Missing: #{ p[:name] }" } unless matched.zero?
+
+    matched, unmatched = wikidata_parties.map(&:count)
+    warn "Wikidata Parties matched: #{matched} ✓ #{unmatched.zero? ? '' : "| #{unmatched} ✘"}"
+    wikidata_parties.last.shuffle.take(5).each { |p| warn "  Missing: #{p[:name]} (#{p[:id]})" } unless matched.zero?
   end
 
   desc 'Build the Positions file'


### PR DESCRIPTION
Remove some of the things that aren't so relevant, make other things more consistent:

*    Don’t report on _how_ we’re merging
*    Only warn of unmatched data if there is some
*    Report only on how many term files created
*    Make Corrections files consistent
*    Warn about some of the unmatched Parties
*    Make Top Identifiers more distinctly a new section
*    Make the 'Reading…" lines green