### PR TITLE
Don’t count "skipped" GenderBalance votes towards threshold

### DIFF
--- a/lib/source.rb
+++ b/lib/source.rb
@@ -102,7 +102,11 @@ module Source
     end
 
     def as_table
-      ::CSV.table(filename, converters: nil)
+      ::CSV.table(filename, converters: converters)
+    end
+    
+    def converters
+      nil
     end
   end
 
@@ -180,6 +184,10 @@ module Source
   end
 
   class Gender < PlainCSV
+    def converters
+      :integer
+    end
+
     def fields 
       %i(gender)
     end


### PR DESCRIPTION
A gender wins if it got at least 80% of the votes for any gender
— ignoring skips.

Also warn if the winning vote differs from any gender already set from a
different source.