### PR TITLE
Reconciler: restrict the clicking area to the header

### DIFF
--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -294,7 +294,7 @@ jQuery(function($) {
 
   });
 
-  $(document).on('click', '.pairing__choices > div', function(){
+  $(document).on('click', '.pairing__choices > div header.person__meta', function(){
     vote($(this));
   });
 

--- a/templates/sass/_styles.scss
+++ b/templates/sass/_styles.scss
@@ -206,7 +206,10 @@ h2 {
   .show-later {
     box-shadow: 0 1px 3px rgba(0,0,0,0.2);
     margin-bottom: 2em;
-    cursor: pointer;
+
+    .person__meta {
+      cursor: pointer;
+    }
 
     &:hover {
       position: relative;


### PR DESCRIPTION
We want to be able to do other things in the card that require clicking
(e.g. following links, adding a "show more…" button), so prepare for
this by restricting the "Click to match" area to the header.

(As 99% of usage of the reconciler is currently by me, and I almost
always use the keyboard rather than the mouse, the negative impact of
this should be negligible)