### PR TITLE
Require 'corrections' to be an explicit Source

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -548,11 +548,11 @@
         "slug": "Representatives",
         "sources_directory": "data/Australia/Representatives/sources",
         "popolo": "data/Australia/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90a553b/data/Australia/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66ecc28/data/Australia/Representatives/ep-popolo-v1.0.json",
         "names": "data/Australia/Representatives/names.csv",
-        "lastmod": "1461162074",
+        "lastmod": "1462261161",
         "person_count": 475,
-        "sha": "90a553b",
+        "sha": "66ecc28",
         "legislative_periods": [
           {
             "id": "term/44",
@@ -560,7 +560,7 @@
             "start_date": "2013-09-07",
             "slug": "44",
             "csv": "data/Australia/Representatives/term-44.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90a553b/data/Australia/Representatives/term-44.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66ecc28/data/Australia/Representatives/term-44.csv"
           },
           {
             "end_date": "2013-09-07",
@@ -569,7 +569,7 @@
             "start_date": "2010-08-21",
             "slug": "43",
             "csv": "data/Australia/Representatives/term-43.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90a553b/data/Australia/Representatives/term-43.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66ecc28/data/Australia/Representatives/term-43.csv"
           },
           {
             "end_date": "2010-08-21",
@@ -578,7 +578,7 @@
             "start_date": "2007-11-24",
             "slug": "42",
             "csv": "data/Australia/Representatives/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90a553b/data/Australia/Representatives/term-42.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66ecc28/data/Australia/Representatives/term-42.csv"
           },
           {
             "end_date": "2007-11-24",
@@ -587,7 +587,7 @@
             "start_date": "2004-10-09",
             "slug": "41",
             "csv": "data/Australia/Representatives/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90a553b/data/Australia/Representatives/term-41.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66ecc28/data/Australia/Representatives/term-41.csv"
           },
           {
             "end_date": "2004-10-09",
@@ -596,7 +596,7 @@
             "start_date": "2001-11-10",
             "slug": "40",
             "csv": "data/Australia/Representatives/term-40.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90a553b/data/Australia/Representatives/term-40.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66ecc28/data/Australia/Representatives/term-40.csv"
           },
           {
             "end_date": "2001-11-10",
@@ -605,7 +605,7 @@
             "start_date": "1998-10-03",
             "slug": "39",
             "csv": "data/Australia/Representatives/term-39.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90a553b/data/Australia/Representatives/term-39.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66ecc28/data/Australia/Representatives/term-39.csv"
           },
           {
             "end_date": "1998-10-03",
@@ -614,7 +614,7 @@
             "start_date": "1996-03-02",
             "slug": "38",
             "csv": "data/Australia/Representatives/term-38.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90a553b/data/Australia/Representatives/term-38.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66ecc28/data/Australia/Representatives/term-38.csv"
           },
           {
             "end_date": "1996-03-02",
@@ -623,7 +623,7 @@
             "start_date": "1993-03-13",
             "slug": "37",
             "csv": "data/Australia/Representatives/term-37.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90a553b/data/Australia/Representatives/term-37.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66ecc28/data/Australia/Representatives/term-37.csv"
           },
           {
             "end_date": "1993-03-13",
@@ -632,7 +632,7 @@
             "start_date": "1990-03-24",
             "slug": "36",
             "csv": "data/Australia/Representatives/term-36.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90a553b/data/Australia/Representatives/term-36.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66ecc28/data/Australia/Representatives/term-36.csv"
           },
           {
             "end_date": "1990-03-24",
@@ -641,7 +641,7 @@
             "start_date": "1987-07-11",
             "slug": "35",
             "csv": "data/Australia/Representatives/term-35.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90a553b/data/Australia/Representatives/term-35.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66ecc28/data/Australia/Representatives/term-35.csv"
           }
         ],
         "statement_count": 35149
@@ -1665,11 +1665,11 @@
         "slug": "Commons",
         "sources_directory": "data/Canada/Commons/sources",
         "popolo": "data/Canada/Commons/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f1540c8/data/Canada/Commons/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/77ab1ef/data/Canada/Commons/ep-popolo-v1.0.json",
         "names": "data/Canada/Commons/names.csv",
-        "lastmod": "1462192918",
+        "lastmod": "1462261152",
         "person_count": 537,
-        "sha": "f1540c8",
+        "sha": "77ab1ef",
         "legislative_periods": [
           {
             "id": "term/42",
@@ -1678,7 +1678,7 @@
             "wikidata": "Q21157957",
             "slug": "42",
             "csv": "data/Canada/Commons/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f1540c8/data/Canada/Commons/term-42.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/77ab1ef/data/Canada/Commons/term-42.csv"
           },
           {
             "end_date": "2015-08-02",
@@ -1688,7 +1688,7 @@
             "wikidata": "Q2816776",
             "slug": "41",
             "csv": "data/Canada/Commons/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f1540c8/data/Canada/Commons/term-41.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/77ab1ef/data/Canada/Commons/term-41.csv"
           }
         ],
         "statement_count": 33440
@@ -2843,11 +2843,11 @@
         "slug": "Eduskunta",
         "sources_directory": "data/Finland/Eduskunta/sources",
         "popolo": "data/Finland/Eduskunta/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbaab8b/data/Finland/Eduskunta/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/025b599/data/Finland/Eduskunta/ep-popolo-v1.0.json",
         "names": "data/Finland/Eduskunta/names.csv",
-        "lastmod": "1462165010",
+        "lastmod": "1462261165",
         "person_count": 492,
-        "sha": "dbaab8b",
+        "sha": "025b599",
         "legislative_periods": [
           {
             "end_date": "2019",
@@ -2856,7 +2856,7 @@
             "start_date": "2015-04-28",
             "slug": "37",
             "csv": "data/Finland/Eduskunta/term-37.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbaab8b/data/Finland/Eduskunta/term-37.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/025b599/data/Finland/Eduskunta/term-37.csv"
           },
           {
             "end_date": "2015-03-14",
@@ -2865,7 +2865,7 @@
             "start_date": "2011-04-20",
             "slug": "36",
             "csv": "data/Finland/Eduskunta/term-36.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbaab8b/data/Finland/Eduskunta/term-36.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/025b599/data/Finland/Eduskunta/term-36.csv"
           },
           {
             "end_date": "2011-04-19",
@@ -2874,7 +2874,7 @@
             "start_date": "2007-03-21",
             "slug": "35",
             "csv": "data/Finland/Eduskunta/term-35.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbaab8b/data/Finland/Eduskunta/term-35.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/025b599/data/Finland/Eduskunta/term-35.csv"
           },
           {
             "end_date": "2007-03-20",
@@ -2883,7 +2883,7 @@
             "start_date": "2003-03-19",
             "slug": "34",
             "csv": "data/Finland/Eduskunta/term-34.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbaab8b/data/Finland/Eduskunta/term-34.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/025b599/data/Finland/Eduskunta/term-34.csv"
           },
           {
             "end_date": "2003-03-18",
@@ -2892,7 +2892,7 @@
             "start_date": "1999-03-24",
             "slug": "33",
             "csv": "data/Finland/Eduskunta/term-33.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbaab8b/data/Finland/Eduskunta/term-33.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/025b599/data/Finland/Eduskunta/term-33.csv"
           },
           {
             "end_date": "1999-03-23",
@@ -2901,7 +2901,7 @@
             "start_date": "1995-03-24",
             "slug": "32",
             "csv": "data/Finland/Eduskunta/term-32.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbaab8b/data/Finland/Eduskunta/term-32.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/025b599/data/Finland/Eduskunta/term-32.csv"
           },
           {
             "end_date": "1995-03-23",
@@ -2910,7 +2910,7 @@
             "start_date": "1991-03-22",
             "slug": "31",
             "csv": "data/Finland/Eduskunta/term-31.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbaab8b/data/Finland/Eduskunta/term-31.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/025b599/data/Finland/Eduskunta/term-31.csv"
           },
           {
             "end_date": "1991-03-21",
@@ -2919,7 +2919,7 @@
             "start_date": "1987-03-21",
             "slug": "30",
             "csv": "data/Finland/Eduskunta/term-30.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbaab8b/data/Finland/Eduskunta/term-30.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/025b599/data/Finland/Eduskunta/term-30.csv"
           },
           {
             "end_date": "1987-03-20",
@@ -2928,7 +2928,7 @@
             "start_date": "1983-03-26",
             "slug": "29",
             "csv": "data/Finland/Eduskunta/term-29.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbaab8b/data/Finland/Eduskunta/term-29.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/025b599/data/Finland/Eduskunta/term-29.csv"
           },
           {
             "end_date": "1983-03-25",
@@ -2937,7 +2937,7 @@
             "start_date": "1979-03-24",
             "slug": "28",
             "csv": "data/Finland/Eduskunta/term-28.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbaab8b/data/Finland/Eduskunta/term-28.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/025b599/data/Finland/Eduskunta/term-28.csv"
           },
           {
             "end_date": "1979-03-23",
@@ -2946,7 +2946,7 @@
             "start_date": "1975-09-27",
             "slug": "27",
             "csv": "data/Finland/Eduskunta/term-27.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbaab8b/data/Finland/Eduskunta/term-27.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/025b599/data/Finland/Eduskunta/term-27.csv"
           },
           {
             "end_date": "1975-09-26",
@@ -2955,7 +2955,7 @@
             "start_date": "1972-01-22",
             "slug": "26",
             "csv": "data/Finland/Eduskunta/term-26.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbaab8b/data/Finland/Eduskunta/term-26.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/025b599/data/Finland/Eduskunta/term-26.csv"
           },
           {
             "end_date": "1972-01-21",
@@ -2964,7 +2964,7 @@
             "start_date": "1970-03-23",
             "slug": "25",
             "csv": "data/Finland/Eduskunta/term-25.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbaab8b/data/Finland/Eduskunta/term-25.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/025b599/data/Finland/Eduskunta/term-25.csv"
           }
         ],
         "statement_count": 36352

--- a/data/Australia/Representatives/sources/instructions.json
+++ b/data/Australia/Representatives/sources/instructions.json
@@ -101,6 +101,10 @@
         "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
+    },
+    {
+      "file": "manual/corrections.csv",
+      "type": "corrections"
     }
   ]
 }

--- a/data/Canada/Commons/sources/instructions.json
+++ b/data/Canada/Commons/sources/instructions.json
@@ -91,6 +91,10 @@
         "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
+    },
+    {
+      "file": "manual/corrections.csv",
+      "type": "corrections"
     }
   ]
 }

--- a/data/Finland/Eduskunta/sources/instructions.json
+++ b/data/Finland/Eduskunta/sources/instructions.json
@@ -68,6 +68,10 @@
         "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
+    },
+    {
+      "file": "manual/corrections.csv",
+      "type": "corrections"
     }
   ]
 }

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -5,15 +5,16 @@ module Source
   class Base
     # Instantiate correct subclass based on instructions
     def self.instantiate(i)
-      return Source::Membership.new(i) if i[:type] == 'membership'
-      return Source::Person.new(i)     if i[:type] == 'person'
-      return Source::Wikidata.new(i)   if i[:type] == 'wikidata'
-      return Source::Group.new(i)      if i[:type] == 'group'
-      return Source::OCD.new(i)        if i[:type] == 'ocd'
-      return Source::Area.new(i)       if i[:type] == 'area-wikidata'
-      return Source::Gender.new(i)     if i[:type] == 'gender'
-      return Source::Positions.new(i)  if i[:type] == 'wikidata-positions'
-      return Source::Term.new(i)       if i[:type] == 'term'
+      return Source::Membership.new(i)  if i[:type] == 'membership'
+      return Source::Person.new(i)      if i[:type] == 'person'
+      return Source::Wikidata.new(i)    if i[:type] == 'wikidata'
+      return Source::Group.new(i)       if i[:type] == 'group'
+      return Source::OCD.new(i)         if i[:type] == 'ocd'
+      return Source::Area.new(i)        if i[:type] == 'area-wikidata'
+      return Source::Gender.new(i)      if i[:type] == 'gender'
+      return Source::Positions.new(i)   if i[:type] == 'wikidata-positions'
+      return Source::Term.new(i)        if i[:type] == 'term'
+      return Source::Corrections.new(i) if i[:type] == 'corrections'
       raise "Don't know how to handle #{i[:type]} files (#{i})" 
     end
 
@@ -203,5 +204,8 @@ module Source
   end
 
   class Positions < JSON
+  end
+
+  class Corrections < PlainCSV
   end
 end

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -297,11 +297,9 @@ namespace :merge_sources do
     end
 
     # Any local corrections in manual/corrections.csv
-    # TODO add this as a Source
-    corrections_file = 'sources/manual/corrections.csv'
-    if File.exist? corrections_file
-      warn "Applying local corrections from #{corrections_file}".green
-      CSV.table(corrections_file, converters: nil).each do |correction|
+    if corrs = sources.find { |src| src.type.downcase == 'corrections' }
+      warn "Applying local corrections from #{corrs.filename}".green
+      corrs.as_table.each do |correction|
         rows = merged_rows.select { |r| r[:uuid] == correction[:uuid] } 
         if rows.empty?
           warn "Can't correct #{correction[:uuid]} — no such person"


### PR DESCRIPTION
Rather than looking for a "corrections" file at a specified location,
require it to be explicitly set in the `instructions.son` file to be used.