### PR TITLE
Add script to report on missing Wikidata

### DIFF
--- a/bin/wikidata_missing_report.rb
+++ b/bin/wikidata_missing_report.rb
@@ -1,0 +1,14 @@
+require 'everypolitician'
+require 'everypolitician/popolo'
+
+# Report on which Legislatures have no-one matched to Wikidata
+
+EveryPolitician.countries_json = 'countries.json'
+EveryPolitician.countries.each do |c|
+  c.legislatures.each do |l|
+    people = Everypolitician::Popolo.read(l.raw_data[:popolo]).persons
+    wdp = people.partition { |p| p.wikidata }
+    puts "- [ ] %s — %s (%d)" % [ c.name, l.name, people.count ] if wdp.first.count.zero?
+  end
+end
+


### PR DESCRIPTION
Generate a report of all legislatures for which we have zero people matched to Wikidata (suitable for keeping the comment on https://github.com/everypolitician/everypolitician/issues/393 up to date)