### PR TITLE
Update shebang lines in scripts to use /usr/bin/env ruby

### DIFF
--- a/bin/last_updated.rb
+++ b/bin/last_updated.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby 
+#!/usr/bin/env ruby
 
 # How long has it been since the data for a legislature changed?
 

--- a/bin/learn_position.rb
+++ b/bin/learn_position.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby 
+#!/usr/bin/env ruby
 
 require 'json'
 require 'pry'

--- a/bin/legislature_wikidata_ids.rb
+++ b/bin/legislature_wikidata_ids.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby 
+#!/usr/bin/env ruby
 
 require 'json'
 require 'pry'

--- a/countries.json
+++ b/countries.json
@@ -1180,11 +1180,11 @@
         "slug": "Assembly",
         "sources_directory": "data/British_Virgin_Islands/Assembly/sources",
         "popolo": "data/British_Virgin_Islands/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eaeaa92/data/British_Virgin_Islands/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f107a57/data/British_Virgin_Islands/Assembly/ep-popolo-v1.0.json",
         "names": "data/British_Virgin_Islands/Assembly/names.csv",
         "lastmod": "1462912751",
         "person_count": 23,
-        "sha": "eaeaa92",
+        "sha": "f107a57",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -1192,7 +1192,7 @@
             "start_date": "2015",
             "slug": "2015",
             "csv": "data/British_Virgin_Islands/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eaeaa92/data/British_Virgin_Islands/Assembly/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f107a57/data/British_Virgin_Islands/Assembly/term-2015.csv"
           },
           {
             "end_date": "2015",
@@ -1201,7 +1201,7 @@
             "start_date": "2011",
             "slug": "2011",
             "csv": "data/British_Virgin_Islands/Assembly/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eaeaa92/data/British_Virgin_Islands/Assembly/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f107a57/data/British_Virgin_Islands/Assembly/term-2011.csv"
           },
           {
             "end_date": "2011",
@@ -1210,7 +1210,7 @@
             "start_date": "2007",
             "slug": "2007",
             "csv": "data/British_Virgin_Islands/Assembly/term-2007.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eaeaa92/data/British_Virgin_Islands/Assembly/term-2007.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f107a57/data/British_Virgin_Islands/Assembly/term-2007.csv"
           }
         ],
         "statement_count": 710
@@ -2813,11 +2813,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Fiji/Parliament/sources",
         "popolo": "data/Fiji/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c4663a/data/Fiji/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bd46301/data/Fiji/Parliament/ep-popolo-v1.0.json",
         "names": "data/Fiji/Parliament/names.csv",
         "lastmod": "1462912511",
         "person_count": 53,
-        "sha": "5c4663a",
+        "sha": "bd46301",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -2825,7 +2825,7 @@
             "start_date": "2014-10-06",
             "slug": "2014",
             "csv": "data/Fiji/Parliament/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c4663a/data/Fiji/Parliament/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bd46301/data/Fiji/Parliament/term-2014.csv"
           }
         ],
         "statement_count": 808
@@ -7892,11 +7892,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Samoa/Parliament/sources",
         "popolo": "data/Samoa/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7f9705b/data/Samoa/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5b076b3/data/Samoa/Parliament/ep-popolo-v1.0.json",
         "names": "data/Samoa/Parliament/names.csv",
         "lastmod": "1462912315",
         "person_count": 49,
-        "sha": "7f9705b",
+        "sha": "5b076b3",
         "legislative_periods": [
           {
             "id": "term/15",
@@ -7904,7 +7904,7 @@
             "start_date": "2011",
             "slug": "15",
             "csv": "data/Samoa/Parliament/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7f9705b/data/Samoa/Parliament/term-15.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5b076b3/data/Samoa/Parliament/term-15.csv"
           }
         ],
         "statement_count": 1657


### PR DESCRIPTION
A shebang line which hardcodes /usr/bin/ruby may cause problems
if you are using rbenv or in any other situation where the version
of ruby that comes first in your PATH is not /usr/bin/ruby.
Using /usr/bin/env ruby in the shebang line will exec the ruby
binary that comes first in your PATH.

Investigated with Dave Whiteland (@davewhiteland).