### PR TITLE
Scotland/NI: move term start date to election day

### DIFF
--- a/data/Northern_Ireland/Assembly/sources/manual/terms.csv
+++ b/data/Northern_Ireland/Assembly/sources/manual/terms.csv
@@ -3,4 +3,4 @@ id,name,start_date,end_date,wikidata
 2,2nd Assembly,2003-11-26,2007-01-30,Q21128144
 3,3rd Assembly,2007-03-09,2011-03-24,Q21128152
 4,4th Assembly,2011-05-06,2016-03-24,Q21124329
-5,5th Assembly,2016-05-09,,Q24050037
+5,5th Assembly,2016-05-05,,Q24050037

--- a/data/Scotland/Parliament/sources/manual/terms.csv
+++ b/data/Scotland/Parliament/sources/manual/terms.csv
@@ -3,4 +3,4 @@ id,name,start_date,end_date
 2,2nd Parliament,2003-05-01,2007-04-02
 3,3rd Parliament,2007-05-03,2011-05-04
 4,4th Parliament,2011-05-06,2016-03-24
-5,5th Parliament,2016-05-12,
+5,5th Parliament,2016-05-05,


### PR DESCRIPTION
Parlparse lists the start date of Memberships as election day, and
parlparse-to-csv gets confused if that's before the start_date of the term.

We should probably fix parlparse-to-csv to Do The Right Thing™ here, but
for now it's simplest to just set the start date.