### PR TITLE
Better error messages when fetching remote urls

### DIFF
--- a/lib/remotesource.rb
+++ b/lib/remotesource.rb
@@ -60,7 +60,11 @@ class RemoteSource::Morph < RemoteSource
     key = ERB::Util.url_encode(morph_api_key)
     query = ERB::Util.url_encode(qs.gsub(/\s+/, ' ').strip)
     url = "https://api.morph.io/#{src}/data.csv?key=#{key}&query=#{query}"
-    open(url).read
+    begin
+      open(url).read
+    rescue => e
+      abort "Failed to perform morph query #{qs.inspect}: #{e.message}"
+    end
   end
 
   def write

--- a/lib/remotesource.rb
+++ b/lib/remotesource.rb
@@ -37,6 +37,8 @@ class RemoteSource
 
   def copy_url(url)
     IO.copy_stream(open(url), i(:file))
+  rescue => e
+    abort "Failed to GET #{url}: #{e.message}"
   end
   
   def regenerate

--- a/lib/wikidata_lookup.rb
+++ b/lib/wikidata_lookup.rb
@@ -154,6 +154,8 @@ class ElectionLookup < WikidataLookup
     result = RestClient.get WDQ_URL, params: { q: query }
     json = JSON.parse(result, symbolize_names: true)
     json[:items].map { |id| "Q#{id}" }
+  rescue RestClient::Exception => e
+    abort "Wikidata query #{query.inspect} failed: #{e.message}"
   end
 end
 


### PR DESCRIPTION
Rather than printing a big stack trace when an http request fails we instead just print an error message and exit.