### PR TITLE
Update to latest version of wikisnakker

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GIT
 
 GIT
   remote: https://github.com/everypolitician/wikisnakker
-  revision: c4939906c4653200c5f77b3a8653615f96bdf11e
+  revision: a68f9fd9ead515ceeaa3c81b838a2f6941db232f
   branch: master
   specs:
     wikisnakker (0.0.1)


### PR DESCRIPTION
The latest version includes a fix for lookups that don't contain any entities - https://github.com/everypolitician/wikisnakker/pull/40.