### PR TITLE
Tweak reporting of Info with no Wikidata

### DIFF
--- a/rake_helpers/generate_final_csvs.rb
+++ b/rake_helpers/generate_final_csvs.rb
@@ -103,12 +103,12 @@ namespace :term_csvs do
       partition { |p| (p[:identifiers] || []).find { |i| i[:scheme] == 'wikidata' } 
     }
     matched, unmatched = wikidata_persons.map(&:count)
-    warn "Wikidata Persons matched: #{matched} ✓ #{unmatched.zero? ? '' : "| #{unmatched} ✘"}"
-    wikidata_persons.last.shuffle.take(10).each { |p| warn "  Missing: #{ p[:name] }" } unless matched.zero?
+    warn "Persons matched to Wikidata: #{matched} ✓ #{unmatched.zero? ? '' : "| #{unmatched} ✘"}"
+    wikidata_persons.last.shuffle.take(10).each { |p| warn "  No wikidata: #{ p[:name] }" } unless matched.zero?
 
     matched, unmatched = wikidata_parties.map(&:count)
-    warn "Wikidata Parties matched: #{matched} ✓ #{unmatched.zero? ? '' : "| #{unmatched} ✘"}"
-    wikidata_parties.last.shuffle.take(5).each { |p| warn "  Missing: #{p[:name]} (#{p[:id]})" } unless matched.zero?
+    warn "Parties matched to Wikidata: #{matched} ✓ #{unmatched.zero? ? '' : "| #{unmatched} ✘"}"
+    wikidata_parties.last.shuffle.take(5).each { |p| warn "  No wikidata: #{p[:name]} (#{p[:id]})" } unless matched.zero?
   end
 
   desc 'Build the Positions file'


### PR DESCRIPTION
"Wikidata Persons matched" is a little ambiguous, as it seems like it
means "People we got from Wikidata who we couldn't match up to existing
people", rather than "People for whom we couldn't find any matches
within Wikidata".

Make it a little more explicit which direction we're reporting on.