### PR TITLE
Remove duplicate memberships from Popolo output

### DIFF
--- a/rake_helpers/generate_ep_popolo.rb
+++ b/rake_helpers/generate_ep_popolo.rb
@@ -100,6 +100,11 @@ namespace :transform do
       m.delete :start_date if m[:start_date].to_s.empty? || (!e[:start_date].to_s.empty? && m[:start_date].to_s <= e[:start_date].to_s)
       m.delete :end_date   if m[:end_date].to_s.empty?   || (!e[:end_date].to_s.empty?   && m[:end_date].to_s   >= e[:end_date].to_s)
     end
+    duplicates = @json[:memberships].size - @json[:memberships].uniq.size
+    if duplicates > 0
+      warn "Discarding #{duplicates} duplicate membership#{duplicates != 1 ? 's' : ''} from Popolo".yellow
+      @json[:memberships].uniq!
+    end
   end
 
   #---------------------------------------------------------------------

--- a/rake_helpers/generate_ep_popolo.rb
+++ b/rake_helpers/generate_ep_popolo.rb
@@ -100,9 +100,11 @@ namespace :transform do
       m.delete :start_date if m[:start_date].to_s.empty? || (!e[:start_date].to_s.empty? && m[:start_date].to_s <= e[:start_date].to_s)
       m.delete :end_date   if m[:end_date].to_s.empty?   || (!e[:end_date].to_s.empty?   && m[:end_date].to_s   >= e[:end_date].to_s)
     end
-    duplicates = @json[:memberships].size - @json[:memberships].uniq.size
-    if duplicates > 0
-      warn "Discarding #{duplicates} duplicate membership#{duplicates != 1 ? 's' : ''} from Popolo".yellow
+    duplicates = @json[:memberships].group_by { |m| m }.select { |_, ms| ms.size > 1 }.map(&:first)
+    if duplicates.any?
+      duplicates.each do |dupe|
+        warn "Discarding duplicate membership: #{dupe}".yellow
+      end
       @json[:memberships].uniq!
     end
   end


### PR DESCRIPTION
If duplicate memberships are detected we emit a warning and then discard
the duplicates.

Fixes https://github.com/everypolitician/everypolitician/issues/395