### PR TITLE
Build speed: Pre-generate date_headers list

### DIFF
--- a/rake_helpers/verify_source_data.rb
+++ b/rake_helpers/verify_source_data.rb
@@ -21,9 +21,11 @@ namespace :verify do
       warn msg
     }
 
+    date_fields = @csv.headers.select { |k| k.to_s.include? '_date' }
+
     @csv.each do |r|
       abort "No `name` in #{r}" if r[:name].to_s.empty?
-      r.to_hash.keys.select { |k| k.to_s.include? '_date' }.each do |d|
+      date_fields.each do |d|
         next if r[d].nil? || r[d].empty?
         if r[d].match(/^\d{4}$/) or r[d].match(/^\d{4}-\d{2}$/)
           # TODO make this warning configurable


### PR DESCRIPTION
Rather than asking each row of `merged.csv` in turn what date columns it
has, pre-build the list of all the date columns in the CSV.

In the most extreme case (Turkey, with over 12,000 rows) this speeds
this task from ~40 seconds to ~0.2 seconds!