### PR TITLE
Antigua and Barbuda (Representatives) — add Group information

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -346,11 +346,11 @@
         "slug": "Representatives",
         "sources_directory": "data/Antigua_and_Barbuda/Representatives/sources",
         "popolo": "data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5e845b5/data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20b7d26/data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
         "names": "data/Antigua_and_Barbuda/Representatives/names.csv",
-        "lastmod": "1462241289",
+        "lastmod": "1464079110",
         "person_count": 63,
-        "sha": "5e845b5",
+        "sha": "20b7d26",
         "legislative_periods": [
           {
             "end_date": "2019",
@@ -359,7 +359,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5e845b5/data/Antigua_and_Barbuda/Representatives/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20b7d26/data/Antigua_and_Barbuda/Representatives/term-2014.csv"
           },
           {
             "end_date": "2014",
@@ -368,7 +368,7 @@
             "start_date": "2009",
             "slug": "2009",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5e845b5/data/Antigua_and_Barbuda/Representatives/term-2009.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20b7d26/data/Antigua_and_Barbuda/Representatives/term-2009.csv"
           },
           {
             "end_date": "2009",
@@ -377,7 +377,7 @@
             "start_date": "2004",
             "slug": "2004",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-2004.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5e845b5/data/Antigua_and_Barbuda/Representatives/term-2004.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20b7d26/data/Antigua_and_Barbuda/Representatives/term-2004.csv"
           },
           {
             "end_date": "2004",
@@ -386,7 +386,7 @@
             "start_date": "1999",
             "slug": "1999",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1999.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5e845b5/data/Antigua_and_Barbuda/Representatives/term-1999.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20b7d26/data/Antigua_and_Barbuda/Representatives/term-1999.csv"
           },
           {
             "end_date": "1999",
@@ -395,7 +395,7 @@
             "start_date": "1994",
             "slug": "1994",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1994.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5e845b5/data/Antigua_and_Barbuda/Representatives/term-1994.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20b7d26/data/Antigua_and_Barbuda/Representatives/term-1994.csv"
           },
           {
             "end_date": "1994",
@@ -404,7 +404,7 @@
             "start_date": "1989",
             "slug": "1989",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1989.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5e845b5/data/Antigua_and_Barbuda/Representatives/term-1989.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20b7d26/data/Antigua_and_Barbuda/Representatives/term-1989.csv"
           },
           {
             "end_date": "1989",
@@ -413,7 +413,7 @@
             "start_date": "1984",
             "slug": "1984",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1984.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5e845b5/data/Antigua_and_Barbuda/Representatives/term-1984.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20b7d26/data/Antigua_and_Barbuda/Representatives/term-1984.csv"
           },
           {
             "end_date": "1984",
@@ -422,7 +422,7 @@
             "start_date": "1980",
             "slug": "1980",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1980.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5e845b5/data/Antigua_and_Barbuda/Representatives/term-1980.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20b7d26/data/Antigua_and_Barbuda/Representatives/term-1980.csv"
           },
           {
             "end_date": "1980",
@@ -431,7 +431,7 @@
             "start_date": "1976",
             "slug": "1976",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1976.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5e845b5/data/Antigua_and_Barbuda/Representatives/term-1976.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20b7d26/data/Antigua_and_Barbuda/Representatives/term-1976.csv"
           },
           {
             "end_date": "1976",
@@ -440,10 +440,10 @@
             "start_date": "1971",
             "slug": "1971",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1971.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5e845b5/data/Antigua_and_Barbuda/Representatives/term-1971.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20b7d26/data/Antigua_and_Barbuda/Representatives/term-1971.csv"
           }
         ],
-        "statement_count": 1708
+        "statement_count": 2190
       }
     ]
   },

--- a/data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json
+++ b/data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json
@@ -1543,7 +1543,105 @@
     {
       "classification": "party",
       "id": "party/ablp",
-      "name": "ABLP"
+      "identifiers": [
+        {
+          "identifier": "Q1277738",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "ABLP",
+      "other_names": [
+        {
+          "lang": "pt",
+          "name": "Partido Trabalhista de Antígua",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ja",
+          "name": "アンティグア労働党",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Parti travailliste d'Antigua",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sh",
+          "name": "Antigvanska laburistička partija",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Antigua and Barbuda Labour Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Partido Laborista de Antigua",
+          "note": "multilingual"
+        },
+        {
+          "lang": "uk",
+          "name": "Антигуанська робітнича партія",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ar",
+          "name": "حزب العمل الأنتيغي",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Antigua Labour Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "de",
+          "name": "Antigua Labour Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ru",
+          "name": "Антигуанская рабочая партия",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh",
+          "name": "安提瓜工黨",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sh",
+          "name": "Antigvanska laburistička stranka",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Antigua Labour Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Arbeiderspartij van Antigua",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Antigua Labour Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "ALP",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "ABLP",
+          "note": "multilingual"
+        }
+      ]
     },
     {
       "classification": "party",
@@ -1553,7 +1651,40 @@
     {
       "classification": "party",
       "id": "party/bpm",
-      "name": "BPM"
+      "identifiers": [
+        {
+          "identifier": "Q3038017",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "BPM",
+      "other_names": [
+        {
+          "lang": "pt",
+          "name": "Movimento Popular de Barbuda",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Mouvement populaire de Barbuda",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Barbuda People's Movement",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ar",
+          "name": "الحركة الشعبية باربودا",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ar",
+          "name": "الحركه الشعبيه باربودا",
+          "note": "multilingual"
+        }
+      ]
     },
     {
       "classification": "legislature",
@@ -1570,22 +1701,725 @@
     {
       "classification": "party",
       "id": "party/ind",
-      "name": "IND"
+      "identifiers": [
+        {
+          "identifier": "Q327591",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "IND",
+      "other_names": [
+        {
+          "lang": "zh-hans",
+          "name": "无党籍人士",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh-hant",
+          "name": "無黨籍人士",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh-hk",
+          "name": "無黨籍人士",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh-cn",
+          "name": "无党籍人士",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh-sg",
+          "name": "无党籍人士",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh-tw",
+          "name": "無黨籍人士",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Sans étiquette",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ko",
+          "name": "무소속",
+          "note": "multilingual"
+        },
+        {
+          "lang": "arz",
+          "name": "سياسى مستقل",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Candidato independiente",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ta",
+          "name": "சுயேட்சை",
+          "note": "multilingual"
+        },
+        {
+          "lang": "de",
+          "name": "Parteiloser",
+          "note": "multilingual"
+        },
+        {
+          "lang": "id",
+          "name": "Independen",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ja",
+          "name": "無所属",
+          "note": "multilingual"
+        },
+        {
+          "lang": "el",
+          "name": "ανεξάρτητος",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "independent politician",
+          "note": "multilingual"
+        },
+        {
+          "lang": "yue",
+          "name": "獨立人士",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "onafhankelijk politicus",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sv",
+          "name": "Partilös",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ar",
+          "name": "سياسي مستقل",
+          "note": "multilingual"
+        },
+        {
+          "lang": "pt",
+          "name": "político sem partido",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ru",
+          "name": "беспартийный",
+          "note": "multilingual"
+        },
+        {
+          "lang": "mn",
+          "name": "Бие даагч",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sr-ec",
+          "name": "независни политичар",
+          "note": "multilingual"
+        },
+        {
+          "lang": "tr",
+          "name": "Bağımsız siyasetçi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ro",
+          "name": "politician independent",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ca",
+          "name": "Independent",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fi",
+          "name": "Sitoutumaton",
+          "note": "multilingual"
+        },
+        {
+          "lang": "cy",
+          "name": "Annibynnwr",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ur",
+          "name": "آزاد",
+          "note": "multilingual"
+        },
+        {
+          "lang": "az",
+          "name": "Partiyasız",
+          "note": "multilingual"
+        },
+        {
+          "lang": "da",
+          "name": "løsgænger",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh",
+          "name": "無黨籍人士",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sr",
+          "name": "независни политичар",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fa",
+          "name": "کنشگر سیاسی مستقل",
+          "note": "multilingual"
+        },
+        {
+          "lang": "war",
+          "name": "Independente",
+          "note": "multilingual"
+        },
+        {
+          "lang": "oc",
+          "name": "Independent",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sr-el",
+          "name": "nezavisni političar",
+          "note": "multilingual"
+        },
+        {
+          "lang": "it",
+          "name": "indipendente",
+          "note": "multilingual"
+        },
+        {
+          "lang": "be",
+          "name": "Беспартыйны",
+          "note": "multilingual"
+        },
+        {
+          "lang": "pl",
+          "name": "polityk niezrzeszony",
+          "note": "multilingual"
+        },
+        {
+          "lang": "mr",
+          "name": "अपक्ष",
+          "note": "multilingual"
+        },
+        {
+          "lang": "be-tarask",
+          "name": "Беспартыйны",
+          "note": "multilingual"
+        },
+        {
+          "lang": "he",
+          "name": "פוליטיקאי עצמאי",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nb",
+          "name": "partiløs",
+          "note": "multilingual"
+        },
+        {
+          "lang": "cs",
+          "name": "nezávislý",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hu",
+          "name": "független politikus",
+          "note": "multilingual"
+        },
+        {
+          "lang": "eo",
+          "name": "Sendependa",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hi",
+          "name": "निर्दलीय",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sh",
+          "name": "Nezavisni",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sco",
+          "name": "independent politeecian",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sk",
+          "name": "Nezávislý politik",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hak",
+          "name": "Mò-tóng-sit",
+          "note": "multilingual"
+        },
+        {
+          "lang": "th",
+          "name": "นักการเมืองอิสระ",
+          "note": "multilingual"
+        },
+        {
+          "lang": "uk",
+          "name": "Незалежний політик",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sd",
+          "name": "آزاد",
+          "note": "multilingual"
+        },
+        {
+          "lang": "la",
+          "name": "Politicus nullius factionis",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh",
+          "name": "無黨派",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh",
+          "name": "无党派人士",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh",
+          "name": "獨立人士",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh",
+          "name": "獨立候選人",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Sans etiquette",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Indépendant",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Non-inscrits",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Non-inscrit",
+          "note": "multilingual"
+        },
+        {
+          "lang": "arz",
+          "name": "Independent",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Candidato civico",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Movimientos cívicos",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Independientes",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Candidatos cívicos",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Candidato Cívico",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Candidatura independiente",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Movimiento Cívico",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Candidatura cívica",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Candidata cívica",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ta",
+          "name": "சுயேச்சை",
+          "note": "multilingual"
+        },
+        {
+          "lang": "de",
+          "name": "Unabhängiger",
+          "note": "multilingual"
+        },
+        {
+          "lang": "de",
+          "name": "freier Abgeordneter",
+          "note": "multilingual"
+        },
+        {
+          "lang": "id",
+          "name": "Politikus independen",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ja",
+          "name": "無所属議員",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "onafhankelijke",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "partijloos",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "partijloze",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "partijlozen",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sv",
+          "name": "Vänstervilde",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sv",
+          "name": "Liberal vilde",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sv",
+          "name": "Moderat vilde",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sv",
+          "name": "Politiska vildar",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sv",
+          "name": "Obunden",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sv",
+          "name": "Politisk vilde",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sv",
+          "name": "Frisinnad vilde",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sv",
+          "name": "Högervilde",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ar",
+          "name": "سياسيون مستقلون",
+          "note": "multilingual"
+        },
+        {
+          "lang": "pt",
+          "name": "Sem partido",
+          "note": "multilingual"
+        },
+        {
+          "lang": "pt",
+          "name": "Político independente",
+          "note": "multilingual"
+        },
+        {
+          "lang": "pt",
+          "name": "Candidato independente",
+          "note": "multilingual"
+        },
+        {
+          "lang": "tr",
+          "name": "Bağımsız Politikacı",
+          "note": "multilingual"
+        },
+        {
+          "lang": "tr",
+          "name": "Serbest siyasetçi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ro",
+          "name": "Politicieni independenţi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ro",
+          "name": "Independent",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ro",
+          "name": "Politicieni independenți",
+          "note": "multilingual"
+        },
+        {
+          "lang": "cy",
+          "name": "Gwleidydd annibynnol",
+          "note": "multilingual"
+        },
+        {
+          "lang": "cy",
+          "name": "Annibynnol",
+          "note": "multilingual"
+        },
+        {
+          "lang": "cy",
+          "name": "Annibynol",
+          "note": "multilingual"
+        },
+        {
+          "lang": "da",
+          "name": "Uden for partierne",
+          "note": "multilingual"
+        },
+        {
+          "lang": "da",
+          "name": "Frigænger",
+          "note": "multilingual"
+        },
+        {
+          "lang": "da",
+          "name": "Udenfor partierne",
+          "note": "multilingual"
+        },
+        {
+          "lang": "da",
+          "name": "Uafhængig",
+          "note": "multilingual"
+        },
+        {
+          "lang": "da",
+          "name": "Partiløs",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "nonpartisan politician",
+          "note": "multilingual"
+        },
+        {
+          "lang": "it",
+          "name": "candidato indipendente",
+          "note": "multilingual"
+        },
+        {
+          "lang": "it",
+          "name": "politico indipendente",
+          "note": "multilingual"
+        },
+        {
+          "lang": "be-tarask",
+          "name": "Беспартыйны палітык",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nb",
+          "name": "uavhengig",
+          "note": "multilingual"
+        },
+        {
+          "lang": "cs",
+          "name": "bezpartajní",
+          "note": "multilingual"
+        },
+        {
+          "lang": "cs",
+          "name": "bez stranické příslušnosti",
+          "note": "multilingual"
+        }
+      ]
     },
     {
       "classification": "party",
       "id": "party/plm",
-      "name": "PLM"
+      "identifiers": [
+        {
+          "identifier": "Q7248757",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "PLM",
+      "other_names": [
+        {
+          "lang": "en",
+          "name": "Progressive Labour Movement",
+          "note": "multilingual"
+        },
+        {
+          "lang": "de",
+          "name": "Progressive Labour Movement",
+          "note": "multilingual"
+        }
+      ]
     },
     {
       "classification": "party",
       "id": "party/undp",
-      "name": "UNDP"
+      "identifiers": [
+        {
+          "identifier": "Q7888291",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "UNDP",
+      "other_names": [
+        {
+          "lang": "en",
+          "name": "United National Democratic Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "de",
+          "name": "United National Democratic Party",
+          "note": "multilingual"
+        }
+      ]
     },
     {
       "classification": "party",
       "id": "party/upp",
-      "name": "UPP"
+      "identifiers": [
+        {
+          "identifier": "Q1285399",
+          "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "website",
+          "url": "http://www.uppantigua.com/"
+        }
+      ],
+      "name": "UPP",
+      "other_names": [
+        {
+          "lang": "pt",
+          "name": "Partido Progressista Unido",
+          "note": "multilingual"
+        },
+        {
+          "lang": "de",
+          "name": "United Progressive Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Parti progressiste unifié",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sh",
+          "name": "Ujedinjena progresivna partija",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "United Progressive Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Partido Progresista Unido",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ar",
+          "name": "الحزب التقدمي الموحد",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "United Progressive Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ru",
+          "name": "Объединенная прогрессивная партия",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nb",
+          "name": "United Progressive Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh-hant",
+          "name": "統一進步黨",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh-cn",
+          "name": "統一進步党",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sh",
+          "name": "Ujedinjena napredna stranka",
+          "note": "multilingual"
+        }
+      ]
     }
   ],
   "meta": {

--- a/data/Antigua_and_Barbuda/Representatives/sources/instructions.json
+++ b/data/Antigua_and_Barbuda/Representatives/sources/instructions.json
@@ -50,6 +50,14 @@
         "from": "wikidata-raw",
         "source": "reconciliation/wikidata.csv"
       }
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "create": {
+        "from": "group-wikidata",
+        "source": "manual/group_wikidata.csv"
+      }
     }
   ]
 }

--- a/data/Antigua_and_Barbuda/Representatives/sources/manual/group_wikidata.csv
+++ b/data/Antigua_and_Barbuda/Representatives/sources/manual/group_wikidata.csv
@@ -1,0 +1,8 @@
+id,wikidata
+alp,Q1277738
+upp,Q1285399
+plm,Q7248757
+ablp,Q1277738
+bpm,Q3038017
+ind,Q327591
+undp,Q7888291

--- a/data/Antigua_and_Barbuda/Representatives/sources/wikidata/groups.json
+++ b/data/Antigua_and_Barbuda/Representatives/sources/wikidata/groups.json
@@ -1,0 +1,848 @@
+{
+  "ablp": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q1277738"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "pt",
+        "name": "Partido Trabalhista de Antígua",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ja",
+        "name": "アンティグア労働党",
+        "note": "multilingual"
+      },
+      {
+        "lang": "fr",
+        "name": "Parti travailliste d'Antigua",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sh",
+        "name": "Antigvanska laburistička partija",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Antigua and Barbuda Labour Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Partido Laborista de Antigua",
+        "note": "multilingual"
+      },
+      {
+        "lang": "uk",
+        "name": "Антигуанська робітнича партія",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ar",
+        "name": "حزب العمل الأنتيغي",
+        "note": "multilingual"
+      },
+      {
+        "lang": "nl",
+        "name": "Antigua Labour Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "de",
+        "name": "Antigua Labour Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ru",
+        "name": "Антигуанская рабочая партия",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh",
+        "name": "安提瓜工黨",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sh",
+        "name": "Antigvanska laburistička stranka",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Antigua Labour Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "nl",
+        "name": "Arbeiderspartij van Antigua",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Antigua Labour Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "ALP",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "ABLP",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "upp": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q1285399"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "pt",
+        "name": "Partido Progressista Unido",
+        "note": "multilingual"
+      },
+      {
+        "lang": "de",
+        "name": "United Progressive Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "fr",
+        "name": "Parti progressiste unifié",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sh",
+        "name": "Ujedinjena progresivna partija",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "United Progressive Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Partido Progresista Unido",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ar",
+        "name": "الحزب التقدمي الموحد",
+        "note": "multilingual"
+      },
+      {
+        "lang": "nl",
+        "name": "United Progressive Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ru",
+        "name": "Объединенная прогрессивная партия",
+        "note": "multilingual"
+      },
+      {
+        "lang": "nb",
+        "name": "United Progressive Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh-hant",
+        "name": "統一進步黨",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh-cn",
+        "name": "統一進步党",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sh",
+        "name": "Ujedinjena napredna stranka",
+        "note": "multilingual"
+      }
+    ],
+    "links": [
+      {
+        "url": "http://www.uppantigua.com/",
+        "note": "website"
+      }
+    ]
+  },
+  "plm": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q7248757"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "en",
+        "name": "Progressive Labour Movement",
+        "note": "multilingual"
+      },
+      {
+        "lang": "de",
+        "name": "Progressive Labour Movement",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "bpm": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q3038017"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "pt",
+        "name": "Movimento Popular de Barbuda",
+        "note": "multilingual"
+      },
+      {
+        "lang": "fr",
+        "name": "Mouvement populaire de Barbuda",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Barbuda People's Movement",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ar",
+        "name": "الحركة الشعبية باربودا",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ar",
+        "name": "الحركه الشعبيه باربودا",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "ind": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q327591"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "zh-hans",
+        "name": "无党籍人士",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh-hant",
+        "name": "無黨籍人士",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh-hk",
+        "name": "無黨籍人士",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh-cn",
+        "name": "无党籍人士",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh-sg",
+        "name": "无党籍人士",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh-tw",
+        "name": "無黨籍人士",
+        "note": "multilingual"
+      },
+      {
+        "lang": "fr",
+        "name": "Sans étiquette",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ko",
+        "name": "무소속",
+        "note": "multilingual"
+      },
+      {
+        "lang": "arz",
+        "name": "سياسى مستقل",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Candidato independiente",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ta",
+        "name": "சுயேட்சை",
+        "note": "multilingual"
+      },
+      {
+        "lang": "de",
+        "name": "Parteiloser",
+        "note": "multilingual"
+      },
+      {
+        "lang": "id",
+        "name": "Independen",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ja",
+        "name": "無所属",
+        "note": "multilingual"
+      },
+      {
+        "lang": "el",
+        "name": "ανεξάρτητος",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "independent politician",
+        "note": "multilingual"
+      },
+      {
+        "lang": "yue",
+        "name": "獨立人士",
+        "note": "multilingual"
+      },
+      {
+        "lang": "nl",
+        "name": "onafhankelijk politicus",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sv",
+        "name": "Partilös",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ar",
+        "name": "سياسي مستقل",
+        "note": "multilingual"
+      },
+      {
+        "lang": "pt",
+        "name": "político sem partido",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ru",
+        "name": "беспартийный",
+        "note": "multilingual"
+      },
+      {
+        "lang": "mn",
+        "name": "Бие даагч",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sr-ec",
+        "name": "независни политичар",
+        "note": "multilingual"
+      },
+      {
+        "lang": "tr",
+        "name": "Bağımsız siyasetçi",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ro",
+        "name": "politician independent",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ca",
+        "name": "Independent",
+        "note": "multilingual"
+      },
+      {
+        "lang": "fi",
+        "name": "Sitoutumaton",
+        "note": "multilingual"
+      },
+      {
+        "lang": "cy",
+        "name": "Annibynnwr",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ur",
+        "name": "آزاد",
+        "note": "multilingual"
+      },
+      {
+        "lang": "az",
+        "name": "Partiyasız",
+        "note": "multilingual"
+      },
+      {
+        "lang": "da",
+        "name": "løsgænger",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh",
+        "name": "無黨籍人士",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sr",
+        "name": "независни политичар",
+        "note": "multilingual"
+      },
+      {
+        "lang": "fa",
+        "name": "کنشگر سیاسی مستقل",
+        "note": "multilingual"
+      },
+      {
+        "lang": "war",
+        "name": "Independente",
+        "note": "multilingual"
+      },
+      {
+        "lang": "oc",
+        "name": "Independent",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sr-el",
+        "name": "nezavisni političar",
+        "note": "multilingual"
+      },
+      {
+        "lang": "it",
+        "name": "indipendente",
+        "note": "multilingual"
+      },
+      {
+        "lang": "be",
+        "name": "Беспартыйны",
+        "note": "multilingual"
+      },
+      {
+        "lang": "pl",
+        "name": "polityk niezrzeszony",
+        "note": "multilingual"
+      },
+      {
+        "lang": "mr",
+        "name": "अपक्ष",
+        "note": "multilingual"
+      },
+      {
+        "lang": "be-tarask",
+        "name": "Беспартыйны",
+        "note": "multilingual"
+      },
+      {
+        "lang": "he",
+        "name": "פוליטיקאי עצמאי",
+        "note": "multilingual"
+      },
+      {
+        "lang": "nb",
+        "name": "partiløs",
+        "note": "multilingual"
+      },
+      {
+        "lang": "cs",
+        "name": "nezávislý",
+        "note": "multilingual"
+      },
+      {
+        "lang": "hu",
+        "name": "független politikus",
+        "note": "multilingual"
+      },
+      {
+        "lang": "eo",
+        "name": "Sendependa",
+        "note": "multilingual"
+      },
+      {
+        "lang": "hi",
+        "name": "निर्दलीय",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sh",
+        "name": "Nezavisni",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sco",
+        "name": "independent politeecian",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sk",
+        "name": "Nezávislý politik",
+        "note": "multilingual"
+      },
+      {
+        "lang": "hak",
+        "name": "Mò-tóng-sit",
+        "note": "multilingual"
+      },
+      {
+        "lang": "th",
+        "name": "นักการเมืองอิสระ",
+        "note": "multilingual"
+      },
+      {
+        "lang": "uk",
+        "name": "Незалежний політик",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sd",
+        "name": "آزاد",
+        "note": "multilingual"
+      },
+      {
+        "lang": "la",
+        "name": "Politicus nullius factionis",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh",
+        "name": "無黨派",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh",
+        "name": "无党派人士",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh",
+        "name": "獨立人士",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh",
+        "name": "獨立候選人",
+        "note": "multilingual"
+      },
+      {
+        "lang": "fr",
+        "name": "Sans etiquette",
+        "note": "multilingual"
+      },
+      {
+        "lang": "fr",
+        "name": "Indépendant",
+        "note": "multilingual"
+      },
+      {
+        "lang": "fr",
+        "name": "Non-inscrits",
+        "note": "multilingual"
+      },
+      {
+        "lang": "fr",
+        "name": "Non-inscrit",
+        "note": "multilingual"
+      },
+      {
+        "lang": "arz",
+        "name": "Independent",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Candidato civico",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Movimientos cívicos",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Independientes",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Candidatos cívicos",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Candidato Cívico",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Candidatura independiente",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Movimiento Cívico",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Candidatura cívica",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Candidata cívica",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ta",
+        "name": "சுயேச்சை",
+        "note": "multilingual"
+      },
+      {
+        "lang": "de",
+        "name": "Unabhängiger",
+        "note": "multilingual"
+      },
+      {
+        "lang": "de",
+        "name": "freier Abgeordneter",
+        "note": "multilingual"
+      },
+      {
+        "lang": "id",
+        "name": "Politikus independen",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ja",
+        "name": "無所属議員",
+        "note": "multilingual"
+      },
+      {
+        "lang": "nl",
+        "name": "onafhankelijke",
+        "note": "multilingual"
+      },
+      {
+        "lang": "nl",
+        "name": "partijloos",
+        "note": "multilingual"
+      },
+      {
+        "lang": "nl",
+        "name": "partijloze",
+        "note": "multilingual"
+      },
+      {
+        "lang": "nl",
+        "name": "partijlozen",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sv",
+        "name": "Vänstervilde",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sv",
+        "name": "Liberal vilde",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sv",
+        "name": "Moderat vilde",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sv",
+        "name": "Politiska vildar",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sv",
+        "name": "Obunden",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sv",
+        "name": "Politisk vilde",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sv",
+        "name": "Frisinnad vilde",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sv",
+        "name": "Högervilde",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ar",
+        "name": "سياسيون مستقلون",
+        "note": "multilingual"
+      },
+      {
+        "lang": "pt",
+        "name": "Sem partido",
+        "note": "multilingual"
+      },
+      {
+        "lang": "pt",
+        "name": "Político independente",
+        "note": "multilingual"
+      },
+      {
+        "lang": "pt",
+        "name": "Candidato independente",
+        "note": "multilingual"
+      },
+      {
+        "lang": "tr",
+        "name": "Bağımsız Politikacı",
+        "note": "multilingual"
+      },
+      {
+        "lang": "tr",
+        "name": "Serbest siyasetçi",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ro",
+        "name": "Politicieni independenţi",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ro",
+        "name": "Independent",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ro",
+        "name": "Politicieni independenți",
+        "note": "multilingual"
+      },
+      {
+        "lang": "cy",
+        "name": "Gwleidydd annibynnol",
+        "note": "multilingual"
+      },
+      {
+        "lang": "cy",
+        "name": "Annibynnol",
+        "note": "multilingual"
+      },
+      {
+        "lang": "cy",
+        "name": "Annibynol",
+        "note": "multilingual"
+      },
+      {
+        "lang": "da",
+        "name": "Uden for partierne",
+        "note": "multilingual"
+      },
+      {
+        "lang": "da",
+        "name": "Frigænger",
+        "note": "multilingual"
+      },
+      {
+        "lang": "da",
+        "name": "Udenfor partierne",
+        "note": "multilingual"
+      },
+      {
+        "lang": "da",
+        "name": "Uafhængig",
+        "note": "multilingual"
+      },
+      {
+        "lang": "da",
+        "name": "Partiløs",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "nonpartisan politician",
+        "note": "multilingual"
+      },
+      {
+        "lang": "it",
+        "name": "candidato indipendente",
+        "note": "multilingual"
+      },
+      {
+        "lang": "it",
+        "name": "politico indipendente",
+        "note": "multilingual"
+      },
+      {
+        "lang": "be-tarask",
+        "name": "Беспартыйны палітык",
+        "note": "multilingual"
+      },
+      {
+        "lang": "nb",
+        "name": "uavhengig",
+        "note": "multilingual"
+      },
+      {
+        "lang": "cs",
+        "name": "bezpartajní",
+        "note": "multilingual"
+      },
+      {
+        "lang": "cs",
+        "name": "bez stranické příslušnosti",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "undp": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q7888291"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "en",
+        "name": "United National Democratic Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "de",
+        "name": "United National Democratic Party",
+        "note": "multilingual"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add Wikidata information about each of the political groups.