### PR TITLE
Only allow a single merge-method

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -1754,11 +1754,11 @@
         "slug": "Commons",
         "sources_directory": "data/Canada/Commons/sources",
         "popolo": "data/Canada/Commons/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd395e0/data/Canada/Commons/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3a479d5/data/Canada/Commons/ep-popolo-v1.0.json",
         "names": "data/Canada/Commons/names.csv",
-        "lastmod": "1464441999",
+        "lastmod": "1464422064",
         "person_count": 537,
-        "sha": "fd395e0",
+        "sha": "3a479d5",
         "legislative_periods": [
           {
             "id": "term/42",
@@ -1767,7 +1767,7 @@
             "wikidata": "Q21157957",
             "slug": "42",
             "csv": "data/Canada/Commons/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd395e0/data/Canada/Commons/term-42.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3a479d5/data/Canada/Commons/term-42.csv"
           },
           {
             "end_date": "2015-08-02",
@@ -1777,7 +1777,7 @@
             "wikidata": "Q2816776",
             "slug": "41",
             "csv": "data/Canada/Commons/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd395e0/data/Canada/Commons/term-41.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3a479d5/data/Canada/Commons/term-41.csv"
           }
         ],
         "statement_count": 33639

--- a/data/Canada/Commons/sources/instructions.json
+++ b/data/Canada/Commons/sources/instructions.json
@@ -29,17 +29,11 @@
       },
       "source": "https://scrapers.herokuapp.com/represent/ca",
       "type": "person",
-      "merge": [
-        {
-          "incoming_field": "id",
-          "existing_field": "id"
-        },
-        {
-          "incoming_field": "name",
-          "existing_field": "name",
-          "reconciliation_file": "reconciliation/represent-42.csv"
-        }
-      ]
+      "merge": {
+        "incoming_field": "name",
+        "existing_field": "name",
+        "reconciliation_file": "reconciliation/represent-42.csv"
+      }
     },
     {
       "file": "morph/wikidata.csv",

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -44,6 +44,10 @@ module Source
       false
     end
 
+    def has_people?
+      false
+    end
+
     # private
     REMAP = {
       area: %w(constituency region district place),
@@ -146,6 +150,10 @@ module Source
       true
     end
 
+    def has_people?
+      true
+    end
+
     def id_map_file
       filename.sub(/.csv$/, '-ids.csv')
     end
@@ -182,13 +190,13 @@ module Source
     def is_bios?
       true
     end
-  end
 
-  class Wikidata < CSV
-    def is_bios?
+    def has_people
       true
     end
+  end
 
+  class Wikidata < Person
     def fields
       super << :identifier__wikidata
     end

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -158,6 +158,13 @@ module Source
       end
     end
 
+    def as_table
+      super.each do |r|
+        # if the source has no ID, generate one
+        r[:id] = r[:name].downcase.gsub(/\s+/, '_') if r[:id].to_s.empty?
+      end
+    end
+
     # Currently we just recognise a hash of k:v pairs to accept if matching
     # TODO: add 'reject' and more complex expressions
     def filtered_table

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -86,8 +86,12 @@ module Source
   end
 
   class PlainCSV < Base
-    def as_table
+    def raw_table
       Rcsv.parse(file_contents, row_as_hash: true, columns: rcsv_column_options)
+    end
+
+    def as_table
+      raw_table
     end
 
     def rcsv_column_options
@@ -115,7 +119,7 @@ module Source
       headers.map { |h| remap(h.downcase) }
     end
 
-    def as_table
+    def raw_table
       rows = []
       super.each do |row|
         # Need to make a copy in case there are multiple source columns
@@ -158,7 +162,7 @@ module Source
       end
     end
 
-    def as_table
+    def raw_table
       super.each do |r|
         # if the source has no ID, generate one
         r[:id] = r[:name].downcase.gsub(/\s+/, '_') if r[:id].to_s.empty?
@@ -167,10 +171,10 @@ module Source
 
     # Currently we just recognise a hash of k:v pairs to accept if matching
     # TODO: add 'reject' and more complex expressions
-    def filtered_table
-      return as_table unless i(:filter)
+    def as_table
+      return raw_table unless i(:filter)
       filter = ->(row) { i(:filter)[:accept].all? { |k, v| row[k] == v } }
-      @_filtered ||= as_table.select { |row| filter.call(row) }
+      @_filtered ||= raw_table.select { |row| filter.call(row) }
     end
   end
 

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -96,12 +96,12 @@ namespace :merge_sources do
 
     # Then merge with Biographical data files
 
-    sources.select(&:is_bios?).each do |pd|
-      warn "Merging with #{pd.filename}".green
+    sources.select(&:is_bios?).each do |src|
+      warn "Merging with #{src.filename}".green
 
-      incoming_data = pd.as_table
+      incoming_data = src.as_table
 
-      abort "No merge instructions for #{pd.filename}" if (approaches = pd.merge_instructions).empty?
+      abort "No merge instructions for #{src.filename}" if (approaches = src.merge_instructions).empty?
       if merge_instructions = approaches.first
         reconciler = Reconciler.new(merge_instructions)
 
@@ -121,7 +121,7 @@ namespace :merge_sources do
         unmatched = []
         incoming_data.each do |incoming_row|
 
-          incoming_row[:identifier__wikidata] ||= incoming_row[:id] if pd.i(:type) == 'wikidata'
+          incoming_row[:identifier__wikidata] ||= incoming_row[:id] if src.i(:type) == 'wikidata'
 
           # TODO factor this out to a Patcher again
           to_patch = matcher.find_all(incoming_row)

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -68,7 +68,7 @@ namespace :merge_sources do
     sources.select(&:is_memberships?).each do |src|
       warn "Add memberships from #{src.filename}".green
       
-      incoming_data = src.filtered_table
+      incoming_data = src.as_table
       id_map = src.id_map
 
       if merge_instructions = src.merge_instructions.first

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -71,13 +71,6 @@ namespace :merge_sources do
       incoming_data = src.filtered_table
       id_map = src.id_map
 
-      # If the row has no ID, we'll need something we can treate as one
-      # This 'pseudo id' defaults to slugified 'name' 
-      # TODO: do this in `filtered_table`
-      incoming_data.select { |r| r[:id].to_s.empty? }.each do |row|
-        row[:id] = row[:name].downcase.gsub(/\s+/, '_') 
-      end
-
       if merging = src.merge_instructions.first
         reconciler = Reconciler.new(merging)
         raise "Can't reconciler memberships with a Reconciliation file yet" unless reconciler.filename

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -102,7 +102,7 @@ namespace :merge_sources do
       incoming_data = pd.as_table
 
       abort "No merge instructions for #{pd.filename}" if (approaches = pd.merge_instructions).empty?
-      approaches.each_with_index do |merge_instructions, i|
+      if merge_instructions = approaches.first
         reconciler = Reconciler.new(merge_instructions)
 
         if reconciler.filename

--- a/rake_helpers/combine_sources.rb
+++ b/rake_helpers/combine_sources.rb
@@ -71,8 +71,8 @@ namespace :merge_sources do
       incoming_data = src.filtered_table
       id_map = src.id_map
 
-      if merging = src.merge_instructions.first
-        reconciler = Reconciler.new(merging)
+      if merge_instructions = src.merge_instructions.first
+        reconciler = Reconciler.new(merge_instructions)
         raise "Can't reconciler memberships with a Reconciliation file yet" unless reconciler.filename
 
         if ENV['GENERATE_RECONCILIATION_INTERFACE'] && reconciler.triggered_by?(ENV['GENERATE_RECONCILIATION_INTERFACE'])


### PR DESCRIPTION
We used to allow multi-approach merging, but this is only used now by
Canada, as it didn't turn out to be a useful approach. Simplifying this
will allow to us harmonise more of this code in advance of switching the
approach more generally.