### PR TITLE
Convert event ids to strings when sorting

### DIFF
--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -65,7 +65,7 @@ def json_write(file, json)
   json[:memberships].sort_by!   { |m| [ 
     m[:person_id], m[:organization_id], m[:legislative_period_id], m[:start_date].to_s, m[:on_behalf_of_id].to_s, m[:area_id].to_s 
   ] }
-  json[:events].sort_by!        { |e| [ e[:start_date] || '', e[:id] ] } if json.key? :events
+  json[:events].sort_by!        { |e| [ e[:start_date].to_s || '', e[:id].to_s ] } if json.key? :events
   json[:areas].sort_by!         { |a| [ a[:id] ] } if json.key? :areas
   final = Hash[deep_sort(json).sort_by { |k, _| k }.reverse]
   File.write(file, JSON.pretty_generate(final))


### PR DESCRIPTION
Some events have string ids and others have symbols. When trying to sort
events those that have the same start_date fall back to sorting by id,
which was failing because of the comparison between a symbol and a
string.

This should fix most of the Rollbar errors that have come in over the past couple of days.