### PR TITLE
Reconciler: order next by weakness of 2nd match

### DIFF
--- a/lib/reconciliation/interface.rb
+++ b/lib/reconciliation/interface.rb
@@ -34,7 +34,9 @@ module Reconciliation
     end
 
     def to_reconcile
-      @to_reconcile ||= fuzzer.score_all.sort_by { |row| row[:existing].first[1] }.reverse
+      # Order by how good the first match is, and then how bad the second 
+      # (i.e. most confident that the first is the correct match)
+      @to_reconcile ||= fuzzer.score_all.sort_by { |row| [ row[:existing][0][1], -row[:existing][1][1] ] }.reverse
     end
 
     def fuzzer


### PR DESCRIPTION
We already ordered the results by how good the first match was. But lots
of the time we have lots of matches that are 100%, so we want to next
order by how _bad_ the second match is (i.e we're even more confident
that the first match must be right, as nothing else is even close)

Closes https://github.com/everypolitician/everypolitician/issues/260