### PR TITLE
Add a `stats.json` file

### DIFF
--- a/bin/dashboard.rb
+++ b/bin/dashboard.rb
@@ -14,6 +14,7 @@ ordering = Hash[drilldown.select { |r| (r[0].to_s.length > 1) && (r[0][0] == r[0
 
 EveryPolitician.countries_json = 'countries.json'
 
+# TODO read lots of these from the `stats.json` files, once populated
 data = EveryPolitician.countries.map do |c|
   c.legislatures.map do |l|
     popolo = Everypolitician::Popolo.read(l.raw_data[:popolo])

--- a/rake_helpers/generate_stats.rb
+++ b/rake_helpers/generate_stats.rb
@@ -1,0 +1,46 @@
+
+#-----------------------------------------------------------------------
+# Update the `stats.json` file for a Legislature
+#-----------------------------------------------------------------------
+
+namespace :stats do
+
+  task :regenerate => 'ep-popolo-v1.0.json' do
+    popolo = Everypolitician::Popolo.read('ep-popolo-v1.0.json')
+    now = DateTime.now.to_date
+
+    events = popolo.events
+    terms = events.select { |e| e.classification == 'legislative period' }
+    elections = events.select { |e| e.classification == 'general election' }
+
+    parties = popolo.organizations.select { |o| o[:classification] == 'party' }.reject { |o| o[:name].downcase == 'unknown' }
+    wd_part = parties.partition { |p| (p[:identifiers] || []).find { |i| i[:scheme] == 'wikidata' } }
+
+    # Ignore elections that are in the following year, or later
+    latest_election = elections.map { |e| e.end_date }.compact.sort_by { |d| "#{d}-12-31" }.select { |d| d[0...4].to_i <= now.year }.last rescue ''
+    latest_term_start = terms.last.start_date rescue ''
+
+    stats = {
+      people: { 
+        count: popolo.persons.count,
+        wikidata: popolo.persons.partition { |p| (p[:identifiers] || []).find { |i| i[:scheme] == 'wikidata' } }.first.count,
+      },
+      groups: { 
+        count: parties.count,
+        wikidata: wd_part.first.count,
+      },
+      terms: { 
+        count: terms.count,
+        latest: latest_term_start,
+      },
+      elections: { 
+        count: elections.count,
+        latest: latest_election || '',
+      }
+    }
+
+    FileUtils.mkpath('unstable')
+    File.write('unstable/stats.json', JSON.pretty_generate(stats))
+  end
+
+end

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -21,6 +21,9 @@
 # Step 5: generate_final_csvs
 # Generates term-by-term CSVs from the ep-popolo
 
+# Step 6: generate_stats
+# Generates statistics about the data we have
+
 require 'colorize'
 require 'csv'
 require 'csv_to_popolo'
@@ -188,11 +191,12 @@ end
 
 desc "Rebuild from source data"
 task :rebuild => [ :clobber, 'ep-popolo-v1.0.json' ]
-task :default => :csvs
+task :default => [ :csvs, 'stats:regenerate' ]
 
 require_relative 'rake_helpers/combine_sources.rb'
 require_relative 'rake_helpers/verify_source_data.rb'
 require_relative 'rake_helpers/turn_csv_to_popolo.rb'
 require_relative 'rake_helpers/generate_ep_popolo.rb'
 require_relative 'rake_helpers/generate_final_csvs.rb'
+require_relative 'rake_helpers/generate_stats.rb'
 


### PR DESCRIPTION
Rather than generating stats from a `bin/` file (as we currently do in
the dashboard script, and others), auto-generate them any time we're
rebuilding a legislature.

This will live in `unstable/` whilst we play around with the format etc for it.