### PR TITLE
Match multiple groups to a single wikidata identifier

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -346,11 +346,11 @@
         "slug": "Representatives",
         "sources_directory": "data/Antigua_and_Barbuda/Representatives/sources",
         "popolo": "data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c47a189/data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/989cf3e/data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
         "names": "data/Antigua_and_Barbuda/Representatives/names.csv",
-        "lastmod": "1465122421",
+        "lastmod": "1465383694",
         "person_count": 63,
-        "sha": "c47a189",
+        "sha": "989cf3e",
         "legislative_periods": [
           {
             "end_date": "2019",
@@ -359,7 +359,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c47a189/data/Antigua_and_Barbuda/Representatives/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/989cf3e/data/Antigua_and_Barbuda/Representatives/term-2014.csv"
           },
           {
             "end_date": "2014",
@@ -368,7 +368,7 @@
             "start_date": "2009",
             "slug": "2009",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c47a189/data/Antigua_and_Barbuda/Representatives/term-2009.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/989cf3e/data/Antigua_and_Barbuda/Representatives/term-2009.csv"
           },
           {
             "end_date": "2009",
@@ -377,7 +377,7 @@
             "start_date": "2004",
             "slug": "2004",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-2004.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c47a189/data/Antigua_and_Barbuda/Representatives/term-2004.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/989cf3e/data/Antigua_and_Barbuda/Representatives/term-2004.csv"
           },
           {
             "end_date": "2004",
@@ -386,7 +386,7 @@
             "start_date": "1999",
             "slug": "1999",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1999.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c47a189/data/Antigua_and_Barbuda/Representatives/term-1999.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/989cf3e/data/Antigua_and_Barbuda/Representatives/term-1999.csv"
           },
           {
             "end_date": "1999",
@@ -395,7 +395,7 @@
             "start_date": "1994",
             "slug": "1994",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1994.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c47a189/data/Antigua_and_Barbuda/Representatives/term-1994.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/989cf3e/data/Antigua_and_Barbuda/Representatives/term-1994.csv"
           },
           {
             "end_date": "1994",
@@ -404,7 +404,7 @@
             "start_date": "1989",
             "slug": "1989",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1989.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c47a189/data/Antigua_and_Barbuda/Representatives/term-1989.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/989cf3e/data/Antigua_and_Barbuda/Representatives/term-1989.csv"
           },
           {
             "end_date": "1989",
@@ -413,7 +413,7 @@
             "start_date": "1984",
             "slug": "1984",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1984.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c47a189/data/Antigua_and_Barbuda/Representatives/term-1984.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/989cf3e/data/Antigua_and_Barbuda/Representatives/term-1984.csv"
           },
           {
             "end_date": "1984",
@@ -422,7 +422,7 @@
             "start_date": "1980",
             "slug": "1980",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1980.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c47a189/data/Antigua_and_Barbuda/Representatives/term-1980.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/989cf3e/data/Antigua_and_Barbuda/Representatives/term-1980.csv"
           },
           {
             "end_date": "1980",
@@ -431,7 +431,7 @@
             "start_date": "1976",
             "slug": "1976",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1976.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c47a189/data/Antigua_and_Barbuda/Representatives/term-1976.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/989cf3e/data/Antigua_and_Barbuda/Representatives/term-1976.csv"
           },
           {
             "end_date": "1976",
@@ -440,10 +440,10 @@
             "start_date": "1971",
             "slug": "1971",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1971.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c47a189/data/Antigua_and_Barbuda/Representatives/term-1971.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/989cf3e/data/Antigua_and_Barbuda/Representatives/term-1971.csv"
           }
         ],
-        "statement_count": 2202
+        "statement_count": 2258
       }
     ]
   },

--- a/data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json
+++ b/data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json
@@ -1646,7 +1646,105 @@
     {
       "classification": "party",
       "id": "party/alp",
-      "name": "ALP"
+      "identifiers": [
+        {
+          "identifier": "Q1277738",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "ALP",
+      "other_names": [
+        {
+          "lang": "pt",
+          "name": "Partido Trabalhista de Antígua",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ja",
+          "name": "アンティグア労働党",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Parti travailliste d'Antigua",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sh",
+          "name": "Antigvanska laburistička partija",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Antigua and Barbuda Labour Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Partido Laborista de Antigua",
+          "note": "multilingual"
+        },
+        {
+          "lang": "uk",
+          "name": "Антигуанська робітнича партія",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ar",
+          "name": "حزب العمل الأنتيغي",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Antigua Labour Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "de",
+          "name": "Antigua Labour Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ru",
+          "name": "Антигуанская рабочая партия",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh",
+          "name": "安提瓜工黨",
+          "note": "multilingual"
+        },
+        {
+          "lang": "sh",
+          "name": "Antigvanska laburistička stranka",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Antigua Labour Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Arbeiderspartij van Antigua",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Antigua Labour Party",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "ALP",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "ABLP",
+          "note": "multilingual"
+        }
+      ]
     },
     {
       "classification": "party",

--- a/data/Antigua_and_Barbuda/Representatives/sources/wikidata/groups.json
+++ b/data/Antigua_and_Barbuda/Representatives/sources/wikidata/groups.json
@@ -1,5 +1,5 @@
 {
-  "ablp": {
+  "alp": {
     "identifiers": [
       {
         "scheme": "wikidata",
@@ -206,6 +206,106 @@
       {
         "lang": "ja",
         "name": "進歩労働運動",
+        "note": "multilingual"
+      }
+    ]
+  },
+  "ablp": {
+    "identifiers": [
+      {
+        "scheme": "wikidata",
+        "identifier": "Q1277738"
+      }
+    ],
+    "other_names": [
+      {
+        "lang": "pt",
+        "name": "Partido Trabalhista de Antígua",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ja",
+        "name": "アンティグア労働党",
+        "note": "multilingual"
+      },
+      {
+        "lang": "fr",
+        "name": "Parti travailliste d'Antigua",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sh",
+        "name": "Antigvanska laburistička partija",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Antigua and Barbuda Labour Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Partido Laborista de Antigua",
+        "note": "multilingual"
+      },
+      {
+        "lang": "uk",
+        "name": "Антигуанська робітнича партія",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ar",
+        "name": "حزب العمل الأنتيغي",
+        "note": "multilingual"
+      },
+      {
+        "lang": "nl",
+        "name": "Antigua Labour Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "de",
+        "name": "Antigua Labour Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "ru",
+        "name": "Антигуанская рабочая партия",
+        "note": "multilingual"
+      },
+      {
+        "lang": "zh",
+        "name": "安提瓜工黨",
+        "note": "multilingual"
+      },
+      {
+        "lang": "sh",
+        "name": "Antigvanska laburistička stranka",
+        "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Antigua Labour Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "nl",
+        "name": "Arbeiderspartij van Antigua",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "Antigua Labour Party",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "ALP",
+        "note": "multilingual"
+      },
+      {
+        "lang": "en",
+        "name": "ABLP",
         "note": "multilingual"
       }
     ]

--- a/data/Antigua_and_Barbuda/Representatives/unstable/stats.json
+++ b/data/Antigua_and_Barbuda/Representatives/unstable/stats.json
@@ -1,0 +1,18 @@
+{
+  "people": {
+    "count": 63,
+    "wikidata": 7
+  },
+  "groups": {
+    "count": 7,
+    "wikidata": 6
+  },
+  "terms": {
+    "count": 10,
+    "latest": "2014"
+  },
+  "elections": {
+    "count": 0,
+    "latest": ""
+  }
+}

--- a/data/Antigua_and_Barbuda/Representatives/unstable/stats.json
+++ b/data/Antigua_and_Barbuda/Representatives/unstable/stats.json
@@ -5,7 +5,7 @@
   },
   "groups": {
     "count": 7,
-    "wikidata": 6
+    "wikidata": 7
   },
   "terms": {
     "count": 10,

--- a/lib/wikidata_lookup.rb
+++ b/lib/wikidata_lookup.rb
@@ -9,13 +9,13 @@ class WikidataLookup
 
   def initialize(mapping)
     @wikidata_id_lookup = Hash[
-      mapping.map { |item| [item[:wikidata], item[:id]] }
+      mapping.map { |item| [item[:id], item[:wikidata]] }
     ]
   end
 
   def to_hash
-    information = wikidata_results.map do |result|
-      [wikidata_id_lookup[result.id], fields_for(result)]
+    information = wikidata_id_lookup.map do |id, wikidata_id|
+      [id, fields_for(wikidata_results[wikidata_id])]
     end
     Hash[information]
   end
@@ -23,14 +23,14 @@ class WikidataLookup
   private
 
   def wikidata_ids
-    @_wikidata_ids ||= wikidata_id_lookup.keys.each do |qid|
+    @_wikidata_ids ||= wikidata_id_lookup.values.uniq.each do |qid|
       abort "#{qid} is not a valid Wikidata id" unless qid.start_with? 'Q'
     end
   end
 
 
   def wikidata_results
-    @wikidata_results ||= Wikisnakker::Item.find(wikidata_ids)
+    @wikidata_results ||= Hash[Wikisnakker::Item.find(wikidata_ids).map { |r| [r.id, r] }]
   end
 
   def names_from(labels)


### PR DESCRIPTION
Allows multiple groups to be matched up to the same wikidata identifer. Previously this didn't work if multiple groups were matched up to a single wikidata id, in that case only one group would be correctly matched to wikidata.

Initial work towards https://github.com/everypolitician/everypolitician/issues/428