### PR TITLE
Fix click voting in reconciler

### DIFF
--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -295,7 +295,7 @@ jQuery(function($) {
   });
 
   $(document).on('click', '.pairing__choices > div header.person__meta', function(){
-    vote($(this));
+    vote($(this).parent());
   });
 
   $(document).on('keydown', handleKeyPress);


### PR DESCRIPTION
Previously, it would attempt to extract the UUID from the header
element though the UUID attribute is actually set on its parent.