### PR TITLE
Australia (House of Representatives) collect twitter data from openaustralia scraper

### DIFF
--- a/data/Australia/Representatives/sources/instructions.json
+++ b/data/Australia/Representatives/sources/instructions.json
@@ -15,7 +15,7 @@
       "create": {
         "from": "morph",
         "scraper": "openaustralia/aus_mp_contact_details",
-        "query": "SELECT aph_id, photo_url AS photo, email, facebook, website FROM data WHERE house = 'representatives' ORDER BY aph_id"
+        "query": "SELECT aph_id, photo_url AS photo, email, facebook, twitter, website FROM data WHERE house = 'representatives' ORDER BY aph_id"
       },
       "merge": {
         "incoming_field": "aph_id",


### PR DESCRIPTION
Spotted that we're not pulling in the twitter data that the OpenAustralia scraper already has, so added `twitter` to the columns we're using.

(Right now, this doesn't pick up any new data, but the more sources the merrier)