### PR TITLE
Colombia (Representatives): better Term dates

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -2017,19 +2017,19 @@
         "slug": "Representatives",
         "sources_directory": "data/Colombia/Representatives/sources",
         "popolo": "data/Colombia/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e8d7300/data/Colombia/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a6df8e/data/Colombia/Representatives/ep-popolo-v1.0.json",
         "names": "data/Colombia/Representatives/names.csv",
-        "lastmod": "1465555987",
+        "lastmod": "1465733412",
         "person_count": 168,
-        "sha": "e8d7300",
+        "sha": "0a6df8e",
         "legislative_periods": [
           {
             "id": "term/2014",
             "name": "2014–",
-            "start_date": "2014",
+            "start_date": "2014-07-20",
             "slug": "2014",
             "csv": "data/Colombia/Representatives/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e8d7300/data/Colombia/Representatives/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a6df8e/data/Colombia/Representatives/term-2014.csv"
           }
         ],
         "statement_count": 4548

--- a/data/Colombia/Representatives/ep-popolo-v1.0.json
+++ b/data/Colombia/Representatives/ep-popolo-v1.0.json
@@ -9452,7 +9452,7 @@
       "id": "term/2014",
       "name": "2014–",
       "organization_id": "legislature",
-      "start_date": "2014"
+      "start_date": "2014-07-20"
     }
   ],
   "areas": [

--- a/data/Colombia/Representatives/sources/manual/terms.csv
+++ b/data/Colombia/Representatives/sources/manual/terms.csv
@@ -1,2 +1,2 @@
 id,name,start_date,end_date,source
-2014,2014–,2014,,https://en.wikipedia.org/wiki/Colombian_parliamentary_election,_2014
+2014,2014–,2014-07-20,,https://en.wikipedia.org/wiki/Colombian_parliamentary_election,_2014

--- a/data/Colombia/Representatives/unstable/stats.json
+++ b/data/Colombia/Representatives/unstable/stats.json
@@ -9,7 +9,7 @@
   },
   "terms": {
     "count": 1,
-    "latest": "2014"
+    "latest": "2014-07-20"
   },
   "elections": {
     "count": 0,


### PR DESCRIPTION
```
Add memberships from sources/morph/data.csv
Merging with sources/morph/wikidata.csv
* 2 of 56 unmatched
	{:id=>"Q6005013", :name=>"María del Socorro Bustamante"}
	{:id=>"Q20022295", :name=>"Yahir Acuña"}
Adding GenderBalance results from sources/gender-balance/results.csv
  ⚥ data for 0; 0 added

Creating 1 term file

Top identifiers:
  54 x wikidata
  1 x isni
  1 x fast
  1 x freebase
  1 x gnd

Creating names.csv
Creating unstable/positions.csv
Persons matched to Wikidata: 54 ✓ | 114 ✘
  No wikidata: LUIS FERNANDO URREGO CARVAJAL (33f1985f-bf69-47e5-96ce-ac1d928cc111)
  No wikidata: NERY OROS ORTÍZ (aed4ba2c-f89d-4f88-8588-a7c5c5d02b15)
  No wikidata: DIELA LILIANA BENAVIDES SOLARTE (6b04d2b3-7e60-4d6f-a380-946c0956f505)
  No wikidata: MARÍA EUGENIA TRIANA VARGAS (8148dfd3-248c-458f-a581-ca9a5b215531)
  No wikidata: JOSÉ BERNARDO FLÓREZ ASPRILLA (47629a2b-877b-4d83-abbb-7caebaee44e9)
  No wikidata: ARGENIS VELASQUEZ RAMÍREZ (ea547f05-3e19-4419-bf95-3f980951e71f)
  No wikidata: ALEJANDRO CARLOS CHACON CAMARGO (04b1033f-335c-467d-98a1-b1234f3639a7)
  No wikidata: CRISANTO PIZO MAZABUEL (f0e8ee88-a9f4-416c-b488-cba1fa2b40f7)
  No wikidata: JOSÉ LUIS PÉREZ OYUELA (9c6ae875-ac4e-491c-81ed-71f638053fb7)
  No wikidata: JAIR ARANGO TORRES (bc0fa546-3cf3-48b4-a324-14e456a919bf)
Parties matched to Wikidata: 13 ✓ | 1 ✘
  No wikidata: Por Un Huila Mejor (party/por_un_huila_mejor)
```