### PR TITLE
Brazil (Deputies): Learn new Positions

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -1254,11 +1254,11 @@
         "slug": "Deputies",
         "sources_directory": "data/Brazil/Deputies/sources",
         "popolo": "data/Brazil/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Brazil/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/53436eb/data/Brazil/Deputies/ep-popolo-v1.0.json",
         "names": "data/Brazil/Deputies/names.csv",
-        "lastmod": "1465812521",
+        "lastmod": "1465817845",
         "person_count": 564,
-        "sha": "75b7651",
+        "sha": "53436eb",
         "legislative_periods": [
           {
             "id": "term/55",
@@ -1266,7 +1266,7 @@
             "start_date": "2015-02-01",
             "slug": "55",
             "csv": "data/Brazil/Deputies/term-55.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Brazil/Deputies/term-55.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/53436eb/data/Brazil/Deputies/term-55.csv"
           }
         ],
         "statement_count": 20195

--- a/data/Brazil/Deputies/sources/manual/position-filter.json
+++ b/data/Brazil/Deputies/sources/manual/position-filter.json
@@ -21,7 +21,10 @@
       }
     ],
     "executive": [
-
+      {
+        "id": "Q24574297",
+        "name": "Minister of Sports"
+      }
     ],
     "party": [
 
@@ -35,11 +38,6 @@
       {
         "id": "Q11812141",
         "name": "List of Governors of Rio de Janeiro",
-        "count": 1
-      },
-      {
-        "id": "Q7579929",
-        "name": "sports minister",
         "count": 1
       }
     ]

--- a/data/Brazil/Deputies/sources/wikidata/positions.json
+++ b/data/Brazil/Deputies/sources/wikidata/positions.json
@@ -6,6 +6,13 @@
       "title": "member of the Chamber of Deputies of Brazil"
     }
   ],
+  "Q10305232": [
+    {
+      "id": "Q20058725",
+      "label": "member of the Chamber of Deputies of Brazil",
+      "title": "member of the Chamber of Deputies of Brazil"
+    }
+  ],
   "Q4723825": [
     {
       "id": "Q18964326",
@@ -228,6 +235,13 @@
       "title": "member of the Chamber of Deputies of Brazil"
     }
   ],
+  "Q9069881": [
+    {
+      "id": "Q20058725",
+      "label": "member of the Chamber of Deputies of Brazil",
+      "title": "member of the Chamber of Deputies of Brazil"
+    }
+  ],
   "Q1486078": [
     {
       "id": "Q20058725",
@@ -320,6 +334,13 @@
     }
   ],
   "Q10363867": [
+    {
+      "id": "Q20058725",
+      "label": "member of the Chamber of Deputies of Brazil",
+      "title": "member of the Chamber of Deputies of Brazil"
+    }
+  ],
+  "Q20045666": [
     {
       "id": "Q20058725",
       "label": "member of the Chamber of Deputies of Brazil",
@@ -609,9 +630,13 @@
       "title": "member of the Chamber of Deputies of Brazil"
     },
     {
-      "id": "Q7579929",
-      "label": "sports minister",
-      "title": "sports minister"
+      "id": "Q24574297",
+      "label": "Minister of Sports",
+      "title": "Minister of Sports",
+      "qualifiers": {
+        "P580": "2015-01-01",
+        "P582": "2016-03-30"
+      }
     }
   ],
   "Q20048428": [
@@ -797,6 +822,13 @@
     }
   ],
   "Q10365112": [
+    {
+      "id": "Q20058725",
+      "label": "member of the Chamber of Deputies of Brazil",
+      "title": "member of the Chamber of Deputies of Brazil"
+    }
+  ],
+  "Q21020376": [
     {
       "id": "Q20058725",
       "label": "member of the Chamber of Deputies of Brazil",
@@ -1011,6 +1043,14 @@
       "id": "Q20058725",
       "label": "member of the Chamber of Deputies of Brazil",
       "title": "member of the Chamber of Deputies of Brazil"
+    },
+    {
+      "id": "Q24574297",
+      "label": "Minister of Sports",
+      "title": "Minister of Sports",
+      "qualifiers": {
+        "P580": "2016-05-12"
+      }
     }
   ],
   "Q18276168": [
@@ -1463,6 +1503,13 @@
     }
   ],
   "Q10273609": [
+    {
+      "id": "Q20058725",
+      "label": "member of the Chamber of Deputies of Brazil",
+      "title": "member of the Chamber of Deputies of Brazil"
+    }
+  ],
+  "Q16337926": [
     {
       "id": "Q20058725",
       "label": "member of the Chamber of Deputies of Brazil",

--- a/data/Brazil/Deputies/unstable/positions.csv
+++ b/data/Brazil/Deputies/unstable/positions.csv
@@ -3,7 +3,9 @@ id,name,position,start_date,end_date
 e34cd9b5-995f-43a3-a8b3-b11ef2501fa4,BENEDITA DA SILVA,Member of the Senate of Brazil,,
 de251ce3-d207-469d-be2e-23d09473be7b,ESPERIDIÃO AMIN,Member of the Senate of Brazil,,
 f9990eba-1396-4a2b-87d2-bf81128a7d48,FLAVIANO MELO,Member of the Senate of Brazil,,
+7b3ecba7-680a-4eec-9a03-4357a0c7f52c,GEORGE HILTON,Minister of Sports,2015-01-01,2016-03-30
 79d6b5be-04c7-47dc-912d-2c000912c2e9,HERÁCLITO FORTES,Member of the Senate of Brazil,,
 c77d96e5-45f0-42f7-ba77-ad7245287aa0,JARBAS VASCONCELOS,Member of the Senate of Brazil,,
+b2c585be-e9d0-4581-8238-f97850d35819,LEONARDO PICCIANI,Minister of Sports,2016-05-12,
 4fe8fb38-a40d-4f3d-8ad6-8ec92b1aa26b,SERGIO SOUZA,Member of the Senate of Brazil,,
 d0e11d9d-28ae-48f4-b25d-c1be4bfa33cc,SIBÁ MACHADO,Member of the Senate of Brazil,,

--- a/data/Brazil/Deputies/unstable/stats.json
+++ b/data/Brazil/Deputies/unstable/stats.json
@@ -16,6 +16,6 @@
     "latest": "2014-10-26"
   },
   "positions": {
-    "executive": 0
+    "executive": 1
   }
 }


### PR DESCRIPTION
```
Add memberships from sources/morph/data.csv
Merging with sources/morph/wikidata.csv
* 11 of 274 unmatched
	{:id=>"Q10393111", :name=>"Walter Shindi Ihoshi"}
	{:id=>"Q16940797", :name=>"Sérgio Olímpio Gomes"}
	{:id=>"Q16940022", :name=>"Flavio Augusto da Silva"}
	{:id=>"Q10390275", :name=>"Vicente Paulo da Silva"}
	{:id=>"Q16337696", :name=>"José Olímpio Silveira Moraes"}
	{:id=>"Q20045978", :name=>"Luis Antonio Franciscatto Covatti"}
	{:id=>"Q10281433", :name=>"Fernando Marroni"}
	{:id=>"Q20045762", :name=>"Fábio Abreu Costa"}
	{:id=>"Q10309081", :name=>"José Carlos Becker de Oliveira e Silva"}
	{:id=>"Q19708978", :name=>"Giovani Feltes"}
Adding GenderBalance results from sources/gender-balance/results.csv
  ⚥ data for 519; 284 added

Creating 1 term file

Top identifiers:
  263 x wikidata
  9 x viaf
  8 x freebase
  2 x lcauth
  2 x bnf

Creating names.csv
Creating unstable/positions.csv
  Unknown position (x1): Q11812141 List of Governors of Rio de Janeiro — e.g. Q4887390
Persons matched to Wikidata: 263 ✓ | 301 ✘
  No wikidata: MISAEL VARELLA (47dbd248-f342-40aa-8964-30b5d4018ca4)
  No wikidata: PAULO MARTINS (ac3f06ca-ab42-45d6-80f0-05f4d74341ba)
  No wikidata: FÁBIO MITIDIERI (2c6c1cea-53e0-4401-9f92-91fd107b8e76)
  No wikidata: SEVERINO NINHO (8d748cb6-276a-4ce3-9641-ca45552567e0)
  No wikidata: ADEMIR CAMILO (d0d0ad60-09c6-489b-af5b-69294b5ea08b)
  No wikidata: JUSCELINO FILHO (8b2ed26d-6591-46ae-8639-a6dc92b96c51)
  No wikidata: SEBASTIÃO OLIVEIRA (29052b13-40a9-47ec-8440-e3341f518942)
  No wikidata: ADALBERTO CAVALCANTI (5ade0a86-2ef1-4e75-a6c6-bf5d2d914f1f)
  No wikidata: MAURO LOPES (0b632431-c0e3-4031-9ba4-41c987442415)
  No wikidata: SANDES JÚNIOR (d3d03897-d393-46eb-8126-75c690e9dafb)
Parties matched to Wikidata: 30 ✓ 
```