### PR TITLE
Dashboard: use raw `start_date` for terms

### DIFF
--- a/bin/dashboard.rb
+++ b/bin/dashboard.rb
@@ -35,7 +35,7 @@ data = EveryPolitician.countries.map do |c|
       wd_parties: stats[:groups][:wikidata],
       terms: l.legislative_periods.count,
       elections: stats[:elections][:count],
-      latest_term: l.legislative_periods.first.start_date.to_s,
+      latest_term: l.legislative_periods.first.raw_data[:start_date],
       latest_election: stats[:elections][:latest],
       executive_positions: stats[:positions][:executive],
     }


### PR DESCRIPTION
The version in `start_date` expands partial dates, e.g. 2014 to
2014-01-01, and we want the underlying information to notice which ones
we need to find more precise information for.