### PR TITLE
Laos (Assembly): better term dates

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -5176,22 +5176,23 @@
         "slug": "Assembly",
         "sources_directory": "data/Laos/Assembly/sources",
         "popolo": "data/Laos/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Laos/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f53be19/data/Laos/Assembly/ep-popolo-v1.0.json",
         "names": "data/Laos/Assembly/names.csv",
-        "lastmod": "1465812521",
+        "lastmod": "1465852502",
         "person_count": 132,
-        "sha": "75b7651",
+        "sha": "f53be19",
         "legislative_periods": [
           {
+            "end_date": "2016-03-20",
             "id": "term/2011",
-            "name": "2011–",
-            "start_date": "2011",
+            "name": "2011–2016",
+            "start_date": "2011-06-15",
             "slug": "2011",
             "csv": "data/Laos/Assembly/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Laos/Assembly/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f53be19/data/Laos/Assembly/term-2011.csv"
           }
         ],
-        "statement_count": 1810
+        "statement_count": 1811
       }
     ]
   },

--- a/data/Laos/Assembly/ep-popolo-v1.0.json
+++ b/data/Laos/Assembly/ep-popolo-v1.0.json
@@ -3126,10 +3126,11 @@
   "events": [
     {
       "classification": "legislative period",
+      "end_date": "2016-03-20",
       "id": "term/2011",
-      "name": "2011–",
+      "name": "2011–2016",
       "organization_id": "legislature",
-      "start_date": "2011"
+      "start_date": "2011-06-15"
     }
   ],
   "areas": [

--- a/data/Laos/Assembly/sources/manual/terms.csv
+++ b/data/Laos/Assembly/sources/manual/terms.csv
@@ -1,2 +1,3 @@
-id,name,start_date,end_date,source
-2011,2011–,2011,,https://en.wikipedia.org/wiki/Elections_in_Laos
+id,name,start_date,end_date
+2011,2011–2016,2011-06-15,2016-03-20
+2016,2016–,2016-04-20,

--- a/data/Laos/Assembly/unstable/stats.json
+++ b/data/Laos/Assembly/unstable/stats.json
@@ -9,7 +9,7 @@
   },
   "terms": {
     "count": 1,
-    "latest": "2011"
+    "latest": "2011-06-15"
   },
   "elections": {
     "count": 0,


### PR DESCRIPTION
```
Add memberships from sources/morph/data.csv
Merging with sources/morph/wikidata.csv
* 37 of 55 unmatched
	{:id=>"Q7429308", :name=>"Saysmone Khomthavong"}
	{:id=>"Q7711395", :name=>"Thatsadaphone Nosing"}
	{:id=>"Q7795970", :name=>"Thongvankham Sithilath"}
	{:id=>"Q6399936", :name=>"Khamchanh Sakountava"}
	{:id=>"Q5072184", :name=>"Chanhthuem Latmany"}
	{:id=>"Q5072182", :name=>"Chanhsouk Bounpachit"}
	{:id=>"Q4855525", :name=>"Bangon Xayalath"}
	{:id=>"Q7111324", :name=>"Ousavanh Thiengthetvonga"}
	{:id=>"Q5072183", :name=>"Chanhsy Vannavongxay"}
	{:id=>"Q6399978", :name=>"Khamlek Keosomphanh"}
Adding GenderBalance results from sources/gender-balance/results.csv
  ⚥ data for 0; 0 added

Creating 1 term file

Top identifiers:
  18 x wikidata

Creating names.csv
Persons matched to Wikidata: 18 ✓ | 114 ✘
  No wikidata: Bounnhong Khinsamone (da28ea4b-0aa0-4c9e-adb4-8b2ef05f92a0)
  No wikidata: Phetsamone Khonpasith (4158cd99-57b4-4711-92ad-791c29525c16)
  No wikidata: Bounpan Douanglaty (04226930-3032-40bb-aa7c-33832247d739)
  No wikidata: Meksavanh Phomphithak (03c30554-bea0-49a9-bd9f-e72d0bc3d1dd)
  No wikidata: Vankham Inthichack (73931e6b-e5d4-409f-8655-14da88c396da)
  No wikidata: Khamphoui Vannachit (ea68cec0-68cd-432e-a2f8-a8b494a11b4a)
  No wikidata: Singphet Bounsavatthiphanh (ba47d676-3360-4a96-bcbc-f57fd66255a6)
  No wikidata: Koukeo Akkhamonti (db9d69bd-f0d7-42f9-bded-8ad5489c9ca0)
  No wikidata: Brigadier General Vilay Duangmany (b0556d56-92e5-4579-8a9e-ad9ec6d18406)
  No wikidata: Somphou Douangsavanh (6f520553-292d-4aa2-a18a-55db97b34dba)
Parties matched to Wikidata: 0 ✓ 
```