### PR TITLE
Moldova (Parlamentul): better Term name

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -6016,19 +6016,19 @@
         "slug": "Parlamentul",
         "sources_directory": "data/Moldova/Parlamentul/sources",
         "popolo": "data/Moldova/Parlamentul/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/570d982/data/Moldova/Parlamentul/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1812292/data/Moldova/Parlamentul/ep-popolo-v1.0.json",
         "names": "data/Moldova/Parlamentul/names.csv",
-        "lastmod": "1465888195",
+        "lastmod": "1465889970",
         "person_count": 115,
-        "sha": "570d982",
+        "sha": "1812292",
         "legislative_periods": [
           {
             "id": "term/2014",
-            "name": "2014–2018",
+            "name": "Legislatura XX",
             "start_date": "2014-12-29",
             "slug": "2014",
             "csv": "data/Moldova/Parlamentul/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/570d982/data/Moldova/Parlamentul/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1812292/data/Moldova/Parlamentul/term-2014.csv"
           }
         ],
         "statement_count": 5726

--- a/data/Moldova/Parlamentul/ep-popolo-v1.0.json
+++ b/data/Moldova/Parlamentul/ep-popolo-v1.0.json
@@ -11074,7 +11074,7 @@
     {
       "classification": "legislative period",
       "id": "term/2014",
-      "name": "2014–2018",
+      "name": "Legislatura XX",
       "organization_id": "legislature",
       "start_date": "2014-12-29"
     }

--- a/data/Moldova/Parlamentul/sources/manual/terms.csv
+++ b/data/Moldova/Parlamentul/sources/manual/terms.csv
@@ -1,2 +1,2 @@
 id,name,start_date
-2014,2014–2018,2014-12-29
+2014,Legislatura XX,2014-12-29


### PR DESCRIPTION
```
Add memberships from sources/morph/data.csv
Add memberships from sources/manual/gone.csv
Merging with sources/morph/wikidata.csv
* 14 of 107 unmatched
	{:id=>"Q6845152", :name=>"Mihai Moldovanu"}
	{:id=>"Q20429568", :name=>"Vasile Bîtca"}
	{:id=>"Q15071201", :name=>"Monica Babuc"}
	{:id=>"Q13428691", :name=>"Vasile Botnari"}
	{:id=>"Q7911411", :name=>"Valeriu Munteanu"}
	{:id=>"Q12731069", :name=>"Irina Vlah"}
	{:id=>"Q6968023", :name=>"Natalia Gherman"}
	{:id=>"Q20431851", :name=>"Oleg Balan"}
	{:id=>"Q15071069", :name=>"Maia Sandu"}
	{:id=>"Q1110215", :name=>"Dorin Chirtoacă"}
Adding GenderBalance results from sources/gender-balance/results.csv
  ⚥ data for 0; 0 added

Creating 1 term file

Top identifiers:
  93 x wikidata
  15 x freebase
  4 x viaf
  2 x isni
  2 x gnd

Creating names.csv
Creating unstable/positions.csv
Persons matched to Wikidata: 93 ✓ | 22 ✘
  No wikidata: Vasile Bolea (0d68ffd3-dc6a-4c20-b2e4-2c25228ebfd8)
  No wikidata: Eugeniu Nichiforciuc (ab3587af-d070-43e3-847a-06656e209696)
  No wikidata: Boris Golovin (85b7728c-155a-48d8-b0f4-12688e3d2419)
  No wikidata: Valerian Bejan (14590f52-186e-408c-9e56-d27c8d9c93b2)
  No wikidata: Molozea Nicolae (4dd0f8da-4326-4091-8333-cf74c1ef9077)
  No wikidata: Igor Vremea (6e280b9a-a7ed-42c9-bdd2-a3805cc2a653)
  No wikidata: Roman Boțan (6b3d355a-6e9c-460a-909d-3f66c869f748)
  No wikidata: Elena Gudumac (7ac868dd-f9ea-4b82-8dfc-a48a159df088)
  No wikidata: Petru Porcescu (b2e10875-d255-4d94-948c-9dd323c99f48)
  No wikidata: Munteanu Valeriu (14121c5f-f09f-4e97-b312-df9533b9768d)
Parties matched to Wikidata: 6 ✓ 
```