### PR TITLE
El Salvador: don't refresh data

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -2683,11 +2683,11 @@
         "slug": "Legislative-Assembly",
         "sources_directory": "data/El_Salvador/Legislative_Assembly/sources",
         "popolo": "data/El_Salvador/Legislative_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1f39282/data/El_Salvador/Legislative_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/67b5cb9/data/El_Salvador/Legislative_Assembly/ep-popolo-v1.0.json",
         "names": "data/El_Salvador/Legislative_Assembly/names.csv",
-        "lastmod": "1465851822",
+        "lastmod": "1466005332",
         "person_count": 84,
-        "sha": "1f39282",
+        "sha": "67b5cb9",
         "legislative_periods": [
           {
             "end_date": "2018",
@@ -2696,7 +2696,7 @@
             "start_date": "2015-05-14",
             "slug": "2015-2018",
             "csv": "data/El_Salvador/Legislative_Assembly/term-2015-2018.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1f39282/data/El_Salvador/Legislative_Assembly/term-2015-2018.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/67b5cb9/data/El_Salvador/Legislative_Assembly/term-2015-2018.csv"
           }
         ],
         "statement_count": 1726

--- a/data/El_Salvador/Legislative_Assembly/sources/instructions.json
+++ b/data/El_Salvador/Legislative_Assembly/sources/instructions.json
@@ -2,11 +2,6 @@
   "sources": [
     {
       "file": "morph/data.csv",
-      "create": {
-        "from": "morph",
-        "scraper": "jennahowe/El_Salvador_Legislative_Assembly",
-        "query": "SELECT * FROM data"
-      },
       "source": "http://asamblea.gob.sv/",
       "type": "membership"
     },


### PR DESCRIPTION
The upstream scraper doesn't have the area columns, and no longer works
against the site anyway, so (at least for now) just use the existing
snapshot (so full rebuilds aren't lossy)