### PR TITLE
Warn of renamed Wikidata items

### DIFF
--- a/lib/wikidata_lookup.rb
+++ b/lib/wikidata_lookup.rb
@@ -14,9 +14,11 @@ class WikidataLookup
   end
 
   def to_hash
-    information = wikidata_id_lookup.map do |id, wikidata_id|
-      result = wikidata_results[wikidata_id] or 
-        warn "No data for #{wikidata_id} [perhaps it's been renamed?]" 
+    found, missing = wikidata_id_lookup.partition { |id, wid| wikidata_results.key? wid }
+    warn "Wikidata renamings:\n\t#{missing.map(&:last).join(", ")}" if missing.any?
+
+    information = found.map do |id, wikidata_id|
+      result = wikidata_results[wikidata_id] 
       [id, fields_for(result)]
     end
     Hash[information]


### PR DESCRIPTION
If we look up the Wikidata for a list of items, and one of those has
been renamed, we will get back the data keyed against the _new_ ID,
rather than the old one. Ideally this would all get resolved
transparently, but for now we can at least cope better with not having
the expected results for an item.

This should stop the Rollbar errors for Lebanon, Sweden, and Greece.