### PR TITLE
Reconciler: don't consider skipped matches when listing duplicates

### DIFF
--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -51,8 +51,11 @@ var vote = function vote($choice){
 var getDuplicateIDs = function(typeOfID) {
   var voteColumn = {'ID': 0, 'UUID': 1}[typeOfID],
   votes = allVotes(),
+  // Filter out any votes that were skipped, which is those where the
+  // second element of the array representing the vote is null.
+  votesNotSkipped = _.filter(votes, function (v) { return v[1] !== null });
   duplicated = _.omit(
-    _.groupBy(votes, function(e) { return e[voteColumn] }),
+    _.groupBy(votesNotSkipped, function(e) { return e[voteColumn] }),
     function(v, k, o) { return v.length <= 1 }
   );
   return _.object(


### PR DESCRIPTION
If you skipped more than one match in the reconciler, they would be
reported a duplicate IDs for the UUID "null".  This commit filters out
such skipped votes before looking for duplicates in them.

Fixes everypolitician/everypolitician#367