### PR TITLE
Warn if Morph queries have no ORDER BY

### DIFF
--- a/lib/remotesource.rb
+++ b/lib/remotesource.rb
@@ -60,6 +60,7 @@ class RemoteSource::Morph < RemoteSource
     key = ERB::Util.url_encode(morph_api_key)
     query = ERB::Util.url_encode(qs.gsub(/\s+/, ' ').strip)
     url = "https://api.morph.io/#{src}/data.csv?key=#{key}&query=#{query}"
+    warn "⤈ No ORDER BY for #{i(:file)}" unless qs.downcase.include? 'order by'
     begin
       open(url).read
     rescue => e


### PR DESCRIPTION
We want the incoming data to be in a consistent order, so that diffs are
more obvious, and we don't get false positives simply from reordering.

So warn any time we have a query that doesn't contain an ORDER BY, so we
can more easily notice and go tidy them up.

Closes https://github.com/everypolitician/everypolitician/issues/458