### PR TITLE
Reconciler: Ensure `;` separated fields are rendered correctly

### DIFF
--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -79,7 +79,9 @@
                   <dt title="{{ field }}">{{ field }}:</dt>
                   <dd>
                   {% if (field == 'image') { %}
-                    <img src="{{ person[field] }}" width="150">
+                    {% person[field].split(';').forEach(function(img) { %}
+                      <img src="{{ img }}" width="150">
+                    {% }) %}
                   {% } else { %}
                     {{ person[field] }} 
                   {% } %}
@@ -106,7 +108,9 @@
                   <dt title="{{ field }}">{{ field }}:</dt>
                   <dd>
                   {% if (field == 'image') { %}
-                    <img src="{{ person[field] }}" width="150">
+                    {% person[field].split(';').forEach(function(img) { %}
+                      <img src="{{ img }}" width="150">
+                    {% }) %}
                   {% } else { %}
                     {% if (compare_with[field] == person[field]) { %} 
                       <span class="match">{{ person[field] }}</span>

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -83,7 +83,7 @@
                       <img src="{{ img }}" width="150">
                     {% }) %}
                   {% } else { %}
-                    {{ person[field] }} 
+                    {{ person[field].split(';').join(', ') }}
                   {% } %}
                   </dd>
                 {% } %}
@@ -112,10 +112,10 @@
                       <img src="{{ img }}" width="150">
                     {% }) %}
                   {% } else { %}
-                    {% if (compare_with[field] == person[field]) { %} 
-                      <span class="match">{{ person[field] }}</span>
+                    {% if (_.any(person[field].split(';'), function(f) { f == compare_with[field] })) { %}
+                      <span class="match">{{ person[field].split(';').join(', ') }}</span>
                     {% } else { %}
-                      <span class="nomatch">{{ person[field] }}</span>
+                      <span class="nomatch">{{ person[field].split(';').join(', ') }}</span>
                     {% } %}
                   {% } %}
                   </dd>


### PR DESCRIPTION
Try to split the fields on the `;` and display all parts separately, rather than as one.

![screen shot 2016-07-20 at 16 58 59](https://cloud.githubusercontent.com/assets/22996/16993818/e2ce1bce-4e9c-11e6-9b16-871a2d6cb324.png)


- [ ] This code has quite a bit of duplication, so could do with a refactor to tidy up some of that and move the logic out of the HTML and into the JavaScript

Fixes https://github.com/everypolitician/everypolitician/issues/469