### PR TITLE
update Burkina Faso term dates to be more accurate

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -1534,11 +1534,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Burkina_Faso/Assembly/sources",
         "popolo": "data/Burkina_Faso/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Burkina_Faso/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f693720/data/Burkina_Faso/Assembly/ep-popolo-v1.0.json",
         "names": "data/Burkina_Faso/Assembly/names.csv",
-        "lastmod": "1465812521",
+        "lastmod": "1469032930",
         "person_count": 475,
-        "sha": "75b7651",
+        "sha": "f693720",
         "legislative_periods": [
           {
             "id": "term/7",
@@ -1546,42 +1546,46 @@
             "start_date": "2015-12-30",
             "slug": "7",
             "csv": "data/Burkina_Faso/Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Burkina_Faso/Assembly/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f693720/data/Burkina_Faso/Assembly/term-7.csv"
           },
           {
+            "end_date": "2014-10-30",
             "id": "term/2012",
             "name": "Ve législature",
             "start_date": "2012-12-02",
             "slug": "2012",
             "csv": "data/Burkina_Faso/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Burkina_Faso/Assembly/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f693720/data/Burkina_Faso/Assembly/term-2012.csv"
           },
           {
+            "end_date": "2007-05-06",
             "id": "term/3",
             "name": "IIIe législature",
-            "start_date": "2002",
+            "start_date": "2002-06-05",
             "slug": "3",
             "csv": "data/Burkina_Faso/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Burkina_Faso/Assembly/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f693720/data/Burkina_Faso/Assembly/term-3.csv"
           },
           {
+            "end_date": "2002-05-05",
             "id": "term/2",
             "name": "IIe législature",
-            "start_date": "1997",
+            "start_date": "1997-06-07",
             "slug": "2",
             "csv": "data/Burkina_Faso/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Burkina_Faso/Assembly/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f693720/data/Burkina_Faso/Assembly/term-2.csv"
           },
           {
+            "end_date": "1997-05-11",
             "id": "term/1",
             "name": "Ie législature",
-            "start_date": "1992",
+            "start_date": "1992-06-15",
             "slug": "1",
             "csv": "data/Burkina_Faso/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7651/data/Burkina_Faso/Assembly/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f693720/data/Burkina_Faso/Assembly/term-1.csv"
           }
         ],
-        "statement_count": 7063
+        "statement_count": 7067
       }
     ]
   },

--- a/data/Burkina_Faso/Assembly/ep-popolo-v1.0.json
+++ b/data/Burkina_Faso/Assembly/ep-popolo-v1.0.json
@@ -11839,10 +11839,11 @@
     },
     {
       "classification": "legislative period",
+      "end_date": "1997-05-11",
       "id": "term/1",
       "name": "Ie législature",
       "organization_id": "legislature",
-      "start_date": "1992"
+      "start_date": "1992-06-15"
     },
     {
       "classification": "general election",
@@ -11853,17 +11854,19 @@
     },
     {
       "classification": "legislative period",
+      "end_date": "2002-05-05",
       "id": "term/2",
       "name": "IIe législature",
       "organization_id": "legislature",
-      "start_date": "1997"
+      "start_date": "1997-06-07"
     },
     {
       "classification": "legislative period",
+      "end_date": "2007-05-06",
       "id": "term/3",
       "name": "IIIe législature",
       "organization_id": "legislature",
-      "start_date": "2002"
+      "start_date": "2002-06-05"
     },
     {
       "classification": "general election",
@@ -11888,6 +11891,7 @@
     },
     {
       "classification": "legislative period",
+      "end_date": "2014-10-30",
       "id": "term/2012",
       "name": "Ve législature",
       "organization_id": "legislature",

--- a/data/Burkina_Faso/Assembly/sources/manual/terms.csv
+++ b/data/Burkina_Faso/Assembly/sources/manual/terms.csv
@@ -1,8 +1,8 @@
 id,name,start_date,source
-1,Ie législature,1992,1997,
-2,IIe législature,1997,2002,
-3,IIIe législature,2002,2007,
-4,IVe législature,2007,2012,
-2012,Ve législature,2012-12-02,2014-10-30,
-6,Conseil Nationale de la Transition,2014,2015,
+1,Ie législature,1992-06-15,1997-05-11,http://www.ipu.org/parline-e/reports/arc/2047_92.htm
+2,IIe législature,1997-06-07,2002-05-05,http://www.ipu.org/parline-e/reports/arc/2047_97.htm
+3,IIIe législature,2002-06-05,2007-05-06,http://www.ipu.org/parline-e/reports/arc/2047_02.htm
+4,IVe législature,2007-06-04,2012-12-02,http://www.ipu.org/parline-e/reports/arc/2047_07.htm
+2012,Ve législature,2012-12-02,2014-10-30,http://www.ipu.org/parline-e/reports/arc/2047_12.htm
+6,Conseil Nationale de la Transition,2014-10-30,2015-11-29,http://www.reuters.com/article/us-burkina-politics-idUSKBN0IJ0NZ20141030
 7,VIIe législature,2015-12-30,,http://www.ipu.org/parline-e/reports/2047.htm

--- a/data/Burkina_Faso/Assembly/sources/manual/terms.csv
+++ b/data/Burkina_Faso/Assembly/sources/manual/terms.csv
@@ -1,4 +1,4 @@
-id,name,start_date,source
+id,name,start_date,end_date,source
 1,Ie législature,1992-06-15,1997-05-11,http://www.ipu.org/parline-e/reports/arc/2047_92.htm
 2,IIe législature,1997-06-07,2002-05-05,http://www.ipu.org/parline-e/reports/arc/2047_97.htm
 3,IIIe législature,2002-06-05,2007-05-06,http://www.ipu.org/parline-e/reports/arc/2047_02.htm


### PR DESCRIPTION
Specifically this is providing end dates that were previously both fuzzy (only years) and missing (missing `end_date` heading in the CSV, whoops)

Closes #13994 