### PR TITLE
Use finer-grained git commit object names in file URLs

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -1,0 +1,35 @@
+# A helpful monkey-patch to MatchData to return named matches as a
+# hash that maps from symbolized match names to the matched text.
+class MatchData
+  def to_hash
+    Hash[ (self.names.map(&:to_sym)).zip(self.captures) ]
+  end
+end
+
+def file_to_commit_metadata(directories)
+  # There's about 2MB of data returned by this command, so rather than
+  # using backticks to turning it into a string and then splitting it,
+  # parse the output line-by-line. As a bonus this doesn't
+  # unnecessarily invoke a shell.
+  command = [
+    'git', '--no-pager', 'log', '--name-only', '--format=%h|%at',
+    '--', *directories
+  ]
+  last_commit = {}
+  commit_details = nil
+  IO.popen(command) do |f|
+    f.each_line do |line|
+      # Each commit is introduced with the abbreviated object name
+      # of the commit and author date timestamp, separated by '|'.
+      # Then there's a blank line, then one filename per line.
+      line.strip!
+      commit_match = line.match /^(?<sha>[a-f\d]+)\|(?<timestamp>\d+)$/
+      if commit_match
+        commit_details = commit_match.to_hash
+      elsif not line.empty?
+        last_commit[line] ||= commit_details
+      end
+    end
+  end
+  last_commit
+end


### PR DESCRIPTION
The `countries.json` file includes the URLs of files via
cdn.rawgit.com, and those URLs include the commit's object name (also
known as its hash or SHA-1) so that a known version of every file is
referred to in each version of countries.json.

The commit object names used in these URLs (for both the Popolo JSON
and term CSV files) would always be the same for all files in a
particular country, since the commit and last modification time would be
found from a command like:

    git --no-pager log --format='%h|%at' -1 data/Australia/

... and the results would be used for all files for that country.

This meant that if any file for that country was updated, then all files
for that country would have a new commit object name in their URL. This
was bad, because a consumer of that data may be using changes in these
URLs to detect if there is new data to process, and this would mean
they'd have to process more data than necessary.

This commit changes that: now when rebuilding the countries.json file a
mapping is first found from each filename under data/ to the most recent
(based on committer date) non-merge commit that changed that file. This
mapping is then used to find the commit by which a file should be
referred to on a per file basis.  This fixes everypolitician/everypolitician#451.

Note that both this and the previous version of the code are incorrect,
strictly speaking. There is no guarantee that the commit found by
either method has the same version of the file as in HEAD. For example,
both methods ignore merge commits, and it's possible that a merge commit
has a different version of the file than the most recent non-merge
commit. Also, the order by committer date can be completely different
from topological order. Because of the workflow by which merges are done
in this repository, however, this isn't likely to cause a problem in
practice, but a more correct way to do this would be:

  - Find the object name of the file's blob in HEAD

  - Find the earliest commit (by whatever ordering) which has that
    blob's object name at that path.

That's rather more awkward to implement, however, so this version should
do for the moment, and, as I said, it's no *more* incorrect than the
previous version.

In terms of performance, this is only a few seconds slower on my laptop
than the previous version; that cost is is dwarfed by the time taken to
reclone the repository each time - see
https://github.com/everypolitician/everypolitician/issues/359