### PR TITLE
Reconciler: Always show twitter links, and make them clicky

### DIFF
--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -84,11 +84,7 @@
                     {% }) %}
                   {% } else if (field == 'twitter') { %}
                     {% person[field].split(';').forEach(function(twitter) { %}
-                      {% if (twitter.startsWith('http')) { %}
-                        <a href="{{ twitter }}">{{ twitter }}</a>
-                      {% } else { %}
-                        <a href="https://twitter.com/{{ twitter }}">{{ twitter }}</a>
-                      {% } %}
+                      {{ twitter_as_link(twitter) }}
                     {% }) %}
                   {% } else { %}
                     {{ person[field].split(';').join(', ') }}
@@ -121,11 +117,7 @@
                     {% }) %}
                   {% } else if (field == 'twitter') { %}
                     {% person[field].split(';').forEach(function(twitter) { %}
-                      {% if (twitter.startsWith('http')) { %}
-                        <a href="{{ twitter }}">{{ twitter }}</a>
-                      {% } else { %}
-                        <a href="https://twitter.com/{{ twitter }}">{{ twitter }}</a>
-                      {% } %}
+                      {{ twitter_as_link(twitter) }}
                     {% }) %}
                   {% } else { %}
                     {% if (_.any(person[field].split(';'), function(f) { f == compare_with[field] })) { %}

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -82,6 +82,14 @@
                     {% person[field].split(';').forEach(function(img) { %}
                       <img src="{{ img }}" width="150">
                     {% }) %}
+                  {% } else if (field == 'twitter') { %}
+                    {% person[field].split(';').forEach(function(twitter) { %}
+                      {% if (twitter.startsWith('http')) { %}
+                        <a href="{{ twitter }}">{{ twitter }}</a>
+                      {% } else { %}
+                        <a href="https://twitter.com/{{ twitter }}">{{ twitter }}</a>
+                      {% } %}
+                    {% }) %}
                   {% } else { %}
                     {{ person[field].split(';').join(', ') }}
                   {% } %}
@@ -110,6 +118,14 @@
                   {% if (field == 'image') { %}
                     {% person[field].split(';').forEach(function(img) { %}
                       <img src="{{ img }}" width="150">
+                    {% }) %}
+                  {% } else if (field == 'twitter') { %}
+                    {% person[field].split(';').forEach(function(twitter) { %}
+                      {% if (twitter.startsWith('http')) { %}
+                        <a href="{{ twitter }}">{{ twitter }}</a>
+                      {% } else { %}
+                        <a href="https://twitter.com/{{ twitter }}">{{ twitter }}</a>
+                      {% } %}
                     {% }) %}
                   {% } else { %}
                     {% if (_.any(person[field].split(';'), function(f) { f == compare_with[field] })) { %}

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -103,6 +103,15 @@ var nextPairing = function nextPairing($currentPairing){
   }
 }
 
+var twitter_as_link = function twitter_as_link(str) {
+  if (str.startsWith('http')) {
+    return '<a href="' + str + '">' + str + '</a>';
+  } else {
+    return '<a href="https://twitter.com/' + str + '">' + str + '</a>';
+  }
+}
+
+
 var highlightExistingVotes = function highlightExistingVotes($pairing){
   var allVotesSoFar = allVotes();
 

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -250,6 +250,8 @@ jQuery(function($) {
       // return;
     // }
     
+    var alwaysInclude = ['image', 'twitter'];
+
     var incomingPersonFields = _.filter(Object.keys(incomingPerson), function(field) {
       return incomingPerson[field];
     });
@@ -257,7 +259,7 @@ jQuery(function($) {
       var person = existing[0];
       return Object.keys(person);
     })));
-    var commonFields = _.intersection(incomingPersonFields, existingPeopleFields);
+    var commonFields = _.union(alwaysInclude, _.intersection(incomingPersonFields, existingPeopleFields));
 
     var incomingPersonHTML = renderTemplate('incomingPerson', {
       person: incomingPerson,
@@ -269,7 +271,7 @@ jQuery(function($) {
     var existingPersonHTML = _.map(match.existing, function(existing) {
       var person = existing[0];
       person.matchStrength = Math.ceil(existing[1] * 100);
-      var fields = _.intersection(incomingPersonFields, Object.keys(person));
+      var fields = _.union(alwaysInclude, _.intersection(incomingPersonFields, Object.keys(person)));
 
       var incomingNameWords = incomingPerson[window.incomingField].toLowerCase().replace(',', '').split(/\s+/);
       var markedName = _.map(person[window.existingField].replace(',', '').split(/\s+/), function(word){


### PR DESCRIPTION
When generating cards in the Reconciler, we previously only included fields
that were common between the incoming card and at least one of the
comparisons. However, there are some fields we should _always_ display. Let's start with images and twitter handles, and make the twitter links clickable.


![screen shot 2016-07-21 at 13 21 00](https://cloud.githubusercontent.com/assets/57483/17022483/10490312-4f46-11e6-8154-dde4f74ce580.png)


Closes https://github.com/everypolitician/everypolitician/issues/468