### PR TITLE
Add UUID for each Country and Legislature

### DIFF
--- a/data/Abkhazia/Assembly/meta.json
+++ b/data/Abkhazia/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "People's Assembly",
   "seats": 35,
-  "wikidata": "Q1514096"
+  "wikidata": "Q1514096",
+  "uuid": "2db1eb26-3d11-4be3-98c5-a2647ed45150"
 }

--- a/data/Abkhazia/meta.json
+++ b/data/Abkhazia/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "GE-AB"
+  "id": "a74a6174-9858-4199-b688-c52ffe348a1c",
+  "name": "Abkhazia",
+  "iso_code": "GE-AB",
+  "wikidata": "Q23334"
 }

--- a/data/Afghanistan/Wolesi_Jirga/meta.json
+++ b/data/Afghanistan/Wolesi_Jirga/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Wolesi Jirga",
   "seats": 249,
-  "wikidata": "Q2108181"
+  "wikidata": "Q2108181",
+  "uuid": "95d7cf9c-1250-45fa-975f-cf175d11dd5a"
 }

--- a/data/Afghanistan/meta.json
+++ b/data/Afghanistan/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "bc59d4fe-515d-4b6b-8405-2b66df000c6c",
+  "name": "Afghanistan",
+  "iso_code": "AF",
+  "wikidata": "Q889"
+}

--- a/data/Aland/Lagting/meta.json
+++ b/data/Aland/Lagting/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Lagting",
   "wikidata": "Q1091494",
-  "seats": 30
+  "seats": 30,
+  "uuid": "f20e26e8-713b-4cff-91c5-baaedb2d0253"
 }

--- a/data/Aland/meta.json
+++ b/data/Aland/meta.json
@@ -1,4 +1,6 @@
 {
+  "id": "48dfb4ce-a7a6-4a5e-8463-e2bb91d241d2",
   "name": "Åland",
-  "iso_code": "AX"
+  "iso_code": "AX",
+  "wikidata": "Q5689"
 }

--- a/data/Albania/Assembly/meta.json
+++ b/data/Albania/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Kuvendi",
   "seats": 140,
-  "wikidata": "Q1135960"
+  "wikidata": "Q1135960",
+  "uuid": "f328d977-3f59-4891-9a07-a5a7ace80e0c"
 }

--- a/data/Albania/meta.json
+++ b/data/Albania/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "4a4c5cc7-0e9e-49fb-9f73-0adc3b738051",
+  "name": "Albania",
+  "iso_code": "AL",
+  "wikidata": "Q222"
+}

--- a/data/Alderney/States/meta.json
+++ b/data/Alderney/States/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "States",
   "wikidata": "Q7604031",
-  "seats": 10
+  "seats": 10,
+  "uuid": "a458ad55-58ef-47d7-9f15-4a5558df7006"
 }

--- a/data/Alderney/meta.json
+++ b/data/Alderney/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "GG-ALD"
+  "id": "fabd174d-37d5-492c-9e66-b91c5749c188",
+  "name": "Alderney",
+  "iso_code": "GG-ALD",
+  "wikidata": "Q179313"
 }

--- a/data/Algeria/Majlis/meta.json
+++ b/data/Algeria/Majlis/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "People's National Assembly",
   "wikidata": "Q633590",
-  "seats": 462
+  "seats": 462,
+  "uuid": "3ce52a04-f9ee-4906-a800-0ddf71ce7b5a"
 }

--- a/data/Algeria/meta.json
+++ b/data/Algeria/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "77d61512-5d03-40d3-82d1-61fadc159573",
+  "name": "Algeria",
+  "iso_code": "DZ",
+  "wikidata": "Q262"
+}

--- a/data/American_Samoa/House/meta.json
+++ b/data/American_Samoa/House/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "seats": 21,
-  "wikidata": "Q4744878"
+  "wikidata": "Q4744878",
+  "uuid": "278c27f6-af47-4f07-909e-b420e2933632"
 }

--- a/data/American_Samoa/meta.json
+++ b/data/American_Samoa/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "deefa772-4c9b-4e5a-83ec-87c1b98ecd40",
+  "name": "American Samoa",
+  "iso_code": "AS",
+  "wikidata": "Q16641"
+}

--- a/data/Andorra/General_Council/meta.json
+++ b/data/Andorra/General_Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Consell General",
   "wikidata": "Q24824",
-  "seats": 28
+  "seats": 28,
+  "uuid": "2cbf8397-a80d-40ef-8b64-b633a56468d7"
 }

--- a/data/Andorra/meta.json
+++ b/data/Andorra/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "8e80bb56-2ba9-490d-bf3f-1642f41ba955",
+  "name": "Andorra",
+  "iso_code": "AD",
+  "wikidata": "Q228"
+}

--- a/data/Angola/National_Assembly/meta.json
+++ b/data/Angola/National_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "wikidata": "Q1969479",
-  "seats": 220
+  "seats": 220,
+  "uuid": "5a0ab6f8-f39d-41e0-9892-ee0ba49c5d03"
 }

--- a/data/Angola/meta.json
+++ b/data/Angola/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "abd91e69-adf1-4489-b343-bd73406a2abe",
+  "name": "Angola",
+  "iso_code": "AO",
+  "wikidata": "Q916"
+}

--- a/data/Anguilla/Assembly/meta.json
+++ b/data/Anguilla/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Assembly",
   "wikidata": "Q4763974",
-  "seats": 11
+  "seats": 11,
+  "uuid": "c16f16f8-7ccf-43e1-af05-2c19839c698c"
 }

--- a/data/Anguilla/meta.json
+++ b/data/Anguilla/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "a917f6e0-4b13-4560-b64c-d77846563588",
+  "name": "Anguilla",
+  "iso_code": "AI",
+  "wikidata": "Q25228"
+}

--- a/data/Antigua_and_Barbuda/Representatives/meta.json
+++ b/data/Antigua_and_Barbuda/Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "wikidata": "Q1266832",
-  "seats": 19
+  "seats": 19,
+  "uuid": "02f06e68-acfc-4e2e-8e71-b6dc70e105fa"
 }

--- a/data/Antigua_and_Barbuda/meta.json
+++ b/data/Antigua_and_Barbuda/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "54be71c0-2547-44c2-9d75-b9259e858c46",
+  "name": "Antigua and Barbuda",
+  "iso_code": "AG",
+  "wikidata": "Q781"
+}

--- a/data/Argentina/Diputados/meta.json
+++ b/data/Argentina/Diputados/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Cámara de Diputados",
   "wikidata": "Q629133",
-  "seats": 257
+  "seats": 257,
+  "uuid": "5b5e0f3d-0f45-41ea-a8a9-8e5de20c3d11"
 }

--- a/data/Argentina/Senado/meta.json
+++ b/data/Argentina/Senado/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Cámara de Senadores",
   "wikidata": "Q2118303",
-  "seats": 72
+  "seats": 72,
+  "uuid": "41634900-1289-4552-abfc-a4e347395b0e"
 }

--- a/data/Argentina/meta.json
+++ b/data/Argentina/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "7d8d1f60-2858-4f10-9e44-c9e7377c10a6",
+  "name": "Argentina",
+  "iso_code": "AR",
+  "wikidata": "Q414"
+}

--- a/data/Armenia/Assembly/meta.json
+++ b/data/Armenia/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 131,
-  "wikidata": "Q1337463"
+  "wikidata": "Q1337463",
+  "uuid": "732f3cfe-3740-49df-bfb1-13c67424f3ac"
 }

--- a/data/Armenia/meta.json
+++ b/data/Armenia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "ccbfe6a9-8613-4079-8d3c-610f97a5bc05",
+  "name": "Armenia",
+  "iso_code": "AM",
+  "wikidata": "Q399"
+}

--- a/data/Aruba/Estates/meta.json
+++ b/data/Aruba/Estates/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Estates of Aruba",
   "wikidata": "Q1283189",
-  "seats": 21
+  "seats": 21,
+  "uuid": "415d6b70-98b1-49cb-98ad-17fedc97a816"
 }

--- a/data/Aruba/meta.json
+++ b/data/Aruba/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "f56c62cd-94df-4648-b346-6cf06520302e",
+  "name": "Aruba",
+  "iso_code": "AW",
+  "wikidata": "Q21203"
+}

--- a/data/Australia/Representatives/meta.json
+++ b/data/Australia/Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "wikidata": "Q783401",
-  "seats": 150
+  "seats": 150,
+  "uuid": "2ab5a3aa-ef1e-46c0-abc9-dad161aa0390"
 }

--- a/data/Australia/Senate/meta.json
+++ b/data/Australia/Senate/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Senate",
   "wikidata": "Q783330",
-  "seats": 76
+  "seats": 76,
+  "uuid": "e84f0da7-38e2-4ad3-b02a-6d5796ba90ad"
 }

--- a/data/Australia/meta.json
+++ b/data/Australia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "646e6b77-f874-4bdf-8197-3e18a4aca6c9",
+  "name": "Australia",
+  "iso_code": "AU",
+  "wikidata": "Q408"
+}

--- a/data/Austria/Nationalrat/meta.json
+++ b/data/Austria/Nationalrat/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Nationalrat",
   "seats": 183,
-  "wikidata": "Q871363"
+  "wikidata": "Q871363",
+  "uuid": "332feca5-e411-4ea6-9c9f-e162170da8b7"
 }

--- a/data/Austria/meta.json
+++ b/data/Austria/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "215d697b-5e56-4e99-8ddb-b7b7078e8d8e",
+  "name": "Austria",
+  "iso_code": "AT",
+  "wikidata": "Q40"
+}

--- a/data/Azerbaijan/National_Assembly/meta.json
+++ b/data/Azerbaijan/National_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "wikidata": "Q330600",
-  "seats": 125
+  "seats": 125,
+  "uuid": "a43e94bf-8bd4-4751-918e-26f746e4f562"
 }

--- a/data/Azerbaijan/meta.json
+++ b/data/Azerbaijan/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "527bb30e-9959-410d-b0ef-07e61f1c1f2c",
+  "name": "Azerbaijan",
+  "iso_code": "AZ",
+  "wikidata": "Q227"
+}

--- a/data/Bahamas/House_of_Assembly/meta.json
+++ b/data/Bahamas/House_of_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Assembly",
   "seats": 38,
-  "wikidata": "Q2948139"
+  "wikidata": "Q2948139",
+  "uuid": "e7203fe5-740b-44fc-9f5e-feee9f1dd5e3"
 }

--- a/data/Bahamas/meta.json
+++ b/data/Bahamas/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "e0bfa4ad-93a2-452a-a850-f815f4d6cddb",
+  "name": "Bahamas",
+  "iso_code": "BS",
+  "wikidata": "Q778"
+}

--- a/data/Bahrain/Council_of_Representatives/meta.json
+++ b/data/Bahrain/Council_of_Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Council of Representatives",
   "seats": 40,
-  "wikidata": "Q4118178"
+  "wikidata": "Q4118178",
+  "uuid": "68e8bbe5-0b13-4963-ab6f-0ea3b8d8d930"
 }

--- a/data/Bahrain/meta.json
+++ b/data/Bahrain/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "99186f2b-b5cd-4671-8e51-3675d5d4c2a4",
+  "name": "Bahrain",
+  "iso_code": "BH",
+  "wikidata": "Q398"
+}

--- a/data/Bangladesh/House/meta.json
+++ b/data/Bangladesh/House/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Jatiyo Sangshad",
   "wikidata": "Q1684080",
-  "seats": 350
+  "seats": 350,
+  "uuid": "a8da8135-339c-411f-95b8-bc2872597fc8"
 }

--- a/data/Bangladesh/meta.json
+++ b/data/Bangladesh/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "e25756e8-1cd1-446d-8fef-dbe4419b00e5",
+  "name": "Bangladesh",
+  "iso_code": "BD",
+  "wikidata": "Q902"
+}

--- a/data/Barbados/House_of_Assembly/meta.json
+++ b/data/Barbados/House_of_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Assembly",
   "wikidata": "Q570619",
-  "seats": 30
+  "seats": 30,
+  "uuid": "0b3ce1ea-3486-4435-bf38-248e4157bba6"
 }

--- a/data/Barbados/meta.json
+++ b/data/Barbados/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "0f47ed78-558f-4752-bbf5-d089dd1cf8a3",
+  "name": "Barbados",
+  "iso_code": "BB",
+  "wikidata": "Q244"
+}

--- a/data/Belarus/Chamber/meta.json
+++ b/data/Belarus/Chamber/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "wikidata": "Q1798607",
-  "seats": 110
+  "seats": 110,
+  "uuid": "2be7ca8f-4489-4098-9493-e5c8a62e91fc"
 }

--- a/data/Belarus/meta.json
+++ b/data/Belarus/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "bd63af67-7ec5-4cda-87e0-7b9e6861a0db",
+  "name": "Belarus",
+  "iso_code": "BY",
+  "wikidata": "Q184"
+}

--- a/data/Belgium/Representatives/meta.json
+++ b/data/Belgium/Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Chamber of Representatives",
   "wikidata": "Q1347545",
-  "seats": 150
+  "seats": 150,
+  "uuid": "a013af0f-352e-4ca9-b17a-efa71edcc695"
 }

--- a/data/Belgium/meta.json
+++ b/data/Belgium/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "f58c1832-c799-48b1-845b-64f9ee0c8aa4",
+  "name": "Belgium",
+  "iso_code": "BE",
+  "wikidata": "Q31"
+}

--- a/data/Belize/Representatives/meta.json
+++ b/data/Belize/Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "seats": 31,
-  "wikidata": "Q827805"
+  "wikidata": "Q827805",
+  "uuid": "60da1355-8aef-4599-9292-5f796f99eb2a"
 }

--- a/data/Belize/meta.json
+++ b/data/Belize/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "5743dec8-ed84-4b76-98d9-d03936596b95",
+  "name": "Belize",
+  "iso_code": "BZ",
+  "wikidata": "Q242"
+}

--- a/data/Benin/National_Assembly/meta.json
+++ b/data/Benin/National_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assemblée Nationale",
   "wikidata": "Q1969527",
-  "seats": 83
+  "seats": 83,
+  "uuid": "77c18b7e-2b64-4402-a19d-26a71a7da48e"
 }

--- a/data/Benin/meta.json
+++ b/data/Benin/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "2be095a5-db1d-45a6-80ed-99e9eeff2ab2",
+  "name": "Benin",
+  "iso_code": "BJ",
+  "wikidata": "Q962"
+}

--- a/data/Bermuda/Assembly/meta.json
+++ b/data/Bermuda/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "wikidata": "Q5914694",
-  "seats": 36
+  "seats": 36,
+  "uuid": "898e60f2-fb36-4c15-946d-d3c026e6316e"
 }

--- a/data/Bermuda/meta.json
+++ b/data/Bermuda/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "861a84b7-211e-46c5-bcec-2856c291cf3c",
+  "name": "Bermuda",
+  "iso_code": "BM",
+  "wikidata": "Q23635"
+}

--- a/data/Bhutan/Assembly/meta.json
+++ b/data/Bhutan/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "wikidata": "Q2579023",
-  "seats": 47
+  "seats": 47,
+  "uuid": "e2932442-90a3-4bfe-a479-9855e3deb001"
 }

--- a/data/Bhutan/meta.json
+++ b/data/Bhutan/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "09564804-b431-447d-9a59-edb489ee43d0",
+  "name": "Bhutan",
+  "iso_code": "BT",
+  "wikidata": "Q917"
+}

--- a/data/Bolivia/Deputies/meta.json
+++ b/data/Bolivia/Deputies/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Chamber of Deputies",
   "wikidata": "Q20081431",
-  "seats": 130
+  "seats": 130,
+  "uuid": "22b091f6-4031-4527-b7ea-b53e6f50b524"
 }

--- a/data/Bolivia/meta.json
+++ b/data/Bolivia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "74e176d8-0154-4647-87f4-e03b980464dd",
+  "name": "Bolivia",
+  "iso_code": "BO",
+  "wikidata": "Q750"
+}

--- a/data/Bosnia_and_Herzegovina/House_of_Representatives/meta.json
+++ b/data/Bosnia_and_Herzegovina/House_of_Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "wikidata": "Q320268",
-  "seats": 42
+  "seats": 42,
+  "uuid": "72d48234-3144-456e-89fd-5ec0b33513ac"
 }

--- a/data/Bosnia_and_Herzegovina/meta.json
+++ b/data/Bosnia_and_Herzegovina/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "5f3d53f4-a7be-41e8-8dc0-d8186dce321a",
+  "name": "Bosnia and Herzegovina",
+  "iso_code": "BA",
+  "wikidata": "Q225"
+}

--- a/data/Botswana/Assembly/meta.json
+++ b/data/Botswana/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "wikidata": "Q859658",
-  "seats": 63
+  "seats": 63,
+  "uuid": "93d742c6-207c-44e3-80b8-4f04845cced3"
 }

--- a/data/Botswana/meta.json
+++ b/data/Botswana/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "8cf76962-7777-4113-88a5-a434b0a28607",
+  "name": "Botswana",
+  "iso_code": "BW",
+  "wikidata": "Q963"
+}

--- a/data/Brazil/Deputies/meta.json
+++ b/data/Brazil/Deputies/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Chamber of Deputies",
   "wikidata": "Q1834804",
-  "seats": 513
+  "seats": 513,
+  "uuid": "c5d9ea98-074a-4a11-9016-a5157e4aa51e"
 }

--- a/data/Brazil/meta.json
+++ b/data/Brazil/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "28f989a8-3a7c-4992-bc80-9a535bf73f88",
+  "name": "Brazil",
+  "iso_code": "BR",
+  "wikidata": "Q155"
+}

--- a/data/British_Virgin_Islands/Assembly/meta.json
+++ b/data/British_Virgin_Islands/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Assembly",
   "wikidata": "Q5914704",
-  "seats": 13
+  "seats": 13,
+  "uuid": "e67b9af0-c0af-403f-a342-27e74b58abc2"
 }

--- a/data/British_Virgin_Islands/Council/meta.json
+++ b/data/British_Virgin_Islands/Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Legislative Council",
   "wikidata": "Q21097717",
-  "seats": 13
+  "seats": 13,
+  "uuid": "b3e370b7-4a05-4ec7-a065-845001cf65cd"
 }

--- a/data/British_Virgin_Islands/meta.json
+++ b/data/British_Virgin_Islands/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "VG"
+  "id": "4fc58569-c192-4b0c-aea0-2ab19f5dc6ca",
+  "name": "British Virgin Islands",
+  "iso_code": "VG",
+  "wikidata": "Q25305"
 }

--- a/data/Brunei/Legislative_Council/meta.json
+++ b/data/Brunei/Legislative_Council/meta.json
@@ -2,5 +2,6 @@
   "iso_code": "BN",
   "name": "Legislative Council of Brunei",
   "seats": 36,
-  "wikidata": "Q2396996"
+  "wikidata": "Q2396996",
+  "uuid": "bb48685a-28e6-4215-95cd-6ac7f309fcb6"
 }

--- a/data/Brunei/meta.json
+++ b/data/Brunei/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "8fdeabde-d3f3-4acb-a072-3a4a7941c6a3",
+  "name": "Brunei",
+  "iso_code": "BN",
+  "wikidata": "Q921"
+}

--- a/data/Bulgaria/National_Assembly/meta.json
+++ b/data/Bulgaria/National_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 240,
-  "wikidata": "Q639704"
+  "wikidata": "Q639704",
+  "uuid": "51d87586-83a3-4f2c-98ef-239a1556c01e"
 }

--- a/data/Bulgaria/meta.json
+++ b/data/Bulgaria/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "0c56ab83-2a0a-41c5-8ef6-aab7474560a9",
+  "name": "Bulgaria",
+  "iso_code": "BG",
+  "wikidata": "Q219"
+}

--- a/data/Burkina_Faso/Assembly/meta.json
+++ b/data/Burkina_Faso/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assemblée Nationale",
   "wikidata": "Q619238",
-  "seats": 127
+  "seats": 127,
+  "uuid": "41a56fd3-f740-43a8-9464-b9bc6e45a17e"
 }

--- a/data/Burkina_Faso/meta.json
+++ b/data/Burkina_Faso/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "5ad8b765-38a3-4d6f-8118-d985795571d2",
+  "name": "Burkina Faso",
+  "iso_code": "BF",
+  "wikidata": "Q965"
+}

--- a/data/Burundi/Assembly/meta.json
+++ b/data/Burundi/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assemblée nationale",
   "seats": 118,
-  "wikidata": "Q720003"
+  "wikidata": "Q720003",
+  "uuid": "c44a21e2-9af5-4da2-8696-f153906fad4d"
 }

--- a/data/Burundi/meta.json
+++ b/data/Burundi/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "66223d1a-d9c1-4c80-8242-7b5141408592",
+  "name": "Burundi",
+  "iso_code": "BI",
+  "wikidata": "Q967"
+}

--- a/data/Cabo_Verde/Assembly/meta.json
+++ b/data/Cabo_Verde/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assembleia Nacional",
   "seats": 72,
-  "wikidata": "Q1718790"
+  "wikidata": "Q1718790",
+  "uuid": "33b73eeb-ccb7-480a-87fa-d0728966d2b9"
 }

--- a/data/Cabo_Verde/meta.json
+++ b/data/Cabo_Verde/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "fed6ee48-f9c2-4f95-b73b-bc619fde1067",
+  "name": "Cabo Verde",
+  "iso_code": "CV",
+  "wikidata": "Q1011"
+}

--- a/data/Cambodia/National_Assembly/meta.json
+++ b/data/Cambodia/National_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 123,
-  "wikidata": "Q1234896"
+  "wikidata": "Q1234896",
+  "uuid": "bf904834-04de-4b67-917a-325d5b202e48"
 }

--- a/data/Cambodia/meta.json
+++ b/data/Cambodia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "98f0caa1-5284-4e1a-a557-926183f2fee0",
+  "name": "Cambodia",
+  "iso_code": "KH",
+  "wikidata": "Q424"
+}

--- a/data/Cameroon/Assembly/meta.json
+++ b/data/Cameroon/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assemblée Nationale",
   "seats": 180,
-  "wikidata": "Q1634099"
+  "wikidata": "Q1634099",
+  "uuid": "3dafd5fb-cc08-4ed1-9633-5e35053948fd"
 }

--- a/data/Cameroon/Senate/meta.json
+++ b/data/Cameroon/Senate/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Sénat",
   "seats": 100,
-  "wikidata": "Q3510836"
+  "wikidata": "Q3510836",
+  "uuid": "eed761a0-3d01-4631-8141-e2a2edde2fb8"
 }

--- a/data/Cameroon/meta.json
+++ b/data/Cameroon/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "8a87cae8-ea83-4f56-bcda-1d8484bcdbf6",
+  "name": "Cameroon",
+  "iso_code": "CM",
+  "wikidata": "Q1009"
+}

--- a/data/Canada/Commons/meta.json
+++ b/data/Canada/Commons/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Commons",
   "seats": 308,
-  "wikidata": "Q383590"
+  "wikidata": "Q383590",
+  "uuid": "66326899-6dd4-432c-ae60-ca6375072785"
 }

--- a/data/Canada/meta.json
+++ b/data/Canada/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "c08d2040-22bf-453d-9ea5-cbed0cc2a96b",
+  "name": "Canada",
+  "iso_code": "CA",
+  "wikidata": "Q16"
+}

--- a/data/Cayman_Islands/Legislative_Assembly/meta.json
+++ b/data/Cayman_Islands/Legislative_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Legislative Assembly",
   "seats": 18,
-  "wikidata": "Q3625554"
+  "wikidata": "Q3625554",
+  "uuid": "8d011df3-c2fc-44b3-940d-564d20880b36"
 }

--- a/data/Cayman_Islands/meta.json
+++ b/data/Cayman_Islands/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "724bc496-2b7f-4f07-898f-dd9e1091cbaf",
+  "name": "Cayman Islands",
+  "iso_code": "KY",
+  "wikidata": "Q5785"
+}

--- a/data/Chad/Assembly/meta.json
+++ b/data/Chad/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assemblée Nationale",
   "seats": 188,
-  "wikidata": "Q1599346"
+  "wikidata": "Q1599346",
+  "uuid": "6a08b966-6561-4115-a43e-3a5d0fa06b0a"
 }

--- a/data/Chad/meta.json
+++ b/data/Chad/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "46d4af2d-8375-48e6-babf-f0074e885f2c",
+  "name": "Chad",
+  "iso_code": "TD",
+  "wikidata": "Q657"
+}

--- a/data/Chile/Deputies/meta.json
+++ b/data/Chile/Deputies/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Congress",
   "seats": 120,
-  "wikidata": "Q1968468"
+  "wikidata": "Q1968468",
+  "uuid": "5e07982c-0efe-41a8-8899-3b5edc94f112"
 }

--- a/data/Chile/meta.json
+++ b/data/Chile/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "d4fcfd2f-d70e-4f67-bda8-d24af041ed12",
+  "name": "Chile",
+  "iso_code": "CL",
+  "wikidata": "Q298"
+}

--- a/data/China/Congress/meta.json
+++ b/data/China/Congress/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National People’s Congress",
   "seats": 2987,
-  "wikidata": "Q19211"
+  "wikidata": "Q19211",
+  "uuid": "98f70a4e-ed84-4fa5-b6ee-a20a4b8538bc"
 }

--- a/data/China/meta.json
+++ b/data/China/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "05637187-f7f8-42ee-998e-8ac44a1b8589",
+  "name": "China",
+  "iso_code": "CN",
+  "wikidata": "Q148"
+}

--- a/data/Colombia/Representatives/meta.json
+++ b/data/Colombia/Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Cámara de Representantes",
   "seats": 166,
-  "wikidata": "Q1571756"
+  "wikidata": "Q1571756",
+  "uuid": "b11bc579-09d0-49d9-b80c-7d64eaf36bf2"
 }

--- a/data/Colombia/Senate/meta.json
+++ b/data/Colombia/Senate/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Senado",
   "seats": 102,
-  "wikidata": "Q2398781"
+  "wikidata": "Q2398781",
+  "uuid": "28acf131-c784-49b9-8e62-18fd5eaa93a0"
 }

--- a/data/Colombia/meta.json
+++ b/data/Colombia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "bedd1348-f630-49d5-9dff-99e096d85522",
+  "name": "Colombia",
+  "iso_code": "CO",
+  "wikidata": "Q739"
+}

--- a/data/Comoros/Assembly/meta.json
+++ b/data/Comoros/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assembly of the Union",
   "seats": 33,
-  "wikidata": "Q1573424"
+  "wikidata": "Q1573424",
+  "uuid": "210ee61e-e9c8-448a-9d6e-6f139c158ff1"
 }

--- a/data/Comoros/meta.json
+++ b/data/Comoros/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "48a492e3-a2f3-459d-8d2c-dcc1b118ad3d",
+  "name": "Comoros",
+  "iso_code": "KM",
+  "wikidata": "Q970"
+}

--- a/data/Congo-Brazzaville/Assembly/meta.json
+++ b/data/Congo-Brazzaville/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assemblee Nationale",
   "seats": 153,
-  "wikidata": "Q1574334"
+  "wikidata": "Q1574334",
+  "uuid": "b0914a86-73e1-4120-bb5c-9008d635bc02"
 }

--- a/data/Congo-Brazzaville/meta.json
+++ b/data/Congo-Brazzaville/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "CG"
+  "id": "630039a5-7fe8-46c3-8669-613c5e4d3fff",
+  "name": "Congo-Brazzaville",
+  "iso_code": "CG",
+  "wikidata": "Q974"
 }

--- a/data/Congo-Kinshasa/Assembly/meta.json
+++ b/data/Congo-Kinshasa/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 500,
-  "wikidata": "Q1574334"
+  "wikidata": "Q1574334",
+  "uuid": "627e8bc6-dc2e-4599-b795-05475769bf85"
 }

--- a/data/Congo-Kinshasa/meta.json
+++ b/data/Congo-Kinshasa/meta.json
@@ -1,4 +1,6 @@
 {
+  "id": "be068d48-c21e-4874-a8e8-6bdd7b5bb57a",
   "name": "Congo-Kinshasa (DRC)",
-  "iso_code": "CD"
+  "iso_code": "CD",
+  "wikidata": "Q974"
 }

--- a/data/Cook_Islands/Parliament/meta.json
+++ b/data/Cook_Islands/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "seats": 24,
-  "wikidata": "Q7138950"
+  "wikidata": "Q7138950",
+  "uuid": "a1a85685-7d9a-4b03-a581-720f77e13a38"
 }

--- a/data/Cook_Islands/meta.json
+++ b/data/Cook_Islands/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "df1c9184-be8e-4f62-a823-3bfee0d4935d",
+  "name": "Cook Islands",
+  "iso_code": "CK",
+  "wikidata": "Q26988"
+}

--- a/data/Costa_Rica/Assembly/meta.json
+++ b/data/Costa_Rica/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Legislative Assembly",
   "seats": 57,
-  "wikidata": "Q1386962"
+  "wikidata": "Q1386962",
+  "uuid": "b1b06472-29ef-4eb1-bed1-407f9e11e731"
 }

--- a/data/Costa_Rica/meta.json
+++ b/data/Costa_Rica/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "783a7d47-2ab5-4ff3-8af6-2aea6fc76226",
+  "name": "Costa Rica",
+  "iso_code": "CR",
+  "wikidata": "Q800"
+}

--- a/data/Croatia/Sabor/meta.json
+++ b/data/Croatia/Sabor/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Sabor",
   "seats": 151,
-  "wikidata": "Q371576"
+  "wikidata": "Q371576",
+  "uuid": "ecec7a71-01ce-46db-af3b-f8ec9b956ca5"
 }

--- a/data/Croatia/meta.json
+++ b/data/Croatia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "1990081b-28da-407a-a197-ef06c8080f7d",
+  "name": "Croatia",
+  "iso_code": "HR",
+  "wikidata": "Q224"
+}

--- a/data/Curacao/Estates/meta.json
+++ b/data/Curacao/Estates/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Estates of Curaçao",
   "seats": 21,
-  "wikidata": "Q2326816"
+  "wikidata": "Q2326816",
+  "uuid": "675643a3-f32d-4079-aa62-8f1994875445"
 }

--- a/data/Curacao/meta.json
+++ b/data/Curacao/meta.json
@@ -1,3 +1,6 @@
 {
-  "name": "Curaçao"
+  "id": "c113aba4-4733-4bfd-bfa4-d41709906673",
+  "name": "Curaçao",
+  "iso_code": "CW",
+  "wikidata": "Q25279"
 }

--- a/data/Cyprus/House_of_Representatives/meta.json
+++ b/data/Cyprus/House_of_Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "seats": 80,
-  "wikidata": "Q1112381"
+  "wikidata": "Q1112381",
+  "uuid": "94d3bc35-8e9a-434b-9062-416ec38582d3"
 }

--- a/data/Cyprus/meta.json
+++ b/data/Cyprus/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "5c6464e9-d40a-42f6-86fc-410c0b3ba284",
+  "name": "Cyprus",
+  "iso_code": "CY",
+  "wikidata": "Q229"
+}

--- a/data/Czech_Republic/Deputies/meta.json
+++ b/data/Czech_Republic/Deputies/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Chamber of Deputies",
   "wikidata": "Q320265",
-  "seats": 200
+  "seats": 200,
+  "uuid": "8b61aee3-0001-4cec-91c1-946ef545ceb1"
 }

--- a/data/Czech_Republic/meta.json
+++ b/data/Czech_Republic/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "ed1af112-a18e-474c-a3ff-12721f477599",
+  "name": "Czech Republic",
+  "iso_code": "CZ",
+  "wikidata": "Q213"
+}

--- a/data/Denmark/Folketing/meta.json
+++ b/data/Denmark/Folketing/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Folketing",
   "seats": 179,
-  "wikidata": "Q209151"
+  "wikidata": "Q209151",
+  "uuid": "4cacca66-8d6f-47f2-a5c4-eaf74fa80999"
 }

--- a/data/Denmark/meta.json
+++ b/data/Denmark/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "f295a007-0492-423f-a960-ddb2aeedc580",
+  "name": "Denmark",
+  "iso_code": "DK",
+  "wikidata": "Q35"
+}

--- a/data/Djibouti/Assembly/meta.json
+++ b/data/Djibouti/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "wikidata": "Q1139363",
-  "seats": 65
+  "seats": 65,
+  "uuid": "ea765c61-894e-47c3-ba02-148ba28a5386"
 }

--- a/data/Djibouti/meta.json
+++ b/data/Djibouti/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "c5f142ed-5043-4a0c-8158-879e2b5c6f0d",
+  "name": "Djibouti",
+  "iso_code": "DJ",
+  "wikidata": "Q977"
+}

--- a/data/Dominica/House_of_Assembly/meta.json
+++ b/data/Dominica/House_of_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Assembly",
   "wikidata": "Q1297237",
-  "seats": 31
+  "seats": 31,
+  "uuid": "1f67ca1f-eb15-4634-94cf-db63f34865be"
 }

--- a/data/Dominica/meta.json
+++ b/data/Dominica/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "9b63519e-6de0-43af-a08a-3f3a2580eb12",
+  "name": "Dominica",
+  "iso_code": "DM",
+  "wikidata": "Q784"
+}

--- a/data/Dominican_Republic/Diputados/meta.json
+++ b/data/Dominican_Republic/Diputados/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Chamber of Deputies",
   "seats": 190,
-  "wikidata": "Q320280"
+  "wikidata": "Q320280",
+  "uuid": "b7c27877-0b17-4145-a87d-3bec5711864c"
 }

--- a/data/Dominican_Republic/meta.json
+++ b/data/Dominican_Republic/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "30e3ee51-e594-4718-b2ec-7998097bf753",
+  "name": "Dominican Republic",
+  "iso_code": "DO",
+  "wikidata": "Q786"
+}

--- a/data/Ecuador/Asamblea/meta.json
+++ b/data/Ecuador/Asamblea/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 137,
-  "wikidata": "Q1319595"
+  "wikidata": "Q1319595",
+  "uuid": "9e0caec8-ba6c-4c1f-aa1f-fedb1ede6535"
 }

--- a/data/Ecuador/meta.json
+++ b/data/Ecuador/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "aa85bdb8-afa4-4eec-a278-2fa8d94dd55f",
+  "name": "Ecuador",
+  "iso_code": "EC",
+  "wikidata": "Q736"
+}

--- a/data/Egypt/Parliament/meta.json
+++ b/data/Egypt/Parliament/meta.json
@@ -1,4 +1,6 @@
 {
   "name": "Parliament",
   "seats": 596,
-  "wikidata": "Q2584535"
+  "wikidata": "Q2584535",
+  "uuid": "c12bfd70-76b4-476b-98a4-0e16a6499688"
+}

--- a/data/Egypt/meta.json
+++ b/data/Egypt/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "79169858-4ef7-4144-b021-6a56b9e7a41a",
+  "name": "Egypt",
+  "iso_code": "EG",
+  "wikidata": "Q79"
+}

--- a/data/El_Salvador/Legislative_Assembly/meta.json
+++ b/data/El_Salvador/Legislative_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Legislative Assembly",
   "seats": 84,
-  "wikidata": "Q1812873"
+  "wikidata": "Q1812873",
+  "uuid": "a8ab9a09-42fe-4444-a43f-e6c5ecc92365"
 }

--- a/data/El_Salvador/meta.json
+++ b/data/El_Salvador/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "5b937a42-8a41-4329-b0b7-190fd3caa20c",
+  "name": "El Salvador",
+  "iso_code": "SV",
+  "wikidata": "Q792"
+}

--- a/data/Estonia/Riigikogu/meta.json
+++ b/data/Estonia/Riigikogu/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Riigikogu",
   "seats": 101,
-  "wikidata": "Q217799"
+  "wikidata": "Q217799",
+  "uuid": "1ba661a9-22ad-4d0f-8a60-fe8e28f2488c"
 }

--- a/data/Estonia/meta.json
+++ b/data/Estonia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "ba8635ae-a247-4f8f-9851-dafef65a2340",
+  "name": "Estonia",
+  "iso_code": "EE",
+  "wikidata": "Q191"
+}

--- a/data/Falkland_Islands/Assembly/meta.json
+++ b/data/Falkland_Islands/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Legislative Assembly",
   "seats": 11,
-  "wikidata": "Q3365321"
+  "wikidata": "Q3365321",
+  "uuid": "07436402-48a2-42ba-93f2-b68fd1b8bbff"
 }

--- a/data/Falkland_Islands/meta.json
+++ b/data/Falkland_Islands/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "93dd429d-f781-44e5-a310-9065067a2256",
+  "name": "Falkland Islands",
+  "iso_code": "FK",
+  "wikidata": "Q9648"
+}

--- a/data/Faroe_Islands/Logting/meta.json
+++ b/data/Faroe_Islands/Logting/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Løgting",
   "wikidata": "Q509668",
-  "seats": 33
+  "seats": 33,
+  "uuid": "6cfc55e3-0ee4-4cf9-9145-c22a0d457feb"
 }

--- a/data/Faroe_Islands/meta.json
+++ b/data/Faroe_Islands/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "f9c84569-1909-4c02-b350-e3ed88366da7",
+  "name": "Faroe Islands",
+  "iso_code": "FO",
+  "wikidata": "Q4628"
+}

--- a/data/Fiji/Parliament/meta.json
+++ b/data/Fiji/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "seats": 50,
-  "wikidata": "Q4345425"
+  "wikidata": "Q4345425",
+  "uuid": "0185d125-915d-45bf-92f6-a8bd2b038853"
 }

--- a/data/Fiji/meta.json
+++ b/data/Fiji/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "15e574f6-8bbc-4c6e-a507-ae154f50ff1c",
+  "name": "Fiji",
+  "iso_code": "FJ",
+  "wikidata": "Q712"
+}

--- a/data/Finland/Eduskunta/meta.json
+++ b/data/Finland/Eduskunta/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Eduskunta",
   "seats": 200,
-  "wikidata": "Q643412"
+  "wikidata": "Q643412",
+  "uuid": "88d9bfa8-a8f8-4312-bfb9-a851657d3780"
 }

--- a/data/Finland/meta.json
+++ b/data/Finland/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "387b3fca-14e7-4dff-b663-85361c08ea22",
+  "name": "Finland",
+  "iso_code": "FI",
+  "wikidata": "Q33"
+}

--- a/data/France/National_Assembly/meta.json
+++ b/data/France/National_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assemblée nationale",
   "seats": 577,
-  "wikidata": "Q193582"
+  "wikidata": "Q193582",
+  "uuid": "2ba488c8-ae69-4ca6-a1a5-d931dbe21563"
 }

--- a/data/France/meta.json
+++ b/data/France/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "70ffc991-146d-4900-bfe7-9080f40c3159",
+  "name": "France",
+  "iso_code": "FR",
+  "wikidata": "Q142"
+}

--- a/data/French_Polynesia/Assembly/meta.json
+++ b/data/French_Polynesia/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assembly",
   "wikidata": "Q2729213",
-  "seats": 57
+  "seats": 57,
+  "uuid": "cc36de97-ff99-4ea5-97a4-b799e6965c15"
 }

--- a/data/French_Polynesia/meta.json
+++ b/data/French_Polynesia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "26f3f62b-9468-4762-874f-24ec021255dc",
+  "name": "French Polynesia",
+  "iso_code": "PF",
+  "wikidata": "Q30971"
+}

--- a/data/Gabon/Assembly/meta.json
+++ b/data/Gabon/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assemblée nationale",
   "seats": 121,
-  "wikidata": "Q1969545"
+  "wikidata": "Q1969545",
+  "uuid": "fa7595d4-6129-4bbd-95c7-51dc37ae8171"
 }

--- a/data/Gabon/meta.json
+++ b/data/Gabon/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "f0b6a3c7-8d37-4253-a902-8bfa17a381d5",
+  "name": "Gabon",
+  "iso_code": "GA",
+  "wikidata": "Q1000"
+}

--- a/data/Gambia/National_Assembly/meta.json
+++ b/data/Gambia/National_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "wikidata": "Q1427127",
-  "seats": 53
+  "seats": 53,
+  "uuid": "19871de8-5cf3-4011-8c60-5a8761c3e09e"
 }

--- a/data/Gambia/meta.json
+++ b/data/Gambia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "b040bf95-e13e-4e2d-8c28-7dba638fb920",
+  "name": "Gambia",
+  "iso_code": "GM",
+  "wikidata": "Q1005"
+}

--- a/data/Georgia/Parliament/meta.json
+++ b/data/Georgia/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament of Georgia",
   "seats": 150,
-  "wikidata": "Q1417210"
+  "wikidata": "Q1417210",
+  "uuid": "a2f5a173-89e1-4eae-99f1-b1626a6f272f"
 }

--- a/data/Georgia/meta.json
+++ b/data/Georgia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "a3522f2e-7bc4-4e2b-9f14-067176c7b238",
+  "name": "Georgia",
+  "iso_code": "GE",
+  "wikidata": "Q230"
+}

--- a/data/Germany/Bundestag/meta.json
+++ b/data/Germany/Bundestag/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Bundestag",
   "wikidata": "Q154797",
-  "seats": 620
+  "seats": 620,
+  "uuid": "4d0242b9-fc34-4341-b9b1-58f5d0cc523a"
 }

--- a/data/Germany/meta.json
+++ b/data/Germany/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "b35b6409-be5b-4119-b2f0-1895b27362d6",
+  "name": "Germany",
+  "iso_code": "DE",
+  "wikidata": "Q183"
+}

--- a/data/Ghana/Parliament/meta.json
+++ b/data/Ghana/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "seats": 228,
-  "wikidata": "Q1807513"
+  "wikidata": "Q1807513",
+  "uuid": "f971230c-76ef-4828-8889-0aba2f8f525e"
 }

--- a/data/Ghana/meta.json
+++ b/data/Ghana/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "72288036-d704-4baf-9d20-9ace2bdffb0f",
+  "name": "Ghana",
+  "iso_code": "GH",
+  "wikidata": "Q117"
+}

--- a/data/Gibraltar/Parliament/meta.json
+++ b/data/Gibraltar/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "wikidata": "Q128852",
-  "seats": 17
+  "seats": 17,
+  "uuid": "d97c3f1d-78c2-46a8-8508-54d879084c3a"
 }

--- a/data/Gibraltar/meta.json
+++ b/data/Gibraltar/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "092fe3d9-cf2a-41ee-9007-1e93f6f0aa89",
+  "name": "Gibraltar",
+  "iso_code": "GI",
+  "wikidata": "Q1410"
+}

--- a/data/Greece/Parliament/meta.json
+++ b/data/Greece/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Hellenic Parliament",
   "seats": 300,
-  "wikidata": "Q477089"
+  "wikidata": "Q477089",
+  "uuid": "022607c0-5226-487d-8057-862ae73442e6"
 }

--- a/data/Greece/meta.json
+++ b/data/Greece/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "ed3f913b-ba7b-4a39-9654-b8fdccb59b6b",
+  "name": "Greece",
+  "iso_code": "GR",
+  "wikidata": "Q41"
+}

--- a/data/Greenland/Inatsisartut/meta.json
+++ b/data/Greenland/Inatsisartut/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Inatsisartut",
   "seats": 31,
-  "wikidata": "Q1257966"
+  "wikidata": "Q1257966",
+  "uuid": "64da7dd5-4a08-41d4-9919-9e53a94352b6"
 }

--- a/data/Greenland/meta.json
+++ b/data/Greenland/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "cef2192f-e993-4efb-bd21-7c7b17d541a0",
+  "name": "Greenland",
+  "iso_code": "GL",
+  "wikidata": "Q223"
+}

--- a/data/Grenada/House_of_Representatives/meta.json
+++ b/data/Grenada/House_of_Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "seats": 15,
-  "wikidata": "Q1253647"
+  "wikidata": "Q1253647",
+  "uuid": "9338f736-550a-4e3c-92ef-78ee1520c827"
 }

--- a/data/Grenada/meta.json
+++ b/data/Grenada/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "c224c76d-a0c8-4f2f-8f1c-ac97f28aa28f",
+  "name": "Grenada",
+  "iso_code": "GD",
+  "wikidata": "Q769"
+}

--- a/data/Guam/Parliament/meta.json
+++ b/data/Guam/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "seats": 15,
-  "wikidata": "Q1563896"
+  "wikidata": "Q1563896",
+  "uuid": "2985f1f3-c6bd-4d86-96fb-224a848db950"
 }

--- a/data/Guam/meta.json
+++ b/data/Guam/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "4c1b026a-9de1-422d-b612-0bc1ae985ce4",
+  "name": "Guam",
+  "iso_code": "GU",
+  "wikidata": "Q16635"
+}

--- a/data/Guatemala/Congress/meta.json
+++ b/data/Guatemala/Congress/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Congress",
   "wikidata": "Q1136026",
-  "seats": 158
+  "seats": 158,
+  "uuid": "d719b911-f7d9-4588-8889-1e208ed3e66b"
 }

--- a/data/Guatemala/meta.json
+++ b/data/Guatemala/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "1052b64e-88e3-4d9f-bdc7-2cc70c3dcd16",
+  "name": "Guatemala",
+  "iso_code": "GT",
+  "wikidata": "Q774"
+}

--- a/data/Guernsey/States/meta.json
+++ b/data/Guernsey/States/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "States",
   "seats": 47,
-  "wikidata": "Q1368324"
+  "wikidata": "Q1368324",
+  "uuid": "b6f68cdb-75cb-44dd-8241-f388f630efde"
 }

--- a/data/Guernsey/meta.json
+++ b/data/Guernsey/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "fd44bc9d-1d15-4454-ab93-f9274bb334c8",
+  "name": "Guernsey",
+  "iso_code": "GG",
+  "wikidata": "Q25230"
+}

--- a/data/Guinea-Bissau/Assembly/meta.json
+++ b/data/Guinea-Bissau/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National People's Assembly",
   "wikidata": "Q740533",
-  "seats": 102
+  "seats": 102,
+  "uuid": "da6d3e09-ae79-41a2-8ef1-0e3d73ba351a"
 }

--- a/data/Guinea-Bissau/meta.json
+++ b/data/Guinea-Bissau/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "c7c556d0-5ee9-426b-8769-f42b07f1bfe1",
+  "name": "Guinea-Bissau",
+  "iso_code": "GW",
+  "wikidata": "Q1007"
+}

--- a/data/Guyana/National_Assembly/meta.json
+++ b/data/Guyana/National_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 65,
-  "wikidata": "Q1512579"
+  "wikidata": "Q1512579",
+  "uuid": "68aa4bab-2857-4923-8b30-2edb03513c9c"
 }

--- a/data/Guyana/meta.json
+++ b/data/Guyana/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "940e9b7f-f583-4571-8113-026ad410cf7d",
+  "name": "Guyana",
+  "iso_code": "GY",
+  "wikidata": "Q734"
+}

--- a/data/Haiti/Deputies/meta.json
+++ b/data/Haiti/Deputies/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Chamber of Deputies",
   "wikidata": "Q320287",
-  "seats": 99
+  "seats": 99,
+  "uuid": "18bdd20a-4fbc-4238-bf27-d58ca1ec5ac5"
 }

--- a/data/Haiti/meta.json
+++ b/data/Haiti/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "d6930ff8-b996-4b49-bcf6-f5cb868c3bd7",
+  "name": "Haiti",
+  "iso_code": "HT",
+  "wikidata": "Q790"
+}

--- a/data/Honduras/Congreso_Nacional/meta.json
+++ b/data/Honduras/Congreso_Nacional/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Congress",
   "wikidata": "Q1415847",
-  "seats": 129
+  "seats": 129,
+  "uuid": "0795c876-b553-40eb-8036-f8371093e15a"
 }

--- a/data/Honduras/meta.json
+++ b/data/Honduras/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "b1052166-c620-456f-9245-58c097b59105",
+  "name": "Honduras",
+  "iso_code": "HN",
+  "wikidata": "Q783"
+}

--- a/data/Hong_Kong/Legislative_Council/meta.json
+++ b/data/Hong_Kong/Legislative_Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Legislative Council",
   "seats": 70,
-  "wikidata": "Q19208"
+  "wikidata": "Q19208",
+  "uuid": "c974194b-cbc8-44ce-975b-16517fae33bf"
 }

--- a/data/Hong_Kong/meta.json
+++ b/data/Hong_Kong/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "4d8fd855-be24-48ca-b223-82cbf457500a",
+  "name": "Hong Kong",
+  "iso_code": "HK",
+  "wikidata": "Q8646"
+}

--- a/data/Hungary/Assembly/meta.json
+++ b/data/Hungary/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Országgyűlés",
   "seats": 386,
-  "wikidata": "Q648716"
+  "wikidata": "Q648716",
+  "uuid": "777902f1-4b1f-42ea-b15a-9f12cc4bb773"
 }

--- a/data/Hungary/meta.json
+++ b/data/Hungary/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "9f5b09bb-ee06-4e7a-b2a2-91c475981f48",
+  "name": "Hungary",
+  "iso_code": "HU",
+  "wikidata": "Q28"
+}

--- a/data/Iceland/Assembly/meta.json
+++ b/data/Iceland/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Alþingi",
   "seats": 63,
-  "wikidata": "Q131279"
+  "wikidata": "Q131279",
+  "uuid": "9be7d6f7-8420-4a3a-a804-fb1a68e8f9ff"
 }

--- a/data/Iceland/meta.json
+++ b/data/Iceland/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "b64b8aa7-ef67-49e0-bded-e54d4e8a090e",
+  "name": "Iceland",
+  "iso_code": "IS",
+  "wikidata": "Q189"
+}

--- a/data/India/Lok_Sabha/meta.json
+++ b/data/India/Lok_Sabha/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Lok Sabha",
   "seats": 545,
-  "wikidata": "Q230003"
+  "wikidata": "Q230003",
+  "uuid": "12bb4025-69d6-4fba-890a-98cbc398eba9"
 }

--- a/data/India/meta.json
+++ b/data/India/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "c8125479-32b0-4fe6-aa90-50153ac23b13",
+  "name": "India",
+  "iso_code": "IN",
+  "wikidata": "Q668"
+}

--- a/data/Indonesia/Council/meta.json
+++ b/data/Indonesia/Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Dewan Perwakilan Rakyat",
   "seats": 560,
-  "wikidata": "Q2670027"
+  "wikidata": "Q2670027",
+  "uuid": "5be5da16-632e-432b-a328-c7eb83b57ac5"
 }

--- a/data/Indonesia/meta.json
+++ b/data/Indonesia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "cfd53bbd-8954-4ba1-9e42-22f28bcf170b",
+  "name": "Indonesia",
+  "iso_code": "ID",
+  "wikidata": "Q252"
+}

--- a/data/Iran/Assembly/meta.json
+++ b/data/Iran/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Majles",
   "seats": 290,
-  "wikidata": "Q378605"
+  "wikidata": "Q378605",
+  "uuid": "82453a9d-2cd3-4163-851c-77ef28ec79df"
 }

--- a/data/Iran/meta.json
+++ b/data/Iran/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "7e8cef31-5c8b-48fe-a68b-6fcc07e3d0f1",
+  "name": "Iran",
+  "iso_code": "IR",
+  "wikidata": "Q794"
+}

--- a/data/Iraq/Majlis/meta.json
+++ b/data/Iraq/Majlis/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Council of Representatives",
   "seats": 328,
-  "wikidata": "Q1973075"
+  "wikidata": "Q1973075",
+  "uuid": "5f11b0cb-bd29-4037-b66a-414886c10bba"
 }

--- a/data/Iraq/meta.json
+++ b/data/Iraq/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "0be339ab-8914-4175-a59e-893d693d59b3",
+  "name": "Iraq",
+  "iso_code": "IQ",
+  "wikidata": "Q796"
+}

--- a/data/Ireland/Dail/meta.json
+++ b/data/Ireland/Dail/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Dáil Éireann",
   "seats": 166,
-  "wikidata": "Q651981"
+  "wikidata": "Q651981",
+  "uuid": "7556a33d-0e3c-4da7-a96e-65bc11ff47af"
 }

--- a/data/Ireland/meta.json
+++ b/data/Ireland/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "403fb473-7c61-421f-a67e-3fbcd4c6eeea",
+  "name": "Ireland",
+  "iso_code": "IE",
+  "wikidata": "Q27"
+}

--- a/data/Isle_of_Man/House_of_Keys/meta.json
+++ b/data/Isle_of_Man/House_of_Keys/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Keys",
   "wikidata": "Q1516957",
-  "seats": 24
+  "seats": 24,
+  "uuid": "304628d1-197d-4ef3-9d04-13d331d6eab0"
 }

--- a/data/Isle_of_Man/meta.json
+++ b/data/Isle_of_Man/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "fefce95c-0737-4823-a244-30a0aa2d3056",
+  "name": "Isle of Man",
+  "iso_code": "IM",
+  "wikidata": "Q9676"
+}

--- a/data/Israel/Knesset/meta.json
+++ b/data/Israel/Knesset/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Knesset",
   "wikidata": "Q133396",
-  "seats": 120
+  "seats": 120,
+  "uuid": "09a71976-8df2-446a-b020-288af06116d7"
 }

--- a/data/Israel/meta.json
+++ b/data/Israel/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "5158810a-2012-4961-af8c-c32c4ffcaa5e",
+  "name": "Israel",
+  "iso_code": "IL",
+  "wikidata": "Q801"
+}

--- a/data/Italy/House/meta.json
+++ b/data/Italy/House/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "seats": 630,
-  "wikidata": "Q841424"
+  "wikidata": "Q841424",
+  "uuid": "d53eb3fc-834c-4ed3-a73c-c2056685e108"
 }

--- a/data/Italy/Senate/meta.json
+++ b/data/Italy/Senate/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Senate",
   "seats": 315,
-  "wikidata": "Q633872"
+  "wikidata": "Q633872",
+  "uuid": "2257aff3-22af-45e6-8002-ff39335c96d6"
 }

--- a/data/Italy/meta.json
+++ b/data/Italy/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "b3ee5383-5304-4fd7-8691-c4c10bf03f3b",
+  "name": "Italy",
+  "iso_code": "IT",
+  "wikidata": "Q38"
+}

--- a/data/Ivory_Coast/Assembly/meta.json
+++ b/data/Ivory_Coast/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 255,
-  "wikidata": "Q1573929"
+  "wikidata": "Q1573929",
+  "uuid": "dee525cf-054c-479b-af13-54fafbd1ea1e"
 }

--- a/data/Ivory_Coast/meta.json
+++ b/data/Ivory_Coast/meta.json
@@ -1,3 +1,6 @@
 {
-  "name": "Côte d'Ivoire"
+  "id": "10c0a9e9-3ee7-40b0-8791-e337033b6414",
+  "name": "Côte d'Ivoire",
+  "iso_code": "CI",
+  "wikidata": "Q1008"
 }

--- a/data/Jamaica/House_of_Representatives/meta.json
+++ b/data/Jamaica/House_of_Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "wikidata": "Q20080342",
-  "seats": 84
+  "seats": 84,
+  "uuid": "5a6d8ba9-87d5-4b06-b48f-11e336432261"
 }

--- a/data/Jamaica/meta.json
+++ b/data/Jamaica/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "27e36471-2fc1-40fa-b1e6-bf228052b4d2",
+  "name": "Jamaica",
+  "iso_code": "JM",
+  "wikidata": "Q766"
+}

--- a/data/Japan/House_of_Representatives/meta.json
+++ b/data/Japan/House_of_Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Shūgiin",
   "seats": 475,
-  "wikidata": "Q659587"
+  "wikidata": "Q659587",
+  "uuid": "a1be0473-97fb-4374-8ec1-5979e28df539"
 }

--- a/data/Japan/meta.json
+++ b/data/Japan/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "6cf35686-db39-46f4-a57b-f25d3d35dcd7",
+  "name": "Japan",
+  "iso_code": "JP",
+  "wikidata": "Q17"
+}

--- a/data/Jersey/States/meta.json
+++ b/data/Jersey/States/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "States",
   "seats": 39,
-  "wikidata": "Q946944"
+  "wikidata": "Q946944",
+  "uuid": "1d510d78-6049-40e3-a70d-20810d36bb24"
 }

--- a/data/Jersey/meta.json
+++ b/data/Jersey/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "105987f4-639b-4a47-a987-52dce59cbfa6",
+  "name": "United Kingdom",
+  "iso_code": "GB",
+  "wikidata": "Q145"
+}

--- a/data/Jordan/House_of_Representatives/meta.json
+++ b/data/Jordan/House_of_Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "wikidata": "Q320304",
-  "seats": 150
+  "seats": 150,
+  "uuid": "4f7d17ea-e78a-4220-9762-eb427dcf4ded"
 }

--- a/data/Jordan/meta.json
+++ b/data/Jordan/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "0d4da61a-aa6d-4755-a61a-3ecff8d81be1",
+  "name": "Jordan",
+  "iso_code": "JO",
+  "wikidata": "Q810"
+}

--- a/data/Kazakhstan/Assembly/meta.json
+++ b/data/Kazakhstan/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Mazhilis",
   "seats": 77,
-  "wikidata": "Q1247199"
+  "wikidata": "Q1247199",
+  "uuid": "fbc80d9c-86e7-4711-b4fe-f68de28af710"
 }

--- a/data/Kazakhstan/meta.json
+++ b/data/Kazakhstan/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "c0f0f6c2-9003-4f3a-8ac1-0c15abff8c65",
+  "name": "Kazakhstan",
+  "iso_code": "KZ",
+  "wikidata": "Q232"
+}

--- a/data/Kenya/Assembly/meta.json
+++ b/data/Kenya/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 349,
-  "wikidata": "Q1701225"
+  "wikidata": "Q1701225",
+  "uuid": "574eff8e-8171-4f2b-8279-60ed8dec1a2a"
 }

--- a/data/Kenya/meta.json
+++ b/data/Kenya/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "c379a356-75d3-44ec-b2aa-359247cec83b",
+  "name": "Kenya",
+  "iso_code": "KE",
+  "wikidata": "Q114"
+}

--- a/data/Kiribati/Parliament/meta.json
+++ b/data/Kiribati/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "seats": 46,
-  "wikidata": "Q1281107"
+  "wikidata": "Q1281107",
+  "uuid": "78e913e8-5a95-44c6-a401-bf6ab80c4369"
 }

--- a/data/Kiribati/meta.json
+++ b/data/Kiribati/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "335515f5-bcab-4047-8ac3-bb40774d55de",
+  "name": "Kiribati",
+  "iso_code": "KI",
+  "wikidata": "Q710"
+}

--- a/data/Kosovo/Assembly/meta.json
+++ b/data/Kosovo/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Kuvendit",
   "seats": 120,
-  "wikidata": "Q1246562"
+  "wikidata": "Q1246562",
+  "uuid": "c70b06ce-c00d-4e28-adf5-a00c1a1434a5"
 }

--- a/data/Kosovo/meta.json
+++ b/data/Kosovo/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "XK"
+  "id": "794d6ee3-ebab-4e2b-a097-9a4c86ad48cf",
+  "name": "Kosovo",
+  "iso_code": "XK",
+  "wikidata": "Q1246"
 }

--- a/data/Kuwait/National_Assembly/meta.json
+++ b/data/Kuwait/National_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 50,
-  "wikidata": "Q1139228"
+  "wikidata": "Q1139228",
+  "uuid": "31e69039-2f8d-4b9b-9748-f707e0e26e13"
 }

--- a/data/Kuwait/meta.json
+++ b/data/Kuwait/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "88167e16-461c-441b-b674-384448c466a9",
+  "name": "Kuwait",
+  "iso_code": "KW",
+  "wikidata": "Q817"
+}

--- a/data/Kyrgyzstan/Council/meta.json
+++ b/data/Kyrgyzstan/Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Supreme Council",
   "wikidata": "Q578193",
-  "seats": 120
+  "seats": 120,
+  "uuid": "b1f61e15-4b07-45e8-9d90-a3200b597751"
 }

--- a/data/Kyrgyzstan/meta.json
+++ b/data/Kyrgyzstan/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "063dc6b4-2183-4dc9-85bd-ed5110009d26",
+  "name": "Kyrgyzstan",
+  "iso_code": "KG",
+  "wikidata": "Q813"
+}

--- a/data/Laos/Assembly/meta.json
+++ b/data/Laos/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 132,
-  "wikidata": "Q1188525"
+  "wikidata": "Q1188525",
+  "uuid": "96ce70d2-b013-44ca-b5ed-b32cc62b8d9a"
 }

--- a/data/Laos/meta.json
+++ b/data/Laos/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "LA"
+  "id": "808e5005-4e1d-4bcc-9306-7883ffab7655",
+  "name": "Laos",
+  "iso_code": "LA",
+  "wikidata": "Q819"
 }

--- a/data/Latvia/Saeima/meta.json
+++ b/data/Latvia/Saeima/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Saeima",
   "seats": 100,
-  "wikidata": "Q822919"
+  "wikidata": "Q822919",
+  "uuid": "6643a93b-016c-4b1b-a2fc-35a9eea3c857"
 }

--- a/data/Latvia/meta.json
+++ b/data/Latvia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "d948b046-1994-4a9b-987a-2987508b8386",
+  "name": "Latvia",
+  "iso_code": "LV",
+  "wikidata": "Q211"
+}

--- a/data/Lebanon/Parliament/meta.json
+++ b/data/Lebanon/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "wikidata": "Q1422275",
-  "seats": 128
+  "seats": 128,
+  "uuid": "a040172c-f708-4c42-a421-1e569bd158f3"
 }

--- a/data/Lebanon/meta.json
+++ b/data/Lebanon/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "3932322b-6ef5-42c2-aa8f-750cb076f94b",
+  "name": "Lebanon",
+  "iso_code": "LB",
+  "wikidata": "Q822"
+}

--- a/data/Lesotho/Assembly/meta.json
+++ b/data/Lesotho/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 120,
-  "wikidata": "Q1138713"
+  "wikidata": "Q1138713",
+  "uuid": "fec02388-0c3d-4df8-802f-738125cdcccc"
 }

--- a/data/Lesotho/meta.json
+++ b/data/Lesotho/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "bc91e8f9-6855-4e18-bbeb-34936c3be544",
+  "name": "Lesotho",
+  "iso_code": "LS",
+  "wikidata": "Q1013"
+}

--- a/data/Liberia/House/meta.json
+++ b/data/Liberia/House/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "seats": 73,
-  "wikidata": "Q1137584"
+  "wikidata": "Q1137584",
+  "uuid": "5803ba28-bbd2-4e28-8566-171533b27b44"
 }

--- a/data/Liberia/meta.json
+++ b/data/Liberia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "c777f97d-e4a0-4bee-ad75-836d3eed3f87",
+  "name": "Liberia",
+  "iso_code": "LR",
+  "wikidata": "Q1014"
+}

--- a/data/Libya/House_of_Representatives/meta.json
+++ b/data/Libya/House_of_Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "seats": 200,
-  "wikidata": "Q17443556"
+  "wikidata": "Q17443556",
+  "uuid": "e2ada220-cc45-40cf-b4ca-f5b9612e5adc"
 }

--- a/data/Libya/meta.json
+++ b/data/Libya/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "59637530-3f79-4896-a5af-4fc6f32d26d9",
+  "name": "Libya",
+  "iso_code": "LY",
+  "wikidata": "Q1016"
+}

--- a/data/Liechtenstein/Landtag/meta.json
+++ b/data/Liechtenstein/Landtag/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Landtag",
   "seats": 25,
-  "wikidata": "Q1149644"
+  "wikidata": "Q1149644",
+  "uuid": "841153dd-50d7-4c7c-a2ca-46d1219a1b6a"
 }

--- a/data/Liechtenstein/meta.json
+++ b/data/Liechtenstein/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "ed78c685-b721-4db7-a2a7-fb8a9a580ada",
+  "name": "Liechtenstein",
+  "iso_code": "LI",
+  "wikidata": "Q347"
+}

--- a/data/Lithuania/Seimas/meta.json
+++ b/data/Lithuania/Seimas/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Seimas",
   "wikidata": "Q374152",
-  "seats": 141
+  "seats": 141,
+  "uuid": "6bbde962-f014-4c7d-b988-10a442342a7c"
 }

--- a/data/Lithuania/meta.json
+++ b/data/Lithuania/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "6fe2c099-c214-4ec9-af5e-44696fcffb31",
+  "name": "Lithuania",
+  "iso_code": "LT",
+  "wikidata": "Q37"
+}

--- a/data/Luxembourg/Chamber/meta.json
+++ b/data/Luxembourg/Chamber/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Chamber of Deputies",
   "wikidata": "Q517449",
-  "seats": 60
+  "seats": 60,
+  "uuid": "4bfa781e-4011-44f9-bee1-f6dcc6c8047d"
 }

--- a/data/Luxembourg/meta.json
+++ b/data/Luxembourg/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "04c1f646-6eff-4b46-9a66-16602a7e4b2b",
+  "name": "Luxembourg",
+  "iso_code": "LU",
+  "wikidata": "Q32"
+}

--- a/data/Macao/Assembly/meta.json
+++ b/data/Macao/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Legislative Assembly",
   "seats": 33,
-  "wikidata": "Q550133"
+  "wikidata": "Q550133",
+  "uuid": "b5728318-17c2-47f7-ad09-feb871e408c6"
 }

--- a/data/Macao/meta.json
+++ b/data/Macao/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "e269b37d-d58e-400b-bed7-af673104d2bd",
+  "name": "Macao",
+  "iso_code": "MO",
+  "wikidata": "Q14773"
+}

--- a/data/Macedonia/Sobranie/meta.json
+++ b/data/Macedonia/Sobranie/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Sobranie",
   "seats": 123,
-  "wikidata": "Q1258164"
+  "wikidata": "Q1258164",
+  "uuid": "ee8b4345-b39d-46e3-accc-af93caae2abd"
 }

--- a/data/Macedonia/meta.json
+++ b/data/Macedonia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "0cfefda7-cb37-4ed3-bd54-1710b527b639",
+  "name": "Macedonia",
+  "iso_code": "MK",
+  "wikidata": "Q221"
+}

--- a/data/Madagascar/Assembly/meta.json
+++ b/data/Madagascar/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 160,
-  "wikidata": "Q1141206"
+  "wikidata": "Q1141206",
+  "uuid": "c760e66c-88d9-42e1-a750-7b559882d49a"
 }

--- a/data/Madagascar/meta.json
+++ b/data/Madagascar/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "f00c5a48-89d1-4752-b5fe-94f2b65c395f",
+  "name": "Madagascar",
+  "iso_code": "MG",
+  "wikidata": "Q1019"
+}

--- a/data/Malawi/Assembly/meta.json
+++ b/data/Malawi/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 194,
-  "wikidata": "Q1577811"
+  "wikidata": "Q1577811",
+  "uuid": "806f3bee-5b26-4afd-b6ab-b5ca21e68477"
 }

--- a/data/Malawi/meta.json
+++ b/data/Malawi/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "d0ea7f42-dbba-43a3-8a16-92cb052f80f8",
+  "name": "Malawi",
+  "iso_code": "MW",
+  "wikidata": "Q1020"
+}

--- a/data/Malaysia/Dewan_Rakyat/meta.json
+++ b/data/Malaysia/Dewan_Rakyat/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Dewan Rakyat",
   "wikidata": "Q1207092",
-  "seats": 222
+  "seats": 222,
+  "uuid": "c13fc044-0bd4-4fb2-8f45-685f331e621a"
 }

--- a/data/Malaysia/meta.json
+++ b/data/Malaysia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "3c02467c-eec6-4953-b48a-9fb72f612ba3",
+  "name": "Malaysia",
+  "iso_code": "MY",
+  "wikidata": "Q833"
+}

--- a/data/Maldives/Majlis/meta.json
+++ b/data/Maldives/Majlis/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Majlis",
   "seats": 85,
-  "wikidata": "Q650066"
+  "wikidata": "Q650066",
+  "uuid": "55a3d4c2-12ef-49b2-a086-0e6b7c09b3d1"
 }

--- a/data/Maldives/meta.json
+++ b/data/Maldives/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "2e0288af-b8f8-401b-8a1a-3373efdd82f1",
+  "name": "Maldives",
+  "iso_code": "MV",
+  "wikidata": "Q826"
+}

--- a/data/Mali/Assembly/meta.json
+++ b/data/Mali/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 160,
-  "wikidata": "Q1138071"
+  "wikidata": "Q1138071",
+  "uuid": "9b081a0d-e662-4f7c-b58b-0f20f0bb0700"
 }

--- a/data/Mali/meta.json
+++ b/data/Mali/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "c08065c9-9e99-47fc-95f1-204c49de63e9",
+  "name": "Mali",
+  "iso_code": "ML",
+  "wikidata": "Q912"
+}

--- a/data/Malta/Assembly/meta.json
+++ b/data/Malta/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "seats": 69,
-  "wikidata": "Q1817866"
+  "wikidata": "Q1817866",
+  "uuid": "88a5ca33-f857-4634-81d7-38f97d81826e"
 }

--- a/data/Malta/meta.json
+++ b/data/Malta/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "4b89f1b6-ecca-4268-a488-e6cf8362d19e",
+  "name": "Malta",
+  "iso_code": "MT",
+  "wikidata": "Q233"
+}

--- a/data/Marshall_Islands/Nitijela/meta.json
+++ b/data/Marshall_Islands/Nitijela/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Nitijela",
   "seats": 33,
-  "wikidata": "Q1280186"
+  "wikidata": "Q1280186",
+  "uuid": "ade1dce6-24c1-43e8-8e00-780367ddcdee"
 }

--- a/data/Marshall_Islands/meta.json
+++ b/data/Marshall_Islands/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "dab4ae45-4256-4821-b0d6-6b127a3e2a61",
+  "name": "Marshall Islands",
+  "iso_code": "MH",
+  "wikidata": "Q709"
+}

--- a/data/Mauritania/National_Assembly/meta.json
+++ b/data/Mauritania/National_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 81,
-  "wikidata": "Q1138935"
+  "wikidata": "Q1138935",
+  "uuid": "beee2f1c-4697-4c8c-a0cd-782ad524ef42"
 }

--- a/data/Mauritania/meta.json
+++ b/data/Mauritania/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "09250c03-fe29-4216-ab5c-f7610c5364c3",
+  "name": "Mauritania",
+  "iso_code": "MR",
+  "wikidata": "Q1025"
+}

--- a/data/Mauritius/National_Assembly/meta.json
+++ b/data/Mauritius/National_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "wikidata": "Q1854129",
-  "seats": 62
+  "seats": 62,
+  "uuid": "948ad600-51a8-4da3-9039-4b8883581b20"
 }

--- a/data/Mauritius/meta.json
+++ b/data/Mauritius/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "c7b99dac-d82c-4bc4-a68f-f494ebffa212",
+  "name": "Mauritius",
+  "iso_code": "MU",
+  "wikidata": "Q1027"
+}

--- a/data/Mexico/Deputies/meta.json
+++ b/data/Mexico/Deputies/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Chamber of Deputies",
   "wikidata": "Q3014316",
-  "seats": 500
+  "seats": 500,
+  "uuid": "4ed355ff-3f76-43ce-aa10-8b6e82a16068"
 }

--- a/data/Mexico/meta.json
+++ b/data/Mexico/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "38a5cad3-961a-4d82-a4ac-44d2a2ec5341",
+  "name": "Mexico",
+  "iso_code": "MX",
+  "wikidata": "Q96"
+}

--- a/data/Micronesia/Congress/meta.json
+++ b/data/Micronesia/Congress/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Congress",
   "seats": 14,
-  "wikidata": "Q1287548"
+  "wikidata": "Q1287548",
+  "uuid": "d4d958ee-62fa-442b-be37-6adefd8d59a2"
 }

--- a/data/Micronesia/meta.json
+++ b/data/Micronesia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "7143bb88-39c7-4cbc-927c-f238453d0fbf",
+  "name": "Micronesia",
+  "iso_code": "FM",
+  "wikidata": "Q702"
+}

--- a/data/Moldova/Parlamentul/meta.json
+++ b/data/Moldova/Parlamentul/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parlament",
   "seats": 101,
-  "wikidata": "Q555809"
+  "wikidata": "Q555809",
+  "uuid": "cb459823-f905-4d88-a0cb-c420eb796e33"
 }

--- a/data/Moldova/meta.json
+++ b/data/Moldova/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "ddb58eb5-71d4-435e-9f81-cbf92e6a7fd8",
+  "name": "Moldova",
+  "iso_code": "MD",
+  "wikidata": "Q217"
+}

--- a/data/Monaco/Council/meta.json
+++ b/data/Monaco/Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Council",
   "seats": 24,
-  "wikidata": "Q1127198"
+  "wikidata": "Q1127198",
+  "uuid": "0fc887d9-c8ef-49ef-80d0-81fef3dbbc85"
 }

--- a/data/Monaco/meta.json
+++ b/data/Monaco/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "846369f4-9799-4471-89d2-086e0fb2028c",
+  "name": "Monaco",
+  "iso_code": "MC",
+  "wikidata": "Q235"
+}

--- a/data/Mongolia/Assembly/meta.json
+++ b/data/Mongolia/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "State Great Khural",
   "seats": 76,
-  "wikidata": "Q1544714"
+  "wikidata": "Q1544714",
+  "uuid": "8f116a9e-8a59-4f88-9a0f-395c53a87a23"
 }

--- a/data/Mongolia/meta.json
+++ b/data/Mongolia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "5360dd3b-a34c-447b-a3f6-41df253d57ff",
+  "name": "Mongolia",
+  "iso_code": "MN",
+  "wikidata": "Q711"
+}

--- a/data/Montenegro/Assembly/meta.json
+++ b/data/Montenegro/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Skupština",
   "wikidata": "Q1579497",
-  "seats": 81
+  "seats": 81,
+  "uuid": "3314d9ac-a9c0-4c6b-a715-4a972ccdd703"
 }

--- a/data/Montenegro/meta.json
+++ b/data/Montenegro/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "e812f6dd-1971-4584-a9da-b99bafa0dbbb",
+  "name": "Montenegro",
+  "iso_code": "ME",
+  "wikidata": "Q236"
+}

--- a/data/Montserrat/Assembly/meta.json
+++ b/data/Montserrat/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Legislative Assembly",
   "wikidata": "Q21029427",
-  "seats": 9
+  "seats": 9,
+  "uuid": "84a76356-d0c5-41de-b64b-457723b88aa4"
 }

--- a/data/Montserrat/meta.json
+++ b/data/Montserrat/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "95120717-8fd5-4d21-a702-10fbd7c1473e",
+  "name": "Montserrat",
+  "iso_code": "MS",
+  "wikidata": "Q13353"
+}

--- a/data/Morocco/House/meta.json
+++ b/data/Morocco/House/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "wikidata": "Q1572773",
-  "seats": 395
+  "seats": 395,
+  "uuid": "f3847dfb-5f61-47e0-8ba8-feb3f505a23e"
 }

--- a/data/Morocco/meta.json
+++ b/data/Morocco/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "40120e67-e71d-4e23-81b7-39f8b0472c9f",
+  "name": "Morocco",
+  "iso_code": "MA",
+  "wikidata": "Q1028"
+}

--- a/data/Mozambique/Assembly/meta.json
+++ b/data/Mozambique/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assembleia da República",
   "seats": 250,
-  "wikidata": "Q1848595"
+  "wikidata": "Q1848595",
+  "uuid": "fe0c8100-e250-4d7f-a79f-06c832daba21"
 }

--- a/data/Mozambique/meta.json
+++ b/data/Mozambique/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "01cd8c7a-9e92-4382-b0bf-0632f418afd5",
+  "name": "Mozambique",
+  "iso_code": "MZ",
+  "wikidata": "Q1029"
+}

--- a/data/Myanmar/House_of_Representatives/meta.json
+++ b/data/Myanmar/House_of_Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "seats": 440,
-  "wikidata": "Q3379823"
+  "wikidata": "Q3379823",
+  "uuid": "a467f432-1bb0-4dbf-a5e3-fa4024b74cbc"
 }

--- a/data/Myanmar/meta.json
+++ b/data/Myanmar/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "cb21d693-1462-4312-bb2e-f8f4a7cc2d3d",
+  "name": "Myanmar",
+  "iso_code": "MM",
+  "wikidata": "Q836"
+}

--- a/data/Nagorno_Karabakh/Assembly/meta.json
+++ b/data/Nagorno_Karabakh/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 33,
-  "wikidata": "Q166619"
+  "wikidata": "Q166619",
+  "uuid": "decd5761-419d-4026-aa5c-b79b12f7df31"
 }

--- a/data/Nagorno_Karabakh/meta.json
+++ b/data/Nagorno_Karabakh/meta.json
@@ -1,4 +1,6 @@
 {
+  "id": "3e501dfb-6b5f-4a46-ae7a-22962a75283e",
   "name": "Nagorno-Karabakh",
-  "iso_code": "AZ--NK"
+  "iso_code": "AZ--NK",
+  "wikidata": "Q244165"
 }

--- a/data/Namibia/Assembly/meta.json
+++ b/data/Namibia/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 78,
-  "wikidata": "Q1769673"
+  "wikidata": "Q1769673",
+  "uuid": "2262ff14-5cd0-460b-9010-edc5ad3cc246"
 }

--- a/data/Namibia/Council/meta.json
+++ b/data/Namibia/Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Council",
   "seats": 26,
-  "wikidata": "Q1969272"
+  "wikidata": "Q1969272",
+  "uuid": "bbb157b0-f8cc-40ee-b789-ea563a98c39f"
 }

--- a/data/Namibia/meta.json
+++ b/data/Namibia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "85690d9b-191d-4a74-ad50-058a78f35589",
+  "name": "Namibia",
+  "iso_code": "NA",
+  "wikidata": "Q1030"
+}

--- a/data/Nauru/Parliament/meta.json
+++ b/data/Nauru/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "wikidata": "Q1972029",
-  "seats": 19
+  "seats": 19,
+  "uuid": "ac665e38-1444-4a44-93d1-744914968c5f"
 }

--- a/data/Nauru/meta.json
+++ b/data/Nauru/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "bf944440-06ac-493e-8cc1-bbe782bc24bd",
+  "name": "Nauru",
+  "iso_code": "NR",
+  "wikidata": "Q697"
+}

--- a/data/Nepal/Assembly/meta.json
+++ b/data/Nepal/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Constituent Assembly",
   "wikidata": "Q16057514",
-  "seats": 601
+  "seats": 601,
+  "uuid": "e77bf6a4-863e-4c3e-ba95-61ae2ca158fa"
 }

--- a/data/Nepal/meta.json
+++ b/data/Nepal/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "41e91407-0e97-4b11-8064-36f2a62c59c2",
+  "name": "Nepal",
+  "iso_code": "NP",
+  "wikidata": "Q837"
+}

--- a/data/Netherlands/House_of_Representatives/meta.json
+++ b/data/Netherlands/House_of_Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Tweede Kamer",
   "seats": 150,
-  "wikidata": "Q233262"
+  "wikidata": "Q233262",
+  "uuid": "4056556b-bc6a-498c-8410-0757553b5f52"
 }

--- a/data/Netherlands/meta.json
+++ b/data/Netherlands/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "cc721f93-7d08-44f7-bf2a-ae66b18d249f",
+  "name": "Netherlands",
+  "iso_code": "NL",
+  "wikidata": "Q55"
+}

--- a/data/New_Caledonia/Congress/meta.json
+++ b/data/New_Caledonia/Congress/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Congress",
   "wikidata": "Q2993118",
-  "seats": 54
+  "seats": 54,
+  "uuid": "03f3cce0-752f-4843-a780-8cb82d10ac14"
 }

--- a/data/New_Caledonia/meta.json
+++ b/data/New_Caledonia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "01d2fa32-231a-4216-90ef-40ea95647e58",
+  "name": "New Caledonia",
+  "iso_code": "NC",
+  "wikidata": "Q33788"
+}

--- a/data/New_Zealand/House/meta.json
+++ b/data/New_Zealand/House/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "New Zealand Parliament",
   "seats": 120,
-  "wikidata": "Q1520966"
+  "wikidata": "Q1520966",
+  "uuid": "62672598-bda6-4574-a402-cf9ffafa46e9"
 }

--- a/data/New_Zealand/meta.json
+++ b/data/New_Zealand/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "d835c4bc-3091-4f9d-8f2f-f115f81290c6",
+  "name": "New Zealand",
+  "iso_code": "NZ",
+  "wikidata": "Q664"
+}

--- a/data/Nicaragua/Asamblea/meta.json
+++ b/data/Nicaragua/Asamblea/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 92,
-  "wikidata": "Q1969591"
+  "wikidata": "Q1969591",
+  "uuid": "18f800ca-400a-4ca8-bc8c-68c877eadbe7"
 }

--- a/data/Nicaragua/meta.json
+++ b/data/Nicaragua/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "bfed0de5-13a8-4e14-a987-f69c23a314fc",
+  "name": "Nicaragua",
+  "iso_code": "NI",
+  "wikidata": "Q811"
+}

--- a/data/Niger/Assembly/meta.json
+++ b/data/Niger/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assemblée nationale",
   "seats": 113,
-  "wikidata": "Q1969585"
+  "wikidata": "Q1969585",
+  "uuid": "b47530ab-a4cb-441e-8452-408015864eb5"
 }

--- a/data/Niger/meta.json
+++ b/data/Niger/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "e49de51d-0146-443f-a02c-b53960da27c0",
+  "name": "Niger",
+  "iso_code": "NE",
+  "wikidata": "Q1032"
+}

--- a/data/Nigeria/Assembly/meta.json
+++ b/data/Nigeria/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 360,
-  "wikidata": "Q2635070"
+  "wikidata": "Q2635070",
+  "uuid": "7cbd22c6-4df6-42f8-b7c0-44b715b88153"
 }

--- a/data/Nigeria/meta.json
+++ b/data/Nigeria/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "c6454831-f417-4398-bc20-99afdab10701",
+  "name": "Nigeria",
+  "iso_code": "NG",
+  "wikidata": "Q1033"
+}

--- a/data/Niue/Assembly/meta.json
+++ b/data/Niue/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assembly",
   "seats": 20,
-  "wikidata": "Q1643140"
+  "wikidata": "Q1643140",
+  "uuid": "93dd3ef7-1c31-4baf-a273-340214ddd651"
 }

--- a/data/Niue/meta.json
+++ b/data/Niue/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "6cfaa639-50a0-4c83-9d9d-5b0a27b9fb89",
+  "name": "Niue",
+  "iso_code": "NU",
+  "wikidata": "Q34020"
+}

--- a/data/Norfolk_Island/Assembly/meta.json
+++ b/data/Norfolk_Island/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Legislative Assembly",
   "wikidata": "Q7051064",
-  "seats": 9
+  "seats": 9,
+  "uuid": "0ad052e9-585a-4697-ae89-fea9085a23c4"
 }

--- a/data/Norfolk_Island/meta.json
+++ b/data/Norfolk_Island/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "21680105-59e2-4878-80b7-4ef2cc4de8a6",
+  "name": "Norfolk Island",
+  "iso_code": "NF",
+  "wikidata": "Q31057"
+}

--- a/data/North_Korea/National_Assembly/meta.json
+++ b/data/North_Korea/National_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Supreme People’s Assembly",
   "seats": 687,
-  "wikidata": "Q714698"
+  "wikidata": "Q714698",
+  "uuid": "ba8804a8-1c70-4245-9534-409151b88474"
 }

--- a/data/North_Korea/meta.json
+++ b/data/North_Korea/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "KP"
+  "id": "649e5a44-7035-487b-a05b-e9a861ed99a1",
+  "name": "North Korea",
+  "iso_code": "KP",
+  "wikidata": "Q423"
 }

--- a/data/Northern_Cyprus/Assembly/meta.json
+++ b/data/Northern_Cyprus/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assembly of the Republic",
   "seats": 50,
-  "wikidata": "Q1515950"
+  "wikidata": "Q1515950",
+  "uuid": "fdd61ead-e65e-43e0-b9db-2b01ffd37b58"
 }

--- a/data/Northern_Cyprus/meta.json
+++ b/data/Northern_Cyprus/meta.json
@@ -1,4 +1,6 @@
 {
+  "id": "54ae5307-c7f9-40c1-a911-484659514d07",
   "name": "Northern Cyprus",
-  "iso_code": "CY-TRNC"
+  "iso_code": "CY-TRNC",
+  "wikidata": "Q23681"
 }

--- a/data/Northern_Ireland/Assembly/meta.json
+++ b/data/Northern_Ireland/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Northern Ireland Assembly",
   "seats": 108,
-  "wikidata": "Q285714"
+  "wikidata": "Q285714",
+  "uuid": "f38cd15e-d461-47a1-8370-c294d1e233b5"
 }

--- a/data/Northern_Ireland/meta.json
+++ b/data/Northern_Ireland/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "GB-NIR"
+  "id": "069e9427-8679-4ef5-bd86-9e569facbf75",
+  "name": "Northern Ireland",
+  "iso_code": "GB-NIR",
+  "wikidata": "Q26"
 }

--- a/data/Northern_Mariana_Islands/House/meta.json
+++ b/data/Northern_Mariana_Islands/House/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "wikidata": "Q7058704",
-  "seats": 20
+  "seats": 20,
+  "uuid": "60977f6a-98c2-464a-863a-fc3bea9d3130"
 }

--- a/data/Northern_Mariana_Islands/meta.json
+++ b/data/Northern_Mariana_Islands/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "62083f5e-53ce-4ba8-ba5e-4e07b91c92b2",
+  "name": "Northern Mariana Islands",
+  "iso_code": "MP",
+  "wikidata": "Q16644"
+}

--- a/data/Norway/Storting/meta.json
+++ b/data/Norway/Storting/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Storting",
   "wikidata": "Q109016",
-  "seats": 169
+  "seats": 169,
+  "uuid": "b383457f-4845-4cfe-82ef-1746ae994ce0"
 }

--- a/data/Norway/meta.json
+++ b/data/Norway/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "f875d195-9226-44ee-b3ed-4bbac325faba",
+  "name": "Norway",
+  "iso_code": "NO",
+  "wikidata": "Q20"
+}

--- a/data/Oman/Majlis/meta.json
+++ b/data/Oman/Majlis/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Majlis al-Shura",
   "wikidata": "Q818704",
-  "seats": 84
+  "seats": 84,
+  "uuid": "d92c9805-900c-4270-8dd2-17ef1b866754"
 }

--- a/data/Oman/meta.json
+++ b/data/Oman/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "88eda503-b090-49e5-8c0b-de68318c5a29",
+  "name": "Oman",
+  "iso_code": "OM",
+  "wikidata": "Q842"
+}

--- a/data/Pakistan/Assembly/meta.json
+++ b/data/Pakistan/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 336,
-  "wikidata": "Q1518223"
+  "wikidata": "Q1518223",
+  "uuid": "65caa270-16bc-435c-ac92-e04751e26884"
 }

--- a/data/Pakistan/meta.json
+++ b/data/Pakistan/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "451b1c20-95bb-4932-839f-db1c682ee1da",
+  "name": "Pakistan",
+  "iso_code": "PK",
+  "wikidata": "Q843"
+}

--- a/data/Palau/House_of_Delegates/meta.json
+++ b/data/Palau/House_of_Delegates/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Delegates",
   "seats": 16,
-  "wikidata": "Q2118228"
+  "wikidata": "Q2118228",
+  "uuid": "f341a566-ce17-4a76-b3d0-3e708ef9fc4d"
 }

--- a/data/Palau/meta.json
+++ b/data/Palau/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "eda069b7-6dd6-4005-9d38-2761f3bd832d",
+  "name": "Palau",
+  "iso_code": "PW",
+  "wikidata": "Q695"
+}

--- a/data/Panama/Assembly/meta.json
+++ b/data/Panama/Assembly/meta.json
@@ -1,6 +1,6 @@
 {
-  "name": "Cámara de Representantes",
-  "seats": 166,
-  "wikidata": "Q1571756",
-  "uuid": "fe1cdc34-eb62-45b0-a6e3-1c04a50c3510"
+  "name": "Asamblea Nacional",
+  "seats": 71,
+  "wikidata": "Q1368588",
+  "uuid": "8946fbd5-f635-42d0-b43a-47b426fe0135"
 }

--- a/data/Panama/Assembly/meta.json
+++ b/data/Panama/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Cámara de Representantes",
   "seats": 166,
-  "wikidata": "Q1571756"
+  "wikidata": "Q1571756",
+  "uuid": "fe1cdc34-eb62-45b0-a6e3-1c04a50c3510"
 }

--- a/data/Panama/meta.json
+++ b/data/Panama/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "7b3594fd-83bb-4942-8c0e-b70c23aac8dc",
+  "name": "Panama",
+  "iso_code": "PA",
+  "wikidata": "Q804"
+}

--- a/data/Papua_New_Guinea/Parliament/meta.json
+++ b/data/Papua_New_Guinea/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Parliament",
   "seats": 109,
-  "wikidata": "Q24563"
+  "wikidata": "Q24563",
+  "uuid": "577fcc83-d248-4f1c-bac9-41ddb90293ff"
 }

--- a/data/Papua_New_Guinea/meta.json
+++ b/data/Papua_New_Guinea/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "441871e0-1724-4ace-8969-ff1fea8f566d",
+  "name": "Papua New Guinea",
+  "iso_code": "PG",
+  "wikidata": "Q691"
+}

--- a/data/Paraguay/Deputies/meta.json
+++ b/data/Paraguay/Deputies/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Chamber of Deputies",
   "seats": 80,
-  "wikidata": "Q320290"
+  "wikidata": "Q320290",
+  "uuid": "56faf65e-f6cd-43cc-8d6d-299c1f5aa7ac"
 }

--- a/data/Paraguay/meta.json
+++ b/data/Paraguay/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "5772cbe2-e4a4-4b07-9633-d8f6de1cfd66",
+  "name": "Paraguay",
+  "iso_code": "PY",
+  "wikidata": "Q733"
+}

--- a/data/Peru/Congreso/meta.json
+++ b/data/Peru/Congreso/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Congress",
   "seats": 130,
-  "wikidata": "Q1357543"
+  "wikidata": "Q1357543",
+  "uuid": "31b88399-5b9e-4b50-9518-43ecfe65be2f"
 }

--- a/data/Peru/meta.json
+++ b/data/Peru/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "b211e658-392f-40bd-b7e4-1538d56a1007",
+  "name": "Peru",
+  "iso_code": "PE",
+  "wikidata": "Q419"
+}

--- a/data/Philippines/House/meta.json
+++ b/data/Philippines/House/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "seats": 292,
-  "wikidata": "Q678545"
+  "wikidata": "Q678545",
+  "uuid": "02e84be8-6151-4224-90bf-94d1317da396"
 }

--- a/data/Philippines/meta.json
+++ b/data/Philippines/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "d11da196-a819-4ead-97c0-5806ac4f7f2e",
+  "name": "Philippines",
+  "iso_code": "PH",
+  "wikidata": "Q928"
+}

--- a/data/Pitcairn/Island_Council/meta.json
+++ b/data/Pitcairn/Island_Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Island Council",
   "wikidata": "Q6083065",
-  "seats": 10
+  "seats": 10,
+  "uuid": "82523cb3-99c7-446b-9441-036fb7493b2a"
 }

--- a/data/Pitcairn/meta.json
+++ b/data/Pitcairn/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "81a89d75-0e53-4de2-8b8a-86d49e3a0a70",
+  "name": "Pitcairn",
+  "iso_code": "PN",
+  "wikidata": "Q35672"
+}

--- a/data/Poland/Sejm/meta.json
+++ b/data/Poland/Sejm/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Sejm",
   "wikidata": "Q98964",
-  "seats": 460
+  "seats": 460,
+  "uuid": "c04d7640-3d85-4845-ad97-54929aa1908b"
 }

--- a/data/Poland/meta.json
+++ b/data/Poland/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "4de18c17-5c7e-4371-97f4-f886c5b5dc1c",
+  "name": "Poland",
+  "iso_code": "PL",
+  "wikidata": "Q36"
+}

--- a/data/Portugal/Assembly/meta.json
+++ b/data/Portugal/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assembleia da República",
   "seats": 230,
-  "wikidata": "Q740564"
+  "wikidata": "Q740564",
+  "uuid": "a1b77ad6-aa9a-4f60-b722-ec544ecf4cea"
 }

--- a/data/Portugal/meta.json
+++ b/data/Portugal/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "2442a7cd-97d7-4045-b0ac-94fea7a3cb27",
+  "name": "Portugal",
+  "iso_code": "PT",
+  "wikidata": "Q45"
+}

--- a/data/Puerto_Rico/House_of_Representatives/meta.json
+++ b/data/Puerto_Rico/House_of_Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "seats": 51,
-  "wikidata": "Q169652"
+  "wikidata": "Q169652",
+  "uuid": "d82e59cc-6c1f-4cb0-bc75-49e69a785ac7"
 }

--- a/data/Puerto_Rico/meta.json
+++ b/data/Puerto_Rico/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "a9ca98a5-c2d8-403e-9494-85ceb9a9bea8",
+  "name": "Puerto Rico",
+  "iso_code": "PR",
+  "wikidata": "Q1183"
+}

--- a/data/Romania/Deputies/meta.json
+++ b/data/Romania/Deputies/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Chamber of Deputies",
   "seats": 412,
-  "wikidata": "Q320306"
+  "wikidata": "Q320306",
+  "uuid": "e9f403b8-1aa9-47c7-94d7-f0a5f6edb74b"
 }

--- a/data/Romania/meta.json
+++ b/data/Romania/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "d29df76a-2b03-47c4-a4b5-cabaf7a2de64",
+  "name": "Romania",
+  "iso_code": "RO",
+  "wikidata": "Q218"
+}

--- a/data/Russia/Duma/meta.json
+++ b/data/Russia/Duma/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Duma",
   "seats": 450,
-  "wikidata": "Q715641"
+  "wikidata": "Q715641",
+  "uuid": "2b944f3a-ffc1-4cd0-a96b-9699b20bb38e"
 }

--- a/data/Russia/meta.json
+++ b/data/Russia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "4b6503aa-185d-49d3-88a4-663e11f845e5",
+  "name": "Russia",
+  "iso_code": "RU",
+  "wikidata": "Q159"
+}

--- a/data/Rwanda/Deputies/meta.json
+++ b/data/Rwanda/Deputies/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Chamber of Deputies",
   "seats": 80,
-  "wikidata": "Q320292"
+  "wikidata": "Q320292",
+  "uuid": "3a6ab8b0-634f-4721-b8e0-0d6e521ea855"
 }

--- a/data/Rwanda/meta.json
+++ b/data/Rwanda/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "0bf3210d-db06-42a1-bc2b-62bf73a2c394",
+  "name": "Rwanda",
+  "iso_code": "RW",
+  "wikidata": "Q1037"
+}

--- a/data/Saint_Barthelemy/Council/meta.json
+++ b/data/Saint_Barthelemy/Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Territorial Council",
   "seats": 19,
-  "wikidata": "Q2994333"
+  "wikidata": "Q2994333",
+  "uuid": "ec10c5bd-512c-4494-a576-a6bc7ff44ca1"
 }

--- a/data/Saint_Barthelemy/meta.json
+++ b/data/Saint_Barthelemy/meta.json
@@ -1,4 +1,6 @@
 {
+  "id": "e591e6e9-6a5e-48ac-b260-cd9390138af7",
   "name": "Saint Barthélemy",
-  "iso_code": "BL"
+  "iso_code": "BL",
+  "wikidata": "Q25362"
 }

--- a/data/Saint_Helena/Legislative_Council/meta.json
+++ b/data/Saint_Helena/Legislative_Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Legislative Council",
   "seats": 15,
-  "wikidata": "Q6518247"
+  "wikidata": "Q6518247",
+  "uuid": "6e770a74-4032-47d7-afe5-3502c239521b"
 }

--- a/data/Saint_Helena/meta.json
+++ b/data/Saint_Helena/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "5fa3c841-a0c0-4c88-ab5c-67493a260d86",
   "name": "Saint Helena",
-  "iso_code": null,
+  "iso_code": "SH",
   "wikidata": "Q34497"
 }

--- a/data/Saint_Helena/meta.json
+++ b/data/Saint_Helena/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "5fa3c841-a0c0-4c88-ab5c-67493a260d86",
+  "name": "Saint Helena",
+  "iso_code": null,
+  "wikidata": "Q34497"
+}

--- a/data/Saint_Kitts_and_Nevis/Assembly/meta.json
+++ b/data/Saint_Kitts_and_Nevis/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 15,
-  "wikidata": "Q654504"
+  "wikidata": "Q654504",
+  "uuid": "7a139477-56c2-4826-8fac-aaddb3c863e4"
 }

--- a/data/Saint_Kitts_and_Nevis/meta.json
+++ b/data/Saint_Kitts_and_Nevis/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "2981e859-8406-4781-8e1d-7838a3efc03e",
+  "name": "Saint Kitts and Nevis",
+  "iso_code": "KN",
+  "wikidata": "Q763"
+}

--- a/data/Saint_Lucia/Assembly/meta.json
+++ b/data/Saint_Lucia/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Assembly",
   "wikidata": "Q1282775",
-  "seats": 18
+  "seats": 18,
+  "uuid": "71f00d4b-5a10-4759-b679-57a45609bac5"
 }

--- a/data/Saint_Lucia/meta.json
+++ b/data/Saint_Lucia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "ea95056d-abb8-4ae7-ac6d-b15b4a8cd336",
+  "name": "Saint Lucia",
+  "iso_code": "LC",
+  "wikidata": "Q760"
+}

--- a/data/Saint_Martin/Council/meta.json
+++ b/data/Saint_Martin/Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Territorial Council",
   "seats": 23,
-  "wikidata": "Q2994334"
+  "wikidata": "Q2994334",
+  "uuid": "67dbc987-d69d-4287-a71a-86e0ab000858"
 }

--- a/data/Saint_Martin/meta.json
+++ b/data/Saint_Martin/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "04d860a0-79c9-4857-ad3b-c5792493b13f",
+  "name": "Saint Martin",
+  "iso_code": "MF",
+  "wikidata": "Q126125"
+}

--- a/data/Saint_Pierre_and_Miquelon/Territorial_Council/meta.json
+++ b/data/Saint_Pierre_and_Miquelon/Territorial_Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Territorial Council",
   "seats": 19,
-  "wikidata": "Q2994335"
+  "wikidata": "Q2994335",
+  "uuid": "5883e5b5-f5e8-4f76-a6eb-ac01aa3daefc"
 }

--- a/data/Saint_Pierre_and_Miquelon/meta.json
+++ b/data/Saint_Pierre_and_Miquelon/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "9d329b49-2f2e-4b73-b50e-cc992ade0c51",
+  "name": "Saint Pierre and Miquelon",
+  "iso_code": "PM",
+  "wikidata": "Q34617"
+}

--- a/data/Saint_Vincent_and_the_Grenadines/Assembly/meta.json
+++ b/data/Saint_Vincent_and_the_Grenadines/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Assembly",
   "wikidata": "Q1138357",
-  "seats": 21
+  "seats": 21,
+  "uuid": "93d8c111-f7c6-4415-836c-1c4bcd795a1e"
 }

--- a/data/Saint_Vincent_and_the_Grenadines/meta.json
+++ b/data/Saint_Vincent_and_the_Grenadines/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "d15329c7-5ab8-4d01-a3e2-bc5198f56033",
+  "name": "Saint Vincent and the Grenadines",
+  "iso_code": "VC",
+  "wikidata": "Q757"
+}

--- a/data/Samoa/Parliament/meta.json
+++ b/data/Samoa/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Fono",
   "wikidata": "Q1269555",
-  "seats": 49
+  "seats": 49,
+  "uuid": "61144f35-c484-46e3-8630-6c9e512923ff"
 }

--- a/data/Samoa/meta.json
+++ b/data/Samoa/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "68ba4b6a-ed28-4c3a-8432-34c3874764bd",
+  "name": "Samoa",
+  "iso_code": "WS",
+  "wikidata": "Q683"
+}

--- a/data/San_Marino/Council/meta.json
+++ b/data/San_Marino/Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Grand and General Council",
   "seats": 60,
-  "wikidata": "Q817979"
+  "wikidata": "Q817979",
+  "uuid": "d2b74f02-b177-4f20-aa57-e3e44e0c4d92"
 }

--- a/data/San_Marino/meta.json
+++ b/data/San_Marino/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "e51220ca-0be1-496f-9933-5fba70a9b5fb",
+  "name": "San Marino",
+  "iso_code": "SM",
+  "wikidata": "Q238"
+}

--- a/data/Sark/Chief_Pleas/meta.json
+++ b/data/Sark/Chief_Pleas/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Chief Pleas",
   "seats": 30,
-  "wikidata": "Q9189683"
+  "wikidata": "Q9189683",
+  "uuid": "9dc18eaf-0cb4-4f2e-8749-4529320a5786"
 }

--- a/data/Sark/meta.json
+++ b/data/Sark/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "GG-SRK"
+  "id": "7961578d-771d-452c-845f-1996dd143415",
+  "name": "Sark",
+  "iso_code": "GG-SRK",
+  "wikidata": "Q3405693"
 }

--- a/data/Saudi_Arabia/Shura/meta.json
+++ b/data/Saudi_Arabia/Shura/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Shura Council",
   "seats": 150,
-  "wikidata": "Q818708"
+  "wikidata": "Q818708",
+  "uuid": "562b3352-9ab8-496b-b57c-f85f48b9c21a"
 }

--- a/data/Saudi_Arabia/meta.json
+++ b/data/Saudi_Arabia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "e180f124-97fd-41ed-ad8b-3046d3dec7b9",
+  "name": "Saudi Arabia",
+  "iso_code": "SA",
+  "wikidata": "Q851"
+}

--- a/data/Scotland/Parliament/meta.json
+++ b/data/Scotland/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Scottish Parliament",
   "seats": 129,
-  "wikidata": "Q206171"
+  "wikidata": "Q206171",
+  "uuid": "adbf5a88-3c23-4fa5-9d4c-377ab8f1fa81"
 }

--- a/data/Scotland/meta.json
+++ b/data/Scotland/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "GB-SCT"
+  "id": "7c83fe39-27aa-450c-b4db-608b73f974d1",
+  "name": "Scotland",
+  "iso_code": "GB-SCT",
+  "wikidata": "Q22"
 }

--- a/data/Senegal/Assembly/meta.json
+++ b/data/Senegal/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 150,
-  "wikidata": "Q1853640"
+  "wikidata": "Q1853640",
+  "uuid": "3a434982-3a0c-4fc2-8826-c8335892885b"
 }

--- a/data/Senegal/meta.json
+++ b/data/Senegal/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "7b81c2fc-658d-48b7-bd54-5ad260363eeb",
+  "name": "Senegal",
+  "iso_code": "SN",
+  "wikidata": "Q1041"
+}

--- a/data/Serbia/National_Assembly/meta.json
+++ b/data/Serbia/National_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 250,
-  "wikidata": "Q920222"
+  "wikidata": "Q920222",
+  "uuid": "bcabb5c4-6ac3-4704-b57e-cdc33c1ddc05"
 }

--- a/data/Serbia/meta.json
+++ b/data/Serbia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "b5004768-6ee9-4353-bdbc-e7a6abb450ef",
+  "name": "Serbia",
+  "iso_code": "RS",
+  "wikidata": "Q403"
+}

--- a/data/Seychelles/Assembly/meta.json
+++ b/data/Seychelles/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 31,
-  "wikidata": "Q676484"
+  "wikidata": "Q676484",
+  "uuid": "b4e819b9-ec55-43bc-8d79-61fa3ff6bfc4"
 }

--- a/data/Seychelles/meta.json
+++ b/data/Seychelles/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "6f0148e3-4253-4753-87d1-7b3558684ce7",
+  "name": "Seychelles",
+  "iso_code": "SC",
+  "wikidata": "Q1042"
+}

--- a/data/Sierra_Leone/Parliament/meta.json
+++ b/data/Sierra_Leone/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "seats": 124,
-  "wikidata": "Q1138130"
+  "wikidata": "Q1138130",
+  "uuid": "8fe9a7c5-b90f-473a-bcfd-e7590b6dcda5"
 }

--- a/data/Sierra_Leone/meta.json
+++ b/data/Sierra_Leone/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "b5db874c-1a3f-4db4-b318-ac7f14955024",
+  "name": "Sierra Leone",
+  "iso_code": "SL",
+  "wikidata": "Q1044"
+}

--- a/data/Singapore/Parliament/meta.json
+++ b/data/Singapore/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "wikidata": "Q1517231",
-  "seats": 99
+  "seats": 99,
+  "uuid": "5f27a768-1cb5-410b-8f3e-abf76b7ee07e"
 }

--- a/data/Singapore/meta.json
+++ b/data/Singapore/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "5eca7922-0cf9-415e-86cd-2fdcc52726f8",
+  "name": "Singapore",
+  "iso_code": "SG",
+  "wikidata": "Q334"
+}

--- a/data/Sint_Maarten/Estates/meta.json
+++ b/data/Sint_Maarten/Estates/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Estates",
   "wikidata": "Q388526",
-  "seats": 15
+  "seats": 15,
+  "uuid": "9501bf4e-e6e6-4c06-811f-e7277c4f7c60"
 }

--- a/data/Sint_Maarten/meta.json
+++ b/data/Sint_Maarten/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "abc6b21c-a03a-4ea6-8bb8-f3369f73446e",
+  "name": "Sint Maarten",
+  "iso_code": "SX",
+  "wikidata": "Q26273"
+}

--- a/data/Slovakia/National_Council/meta.json
+++ b/data/Slovakia/National_Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Council",
   "wikidata": "Q1139204",
-  "seats": 150
+  "seats": 150,
+  "uuid": "31622b07-7f1b-4639-8cb7-adc8dc6faa49"
 }

--- a/data/Slovakia/meta.json
+++ b/data/Slovakia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "e8fec744-01bf-47ff-a112-15be2af83085",
+  "name": "Slovakia",
+  "iso_code": "SK",
+  "wikidata": "Q214"
+}

--- a/data/Slovenia/National_Assembly/meta.json
+++ b/data/Slovenia/National_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Državni zbor",
   "seats": 90,
-  "wikidata": "Q1568676"
+  "wikidata": "Q1568676",
+  "uuid": "318b4a81-c7a3-4d6c-a3ce-80e08345d86e"
 }

--- a/data/Slovenia/meta.json
+++ b/data/Slovenia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "b50cf5f9-3d2b-4b6d-99dd-2e7dc8320abb",
+  "name": "Slovenia",
+  "iso_code": "SI",
+  "wikidata": "Q215"
+}

--- a/data/Solomon_Islands/Parliament/meta.json
+++ b/data/Solomon_Islands/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Parliament",
   "wikidata": "Q727851",
-  "seats": 50
+  "seats": 50,
+  "uuid": "95ee1a0f-d480-498d-9de5-a4d03108d83c"
 }

--- a/data/Solomon_Islands/meta.json
+++ b/data/Solomon_Islands/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "3691320e-644f-4c8c-8b96-7cb0ebf6688e",
+  "name": "Solomon Islands",
+  "iso_code": "SB",
+  "wikidata": "Q685"
+}

--- a/data/Somalia/Lower/meta.json
+++ b/data/Somalia/Lower/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of the People",
   "wikidata": "Q21078126",
-  "seats": 275
+  "seats": 275,
+  "uuid": "89f7566b-a147-42b5-bcad-d8642da1a675"
 }

--- a/data/Somalia/meta.json
+++ b/data/Somalia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "c184f426-0e2f-4c50-a270-769c053667f0",
+  "name": "Somalia",
+  "iso_code": "SO",
+  "wikidata": "Q1045"
+}

--- a/data/Somaliland/Representatives/meta.json
+++ b/data/Somaliland/Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "wikidata": "Q16965447",
-  "seats": 82
+  "seats": 82,
+  "uuid": "f2622e80-b9c6-48e7-8efb-0e278e6c6444"
 }

--- a/data/Somaliland/meta.json
+++ b/data/Somaliland/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "SO-SOM"
+  "id": "f1d216ee-96da-4034-abef-730dd97e57f4",
+  "name": "Somaliland",
+  "iso_code": "SO-SOM",
+  "wikidata": "Q34754"
 }

--- a/data/South_Africa/Assembly/meta.json
+++ b/data/South_Africa/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 400,
-  "wikidata": "Q240823"
+  "wikidata": "Q240823",
+  "uuid": "a36b27d7-5cb0-49f9-bba3-8e0b68bfdcbd"
 }

--- a/data/South_Africa/meta.json
+++ b/data/South_Africa/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "871b90f1-c535-45d4-b871-496574ba8fcd",
+  "name": "South Africa",
+  "iso_code": "ZA",
+  "wikidata": "Q258"
+}

--- a/data/South_Korea/National_Assembly/meta.json
+++ b/data/South_Korea/National_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 300,
-  "wikidata": "Q494162"
+  "wikidata": "Q494162",
+  "uuid": "eb645257-3387-42ac-9cc1-d6379eff8ca2"
 }

--- a/data/South_Korea/meta.json
+++ b/data/South_Korea/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "KR"
+  "id": "4073f568-be73-4cf9-a04e-90bc2ada2c9c",
+  "name": "South Korea",
+  "iso_code": "KR",
+  "wikidata": "Q884"
 }

--- a/data/South_Ossetia/Parliament/meta.json
+++ b/data/South_Ossetia/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "seats": 34,
-  "wikidata": "Q2063555"
+  "wikidata": "Q2063555",
+  "uuid": "6ace9785-8aad-4bca-88b5-418640558929"
 }

--- a/data/South_Ossetia/meta.json
+++ b/data/South_Ossetia/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "X-SO"
+  "id": "308a0467-ece4-43ae-abcb-d0c76a4c9f41",
+  "name": "South Ossetia",
+  "iso_code": "X-SO",
+  "wikidata": "Q23427"
 }

--- a/data/South_Sudan/Assembly/meta.json
+++ b/data/South_Sudan/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Legislative Assembly",
   "seats": 170,
-  "wikidata": "Q1968103"
+  "wikidata": "Q1968103",
+  "uuid": "50d0c1f9-7153-41d8-be8c-a646f4b66764"
 }

--- a/data/South_Sudan/meta.json
+++ b/data/South_Sudan/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "d8265a33-328d-4041-a762-e9f44bc40818",
+  "name": "South Sudan",
+  "iso_code": "SS",
+  "wikidata": "Q958"
+}

--- a/data/Spain/Congress/meta.json
+++ b/data/Spain/Congress/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Congreso de los Diputados",
   "seats": 350,
-  "wikidata": "Q539149"
+  "wikidata": "Q539149",
+  "uuid": "a0ade8ef-8127-47eb-8cb5-9403d5dbeb4c"
 }

--- a/data/Spain/meta.json
+++ b/data/Spain/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "4e1a2990-8662-4a12-9ac0-356ef758bb45",
+  "name": "Spain",
+  "iso_code": "ES",
+  "wikidata": "Q29"
+}

--- a/data/Sri_Lanka/Parliament/meta.json
+++ b/data/Sri_Lanka/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "seats": 225,
-  "wikidata": "Q1450753"
+  "wikidata": "Q1450753",
+  "uuid": "ca251504-0fe1-46f5-b838-d5ec76359a47"
 }

--- a/data/Sri_Lanka/meta.json
+++ b/data/Sri_Lanka/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "26066418-02b3-4c89-bee3-67c0615a75ac",
+  "name": "Sri Lanka",
+  "iso_code": "LK",
+  "wikidata": "Q854"
+}

--- a/data/Suriname/Assembly/meta.json
+++ b/data/Suriname/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 51,
-  "wikidata": "Q1760847"
+  "wikidata": "Q1760847",
+  "uuid": "2f191010-34fe-4273-95f4-9d5b300feb28"
 }

--- a/data/Suriname/meta.json
+++ b/data/Suriname/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "be08e61e-4528-471d-a1b8-b2126264ddb7",
+  "name": "Suriname",
+  "iso_code": "SR",
+  "wikidata": "Q730"
+}

--- a/data/Swaziland/Assembly/meta.json
+++ b/data/Swaziland/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Assembly",
   "seats": 55,
-  "wikidata": "Q5914707"
+  "wikidata": "Q5914707",
+  "uuid": "33273a3e-36c6-4ced-8e58-862913a4335e"
 }

--- a/data/Swaziland/meta.json
+++ b/data/Swaziland/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "ecc10264-ec2b-4048-943c-d4d1b071c5d8",
+  "name": "Swaziland",
+  "iso_code": "SZ",
+  "wikidata": "Q1050"
+}

--- a/data/Sweden/Riksdag/meta.json
+++ b/data/Sweden/Riksdag/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Riksdag",
   "seats": 349,
-  "wikidata": "Q272930"
+  "wikidata": "Q272930",
+  "uuid": "984f0a80-7942-4438-948e-6094b55f65ce"
 }

--- a/data/Sweden/meta.json
+++ b/data/Sweden/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "356bf147-da78-4bfd-9b71-c67e6ffdca72",
+  "name": "Sweden",
+  "iso_code": "SE",
+  "wikidata": "Q34"
+}

--- a/data/Switzerland/National_Council/meta.json
+++ b/data/Switzerland/National_Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Council",
   "seats": 200,
-  "wikidata": "Q676078"
+  "wikidata": "Q676078",
+  "uuid": "8f4f13a5-bf1b-4999-a86a-9318f3ca7606"
 }

--- a/data/Switzerland/meta.json
+++ b/data/Switzerland/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "7d6c2967-a1b3-411c-a8cd-e290e33b496f",
+  "name": "Switzerland",
+  "iso_code": "CH",
+  "wikidata": "Q39"
+}

--- a/data/Syria/Majlis/meta.json
+++ b/data/Syria/Majlis/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "People’s Council",
   "seats": 250,
-  "wikidata": "Q1372196"
+  "wikidata": "Q1372196",
+  "uuid": "38d3ebeb-ed76-41c6-8b30-5ad9900f8f21"
 }

--- a/data/Syria/meta.json
+++ b/data/Syria/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "a0b25004-761c-4c3f-96c8-93edba25847b",
+  "name": "Syria",
+  "iso_code": "SY",
+  "wikidata": "Q858"
+}

--- a/data/Taiwan/Legislative_Yuan/meta.json
+++ b/data/Taiwan/Legislative_Yuan/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Legislative Yuan",
   "seats": 113,
-  "wikidata": "Q715869"
+  "wikidata": "Q715869",
+  "uuid": "e1fef832-4c78-497c-ad3a-6a8df1fef861"
 }

--- a/data/Taiwan/meta.json
+++ b/data/Taiwan/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "b9e323a4-e0b9-4e0e-ba07-06f64f30a3a4",
+  "name": "Taiwan",
+  "iso_code": "TW",
+  "wikidata": "Q865"
+}

--- a/data/Tajikistan/Representatives/meta.json
+++ b/data/Tajikistan/Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assembly of Representatives",
   "wikidata": "Q9390763",
-  "seats": 63
+  "seats": 63,
+  "uuid": "690a9c82-c02e-477d-9128-a9c67cbca09b"
 }

--- a/data/Tajikistan/meta.json
+++ b/data/Tajikistan/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "3cd0400e-16a1-4db4-a9c7-def28f312978",
+  "name": "Tajikistan",
+  "iso_code": "TJ",
+  "wikidata": "Q863"
+}

--- a/data/Tanzania/Assembly/meta.json
+++ b/data/Tanzania/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 357,
-  "wikidata": "Q1138299"
+  "wikidata": "Q1138299",
+  "uuid": "0a742811-0f27-4d3c-b69e-099c4f821b7b"
 }

--- a/data/Tanzania/meta.json
+++ b/data/Tanzania/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "cbab1b1b-e267-49a3-a90d-4c645c5d3c3a",
+  "name": "Tanzania",
+  "iso_code": "TZ",
+  "wikidata": "Q924"
+}

--- a/data/Thailand/National_Legislative_Assembly/meta.json
+++ b/data/Thailand/National_Legislative_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Legislative Assembly",
   "wikidata": "Q1368318",
-  "seats": 250
+  "seats": 250,
+  "uuid": "e441ca10-6c4b-4991-8f1d-4a4ea0dae3d0"
 }

--- a/data/Thailand/meta.json
+++ b/data/Thailand/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "076aeeb6-2570-4cd6-8288-013f16d3f746",
+  "name": "Thailand",
+  "iso_code": "TH",
+  "wikidata": "Q869"
+}

--- a/data/Timor_Leste/Parlamento/meta.json
+++ b/data/Timor_Leste/Parlamento/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parlamento",
   "seats": 65,
-  "wikidata": "Q680806"
+  "wikidata": "Q680806",
+  "uuid": "0f00ed19-6f37-4fd6-ad8f-289326d77663"
 }

--- a/data/Timor_Leste/meta.json
+++ b/data/Timor_Leste/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "TL"
+  "id": "35813e72-3722-4c0f-a731-4265257eec7f",
+  "name": "Timor Leste",
+  "iso_code": "TL",
+  "wikidata": "Q574"
 }

--- a/data/Togo/Assembly/meta.json
+++ b/data/Togo/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 91,
-  "wikidata": "Q1969578"
+  "wikidata": "Q1969578",
+  "uuid": "988ba314-0b40-461b-bbd8-8f23acd27099"
 }

--- a/data/Togo/meta.json
+++ b/data/Togo/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "3b41979a-549a-48dd-abf2-9f18d16df74e",
+  "name": "Togo",
+  "iso_code": "TG",
+  "wikidata": "Q945"
+}

--- a/data/Tonga/Assembly/meta.json
+++ b/data/Tonga/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Legislative Assembly",
   "seats": 26,
-  "wikidata": "Q1287831"
+  "wikidata": "Q1287831",
+  "uuid": "b8ba010c-a6c6-4b93-b97f-df2c7f4112ba"
 }

--- a/data/Tonga/meta.json
+++ b/data/Tonga/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "fc427a8c-224b-43a3-9f81-d91aaf92c985",
+  "name": "Tonga",
+  "iso_code": "TO",
+  "wikidata": "Q678"
+}

--- a/data/Transnistria/Supreme_Council/meta.json
+++ b/data/Transnistria/Supreme_Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Supreme Council",
   "seats": 43,
-  "wikidata": "Q2656777"
+  "wikidata": "Q2656777",
+  "uuid": "85818632-502f-4e63-ad5e-74073936b289"
 }

--- a/data/Transnistria/meta.json
+++ b/data/Transnistria/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "MD-PMR"
+  "id": "ac9c377c-5f0b-4df8-8bfb-eacc06a5c724",
+  "name": "Transnistria",
+  "iso_code": "MD-PMR",
+  "wikidata": "Q907112"
 }

--- a/data/Trinidad_and_Tobago/Representatives/meta.json
+++ b/data/Trinidad_and_Tobago/Representatives/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "wikidata": "Q2145199",
-  "seats": 41
+  "seats": 41,
+  "uuid": "fe0aaad9-a550-467f-9315-f556a393f4fa"
 }

--- a/data/Trinidad_and_Tobago/Senate/meta.json
+++ b/data/Trinidad_and_Tobago/Senate/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Senate",
   "wikidata": "Q3510869",
-  "seats": 31
+  "seats": 31,
+  "uuid": "537f7464-0bf8-458d-8282-f087f73f6d79"
 }

--- a/data/Trinidad_and_Tobago/meta.json
+++ b/data/Trinidad_and_Tobago/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "6a19bbae-a6f0-4438-a30b-35da134ab52f",
+  "name": "Trinidad and Tobago",
+  "iso_code": "TT",
+  "wikidata": "Q754"
+}

--- a/data/Tunisia/Majlis/meta.json
+++ b/data/Tunisia/Majlis/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Assembly of the Representatives of the People",
   "seats": 217,
-  "wikidata": "Q18342090"
+  "wikidata": "Q18342090",
+  "uuid": "2248fcda-00c5-4c70-a4c3-5c7927bf1c8e"
 }

--- a/data/Tunisia/meta.json
+++ b/data/Tunisia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "706ad148-62ae-43f0-adea-ec046b74f61b",
+  "name": "Tunisia",
+  "iso_code": "TN",
+  "wikidata": "Q948"
+}

--- a/data/Turkey/Assembly/meta.json
+++ b/data/Turkey/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Grand National Assembly",
   "wikidata": "Q274918",
-  "seats": 550
+  "seats": 550,
+  "uuid": "83911419-04ab-4add-a687-93a4e8845296"
 }

--- a/data/Turkey/meta.json
+++ b/data/Turkey/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "bbb1eda5-1c89-48b3-8954-9e810bbaa86c",
+  "name": "Turkey",
+  "iso_code": "TR",
+  "wikidata": "Q43"
+}

--- a/data/Turkmenistan/Mejlis/meta.json
+++ b/data/Turkmenistan/Mejlis/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Mejlis",
   "seats": 125,
-  "wikidata": "Q630145"
+  "wikidata": "Q630145",
+  "uuid": "2836b8cd-4775-40fb-bb79-1363c8f23254"
 }

--- a/data/Turkmenistan/meta.json
+++ b/data/Turkmenistan/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "3c699100-b708-4b9f-b124-ffa4febf5e8a",
+  "name": "Turkmenistan",
+  "iso_code": "TM",
+  "wikidata": "Q874"
+}

--- a/data/Turks_and_Caicos_Islands/Assembly/meta.json
+++ b/data/Turks_and_Caicos_Islands/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Assembly",
   "seats": 19,
-  "wikidata": "Q7855481"
+  "wikidata": "Q7855481",
+  "uuid": "4a7295b6-f9e2-4cca-ac01-19f21e00bda9"
 }

--- a/data/Turks_and_Caicos_Islands/meta.json
+++ b/data/Turks_and_Caicos_Islands/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "a7151109-cbd7-48a4-9298-2acf23af58a8",
+  "name": "Turks and Caicos Islands",
+  "iso_code": "TC",
+  "wikidata": "Q18221"
+}

--- a/data/Tuvalu/Parliament/meta.json
+++ b/data/Tuvalu/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "wikidata": "Q897278",
-  "seats": 15
+  "seats": 15,
+  "uuid": "153fea0b-2fd9-4947-8cde-0ed2db820827"
 }

--- a/data/Tuvalu/meta.json
+++ b/data/Tuvalu/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "8027c552-8093-47a9-8cfd-888b7b768456",
+  "name": "Tuvalu",
+  "iso_code": "TV",
+  "wikidata": "Q672"
+}

--- a/data/UK/Commons/meta.json
+++ b/data/UK/Commons/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Commons",
   "seats": 650,
-  "wikidata": "Q11005"
+  "wikidata": "Q11005",
+  "uuid": "8bbf6031-aa59-4b0a-80b2-1cdc81e4047d"
 }

--- a/data/UK/meta.json
+++ b/data/UK/meta.json
@@ -1,4 +1,6 @@
 {
+  "id": "86e7ad99-c3cb-4cc7-8d51-c13440318634",
+  "name": "United Kingdom",
   "iso_code": "GB",
-  "name": "United Kingdom"
+  "wikidata": "Q145"
 }

--- a/data/US_Virgin_Islands/Legislature/meta.json
+++ b/data/US_Virgin_Islands/Legislature/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Legislature",
   "wikidata": "Q6518465",
-  "seats": 15
+  "seats": 15,
+  "uuid": "ea67f9ea-68f6-4afd-95db-a9aef56efc0c"
 }

--- a/data/US_Virgin_Islands/meta.json
+++ b/data/US_Virgin_Islands/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "VI"
+  "id": "9826080c-43a1-4c78-acbe-ecbc137c5e29",
+  "name": "US Virgin Islands",
+  "iso_code": "VI",
+  "wikidata": "Q11703"
 }

--- a/data/Uganda/Parliament/meta.json
+++ b/data/Uganda/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "wikidata": "Q2052850",
-  "seats": 385
+  "seats": 385,
+  "uuid": "c0450875-2933-4737-b774-d03e0ffa61ec"
 }

--- a/data/Uganda/meta.json
+++ b/data/Uganda/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "64490ab5-e4e8-45c8-ad76-7a011f309d7c",
+  "name": "Uganda",
+  "iso_code": "UG",
+  "wikidata": "Q1036"
+}

--- a/data/Ukraine/Verkhovna_Rada/meta.json
+++ b/data/Ukraine/Verkhovna_Rada/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Verkhovna Rada",
   "wikidata": "Q176296",
-  "seats": 450
+  "seats": 450,
+  "uuid": "b5c89217-0658-4ede-9968-852d36d31866"
 }

--- a/data/Ukraine/meta.json
+++ b/data/Ukraine/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "6866999e-84d6-42a3-8a86-0410ca88f3a2",
+  "name": "Ukraine",
+  "iso_code": "UA",
+  "wikidata": "Q212"
+}

--- a/data/United_Arab_Emirates/Federal_National_Council/meta.json
+++ b/data/United_Arab_Emirates/Federal_National_Council/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Federal National Council",
   "seats": 40,
-  "wikidata": "Q1479761"
+  "wikidata": "Q1479761",
+  "uuid": "8dcd2391-4d51-4d21-a348-37b45f8a223a"
 }

--- a/data/United_Arab_Emirates/meta.json
+++ b/data/United_Arab_Emirates/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "5ac4afed-5f9c-4151-9e55-01b1673485bd",
+  "name": "United Arab Emirates",
+  "iso_code": "AE",
+  "wikidata": "Q878"
+}

--- a/data/United_States_of_America/House/meta.json
+++ b/data/United_States_of_America/House/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "seats": 435,
-  "wikidata": "Q11701"
+  "wikidata": "Q11701",
+  "uuid": "d56acebe-8fdc-47bc-8b53-20170a3214bc"
 }

--- a/data/United_States_of_America/Senate/meta.json
+++ b/data/United_States_of_America/Senate/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Senate",
   "seats": 100,
-  "wikidata": "Q66096"
+  "wikidata": "Q66096",
+  "uuid": "8fa6c3d2-71dc-4788-b9f8-4ca70d5a7d85"
 }

--- a/data/United_States_of_America/meta.json
+++ b/data/United_States_of_America/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "5971e846-37dd-4af7-a4ca-74b830542d70",
+  "name": "United States of America",
+  "iso_code": "US",
+  "wikidata": "Q30"
+}

--- a/data/Uruguay/Deputies/meta.json
+++ b/data/Uruguay/Deputies/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Chamber of Deputies",
   "wikidata": "Q320303",
-  "seats": 99
+  "seats": 99,
+  "uuid": "1f8d1d06-4b31-4afd-86c5-80de2638b93c"
 }

--- a/data/Uruguay/meta.json
+++ b/data/Uruguay/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "1b606efc-8be0-4a2f-939d-30a73242db0f",
+  "name": "Uruguay",
+  "iso_code": "UY",
+  "wikidata": "Q77"
+}

--- a/data/Uzbekistan/Legislative_Chamber/meta.json
+++ b/data/Uzbekistan/Legislative_Chamber/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Legislative Chamber",
   "seats": 150,
-  "wikidata": "Q6518225"
+  "wikidata": "Q6518225",
+  "uuid": "f5d9e203-2917-4120-88a6-938a9b2c4b46"
 }

--- a/data/Uzbekistan/meta.json
+++ b/data/Uzbekistan/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "600793fe-7def-44bb-8076-a3bed7a152cc",
+  "name": "Uzbekistan",
+  "iso_code": "UZ",
+  "wikidata": "Q265"
+}

--- a/data/Vanuatu/Parliament/meta.json
+++ b/data/Vanuatu/Parliament/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Parliament",
   "wikidata": "Q764201",
-  "seats": 33
+  "seats": 33,
+  "uuid": "76b3861e-919b-4110-bd8b-b178b350b0d7"
 }

--- a/data/Vanuatu/meta.json
+++ b/data/Vanuatu/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "cd101082-23bf-40af-9fec-30ba20ec10da",
+  "name": "Vanuatu",
+  "iso_code": "VU",
+  "wikidata": "Q686"
+}

--- a/data/Vatican_City/Pontifical_Commission/meta.json
+++ b/data/Vatican_City/Pontifical_Commission/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Pontifical Commission",
   "seats": 7,
-  "wikidata": "Q7478146"
+  "wikidata": "Q7478146",
+  "uuid": "3d569fe9-6f9f-454d-b799-eec3d1a95d1f"
 }

--- a/data/Vatican_City/meta.json
+++ b/data/Vatican_City/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "VA"
+  "id": "7c0772a6-0945-47cb-a209-3cb3c162d4fd",
+  "name": "Vatican City",
+  "iso_code": "VA",
+  "wikidata": "Q237"
 }

--- a/data/Venezuela/Assembly/meta.json
+++ b/data/Venezuela/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "wikidata": "Q1585014",
-  "seats": 163
+  "seats": 163,
+  "uuid": "1ece6348-141e-4df5-a7f2-1b24fccaf41d"
 }

--- a/data/Venezuela/meta.json
+++ b/data/Venezuela/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "4a583b92-459c-4bce-b011-c10805b9637d",
+  "name": "Venezuela",
+  "iso_code": "VE",
+  "wikidata": "Q717"
+}

--- a/data/Vietnam/National_Assembly/meta.json
+++ b/data/Vietnam/National_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 500,
-  "wikidata": "Q1765001"
+  "wikidata": "Q1765001",
+  "uuid": "d201cd06-340c-4f72-a23f-8eca816bff46"
 }

--- a/data/Vietnam/meta.json
+++ b/data/Vietnam/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "vn"
+  "id": "162f8b2c-7dc5-4058-9bff-4410d0f0c5cd",
+  "name": "Vietnam",
+  "iso_code": "vn",
+  "wikidata": "Q881"
 }

--- a/data/Wales/Assembly/meta.json
+++ b/data/Wales/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly for Wales",
   "seats": 60,
-  "wikidata": "Q493517"
+  "wikidata": "Q493517",
+  "uuid": "6d1dfea8-f6a3-4873-a8e1-d906ca8ab578"
 }

--- a/data/Wales/meta.json
+++ b/data/Wales/meta.json
@@ -1,3 +1,6 @@
 {
-  "iso_code": "GB-WLS"
+  "id": "f779f32a-933e-4971-9529-0285a2c76424",
+  "name": "Wales",
+  "iso_code": "GB-WLS",
+  "wikidata": "Q25"
 }

--- a/data/Wallis_and_Futuna/Territorial_Assembly/meta.json
+++ b/data/Wallis_and_Futuna/Territorial_Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Territorial Assembly",
   "wikidata": "Q2867129",
-  "seats": 20
+  "seats": 20,
+  "uuid": "8a5d6b93-2bd5-4ac6-a385-ceae0ce11b87"
 }

--- a/data/Wallis_and_Futuna/meta.json
+++ b/data/Wallis_and_Futuna/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "fe3af501-2125-4f74-9c8e-0ebe93caa8b9",
+  "name": "Wallis and Futuna",
+  "iso_code": "WF",
+  "wikidata": "Q35555"
+}

--- a/data/Yemen/Majlis/meta.json
+++ b/data/Yemen/Majlis/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Representatives",
   "seats": 301,
-  "wikidata": "Q1484102"
+  "wikidata": "Q1484102",
+  "uuid": "3f8ae19c-17ba-4e30-ba61-b29608d0760c"
 }

--- a/data/Yemen/meta.json
+++ b/data/Yemen/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "4715ad2a-85d3-49f3-9fa2-6bbc2ec38da4",
+  "name": "Yemen",
+  "iso_code": "YE",
+  "wikidata": "Q805"
+}

--- a/data/Zambia/Assembly/meta.json
+++ b/data/Zambia/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "National Assembly",
   "seats": 150,
-  "wikidata": "Q1784088"
+  "wikidata": "Q1784088",
+  "uuid": "9b4913bc-bbad-4646-bc73-a510b11a921f"
 }

--- a/data/Zambia/meta.json
+++ b/data/Zambia/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "0e7f8945-2fdd-4a35-a6ed-12fb8d837d6f",
+  "name": "Zambia",
+  "iso_code": "ZM",
+  "wikidata": "Q953"
+}

--- a/data/Zimbabwe/Assembly/meta.json
+++ b/data/Zimbabwe/Assembly/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "House of Assembly",
   "seats": 210,
-  "wikidata": "Q1631396"
+  "wikidata": "Q1631396",
+  "uuid": "ef03883e-e4c9-490a-bd50-d3b05bcb9562"
 }

--- a/data/Zimbabwe/Senate/meta.json
+++ b/data/Zimbabwe/Senate/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Senate",
   "seats": 80,
-  "wikidata": "Q659211"
+  "wikidata": "Q659211",
+  "uuid": "713672e7-18c5-4d1d-abd1-8d597b143847"
 }

--- a/data/Zimbabwe/meta.json
+++ b/data/Zimbabwe/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "38da2ce6-9275-44ed-9552-ced4bf63c3fe",
+  "name": "Zimbabwe",
+  "iso_code": "ZW",
+  "wikidata": "Q954"
+}

--- a/rake_generate/country_info.rb
+++ b/rake_generate/country_info.rb
@@ -1,0 +1,23 @@
+
+require 'wikisnakker'
+
+desc "Refresh the information in the country meta.json"
+task :refresh_country_meta do
+  l_json = json_load('meta.json')
+  c_json = json_load('../meta.json') rescue {}
+
+  abort "No wikidata!" unless l_json[:wikidata]
+  legislature = Wikisnakker::Item.find(l_json[:wikidata])
+  jurisdiction = (legislature.P1001 || legislature.P131 || legislature.P17 || binding.pry).value
+
+  data = {
+    name: jurisdiction.label('en'),
+    iso_code: jurisdiction.P297,
+    wikidata: jurisdiction.id,
+  }.merge(c_json)
+  
+  puts JSON.pretty_generate(data)
+
+  File.write('../meta.json', JSON.pretty_generate(c_json))
+end
+

--- a/rake_generate/country_info.rb
+++ b/rake_generate/country_info.rb
@@ -13,7 +13,7 @@ task :refresh_country_meta do
   data = {
     id: SecureRandom.uuid,
     name: jurisdiction.label('en'),
-    iso_code: jurisdiction.P297,
+    iso_code: jurisdiction.P297 || jurisdiction.P300,
     wikidata: jurisdiction.id,
   }.merge(c_json)
   

--- a/rake_generate/country_info.rb
+++ b/rake_generate/country_info.rb
@@ -20,5 +20,10 @@ task :refresh_country_meta do
   puts JSON.pretty_generate(data)
 
   File.write('../meta.json', JSON.pretty_generate(data))
+
+  unless l_json.key? :uuid
+    l_json[:uuid] = SecureRandom.uuid
+    File.write('meta.json', JSON.pretty_generate(l_json))
+  end
 end
 

--- a/rake_generate/country_info.rb
+++ b/rake_generate/country_info.rb
@@ -11,6 +11,7 @@ task :refresh_country_meta do
   jurisdiction = (legislature.P1001 || legislature.P131 || legislature.P17 || binding.pry).value
 
   data = {
+    id: SecureRandom.uuid,
     name: jurisdiction.label('en'),
     iso_code: jurisdiction.P297,
     wikidata: jurisdiction.id,
@@ -18,6 +19,6 @@ task :refresh_country_meta do
   
   puts JSON.pretty_generate(data)
 
-  File.write('../meta.json', JSON.pretty_generate(c_json))
+  File.write('../meta.json', JSON.pretty_generate(data))
 end
 

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -116,14 +116,5 @@ desc "Rebuild from source data"
 task :rebuild => [ :clobber, 'ep-popolo-v1.0.json' ]
 task :default => [ :csvs, 'stats:regenerate' ]
 
-require_relative 'rake_build/combine_sources.rb'
-require_relative 'rake_build/verify_source_data.rb'
-require_relative 'rake_build/turn_csv_to_popolo.rb'
-require_relative 'rake_build/generate_ep_popolo.rb'
-require_relative 'rake_build/generate_final_csvs.rb'
-require_relative 'rake_build/generate_stats.rb'
-
-require_relative 'rake_generate/election_info.rb'
-require_relative 'rake_generate/position_info.rb'
-require_relative 'rake_generate/groups_info.rb'
+Dir[File.dirname(__FILE__) + '/rake_*/*.rb'].each { |file| require file }
 


### PR DESCRIPTION
Previously, each country could have a `meta.json` file, containing its name
(if different from the directory it's in), and its ISO code (or the one
we’re effectively using), if that can't be looked up easily using
`IsoCountryCodes`

We now want to make all of this explicit, so add a rake command that,
for any legislature, creates or updates the `meta.json` of its country
to include that country's name, Wikidata ID, and ISO 3166-1 alpha-2
code, and gives both the Country and the Legislature a UUID.

Part of https://github.com/everypolitician/everypolitician/issues/427

Part of https://github.com/everypolitician/everypolitician/issues/470