### PR TITLE
Use the legislature’s UUID as its ID

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ﻿# This file documents substantial changes to the format of data files
 
+2016-07-26
+
+* The `Organization` for each legislature now has a unique ID, rather
+than being simply "legislature" everywhere.
+
 2016-05-29
 
 * Some Election data is now available as Popolo `Event`s.

--- a/rake_build/generate_ep_popolo.rb
+++ b/rake_build/generate_ep_popolo.rb
@@ -56,6 +56,12 @@ namespace :transform do
       scheme: 'wikidata',
       identifier: @legislature.delete(:wikidata)
     } if @legislature.key?(:wikidata)
+
+    # Switch the legislature ID
+    @json[:memberships].select { |m| m[:organization_id] == @legislature[:id] }.each do |m|
+      m[:organization_id] = @legislature[:uuid]
+    end
+    @legislature[:id] = @legislature.delete :uuid
   end
 
   #---------------------------------------------------------------------


### PR DESCRIPTION
Since 0f58dcfe42d32f5941f452c7e66ad17e1591609e, each legislature has had its own UUID. Use that as the ID (taking care to make sure that legislative memberships reflect it)

Closes https://github.com/everypolitician/everypolitician/issues/427