### PR TITLE
Reconciler: standardise Twitter handles when comparing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'unicode_utils'
 gem 'wikisnakker', '~> 0.6.0', github: 'everypolitician/wikisnakker'
 gem 'everypolitician', github: 'everypolitician/everypolitician-ruby'
 gem 'everypolitician-popolo', github: 'everypolitician/everypolitician-popolo'
+gem 'twitter_username_extractor', github: 'everypolitician/twitter_username_extractor'
 gem 'facebook_username_extractor', '~> 0.2.0'
 gem 'json5'
 gem 'slop', '~> 3.6.0' # tied to pry version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,12 @@ GIT
       everypolitician-popolo
 
 GIT
+  remote: git://github.com/everypolitician/twitter_username_extractor.git
+  revision: 891a0f4ea587195fc952305562048f53498b2d84
+  specs:
+    twitter_username_extractor (0.1.0)
+
+GIT
   remote: git://github.com/everypolitician/wikisnakker.git
   revision: c2895a600fb78b2ad0df3e8ae3d24b4586a94179
   specs:
@@ -70,7 +76,6 @@ GEM
     safe_yaml (1.0.4)
     sass (3.4.22)
     slop (3.6.0)
-    twitter_username_extractor (0.1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
@@ -103,6 +108,7 @@ DEPENDENCIES
   rest-client
   sass
   slop (~> 3.6.0)
+  twitter_username_extractor!
   unicode_utils
   vcr
   webmock

--- a/lib/reconciliation/fuzzer.rb
+++ b/lib/reconciliation/fuzzer.rb
@@ -18,14 +18,12 @@ module Reconciliation
       @instructions = instructions
     end
 
+
     # Ensure we only have one row per UUID, and generate for each row a
-    # 'fuzzit' field that we'll be checking against. For now this just
-    # defaults to the lowercase value of the 'existing_field' field
-    # (usually name) — later we'll want to be able to expand this to 
-    # something more complex. (e.g. multiple fields)
-    #
+    # 'fuzzit' field that we'll be checking against. 
+    # TODO allow this to be more complex — e.g. multiple fields
     def existing_people
-      @_existing_people ||= existing_rows.uniq { |r| r[:uuid] }.each { |r| r[:fuzzit] = UnicodeUtils.downcase(r[existing_field].to_s) }
+      @_existing_people ||= existing_rows.uniq { |r| r[:uuid] }.each { |r| r[:fuzzit] = comparable(r[existing_field]) }
     end
 
     def fuzzer
@@ -38,7 +36,7 @@ module Reconciliation
           warn "No #{incoming_field} in #{incoming_row.reject { |k, v| v.to_s.empty? }}".red
           next
         end
-        matches = fuzzer.find_all_with_score(UnicodeUtils.downcase(incoming_row[incoming_field]))
+        matches = fuzzer.find_all_with_score(comparable(incoming_row[incoming_field]))
         unless matches.any?
           warn "No fuzzed matches for #{incoming_row.reject { |k, v| v.to_s.empty? }}"
           next
@@ -65,6 +63,16 @@ module Reconciliation
       instructions[:existing_field].to_sym
     rescue NoMethodError
       raise('Need an `existing_field` to match on')
+    end
+
+    # Standardise the strings we're comparing 
+    # For now just downcase it (in a Unicode-friendly way); later we'll
+    # want to make this more cmomplex (e.g. accent folding)
+    def comparable(str, field=nil)
+      if field == :twitter
+        binding.pry
+      end
+      UnicodeUtils.downcase(str.to_s)
     end
 
     def display(row)

--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -84,7 +84,7 @@
                     {% }) %}
                   {% } else if (field == 'twitter') { %}
                     {% person[field].split(';').forEach(function(twitter) { %}
-                      {{ twitter_as_link(twitter) }}
+                      {{ twitterAsLink(twitter) }}
                     {% }) %}
                   {% } else { %}
                     {{ person[field].split(';').join(', ') }}
@@ -117,7 +117,7 @@
                     {% }) %}
                   {% } else if (field == 'twitter') { %}
                     {% person[field].split(';').forEach(function(twitter) { %}
-                      {{ twitter_as_link(twitter) }}
+                      {{ twitterAsLink(twitter) }}
                     {% }) %}
                   {% } else { %}
                     {% if (_.any(person[field].split(';'), function(f) { f == compare_with[field] })) { %}

--- a/templates/reconciliation.js
+++ b/templates/reconciliation.js
@@ -103,7 +103,7 @@ var nextPairing = function nextPairing($currentPairing){
   }
 }
 
-var twitter_as_link = function twitter_as_link(str) {
+var twitterAsLink = function twitter_as_link(str) {
   if (str.startsWith('http')) {
     return '<a href="' + str + '">' + str + '</a>';
   } else {


### PR DESCRIPTION
If we’re comparing twitter handles, it’s _much_ better if they’re actually
in the same format, rather than comparing "tmtm" with "https://www.twitter.com/tmtm"

![screen shot 2016-07-27 at 12 29 09](https://cloud.githubusercontent.com/assets/57483/17173945/c246279e-53f5-11e6-8032-979e2ca906ac.png)


Closes https://github.com/everypolitician/everypolitician/issues/476