### PR TITLE
Build: extract filenames as constants

### DIFF
--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -68,14 +68,14 @@ namespace :merge_sources do
   end
 
   desc "Combine Sources"
-  task 'sources/merged.csv' => :fetch_missing do
+  task MERGED_CSV => :fetch_missing do
     combine_sources
   end
 
   @recreatable = instructions(:sources).find_all { |i| i.key? :create }
   CLOBBER.include FileList.new(@recreatable.map { |i| i[:file] })
 
-  CLEAN.include 'sources/merged.csv'
+  CLEAN.include MERGED_CSV
 
   # We re-fetch any file that is missing, or, if REBUILD_SOURCE is set,
   # any file that matches that.
@@ -303,7 +303,7 @@ namespace :merge_sources do
     merged_rows.each { |row| row[:id] = row[:uuid] }
 
     # Then write it all out
-    CSV.open("sources/merged.csv", "w") do |out|
+    CSV.open(MERGED_CSV, "w") do |out|
       out << all_headers
       merged_rows.each { |r| out << all_headers.map { |header| r[header.to_sym] } }
     end

--- a/rake_build/generate_ep_popolo.rb
+++ b/rake_build/generate_ep_popolo.rb
@@ -12,8 +12,8 @@ namespace :transform do
   file 'ep-popolo-v1.0.json' => :write
   CLEAN.include('ep-popolo-v1.0.json', 'final.json')
 
-  task :load => 'sources/merged.json' do
-    @json = JSON.parse(File.read('sources/merged.json'), symbolize_names: true )
+  task :load => MERGED_JSON do
+    @json = JSON.parse(MERGED_JSON.read, symbolize_names: true )
   end
 
   task :write do

--- a/rake_build/generate_stats.rb
+++ b/rake_build/generate_stats.rb
@@ -1,4 +1,3 @@
-
 #-----------------------------------------------------------------------
 # Update the `stats.json` file for a Legislature
 #-----------------------------------------------------------------------
@@ -20,9 +19,8 @@ namespace :stats do
     latest_election = elections.map { |e| e.end_date }.compact.sort_by { |d| "#{d}-12-31" }.select { |d| d[0...4].to_i <= now.year }.last rescue ''
     latest_term_start = terms.last.start_date rescue ''
 
-    posn_file = 'sources/manual/position-filter.json'
-    if File.exist? posn_file
-      posns = JSON.parse(File.read(posn_file), symbolize_names: true )
+    if POSITION_FILTER.file?
+      posns = JSON.parse(POSITION_FILTER.read, symbolize_names: true )
       executive_positions = posns[:include][:executive].count rescue 0
     else 
       executive_positions = 0

--- a/rake_build/turn_csv_to_popolo.rb
+++ b/rake_build/turn_csv_to_popolo.rb
@@ -1,14 +1,14 @@
 
 desc "Generate merged.json"
-task :whittle => [:clobber, 'sources/merged.json']
+task :whittle => [:clobber, MERGED_JSON]
 
 namespace :whittle do
 
-  file 'sources/merged.json' => :write 
-  CLEAN.include('sources/merged.json')
+  file MERGED_JSON => :write 
+  CLEAN.include MERGED_JSON
 
   task :load => 'verify:check_data' do
-    @json = Popolo::CSV.new('sources/merged.csv').data
+    @json = Popolo::CSV.new(MERGED_CSV).data
   end
 
   task :meta_info => :load do
@@ -25,9 +25,7 @@ namespace :whittle do
 
   # TODO work out how to make this do the 'only run if needed'
   task :write => :meta_info do
-    unless File.exists? 'sources/merged.json'
-      json_write('sources/merged.json', @json)
-    end
+    json_write(MERGED_JSON, @json) unless MERGED_JSON.exist? 
   end
 
   #---------------------------------------------------------------------

--- a/rake_build/verify_source_data.rb
+++ b/rake_build/verify_source_data.rb
@@ -10,7 +10,7 @@ desc "Verify merged data"
 namespace :verify do
 
   task :load => 'merge_sources:sources/merged.csv' do
-    csv_data = File.read('sources/merged.csv')
+    csv_data = MERGED_CSV.read
     @csv_headers = Rcsv.raw_parse(StringIO.new(csv_data.each_line.first)).first
     @csv = Rcsv.parse(
       csv_data,

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -32,10 +32,14 @@ require 'fileutils'
 require 'fuzzy_match'
 require 'json'
 require 'open-uri'
+require 'pathname'
 require 'pry'
 require 'rake/clean'
 require 'set'
 require 'yajl/json_gem'
+
+MERGED_JSON = Pathname.new('sources/merged.json')
+MERGED_CSV  = Pathname.new('sources/merged.csv')
 
 Numeric.class_eval { def empty?; false; end }
 

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -40,6 +40,9 @@ require 'yajl/json_gem'
 
 MERGED_JSON = Pathname.new('sources/merged.json')
 MERGED_CSV  = Pathname.new('sources/merged.csv')
+POSITION_FILTER = Pathname.new('sources/manual/position-filter.json')
+POSITION_RAW = Pathname.new('sources/wikidata/positions.json')
+POSITION_CSV = Pathname.new('unstable/positions.csv')
 
 Numeric.class_eval { def empty?; false; end }
 


### PR DESCRIPTION
To simplify the build logic, extact some of the fixed filenames we use
(e.g. merged.csv, merged.json, positions files) as constants, and use
Pathname to make them easier to handle.