### PR TITLE
Split out a 'base' Rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,47 +3,6 @@ AllCops:
     - 'data/**/*'
     - 'vendor/**/*'
 
-Lint/AssignmentInCondition:
-  Enabled: false
-
-Lint/Debugger:
-  Enabled: false
-
-Style/AlignHash:
-  EnforcedHashRocketStyle: table
-  EnforcedColonStyle: table
-
-Style/ClassAndModuleCamelCase:
-  Enabled: false
-
-Style/CollectionMethods:
-  Enabled: true
-
-Style/Documentation:
-  Enabled: false
-
-Style/FormatString:
-  EnforcedStyle: percent
-
-Style/HashSyntax:
-  EnforcedStyle: ruby19_no_mixed_keys
-
-Style/RegexpLiteral:
-  AllowInnerSlashes: true
-
-Style/RescueModifier:
-  Enabled: false
-
-Style/SignalException:
-  Enabled: false
-
-Style/SymbolArray:
-  Enabled: true
-
-Style/TrailingCommaInLiteral:
-  EnforcedStyleForMultiline: consistent_comma
-
-
 Metrics/ClassLength:
   Max: 250
 
@@ -62,8 +21,7 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 8
 
-Performance/Casecmp:
-  Enabled: false
 
-# Get rid of these ones over time
-inherit_from: .rubocop_todo.yml
+inherit_from: 
+  - .rubocop_base.yml
+  - .rubocop_todo.yml

--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -1,0 +1,48 @@
+# A base Rubocop configuration that other repos can inherit from
+# http://rubocop.readthedocs.io/en/latest/configuration/#inheriting-configuration-from-a-remote-url
+
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Lint/Debugger:
+  Enabled: false
+
+
+Performance/Casecmp:
+  Enabled: false
+
+
+Style/AlignHash:
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
+
+Style/ClassAndModuleCamelCase:
+  Enabled: false
+
+Style/CollectionMethods:
+  Enabled: true
+
+Style/Documentation:
+  Enabled: false
+
+Style/FormatString:
+  EnforcedStyle: percent
+
+Style/HashSyntax:
+  EnforcedStyle: ruby19_no_mixed_keys
+
+Style/RegexpLiteral:
+  AllowInnerSlashes: true
+
+Style/RescueModifier:
+  Enabled: false
+
+Style/SignalException:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: true
+
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+


### PR DESCRIPTION
Rubocop can inherit configuration from a file at a remote URL. This
allows us to use the config in this repo, as the base for _all_ our
related ones, rather than having to keep them all in sync manually.

So split out the inheritable one to `.rubocop_base.yml`, and keep the
project specific config on the main .`rubocop.yml`