### PR TITLE
Change our default Rubocop Regex preferences

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -31,9 +31,6 @@ Style/FormatString:
 Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys
 
-Style/RegexpLiteral:
-  AllowInnerSlashes: true
-
 Style/RescueModifier:
   Enabled: false
 


### PR DESCRIPTION
We actually want the default behaviour here, which is to always prefer `/…/` style regexes, except where there's a literal slash, in which case switch to `%r{}`-style.

(NB: http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RegexpLiteral is
more than a little confusing (largely as it doesn't define what 'mixed' means),
but the default config file includes a much better explanation!)