### PR TITLE
Move 'type'-checking into Source class

### DIFF
--- a/lib/source.rb
+++ b/lib/source.rb
@@ -4,6 +4,7 @@ module Source
   class Base
     # Instantiate correct subclass based on instructions
     def self.instantiate(i)
+      raise "Missing `type` in #{i}" unless i.key? :type
       return Source::Membership.new(i)  if i[:type] == 'membership'
       return Source::Person.new(i)      if i[:type] == 'person'
       return Source::Wikidata.new(i)    if i[:type] == 'wikidata'

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -101,11 +101,6 @@ namespace :merge_sources do
   end
 
   def combine_sources
-    # Make sure all instructions have a `type`
-    if (no_type = instructions(:sources).find { |src| src[:type].to_s.empty? })
-      raise "Missing `type` in #{no_type} file"
-    end
-
     sources = instructions(:sources).map { |s| Source::Base.instantiate(s) }
     all_headers = (%i(id uuid) + sources.map(&:fields)).flatten.uniq
 


### PR DESCRIPTION
Today's inch-by-inch refactoring of `combine_sources`:

Rather than pre-scanning the configuration of each source to make sure
it has a 'type', move that check into the constructor method.

(`flog` score moves from 460.0 to 451.2)