### PR TITLE
Fix reconciler match highlighting

### DIFF
--- a/templates/reconciliation.html.erb
+++ b/templates/reconciliation.html.erb
@@ -120,7 +120,7 @@
                       {{ twitterAsLink(twitter) }}
                     {% }) %}
                   {% } else { %}
-                    {% if (_.any(person[field].split(';'), function(f) { f == compare_with[field] })) { %}
+                    {% if (_.any(person[field].split(';'), function(f) { return f == compare_with[field]; })) { %}
                       <span class="match">{{ person[field].split(';').join(', ') }}</span>
                     {% } else { %}
                       <span class="nomatch">{{ person[field].split(';').join(', ') }}</span>


### PR DESCRIPTION
This was broken in a previous pull request because I forgot the `return` from the `_.any` function body.

Fixes https://github.com/everypolitician/everypolitician/issues/478

![screen shot 2016-08-10 at 11 31 04](https://cloud.githubusercontent.com/assets/22996/17550715/3d4353ce-5eee-11e6-8e98-2e7af97077bc.png)
