### PR TITLE
Refactor interface with Reconciler

### DIFF
--- a/lib/reconciliation.rb
+++ b/lib/reconciliation.rb
@@ -5,9 +5,13 @@ require_relative './reconciliation/template'
 require 'csv'
 
 class Reconciler
-  def initialize(i, t)
+  attr_reader :merged_rows, :incoming_data
+
+  def initialize(i, trigger, merged_rows, incoming_data)
     @instructions = i
-    @trigger = t
+    @trigger = trigger
+    @merged_rows = merged_rows
+    @incoming_data = incoming_data.uniq { |r| r[:id] }
   end
 
   def filename
@@ -36,7 +40,7 @@ class Reconciler
     @_pr ||= File.exist?(filename) ? CSV.table(filename, converters: nil) : CSV::Table.new([])
   end
 
-  def generate_interface!(merged_rows, incoming_data)
+  def generate_interface!
     interface = Reconciliation::Interface.new(merged_rows, incoming_data, previously_reconciled, @instructions)
     write_file!(interface_filename, interface.html)
     "Created #{interface_filename} — please check it and re-run"

--- a/lib/reconciliation.rb
+++ b/lib/reconciliation.rb
@@ -26,6 +26,11 @@ class Reconciler
     @_ifn ||= filename.sub('.csv', '.html')
   end
 
+  def reconciliation_data
+    raise "No reconciliation data. Rerun with GENERATE_RECONCILIATION_INTERFACE=#{trigger_name}" if previously_reconciled.empty?
+    previously_reconciled
+  end
+
   def previously_reconciled
     @_pr ||= File.exist?(filename) ? CSV.table(filename, converters: nil) : CSV::Table.new([])
   end

--- a/lib/reconciliation.rb
+++ b/lib/reconciliation.rb
@@ -32,6 +32,7 @@ class Reconciler
   end
 
   def reconciliation_data
+    raise generate_interface! if triggered?
     raise "No reconciliation data. Rerun with GENERATE_RECONCILIATION_INTERFACE=#{trigger_name}" if previously_reconciled.empty?
     previously_reconciled
   end

--- a/lib/reconciliation.rb
+++ b/lib/reconciliation.rb
@@ -39,7 +39,7 @@ class Reconciler
   def generate_interface!(merged_rows, incoming_data)
     interface = Reconciliation::Interface.new(merged_rows, incoming_data, previously_reconciled, @instructions)
     write_file!(interface_filename, interface.html)
-    interface_filename
+    "Created #{interface_filename} — please check it and re-run"
   end
 
   def incoming_field

--- a/lib/reconciliation.rb
+++ b/lib/reconciliation.rb
@@ -5,8 +5,9 @@ require_relative './reconciliation/template'
 require 'csv'
 
 class Reconciler
-  def initialize(i)
+  def initialize(i, t)
     @instructions = i
+    @trigger = t
   end
 
   def filename
@@ -18,8 +19,8 @@ class Reconciler
     File.basename(filename, '.csv')
   end
 
-  def triggered_by?(str)
-    trigger_name.include? str
+  def triggered?
+    @trigger && trigger_name.include?(@trigger)
   end
 
   def interface_filename

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -114,9 +114,9 @@ namespace :merge_sources do
       id_map = src.id_map
 
       if merge_instructions = src.merge_instructions
-        reconciler = Reconciler.new(merge_instructions, ENV['GENERATE_RECONCILIATION_INTERFACE'])
+        reconciler = Reconciler.new(merge_instructions, ENV['GENERATE_RECONCILIATION_INTERFACE'], merged_rows, incoming_data)
         raise "Can't reconciler memberships with a Reconciliation file yet" unless reconciler.filename
-        abort reconciler.generate_interface!(merged_rows, incoming_data.uniq { |r| r[:id] }) if reconciler.triggered?
+        abort reconciler.generate_interface! if reconciler.triggered?
 
         pr = reconciler.reconciliation_data rescue abort($!.to_s)
         pr.each { |r| id_map[r[:id]] = r[:uuid] }
@@ -144,10 +144,10 @@ namespace :merge_sources do
       incoming_data = src.as_table
 
       abort "No merge instructions for #{src.filename}" unless merge_instructions = src.merge_instructions
-      reconciler = Reconciler.new(merge_instructions, ENV['GENERATE_RECONCILIATION_INTERFACE'])
+      reconciler = Reconciler.new(merge_instructions, ENV['GENERATE_RECONCILIATION_INTERFACE'], merged_rows, incoming_data)
 
       if reconciler.filename
-        abort reconciler.generate_interface!(merged_rows, incoming_data.uniq { |r| r[:id] }) if reconciler.triggered?
+        abort reconciler.generate_interface! if reconciler.triggered?
 
         pr = reconciler.reconciliation_data rescue abort($!.to_s)
         matcher = Matcher::Reconciled.new(merged_rows, merge_instructions, pr)

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -114,10 +114,10 @@ namespace :merge_sources do
       id_map = src.id_map
 
       if merge_instructions = src.merge_instructions
-        reconciler = Reconciler.new(merge_instructions)
+        reconciler = Reconciler.new(merge_instructions, ENV['GENERATE_RECONCILIATION_INTERFACE'])
         raise "Can't reconciler memberships with a Reconciliation file yet" unless reconciler.filename
 
-        if ENV['GENERATE_RECONCILIATION_INTERFACE'] && reconciler.triggered_by?(ENV['GENERATE_RECONCILIATION_INTERFACE'])
+        if reconciler.triggered?
           filename = reconciler.generate_interface!(merged_rows, incoming_data.uniq { |r| r[:id] })
           abort "Created #{filename} — please check it and re-run".green
         end
@@ -148,10 +148,10 @@ namespace :merge_sources do
       incoming_data = src.as_table
 
       abort "No merge instructions for #{src.filename}" unless merge_instructions = src.merge_instructions
-      reconciler = Reconciler.new(merge_instructions)
+      reconciler = Reconciler.new(merge_instructions, ENV['GENERATE_RECONCILIATION_INTERFACE'])
 
       if reconciler.filename
-        if ENV['GENERATE_RECONCILIATION_INTERFACE'] && reconciler.triggered_by?(ENV['GENERATE_RECONCILIATION_INTERFACE'])
+        if reconciler.triggered?
           filename = reconciler.generate_interface!(merged_rows, incoming_data.uniq { |r| r[:id] })
           abort "Created #{filename} — please check it and re-run".green
         end

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -122,8 +122,7 @@ namespace :merge_sources do
           abort "Created #{filename} — please check it and re-run".green
         end
 
-        pr = reconciler.previously_reconciled
-        abort "No reconciliation data. Rerun with GENERATE_RECONCILIATION_INTERFACE=#{reconciler.trigger_name}" if pr.empty?
+        pr = reconciler.reconciliation_data rescue abort($!.to_s)
         pr.each { |r| id_map[r[:id]] = r[:uuid] }
       end
 
@@ -157,8 +156,7 @@ namespace :merge_sources do
           abort "Created #{filename} — please check it and re-run".green
         end
 
-        pr = reconciler.previously_reconciled
-        abort "No reconciliation data. Rerun with GENERATE_RECONCILIATION_INTERFACE=#{reconciler.trigger_name}" if pr.empty?
+        pr = reconciler.reconciliation_data rescue abort($!.to_s)
         matcher = Matcher::Reconciled.new(merged_rows, merge_instructions, pr)
       else
         matcher = Matcher::Exact.new(merged_rows, merge_instructions)

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -116,7 +116,6 @@ namespace :merge_sources do
       if merge_instructions = src.merge_instructions
         reconciler = Reconciler.new(merge_instructions, ENV['GENERATE_RECONCILIATION_INTERFACE'], merged_rows, incoming_data)
         raise "Can't reconciler memberships with a Reconciliation file yet" unless reconciler.filename
-        abort reconciler.generate_interface! if reconciler.triggered?
 
         pr = reconciler.reconciliation_data rescue abort($!.to_s)
         pr.each { |r| id_map[r[:id]] = r[:uuid] }
@@ -147,8 +146,6 @@ namespace :merge_sources do
       reconciler = Reconciler.new(merge_instructions, ENV['GENERATE_RECONCILIATION_INTERFACE'], merged_rows, incoming_data)
 
       if reconciler.filename
-        abort reconciler.generate_interface! if reconciler.triggered?
-
         pr = reconciler.reconciliation_data rescue abort($!.to_s)
         matcher = Matcher::Reconciled.new(merged_rows, merge_instructions, pr)
       else

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -116,11 +116,7 @@ namespace :merge_sources do
       if merge_instructions = src.merge_instructions
         reconciler = Reconciler.new(merge_instructions, ENV['GENERATE_RECONCILIATION_INTERFACE'])
         raise "Can't reconciler memberships with a Reconciliation file yet" unless reconciler.filename
-
-        if reconciler.triggered?
-          filename = reconciler.generate_interface!(merged_rows, incoming_data.uniq { |r| r[:id] })
-          abort "Created #{filename} — please check it and re-run".green
-        end
+        abort reconciler.generate_interface!(merged_rows, incoming_data.uniq { |r| r[:id] }) if reconciler.triggered?
 
         pr = reconciler.reconciliation_data rescue abort($!.to_s)
         pr.each { |r| id_map[r[:id]] = r[:uuid] }
@@ -151,10 +147,7 @@ namespace :merge_sources do
       reconciler = Reconciler.new(merge_instructions, ENV['GENERATE_RECONCILIATION_INTERFACE'])
 
       if reconciler.filename
-        if reconciler.triggered?
-          filename = reconciler.generate_interface!(merged_rows, incoming_data.uniq { |r| r[:id] })
-          abort "Created #{filename} — please check it and re-run".green
-        end
+        abort reconciler.generate_interface!(merged_rows, incoming_data.uniq { |r| r[:id] }) if reconciler.triggered?
 
         pr = reconciler.reconciliation_data rescue abort($!.to_s)
         matcher = Matcher::Reconciled.new(merged_rows, merge_instructions, pr)


### PR DESCRIPTION
This returns the previously_reconciled data, or throws an error if empty.

On the way out we simply catch it and abort with it.

(Flog drops from 457.1 to 425.7)