### PR TITLE
Gradually move -ids.csv files

### DIFF
--- a/lib/uuid_map.rb
+++ b/lib/uuid_map.rb
@@ -4,23 +4,28 @@ require 'rcsv'
 # Encapsulates the 'data-ids' files that tie
 # incoming source IDs to our UUIDs
 #
+# We're in the process of moving the location of those files, so for
+# this currently checks _both_ locations for reading, but always writes
+# back out to the new location
+#
 # TODO: Add the 'give me a new UUID' logic here
 
 class UuidMapFile
-  def initialize(filename)
-    @filename = filename
+  def initialize(pathname)
+    @oldfile = pathname
+    @newfile = @oldfile.parent.parent + 'idmap/' + @oldfile.basename.sub('-ids', '')
   end
 
   def mapping
-    return {} unless @filename.exist?
-    raw = @filename.read
+    raw = [@newfile, @oldfile].find(&:exist?).read
     return {} if raw.empty?
     Hash[Rcsv.parse(raw, row_as_hash: true, columns: {}).map { |r| [r['id'], r['uuid']] }]
   end
 
   def rewrite(data)
-    @filename.parent.mkpath
-    ::CSV.open(@filename, 'w') do |csv|
+    @oldfile.delete if @oldfile.exist?
+    @newfile.parent.mkpath
+    ::CSV.open(@newfile, 'w') do |csv|
       csv << %i(id uuid)
       data.each { |id, uuid| csv << [id, uuid] }
     end

--- a/test/uuid_map_test.rb
+++ b/test/uuid_map_test.rb
@@ -1,8 +1,16 @@
 require 'test_helper'
 require_relative '../lib/uuid_map'
 
+# As we need to sometimes move the file to a sibling directory, we need
+# to make sure we create a tempfile one level deep in a subdir. There's
+# possibly some option to Tempfile that does this in one shot, but I
+# couldn't find it, so we instead create a dummy tempfile, then make a
+# subdir at the same level as that, and put our "real" test file in it.
 def new_tempfile
-  Pathname.new(Tempfile.new(['data-ids', '.csv']).path)
+  intopdir = Pathname.new(Tempfile.new('dummy').path)
+  subdir = intopdir.parent + 'manual/'
+  subdir.mkpath
+  Pathname.new(Tempfile.new(['data-ids', '.csv'], subdir).path)
 end
 
 describe 'UUID Mapper' do


### PR DESCRIPTION
Every Membership source has a parallel `source-ids.csv` file to provide
the mapping between the incoming source IDs, and our matching UUIDs.
Currently those live in the same directory as the source file.

We would like to, instead, move those into their own directory, so that
it's much more obvious that these are a different type of file, and the
source directory only contains files that are actually from the remote
sources.

We can do that by hooking into the UUID Map class to make it aware of
both the old location, and the new one. Then if it can't read from the
new location, it will fall back on the old location — but always
rewrite the file out to the new location. Over time, as we build every
country, the files will gradually all be moved, and we can simplify
this down again.