### PR TITLE
Fix meta.json for Jersey

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -4945,11 +4945,11 @@
         "slug": "States",
         "sources_directory": "data/Jersey/States/sources",
         "popolo": "data/Jersey/States/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4bce540/data/Jersey/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7352b16/data/Jersey/States/ep-popolo-v1.0.json",
         "names": "data/Jersey/States/names.csv",
-        "lastmod": "1467810995",
+        "lastmod": "1469384206",
         "person_count": 61,
-        "sha": "4bce540",
+        "sha": "7352b16",
         "legislative_periods": [
           {
             "id": "term/2011",

--- a/data/Jersey/meta.json
+++ b/data/Jersey/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "105987f4-639b-4a47-a987-52dce59cbfa6",
-  "name": "United Kingdom",
-  "iso_code": "GB",
-  "wikidata": "Q145"
+  "name": "Jersey",
+  "iso_code": "JE",
+  "wikidata": "Q785"
 }


### PR DESCRIPTION
This got set to UK data by error, as Wikidata doesn't have a `Country` set,
but only an "located in the administrative territorial entity" which is set
to "UK"