### PR TITLE
Add `flog` to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :test do
   gem 'vcr'
   gem 'webmock'
   gem 'rubocop'
+  gem 'flog'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,10 @@ GEM
     domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
     facebook_username_extractor (0.2.0)
+    flog (4.4.0)
+      path_expander (~> 1.0)
+      ruby_parser (~> 3.1, > 3.1.0)
+      sexp_processor (~> 4.4)
     fuzzy_match (2.1.0)
     hashdiff (0.3.0)
     http-cookie (1.0.2)
@@ -65,6 +69,7 @@ GEM
       pkg-config (~> 1.1.7)
     parser (2.3.1.2)
       ast (~> 2.2)
+    path_expander (1.0.0)
     pkg-config (1.1.7)
     powerpack (0.1.1)
     pry (0.10.4)
@@ -85,8 +90,11 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
+    ruby_parser (3.8.2)
+      sexp_processor (~> 4.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
+    sexp_processor (4.7.0)
     slop (3.6.0)
     unf (0.1.4)
       unf_ext
@@ -109,6 +117,7 @@ DEPENDENCIES
   everypolitician!
   everypolitician-popolo (~> 0.5.0)!
   facebook_username_extractor (~> 0.2.0)
+  flog
   fuzzy_match
   json
   json5


### PR DESCRIPTION
We want to reduce the complexity of the build process, so tracking the [Flog](http://ruby.sadi.st/Flog.html) scores is a good proxy for checking if we're moving in the right direction.