### PR TITLE
Require ruby 2.1.0 onwards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-abort 'Ruby should be >= 2.0.0' unless RUBY_VERSION.to_f >= 2.0
+abort 'Ruby should be >= 2.1.0' unless RUBY_VERSION.to_f >= 2.1
 
 gem 'json'
 gem 'nokogiri'


### PR DESCRIPTION
support for ruby 2.0.0 (including security fixes) ended in February:
 https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/

Upgrading our minimal version to 2.1 also gives us aaccess to a few features we
want to start using, including:
* Pathname.write
* required named parameters