### PR TITLE
Use full commit hash rather than abbreviated one

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -10,11 +10,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Abkhazia/Assembly/sources",
         "popolo": "data/Abkhazia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f6d50a3/data/Abkhazia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f6d50a35cc011023ead76d1a738a03fc5e944ac4/data/Abkhazia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Abkhazia/Assembly/names.csv",
         "lastmod": "1469382534",
         "person_count": 35,
-        "sha": "f6d50a3",
+        "sha": "f6d50a35cc011023ead76d1a738a03fc5e944ac4",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -22,7 +22,7 @@
             "start_date": "2012-04-03",
             "slug": "5",
             "csv": "data/Abkhazia/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ceb5b4e/data/Abkhazia/Assembly/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ceb5b4eea3f358da1d6e3ae6a7ce43c00d6ae902/data/Abkhazia/Assembly/term-5.csv"
           }
         ],
         "statement_count": 694
@@ -40,11 +40,11 @@
         "slug": "Wolesi-Jirga",
         "sources_directory": "data/Afghanistan/Wolesi_Jirga/sources",
         "popolo": "data/Afghanistan/Wolesi_Jirga/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d21a3cf/data/Afghanistan/Wolesi_Jirga/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d21a3cfa71865aba59bf453da59be6128d755d41/data/Afghanistan/Wolesi_Jirga/ep-popolo-v1.0.json",
         "names": "data/Afghanistan/Wolesi_Jirga/names.csv",
         "lastmod": "1470532082",
         "person_count": 228,
-        "sha": "d21a3cf",
+        "sha": "d21a3cfa71865aba59bf453da59be6128d755d41",
         "legislative_periods": [
           {
             "end_date": "2015-06-22",
@@ -53,7 +53,7 @@
             "start_date": "2011-01-26",
             "slug": "2010",
             "csv": "data/Afghanistan/Wolesi_Jirga/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d21a3cf/data/Afghanistan/Wolesi_Jirga/term-2010.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d21a3cfa71865aba59bf453da59be6128d755d41/data/Afghanistan/Wolesi_Jirga/term-2010.csv"
           }
         ],
         "statement_count": 3478
@@ -71,11 +71,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Albania/Assembly/sources",
         "popolo": "data/Albania/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/28e4f20/data/Albania/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/28e4f20bdc9cea2e280cc738d258d4e6c7d9b622/data/Albania/Assembly/ep-popolo-v1.0.json",
         "names": "data/Albania/Assembly/names.csv",
         "lastmod": "1471216166",
         "person_count": 213,
-        "sha": "28e4f20",
+        "sha": "28e4f20bdc9cea2e280cc738d258d4e6c7d9b622",
         "legislative_periods": [
           {
             "id": "term/8",
@@ -83,7 +83,7 @@
             "start_date": "2013-09-09",
             "slug": "8",
             "csv": "data/Albania/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d89e12/data/Albania/Assembly/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d89e12ed313ad09c527aa3584802897b51d09e0/data/Albania/Assembly/term-8.csv"
           },
           {
             "end_date": "2013",
@@ -92,7 +92,7 @@
             "start_date": "2009",
             "slug": "7",
             "csv": "data/Albania/Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/28e4f20/data/Albania/Assembly/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/28e4f20bdc9cea2e280cc738d258d4e6c7d9b622/data/Albania/Assembly/term-7.csv"
           }
         ],
         "statement_count": 9898
@@ -110,11 +110,11 @@
         "slug": "States",
         "sources_directory": "data/Alderney/States/sources",
         "popolo": "data/Alderney/States/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/813d473/data/Alderney/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/813d4736fe9f1dc0b819387dbaf17dddc69decdd/data/Alderney/States/ep-popolo-v1.0.json",
         "names": "data/Alderney/States/names.csv",
         "lastmod": "1469382586",
         "person_count": 10,
-        "sha": "813d473",
+        "sha": "813d4736fe9f1dc0b819387dbaf17dddc69decdd",
         "legislative_periods": [
           {
             "end_date": "2016-11",
@@ -123,7 +123,7 @@
             "start_date": "2014-11-22",
             "slug": "2014",
             "csv": "data/Alderney/States/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/550097b/data/Alderney/States/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/550097b6f223687964943203cf5797c8c4ce28e3/data/Alderney/States/term-2014.csv"
           }
         ],
         "statement_count": 531
@@ -141,11 +141,11 @@
         "slug": "Majlis",
         "sources_directory": "data/Algeria/Majlis/sources",
         "popolo": "data/Algeria/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/decf5dd/data/Algeria/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/decf5dde5dc28b845b70c574b6ffadad6cd6d3a5/data/Algeria/Majlis/ep-popolo-v1.0.json",
         "names": "data/Algeria/Majlis/names.csv",
         "lastmod": "1471717078",
         "person_count": 478,
-        "sha": "decf5dd",
+        "sha": "decf5dde5dc28b845b70c574b6ffadad6cd6d3a5",
         "legislative_periods": [
           {
             "id": "term/7",
@@ -153,7 +153,7 @@
             "start_date": "2012-05-10",
             "slug": "7",
             "csv": "data/Algeria/Majlis/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7806801/data/Algeria/Majlis/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/780680134e2d2d3303ab8940d657960910d36995/data/Algeria/Majlis/term-7.csv"
           }
         ],
         "statement_count": 8281
@@ -171,11 +171,11 @@
         "slug": "House",
         "sources_directory": "data/American_Samoa/House/sources",
         "popolo": "data/American_Samoa/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aac7c53/data/American_Samoa/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aac7c53fc62cbb0e9bbd0f7ffe4e4a78d1430ee8/data/American_Samoa/House/ep-popolo-v1.0.json",
         "names": "data/American_Samoa/House/names.csv",
         "lastmod": "1470197073",
         "person_count": 17,
-        "sha": "aac7c53",
+        "sha": "aac7c53fc62cbb0e9bbd0f7ffe4e4a78d1430ee8",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -183,7 +183,7 @@
             "start_date": "2015-01-03",
             "slug": "2014",
             "csv": "data/American_Samoa/House/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f5fa566/data/American_Samoa/House/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f5fa566b619091ce9cc70f5ffb56fb2c2710a006/data/American_Samoa/House/term-2014.csv"
           }
         ],
         "statement_count": 658
@@ -201,11 +201,11 @@
         "slug": "General-Council",
         "sources_directory": "data/Andorra/General_Council/sources",
         "popolo": "data/Andorra/General_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65b1472/data/Andorra/General_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65b1472bbb784576eebfb19aeaa79dca316ec708/data/Andorra/General_Council/ep-popolo-v1.0.json",
         "names": "data/Andorra/General_Council/names.csv",
         "lastmod": "1471016415",
         "person_count": 30,
-        "sha": "65b1472",
+        "sha": "65b1472bbb784576eebfb19aeaa79dca316ec708",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -213,7 +213,7 @@
             "start_date": "2015-03-23",
             "slug": "2015",
             "csv": "data/Andorra/General_Council/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c5640c2/data/Andorra/General_Council/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c5640c22fc9f6832b5916e269fe855884d29b936/data/Andorra/General_Council/term-2015.csv"
           }
         ],
         "statement_count": 890
@@ -231,11 +231,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Angola/National_Assembly/sources",
         "popolo": "data/Angola/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/282f77d/data/Angola/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/282f77d169c6a81103f5de2a0879d44a9a640c6e/data/Angola/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Angola/National_Assembly/names.csv",
         "lastmod": "1469382643",
         "person_count": 216,
-        "sha": "282f77d",
+        "sha": "282f77d169c6a81103f5de2a0879d44a9a640c6e",
         "legislative_periods": [
           {
             "id": "term/3",
@@ -243,7 +243,7 @@
             "start_date": "2012-09-27",
             "slug": "3",
             "csv": "data/Angola/National_Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5d4ac3b/data/Angola/National_Assembly/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5d4ac3bd4b76eb18a9b55acdbf648157b98fb399/data/Angola/National_Assembly/term-3.csv"
           }
         ],
         "statement_count": 4107
@@ -261,11 +261,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Anguilla/Assembly/sources",
         "popolo": "data/Anguilla/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eea2d01/data/Anguilla/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eea2d01d65fd1f480a58dc21d1fa91f4f7f2a184/data/Anguilla/Assembly/ep-popolo-v1.0.json",
         "names": "data/Anguilla/Assembly/names.csv",
         "lastmod": "1469382673",
         "person_count": 18,
-        "sha": "eea2d01",
+        "sha": "eea2d01d65fd1f480a58dc21d1fa91f4f7f2a184",
         "legislative_periods": [
           {
             "end_date": "2020",
@@ -274,7 +274,7 @@
             "start_date": "2015",
             "slug": "2015",
             "csv": "data/Anguilla/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b9f249/data/Anguilla/Assembly/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b9f24921ebc9188eff3c677880de3df897be636/data/Anguilla/Assembly/term-2015.csv"
           },
           {
             "end_date": "2015",
@@ -283,7 +283,7 @@
             "start_date": "2010",
             "slug": "2010",
             "csv": "data/Anguilla/Assembly/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2a5031/data/Anguilla/Assembly/term-2010.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2a5031d650e3bc4e954255b8e109537d7921632/data/Anguilla/Assembly/term-2010.csv"
           },
           {
             "end_date": "2010",
@@ -292,7 +292,7 @@
             "start_date": "2005",
             "slug": "2005",
             "csv": "data/Anguilla/Assembly/term-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2a5031/data/Anguilla/Assembly/term-2005.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2a5031d650e3bc4e954255b8e109537d7921632/data/Anguilla/Assembly/term-2005.csv"
           },
           {
             "end_date": "2005",
@@ -301,7 +301,7 @@
             "start_date": "2000",
             "slug": "2000",
             "csv": "data/Anguilla/Assembly/term-2000.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2a5031/data/Anguilla/Assembly/term-2000.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2a5031d650e3bc4e954255b8e109537d7921632/data/Anguilla/Assembly/term-2000.csv"
           },
           {
             "end_date": "2000",
@@ -310,7 +310,7 @@
             "start_date": "1999",
             "slug": "1999",
             "csv": "data/Anguilla/Assembly/term-1999.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2a5031/data/Anguilla/Assembly/term-1999.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2a5031d650e3bc4e954255b8e109537d7921632/data/Anguilla/Assembly/term-1999.csv"
           },
           {
             "end_date": "1999",
@@ -319,7 +319,7 @@
             "start_date": "1994",
             "slug": "1994",
             "csv": "data/Anguilla/Assembly/term-1994.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2a5031/data/Anguilla/Assembly/term-1994.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2a5031d650e3bc4e954255b8e109537d7921632/data/Anguilla/Assembly/term-1994.csv"
           },
           {
             "end_date": "1994",
@@ -328,7 +328,7 @@
             "start_date": "1989",
             "slug": "1989",
             "csv": "data/Anguilla/Assembly/term-1989.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2a5031/data/Anguilla/Assembly/term-1989.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2a5031d650e3bc4e954255b8e109537d7921632/data/Anguilla/Assembly/term-1989.csv"
           }
         ],
         "statement_count": 1006
@@ -346,11 +346,11 @@
         "slug": "Representatives",
         "sources_directory": "data/Antigua_and_Barbuda/Representatives/sources",
         "popolo": "data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5417293/data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5417293706018586200cb9e5e326e04564b7f413/data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
         "names": "data/Antigua_and_Barbuda/Representatives/names.csv",
         "lastmod": "1470268561",
         "person_count": 63,
-        "sha": "5417293",
+        "sha": "5417293706018586200cb9e5e326e04564b7f413",
         "legislative_periods": [
           {
             "end_date": "2019",
@@ -359,7 +359,7 @@
             "start_date": "2014-06-25",
             "slug": "2014",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640fac/data/Antigua_and_Barbuda/Representatives/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640facb22f61f56e76789b3a7c809f443df15de/data/Antigua_and_Barbuda/Representatives/term-2014.csv"
           },
           {
             "end_date": "2014-04-26",
@@ -368,7 +368,7 @@
             "start_date": "2009-04-27",
             "slug": "2009",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640fac/data/Antigua_and_Barbuda/Representatives/term-2009.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640facb22f61f56e76789b3a7c809f443df15de/data/Antigua_and_Barbuda/Representatives/term-2009.csv"
           },
           {
             "end_date": "2009-02-09",
@@ -377,7 +377,7 @@
             "start_date": "2004-03-24",
             "slug": "2004",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-2004.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6fa705a/data/Antigua_and_Barbuda/Representatives/term-2004.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6fa705a4a65059331ad44e27787859280068404c/data/Antigua_and_Barbuda/Representatives/term-2004.csv"
           },
           {
             "end_date": "2004",
@@ -386,7 +386,7 @@
             "start_date": "1999",
             "slug": "1999",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1999.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1e22e0/data/Antigua_and_Barbuda/Representatives/term-1999.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1e22e0b61be1190e18cf454b7f770c2218def85/data/Antigua_and_Barbuda/Representatives/term-1999.csv"
           },
           {
             "end_date": "1999",
@@ -395,7 +395,7 @@
             "start_date": "1994",
             "slug": "1994",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1994.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1e22e0/data/Antigua_and_Barbuda/Representatives/term-1994.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1e22e0b61be1190e18cf454b7f770c2218def85/data/Antigua_and_Barbuda/Representatives/term-1994.csv"
           },
           {
             "end_date": "1994",
@@ -404,7 +404,7 @@
             "start_date": "1989",
             "slug": "1989",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1989.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1e22e0/data/Antigua_and_Barbuda/Representatives/term-1989.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1e22e0b61be1190e18cf454b7f770c2218def85/data/Antigua_and_Barbuda/Representatives/term-1989.csv"
           },
           {
             "end_date": "1989",
@@ -413,7 +413,7 @@
             "start_date": "1984",
             "slug": "1984",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1984.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1e22e0/data/Antigua_and_Barbuda/Representatives/term-1984.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1e22e0b61be1190e18cf454b7f770c2218def85/data/Antigua_and_Barbuda/Representatives/term-1984.csv"
           },
           {
             "end_date": "1984",
@@ -422,7 +422,7 @@
             "start_date": "1980",
             "slug": "1980",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1980.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1e22e0/data/Antigua_and_Barbuda/Representatives/term-1980.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1e22e0b61be1190e18cf454b7f770c2218def85/data/Antigua_and_Barbuda/Representatives/term-1980.csv"
           },
           {
             "end_date": "1980",
@@ -431,7 +431,7 @@
             "start_date": "1976",
             "slug": "1976",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1976.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1e22e0/data/Antigua_and_Barbuda/Representatives/term-1976.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1e22e0b61be1190e18cf454b7f770c2218def85/data/Antigua_and_Barbuda/Representatives/term-1976.csv"
           },
           {
             "end_date": "1976",
@@ -440,7 +440,7 @@
             "start_date": "1971",
             "slug": "1971",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1971.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1e22e0/data/Antigua_and_Barbuda/Representatives/term-1971.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1e22e0b61be1190e18cf454b7f770c2218def85/data/Antigua_and_Barbuda/Representatives/term-1971.csv"
           }
         ],
         "statement_count": 2365
@@ -458,11 +458,11 @@
         "slug": "Diputados",
         "sources_directory": "data/Argentina/Diputados/sources",
         "popolo": "data/Argentina/Diputados/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba00071/data/Argentina/Diputados/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba00071d2516c38d40055b7221ece1da446fd9aa/data/Argentina/Diputados/ep-popolo-v1.0.json",
         "names": "data/Argentina/Diputados/names.csv",
         "lastmod": "1470043767",
         "person_count": 390,
-        "sha": "ba00071",
+        "sha": "ba00071d2516c38d40055b7221ece1da446fd9aa",
         "legislative_periods": [
           {
             "id": "term/133",
@@ -470,7 +470,7 @@
             "start_date": "2015",
             "slug": "133",
             "csv": "data/Argentina/Diputados/term-133.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e7335de/data/Argentina/Diputados/term-133.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e7335de0e1cb83e9d9c3d1a202c9450d38909d79/data/Argentina/Diputados/term-133.csv"
           }
         ],
         "statement_count": 14883
@@ -480,11 +480,11 @@
         "slug": "Senado",
         "sources_directory": "data/Argentina/Senado/sources",
         "popolo": "data/Argentina/Senado/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25257c4/data/Argentina/Senado/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25257c4a3a48105bbfbf6dfe240eff2bff0abcee/data/Argentina/Senado/ep-popolo-v1.0.json",
         "names": "data/Argentina/Senado/names.csv",
         "lastmod": "1471507861",
         "person_count": 72,
-        "sha": "25257c4",
+        "sha": "25257c4a3a48105bbfbf6dfe240eff2bff0abcee",
         "legislative_periods": [
           {
             "end_date": "2017-12-09",
@@ -493,7 +493,7 @@
             "start_date": "2015-12-10",
             "slug": "2015",
             "csv": "data/Argentina/Senado/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25257c4/data/Argentina/Senado/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25257c4a3a48105bbfbf6dfe240eff2bff0abcee/data/Argentina/Senado/term-2015.csv"
           }
         ],
         "statement_count": 3986
@@ -511,11 +511,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Armenia/Assembly/sources",
         "popolo": "data/Armenia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa343bc/data/Armenia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa343bce5100fd10f37ff87c82ba45ec34dd71da/data/Armenia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Armenia/Assembly/names.csv",
         "lastmod": "1472102607",
         "person_count": 132,
-        "sha": "fa343bc",
+        "sha": "fa343bce5100fd10f37ff87c82ba45ec34dd71da",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -523,7 +523,7 @@
             "start_date": "2012-05-31",
             "slug": "5",
             "csv": "data/Armenia/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/98bd680/data/Armenia/Assembly/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/98bd680e6ec2283cbf2626194c350cfad7ee2954/data/Armenia/Assembly/term-5.csv"
           }
         ],
         "statement_count": 5741
@@ -541,11 +541,11 @@
         "slug": "Estates",
         "sources_directory": "data/Aruba/Estates/sources",
         "popolo": "data/Aruba/Estates/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/76eec4a/data/Aruba/Estates/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/76eec4add6ab0c421767dc4664837bf301d6f34f/data/Aruba/Estates/ep-popolo-v1.0.json",
         "names": "data/Aruba/Estates/names.csv",
         "lastmod": "1469382752",
         "person_count": 21,
-        "sha": "76eec4a",
+        "sha": "76eec4add6ab0c421767dc4664837bf301d6f34f",
         "legislative_periods": [
           {
             "id": "term/7",
@@ -553,7 +553,7 @@
             "start_date": "2013",
             "slug": "7",
             "csv": "data/Aruba/Estates/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e6ef189/data/Aruba/Estates/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e6ef1899f09ab25e2508c25c3f08484de2fe4cca/data/Aruba/Estates/term-7.csv"
           }
         ],
         "statement_count": 605
@@ -571,11 +571,11 @@
         "slug": "Representatives",
         "sources_directory": "data/Australia/Representatives/sources",
         "popolo": "data/Australia/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f81011/data/Australia/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f8101123c5968fdd94bb4c1d4a47261557f54ec/data/Australia/Representatives/ep-popolo-v1.0.json",
         "names": "data/Australia/Representatives/names.csv",
         "lastmod": "1472108121",
         "person_count": 475,
-        "sha": "8f81011",
+        "sha": "8f8101123c5968fdd94bb4c1d4a47261557f54ec",
         "legislative_periods": [
           {
             "id": "term/44",
@@ -583,7 +583,7 @@
             "start_date": "2013-09-07",
             "slug": "44",
             "csv": "data/Australia/Representatives/term-44.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c773f74/data/Australia/Representatives/term-44.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c773f740521ec39edb7509c344db3322223d782c/data/Australia/Representatives/term-44.csv"
           },
           {
             "end_date": "2013-09-07",
@@ -592,7 +592,7 @@
             "start_date": "2010-08-21",
             "slug": "43",
             "csv": "data/Australia/Representatives/term-43.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f81011/data/Australia/Representatives/term-43.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f8101123c5968fdd94bb4c1d4a47261557f54ec/data/Australia/Representatives/term-43.csv"
           },
           {
             "end_date": "2010-08-21",
@@ -601,7 +601,7 @@
             "start_date": "2007-11-24",
             "slug": "42",
             "csv": "data/Australia/Representatives/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f81011/data/Australia/Representatives/term-42.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f8101123c5968fdd94bb4c1d4a47261557f54ec/data/Australia/Representatives/term-42.csv"
           },
           {
             "end_date": "2007-11-24",
@@ -610,7 +610,7 @@
             "start_date": "2004-10-09",
             "slug": "41",
             "csv": "data/Australia/Representatives/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f81011/data/Australia/Representatives/term-41.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f8101123c5968fdd94bb4c1d4a47261557f54ec/data/Australia/Representatives/term-41.csv"
           },
           {
             "end_date": "2004-10-09",
@@ -619,7 +619,7 @@
             "start_date": "2001-11-10",
             "slug": "40",
             "csv": "data/Australia/Representatives/term-40.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f81011/data/Australia/Representatives/term-40.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f8101123c5968fdd94bb4c1d4a47261557f54ec/data/Australia/Representatives/term-40.csv"
           },
           {
             "end_date": "2001-11-10",
@@ -628,7 +628,7 @@
             "start_date": "1998-10-03",
             "slug": "39",
             "csv": "data/Australia/Representatives/term-39.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f81011/data/Australia/Representatives/term-39.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f8101123c5968fdd94bb4c1d4a47261557f54ec/data/Australia/Representatives/term-39.csv"
           },
           {
             "end_date": "1998-10-03",
@@ -637,7 +637,7 @@
             "start_date": "1996-03-02",
             "slug": "38",
             "csv": "data/Australia/Representatives/term-38.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f81011/data/Australia/Representatives/term-38.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f8101123c5968fdd94bb4c1d4a47261557f54ec/data/Australia/Representatives/term-38.csv"
           },
           {
             "end_date": "1996-03-02",
@@ -646,7 +646,7 @@
             "start_date": "1993-03-13",
             "slug": "37",
             "csv": "data/Australia/Representatives/term-37.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f81011/data/Australia/Representatives/term-37.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f8101123c5968fdd94bb4c1d4a47261557f54ec/data/Australia/Representatives/term-37.csv"
           },
           {
             "end_date": "1993-03-13",
@@ -655,7 +655,7 @@
             "start_date": "1990-03-24",
             "slug": "36",
             "csv": "data/Australia/Representatives/term-36.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f81011/data/Australia/Representatives/term-36.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f8101123c5968fdd94bb4c1d4a47261557f54ec/data/Australia/Representatives/term-36.csv"
           },
           {
             "end_date": "1990-03-24",
@@ -664,7 +664,7 @@
             "start_date": "1987-07-11",
             "slug": "35",
             "csv": "data/Australia/Representatives/term-35.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f81011/data/Australia/Representatives/term-35.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f8101123c5968fdd94bb4c1d4a47261557f54ec/data/Australia/Representatives/term-35.csv"
           }
         ],
         "statement_count": 36421
@@ -674,11 +674,11 @@
         "slug": "Senate",
         "sources_directory": "data/Australia/Senate/sources",
         "popolo": "data/Australia/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f66db5b/data/Australia/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f66db5b3cde779f95ece77e1ce60ad600cfea3b5/data/Australia/Senate/ep-popolo-v1.0.json",
         "names": "data/Australia/Senate/names.csv",
         "lastmod": "1472015907",
         "person_count": 244,
-        "sha": "f66db5b",
+        "sha": "f66db5b3cde779f95ece77e1ce60ad600cfea3b5",
         "legislative_periods": [
           {
             "id": "term/44",
@@ -686,7 +686,7 @@
             "start_date": "2013-09-07",
             "slug": "44",
             "csv": "data/Australia/Senate/term-44.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fb1d17/data/Australia/Senate/term-44.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fb1d1725d0284e4ba8d0acafe25deea9b6824a6/data/Australia/Senate/term-44.csv"
           },
           {
             "end_date": "2013-09-07",
@@ -695,7 +695,7 @@
             "start_date": "2010-08-21",
             "slug": "43",
             "csv": "data/Australia/Senate/term-43.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fb1d17/data/Australia/Senate/term-43.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fb1d1725d0284e4ba8d0acafe25deea9b6824a6/data/Australia/Senate/term-43.csv"
           },
           {
             "end_date": "2010-08-21",
@@ -704,7 +704,7 @@
             "start_date": "2007-11-24",
             "slug": "42",
             "csv": "data/Australia/Senate/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fb26611/data/Australia/Senate/term-42.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fb266116ab4963f8b90e561f7f9f0565287adcdf/data/Australia/Senate/term-42.csv"
           },
           {
             "end_date": "2007-11-24",
@@ -713,7 +713,7 @@
             "start_date": "2004-10-09",
             "slug": "41",
             "csv": "data/Australia/Senate/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fb26611/data/Australia/Senate/term-41.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fb266116ab4963f8b90e561f7f9f0565287adcdf/data/Australia/Senate/term-41.csv"
           },
           {
             "end_date": "2004-10-09",
@@ -722,7 +722,7 @@
             "start_date": "2001-11-10",
             "slug": "40",
             "csv": "data/Australia/Senate/term-40.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fb26611/data/Australia/Senate/term-40.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fb266116ab4963f8b90e561f7f9f0565287adcdf/data/Australia/Senate/term-40.csv"
           },
           {
             "end_date": "2001-11-10",
@@ -731,7 +731,7 @@
             "start_date": "1998-10-03",
             "slug": "39",
             "csv": "data/Australia/Senate/term-39.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/97d9f74/data/Australia/Senate/term-39.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/97d9f74817551a51932d19802da0a10ca8610ac4/data/Australia/Senate/term-39.csv"
           },
           {
             "end_date": "1998-10-03",
@@ -740,7 +740,7 @@
             "start_date": "1996-03-02",
             "slug": "38",
             "csv": "data/Australia/Senate/term-38.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/97d9f74/data/Australia/Senate/term-38.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/97d9f74817551a51932d19802da0a10ca8610ac4/data/Australia/Senate/term-38.csv"
           },
           {
             "end_date": "1996-03-02",
@@ -749,7 +749,7 @@
             "start_date": "1993-03-13",
             "slug": "37",
             "csv": "data/Australia/Senate/term-37.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/97d9f74/data/Australia/Senate/term-37.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/97d9f74817551a51932d19802da0a10ca8610ac4/data/Australia/Senate/term-37.csv"
           },
           {
             "end_date": "1993-03-13",
@@ -758,7 +758,7 @@
             "start_date": "1990-03-24",
             "slug": "36",
             "csv": "data/Australia/Senate/term-36.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/97d9f74/data/Australia/Senate/term-36.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/97d9f74817551a51932d19802da0a10ca8610ac4/data/Australia/Senate/term-36.csv"
           },
           {
             "end_date": "1990-03-24",
@@ -767,7 +767,7 @@
             "start_date": "1987-07-11",
             "slug": "35",
             "csv": "data/Australia/Senate/term-35.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0d975c0/data/Australia/Senate/term-35.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0d975c00c5ba8b50c59fa16d80029a5a294958e2/data/Australia/Senate/term-35.csv"
           }
         ],
         "statement_count": 19825
@@ -785,11 +785,11 @@
         "slug": "Nationalrat",
         "sources_directory": "data/Austria/Nationalrat/sources",
         "popolo": "data/Austria/Nationalrat/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90a3b85/data/Austria/Nationalrat/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90a3b85c630e56aebed97bcc6c8aaf1fc87c7baf/data/Austria/Nationalrat/ep-popolo-v1.0.json",
         "names": "data/Austria/Nationalrat/names.csv",
         "lastmod": "1471079728",
         "person_count": 182,
-        "sha": "90a3b85",
+        "sha": "90a3b85c630e56aebed97bcc6c8aaf1fc87c7baf",
         "legislative_periods": [
           {
             "id": "term/25",
@@ -797,7 +797,7 @@
             "start_date": "2013-09-29",
             "slug": "25",
             "csv": "data/Austria/Nationalrat/term-25.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90a3b85/data/Austria/Nationalrat/term-25.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90a3b85c630e56aebed97bcc6c8aaf1fc87c7baf/data/Austria/Nationalrat/term-25.csv"
           }
         ],
         "statement_count": 13525
@@ -815,11 +815,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Azerbaijan/National_Assembly/sources",
         "popolo": "data/Azerbaijan/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f5e4559/data/Azerbaijan/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f5e45596dfaec17c6f6efce714cde653ad1ac239/data/Azerbaijan/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Azerbaijan/National_Assembly/names.csv",
         "lastmod": "1471524653",
         "person_count": 152,
-        "sha": "f5e4559",
+        "sha": "f5e45596dfaec17c6f6efce714cde653ad1ac239",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -827,7 +827,7 @@
             "start_date": "2015-12-01",
             "slug": "5",
             "csv": "data/Azerbaijan/National_Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f5e4559/data/Azerbaijan/National_Assembly/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f5e45596dfaec17c6f6efce714cde653ad1ac239/data/Azerbaijan/National_Assembly/term-5.csv"
           },
           {
             "end_date": "2015",
@@ -836,7 +836,7 @@
             "start_date": "2010",
             "slug": "4",
             "csv": "data/Azerbaijan/National_Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f5e4559/data/Azerbaijan/National_Assembly/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f5e45596dfaec17c6f6efce714cde653ad1ac239/data/Azerbaijan/National_Assembly/term-4.csv"
           }
         ],
         "statement_count": 5375
@@ -854,11 +854,11 @@
         "slug": "House-of-Assembly",
         "sources_directory": "data/Bahamas/House_of_Assembly/sources",
         "popolo": "data/Bahamas/House_of_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6121b3f/data/Bahamas/House_of_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6121b3f707c19923f03cda09fa7fd5381c479f88/data/Bahamas/House_of_Assembly/ep-popolo-v1.0.json",
         "names": "data/Bahamas/House_of_Assembly/names.csv",
         "lastmod": "1470444172",
         "person_count": 38,
-        "sha": "6121b3f",
+        "sha": "6121b3f707c19923f03cda09fa7fd5381c479f88",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -866,7 +866,7 @@
             "start_date": "2012-05-08",
             "slug": "2012",
             "csv": "data/Bahamas/House_of_Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9d28d98/data/Bahamas/House_of_Assembly/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9d28d983cc4e8e7d025d3894ca608dec8139c2b8/data/Bahamas/House_of_Assembly/term-2012.csv"
           }
         ],
         "statement_count": 1394
@@ -884,11 +884,11 @@
         "slug": "Council-of-Representatives",
         "sources_directory": "data/Bahrain/Council_of_Representatives/sources",
         "popolo": "data/Bahrain/Council_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f41841d/data/Bahrain/Council_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f41841d836533e1af1dcc21a38c3ca551a76f481/data/Bahrain/Council_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Bahrain/Council_of_Representatives/names.csv",
         "lastmod": "1469383139",
         "person_count": 40,
-        "sha": "f41841d",
+        "sha": "f41841d836533e1af1dcc21a38c3ca551a76f481",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -896,7 +896,7 @@
             "start_date": "2014-12-14",
             "slug": "2014",
             "csv": "data/Bahrain/Council_of_Representatives/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b04fb2a/data/Bahrain/Council_of_Representatives/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b04fb2a90055d815d22e9781d04b4e6ed93a4bbe/data/Bahrain/Council_of_Representatives/term-2014.csv"
           }
         ],
         "statement_count": 523
@@ -914,11 +914,11 @@
         "slug": "House",
         "sources_directory": "data/Bangladesh/House/sources",
         "popolo": "data/Bangladesh/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8c40e7b/data/Bangladesh/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8c40e7b1aae2dca26d1a6d1573ada30ddacb5983/data/Bangladesh/House/ep-popolo-v1.0.json",
         "names": "data/Bangladesh/House/names.csv",
         "lastmod": "1470551562",
         "person_count": 545,
-        "sha": "8c40e7b",
+        "sha": "8c40e7b1aae2dca26d1a6d1573ada30ddacb5983",
         "legislative_periods": [
           {
             "id": "term/10",
@@ -926,7 +926,7 @@
             "start_date": "2014-01-29",
             "slug": "10",
             "csv": "data/Bangladesh/House/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4c9cc33/data/Bangladesh/House/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4c9cc3377e1d6cde39894f1a1c9ccb86325cd967/data/Bangladesh/House/term-10.csv"
           },
           {
             "end_date": "2014-01-24",
@@ -935,7 +935,7 @@
             "start_date": "2009-01-25",
             "slug": "9",
             "csv": "data/Bangladesh/House/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4c9cc33/data/Bangladesh/House/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4c9cc3377e1d6cde39894f1a1c9ccb86325cd967/data/Bangladesh/House/term-9.csv"
           }
         ],
         "statement_count": 12157
@@ -953,11 +953,11 @@
         "slug": "House-of-Assembly",
         "sources_directory": "data/Barbados/House_of_Assembly/sources",
         "popolo": "data/Barbados/House_of_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/96ff930/data/Barbados/House_of_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/96ff93097bf0d1d2d1d39a7092459d301c545ffb/data/Barbados/House_of_Assembly/ep-popolo-v1.0.json",
         "names": "data/Barbados/House_of_Assembly/names.csv",
         "lastmod": "1469383152",
         "person_count": 30,
-        "sha": "96ff930",
+        "sha": "96ff93097bf0d1d2d1d39a7092459d301c545ffb",
         "legislative_periods": [
           {
             "id": "term/2013",
@@ -965,7 +965,7 @@
             "start_date": "2013-03-06",
             "slug": "2013",
             "csv": "data/Barbados/House_of_Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e6046d2/data/Barbados/House_of_Assembly/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e6046d2035df58be8815247ae7d1148432b9e207/data/Barbados/House_of_Assembly/term-2013.csv"
           }
         ],
         "statement_count": 904
@@ -983,11 +983,11 @@
         "slug": "Chamber",
         "sources_directory": "data/Belarus/Chamber/sources",
         "popolo": "data/Belarus/Chamber/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f02f234/data/Belarus/Chamber/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f02f234fa73fcc940a660ba241920a72e6a98e03/data/Belarus/Chamber/ep-popolo-v1.0.json",
         "names": "data/Belarus/Chamber/names.csv",
         "lastmod": "1471518772",
         "person_count": 109,
-        "sha": "f02f234",
+        "sha": "f02f234fa73fcc940a660ba241920a72e6a98e03",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -995,7 +995,7 @@
             "start_date": "2012-09-23",
             "slug": "5",
             "csv": "data/Belarus/Chamber/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20f29b1/data/Belarus/Chamber/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20f29b1769f4d04235d8be330169e7f9bd0d06a8/data/Belarus/Chamber/term-5.csv"
           }
         ],
         "statement_count": 3340
@@ -1013,11 +1013,11 @@
         "slug": "Representatives",
         "sources_directory": "data/Belgium/Representatives/sources",
         "popolo": "data/Belgium/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0f7df6e/data/Belgium/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0f7df6e35b2ddccd54a9040fe49715f213b2a45f/data/Belgium/Representatives/ep-popolo-v1.0.json",
         "names": "data/Belgium/Representatives/names.csv",
         "lastmod": "1472064404",
         "person_count": 168,
-        "sha": "0f7df6e",
+        "sha": "0f7df6e35b2ddccd54a9040fe49715f213b2a45f",
         "legislative_periods": [
           {
             "id": "term/54",
@@ -1025,7 +1025,7 @@
             "start_date": "2014-06-19",
             "slug": "54",
             "csv": "data/Belgium/Representatives/term-54.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f778f6/data/Belgium/Representatives/term-54.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f778f6df8c4882dfdd94047a3d0f8fcf0941bc5/data/Belgium/Representatives/term-54.csv"
           }
         ],
         "statement_count": 12528
@@ -1043,11 +1043,11 @@
         "slug": "Representatives",
         "sources_directory": "data/Belize/Representatives/sources",
         "popolo": "data/Belize/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/91d6482/data/Belize/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/91d64820c5942e6ac0fbedda05bef8891286c2fd/data/Belize/Representatives/ep-popolo-v1.0.json",
         "names": "data/Belize/Representatives/names.csv",
         "lastmod": "1469383167",
         "person_count": 27,
-        "sha": "91d6482",
+        "sha": "91d64820c5942e6ac0fbedda05bef8891286c2fd",
         "legislative_periods": [
           {
             "end_date": "2017",
@@ -1056,7 +1056,7 @@
             "start_date": "2012-03-21",
             "slug": "2012",
             "csv": "data/Belize/Representatives/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bab35ae/data/Belize/Representatives/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bab35ae15ccbc2197aada695c4dea2725febb2f6/data/Belize/Representatives/term-2012.csv"
           }
         ],
         "statement_count": 1229
@@ -1074,11 +1074,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Benin/National_Assembly/sources",
         "popolo": "data/Benin/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65aa0db/data/Benin/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65aa0db05449cd898bff32b53ac69bc9c697a771/data/Benin/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Benin/National_Assembly/names.csv",
         "lastmod": "1469383172",
         "person_count": 83,
-        "sha": "65aa0db",
+        "sha": "65aa0db05449cd898bff32b53ac69bc9c697a771",
         "legislative_periods": [
           {
             "id": "term/6",
@@ -1086,7 +1086,7 @@
             "start_date": "2015-04-26",
             "slug": "6",
             "csv": "data/Benin/National_Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a5e073/data/Benin/National_Assembly/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a5e0733a7e47c64285f79ddaf7fda6ec15cef74/data/Benin/National_Assembly/term-6.csv"
           }
         ],
         "statement_count": 1848
@@ -1104,11 +1104,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Bermuda/Assembly/sources",
         "popolo": "data/Bermuda/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9614396/data/Bermuda/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9614396183119f7ca3260ee79a792ee86e00cd24/data/Bermuda/Assembly/ep-popolo-v1.0.json",
         "names": "data/Bermuda/Assembly/names.csv",
         "lastmod": "1469383176",
         "person_count": 37,
-        "sha": "9614396",
+        "sha": "9614396183119f7ca3260ee79a792ee86e00cd24",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -1116,7 +1116,7 @@
             "start_date": "2012-12-17",
             "slug": "2012",
             "csv": "data/Bermuda/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/12df4a1/data/Bermuda/Assembly/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/12df4a1aec9e6bd1f38313acfa48a95cb7112105/data/Bermuda/Assembly/term-2012.csv"
           }
         ],
         "statement_count": 1223
@@ -1134,11 +1134,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Bhutan/Assembly/sources",
         "popolo": "data/Bhutan/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d5ee635/data/Bhutan/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d5ee6358ce2bc11c6aac7f455feb24905940dac3/data/Bhutan/Assembly/ep-popolo-v1.0.json",
         "names": "data/Bhutan/Assembly/names.csv",
         "lastmod": "1469383180",
         "person_count": 47,
-        "sha": "d5ee635",
+        "sha": "d5ee6358ce2bc11c6aac7f455feb24905940dac3",
         "legislative_periods": [
           {
             "id": "term/2",
@@ -1146,7 +1146,7 @@
             "start_date": "2013-07-13",
             "slug": "2",
             "csv": "data/Bhutan/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c922fec/data/Bhutan/Assembly/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c922fec406c3a7937a48a0d6c85ce29fd64c50b1/data/Bhutan/Assembly/term-2.csv"
           }
         ],
         "statement_count": 1098
@@ -1164,11 +1164,11 @@
         "slug": "Deputies",
         "sources_directory": "data/Bolivia/Deputies/sources",
         "popolo": "data/Bolivia/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a5da254/data/Bolivia/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a5da254c9a6870b233a6636903c933fa885442c6/data/Bolivia/Deputies/ep-popolo-v1.0.json",
         "names": "data/Bolivia/Deputies/names.csv",
         "lastmod": "1471821587",
         "person_count": 128,
-        "sha": "a5da254",
+        "sha": "a5da254c9a6870b233a6636903c933fa885442c6",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -1176,7 +1176,7 @@
             "start_date": "2015-01-21",
             "slug": "2015",
             "csv": "data/Bolivia/Deputies/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/013ebe5/data/Bolivia/Deputies/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/013ebe5fabb1c86c7c079cc470caad296509e476/data/Bolivia/Deputies/term-2015.csv"
           }
         ],
         "statement_count": 2392
@@ -1194,11 +1194,11 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Bosnia_and_Herzegovina/House_of_Representatives/sources",
         "popolo": "data/Bosnia_and_Herzegovina/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/24f94e0/data/Bosnia_and_Herzegovina/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/24f94e0ddf63bdd5a042299312ee478ab81d1eda/data/Bosnia_and_Herzegovina/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Bosnia_and_Herzegovina/House_of_Representatives/names.csv",
         "lastmod": "1469383187",
         "person_count": 42,
-        "sha": "24f94e0",
+        "sha": "24f94e0ddf63bdd5a042299312ee478ab81d1eda",
         "legislative_periods": [
           {
             "id": "term/7",
@@ -1206,7 +1206,7 @@
             "start_date": "2014-12-09",
             "slug": "7",
             "csv": "data/Bosnia_and_Herzegovina/House_of_Representatives/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70c2ca4/data/Bosnia_and_Herzegovina/House_of_Representatives/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70c2ca47333904adf371b383740ec4a51d8e6ea8/data/Bosnia_and_Herzegovina/House_of_Representatives/term-7.csv"
           }
         ],
         "statement_count": 1501
@@ -1224,11 +1224,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Botswana/Assembly/sources",
         "popolo": "data/Botswana/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1883f99/data/Botswana/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1883f99faaeead8a3deeab9249d9b89d7ea1c017/data/Botswana/Assembly/ep-popolo-v1.0.json",
         "names": "data/Botswana/Assembly/names.csv",
         "lastmod": "1469383393",
         "person_count": 63,
-        "sha": "1883f99",
+        "sha": "1883f99faaeead8a3deeab9249d9b89d7ea1c017",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -1236,7 +1236,7 @@
             "start_date": "2014-10-29",
             "slug": "2014",
             "csv": "data/Botswana/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/964b706/data/Botswana/Assembly/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/964b706e86dc3058a0df0c446bd7cd36cf4cc3bb/data/Botswana/Assembly/term-2014.csv"
           }
         ],
         "statement_count": 1665
@@ -1254,11 +1254,11 @@
         "slug": "Deputies",
         "sources_directory": "data/Brazil/Deputies/sources",
         "popolo": "data/Brazil/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3e2582c/data/Brazil/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3e2582cfc8914fd429e43dc189e354c1a42ac9d9/data/Brazil/Deputies/ep-popolo-v1.0.json",
         "names": "data/Brazil/Deputies/names.csv",
         "lastmod": "1471525370",
         "person_count": 929,
-        "sha": "3e2582c",
+        "sha": "3e2582cfc8914fd429e43dc189e354c1a42ac9d9",
         "legislative_periods": [
           {
             "id": "term/55",
@@ -1266,7 +1266,7 @@
             "start_date": "2015-02-01",
             "slug": "55",
             "csv": "data/Brazil/Deputies/term-55.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3e2582c/data/Brazil/Deputies/term-55.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3e2582cfc8914fd429e43dc189e354c1a42ac9d9/data/Brazil/Deputies/term-55.csv"
           },
           {
             "end_date": "2015",
@@ -1275,7 +1275,7 @@
             "start_date": "2011",
             "slug": "54",
             "csv": "data/Brazil/Deputies/term-54.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d34d9ac/data/Brazil/Deputies/term-54.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d34d9ac44f00c4d9fec4c20120aa1583f527ad41/data/Brazil/Deputies/term-54.csv"
           }
         ],
         "statement_count": 34198
@@ -1293,11 +1293,11 @@
         "slug": "Assembly",
         "sources_directory": "data/British_Virgin_Islands/Assembly/sources",
         "popolo": "data/British_Virgin_Islands/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/13ea751/data/British_Virgin_Islands/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/13ea75127a7291391d438bda123b3f3e2131d1ce/data/British_Virgin_Islands/Assembly/ep-popolo-v1.0.json",
         "names": "data/British_Virgin_Islands/Assembly/names.csv",
         "lastmod": "1470226921",
         "person_count": 23,
-        "sha": "13ea751",
+        "sha": "13ea75127a7291391d438bda123b3f3e2131d1ce",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -1305,7 +1305,7 @@
             "start_date": "2015-06-08",
             "slug": "2015",
             "csv": "data/British_Virgin_Islands/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/76647a7/data/British_Virgin_Islands/Assembly/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/76647a7d8f88b0fe0ae294cb36459d3b5468e30f/data/British_Virgin_Islands/Assembly/term-2015.csv"
           },
           {
             "end_date": "2015",
@@ -1314,7 +1314,7 @@
             "start_date": "2011",
             "slug": "2011",
             "csv": "data/British_Virgin_Islands/Assembly/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/61e40dd/data/British_Virgin_Islands/Assembly/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/61e40dda7a1796b65bd1a072e683adcf6ead6a47/data/British_Virgin_Islands/Assembly/term-2011.csv"
           },
           {
             "end_date": "2011",
@@ -1323,7 +1323,7 @@
             "start_date": "2007",
             "slug": "2007",
             "csv": "data/British_Virgin_Islands/Assembly/term-2007.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/61e40dd/data/British_Virgin_Islands/Assembly/term-2007.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/61e40dda7a1796b65bd1a072e683adcf6ead6a47/data/British_Virgin_Islands/Assembly/term-2007.csv"
           }
         ],
         "statement_count": 1174
@@ -1333,11 +1333,11 @@
         "slug": "Council",
         "sources_directory": "data/British_Virgin_Islands/Council/sources",
         "popolo": "data/British_Virgin_Islands/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51ea257/data/British_Virgin_Islands/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51ea257e2a6c2a19e34addbe5956a5681a1c1d53/data/British_Virgin_Islands/Council/ep-popolo-v1.0.json",
         "names": "data/British_Virgin_Islands/Council/names.csv",
         "lastmod": "1469383417",
         "person_count": 36,
-        "sha": "51ea257",
+        "sha": "51ea257e2a6c2a19e34addbe5956a5681a1c1d53",
         "legislative_periods": [
           {
             "end_date": "2007-08-20",
@@ -1346,7 +1346,7 @@
             "start_date": "2003-06-16",
             "slug": "2003",
             "csv": "data/British_Virgin_Islands/Council/term-2003.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5dd2b6b/data/British_Virgin_Islands/Council/term-2003.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5dd2b6b8fd1600eb35bec4b1ee04a7ae98200c1d/data/British_Virgin_Islands/Council/term-2003.csv"
           },
           {
             "end_date": "2003",
@@ -1355,7 +1355,7 @@
             "start_date": "1999",
             "slug": "1999",
             "csv": "data/British_Virgin_Islands/Council/term-1999.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5dd2b6b/data/British_Virgin_Islands/Council/term-1999.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5dd2b6b8fd1600eb35bec4b1ee04a7ae98200c1d/data/British_Virgin_Islands/Council/term-1999.csv"
           },
           {
             "end_date": "1999",
@@ -1364,7 +1364,7 @@
             "start_date": "1995",
             "slug": "1995",
             "csv": "data/British_Virgin_Islands/Council/term-1995.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b6a89a/data/British_Virgin_Islands/Council/term-1995.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b6a89a090c5b6972a0299f90b68384d7affd7aa/data/British_Virgin_Islands/Council/term-1995.csv"
           },
           {
             "end_date": "1995",
@@ -1373,7 +1373,7 @@
             "start_date": "1990",
             "slug": "1990",
             "csv": "data/British_Virgin_Islands/Council/term-1990.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b6a89a/data/British_Virgin_Islands/Council/term-1990.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b6a89a090c5b6972a0299f90b68384d7affd7aa/data/British_Virgin_Islands/Council/term-1990.csv"
           },
           {
             "end_date": "1990",
@@ -1382,7 +1382,7 @@
             "start_date": "1986",
             "slug": "1986",
             "csv": "data/British_Virgin_Islands/Council/term-1986.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b6a89a/data/British_Virgin_Islands/Council/term-1986.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b6a89a090c5b6972a0299f90b68384d7affd7aa/data/British_Virgin_Islands/Council/term-1986.csv"
           },
           {
             "end_date": "1986",
@@ -1391,7 +1391,7 @@
             "start_date": "1983",
             "slug": "1983",
             "csv": "data/British_Virgin_Islands/Council/term-1983.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b6a89a/data/British_Virgin_Islands/Council/term-1983.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b6a89a090c5b6972a0299f90b68384d7affd7aa/data/British_Virgin_Islands/Council/term-1983.csv"
           },
           {
             "end_date": "1983",
@@ -1400,7 +1400,7 @@
             "start_date": "1979",
             "slug": "1979",
             "csv": "data/British_Virgin_Islands/Council/term-1979.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b6a89a/data/British_Virgin_Islands/Council/term-1979.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b6a89a090c5b6972a0299f90b68384d7affd7aa/data/British_Virgin_Islands/Council/term-1979.csv"
           },
           {
             "end_date": "1979",
@@ -1409,7 +1409,7 @@
             "start_date": "1975",
             "slug": "1975",
             "csv": "data/British_Virgin_Islands/Council/term-1975.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b6a89a/data/British_Virgin_Islands/Council/term-1975.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b6a89a090c5b6972a0299f90b68384d7affd7aa/data/British_Virgin_Islands/Council/term-1975.csv"
           },
           {
             "end_date": "1975",
@@ -1418,7 +1418,7 @@
             "start_date": "1971",
             "slug": "1971",
             "csv": "data/British_Virgin_Islands/Council/term-1971.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b6a89a/data/British_Virgin_Islands/Council/term-1971.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b6a89a090c5b6972a0299f90b68384d7affd7aa/data/British_Virgin_Islands/Council/term-1971.csv"
           }
         ],
         "statement_count": 2007
@@ -1436,11 +1436,11 @@
         "slug": "Legislative-Council",
         "sources_directory": "data/Brunei/Legislative_Council/sources",
         "popolo": "data/Brunei/Legislative_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5f92aa8/data/Brunei/Legislative_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5f92aa824fd9e1f8724533ee1f962e6e9d96c986/data/Brunei/Legislative_Council/ep-popolo-v1.0.json",
         "names": "data/Brunei/Legislative_Council/names.csv",
         "lastmod": "1469383421",
         "person_count": 19,
-        "sha": "5f92aa8",
+        "sha": "5f92aa824fd9e1f8724533ee1f962e6e9d96c986",
         "legislative_periods": [
           {
             "end_date": "2015-03-24",
@@ -1449,7 +1449,7 @@
             "start_date": "2015-03-05",
             "slug": "11",
             "csv": "data/Brunei/Legislative_Council/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a1ee914/data/Brunei/Legislative_Council/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a1ee914c2e9714d5f3dbcb5e8c3f9ddde471ec2d/data/Brunei/Legislative_Council/term-11.csv"
           }
         ],
         "statement_count": 311
@@ -1467,11 +1467,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Bulgaria/National_Assembly/sources",
         "popolo": "data/Bulgaria/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6a113e2/data/Bulgaria/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6a113e28d3a663844a7bf9bc700ce705f4aa0ca6/data/Bulgaria/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Bulgaria/National_Assembly/names.csv",
         "lastmod": "1471737355",
         "person_count": 940,
-        "sha": "6a113e2",
+        "sha": "6a113e28d3a663844a7bf9bc700ce705f4aa0ca6",
         "legislative_periods": [
           {
             "end_date": "2015-09-10",
@@ -1480,7 +1480,7 @@
             "start_date": "2014-10-27",
             "slug": "43",
             "csv": "data/Bulgaria/National_Assembly/term-43.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ffb3a0/data/Bulgaria/National_Assembly/term-43.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ffb3a02a15e0340eb5503eef1616686a235af5c/data/Bulgaria/National_Assembly/term-43.csv"
           },
           {
             "end_date": "2014-08-05",
@@ -1489,7 +1489,7 @@
             "start_date": "2013-05-21",
             "slug": "42",
             "csv": "data/Bulgaria/National_Assembly/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6a113e2/data/Bulgaria/National_Assembly/term-42.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6a113e28d3a663844a7bf9bc700ce705f4aa0ca6/data/Bulgaria/National_Assembly/term-42.csv"
           },
           {
             "end_date": "2013-03-14",
@@ -1498,7 +1498,7 @@
             "start_date": "2009-07-14",
             "slug": "41",
             "csv": "data/Bulgaria/National_Assembly/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6a113e2/data/Bulgaria/National_Assembly/term-41.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6a113e28d3a663844a7bf9bc700ce705f4aa0ca6/data/Bulgaria/National_Assembly/term-41.csv"
           },
           {
             "end_date": "2009-06-25",
@@ -1507,7 +1507,7 @@
             "start_date": "2005-07-11",
             "slug": "40",
             "csv": "data/Bulgaria/National_Assembly/term-40.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ffb3a0/data/Bulgaria/National_Assembly/term-40.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ffb3a02a15e0340eb5503eef1616686a235af5c/data/Bulgaria/National_Assembly/term-40.csv"
           },
           {
             "end_date": "2005-06-17",
@@ -1516,7 +1516,7 @@
             "start_date": "2001-07-05",
             "slug": "39",
             "csv": "data/Bulgaria/National_Assembly/term-39.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c2432a/data/Bulgaria/National_Assembly/term-39.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c2432a6146ed4a3328df961d7276417be7bb1eb/data/Bulgaria/National_Assembly/term-39.csv"
           }
         ],
         "statement_count": 38665
@@ -1534,11 +1534,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Burkina_Faso/Assembly/sources",
         "popolo": "data/Burkina_Faso/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3ee7a4e/data/Burkina_Faso/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3ee7a4e410d2e6f11cc67422dd835f8a22500939/data/Burkina_Faso/Assembly/ep-popolo-v1.0.json",
         "names": "data/Burkina_Faso/Assembly/names.csv",
         "lastmod": "1469383428",
         "person_count": 475,
-        "sha": "3ee7a4e",
+        "sha": "3ee7a4e410d2e6f11cc67422dd835f8a22500939",
         "legislative_periods": [
           {
             "id": "term/7",
@@ -1546,7 +1546,7 @@
             "start_date": "2015-12-30",
             "slug": "7",
             "csv": "data/Burkina_Faso/Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0f1964d/data/Burkina_Faso/Assembly/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0f1964d0de0a9587b237664f71a6e5724220456d/data/Burkina_Faso/Assembly/term-7.csv"
           },
           {
             "end_date": "2014-10-30",
@@ -1555,7 +1555,7 @@
             "start_date": "2012-12-02",
             "slug": "2012",
             "csv": "data/Burkina_Faso/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8cfc295/data/Burkina_Faso/Assembly/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8cfc29587dc4e3c276c24bcb2dc739fdc5f14d2a/data/Burkina_Faso/Assembly/term-2012.csv"
           },
           {
             "end_date": "2007-05-06",
@@ -1564,7 +1564,7 @@
             "start_date": "2002-06-05",
             "slug": "3",
             "csv": "data/Burkina_Faso/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/94aae4c/data/Burkina_Faso/Assembly/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/94aae4c948cff6e0005a394c893a7d696633db10/data/Burkina_Faso/Assembly/term-3.csv"
           },
           {
             "end_date": "2002-05-05",
@@ -1573,7 +1573,7 @@
             "start_date": "1997-06-07",
             "slug": "2",
             "csv": "data/Burkina_Faso/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0f1964d/data/Burkina_Faso/Assembly/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0f1964d0de0a9587b237664f71a6e5724220456d/data/Burkina_Faso/Assembly/term-2.csv"
           },
           {
             "end_date": "1997-05-11",
@@ -1582,7 +1582,7 @@
             "start_date": "1992-06-15",
             "slug": "1",
             "csv": "data/Burkina_Faso/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8cfc295/data/Burkina_Faso/Assembly/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8cfc29587dc4e3c276c24bcb2dc739fdc5f14d2a/data/Burkina_Faso/Assembly/term-1.csv"
           }
         ],
         "statement_count": 7067
@@ -1600,11 +1600,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Burundi/Assembly/sources",
         "popolo": "data/Burundi/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65e0a0c/data/Burundi/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65e0a0c00f71de4d081ad3e91eb145606b51f4bf/data/Burundi/Assembly/ep-popolo-v1.0.json",
         "names": "data/Burundi/Assembly/names.csv",
         "lastmod": "1469383434",
         "person_count": 227,
-        "sha": "65e0a0c",
+        "sha": "65e0a0c00f71de4d081ad3e91eb145606b51f4bf",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -1612,7 +1612,7 @@
             "start_date": "2015-07-27",
             "slug": "2015",
             "csv": "data/Burundi/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c95447/data/Burundi/Assembly/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c9544747279fd51bf3d47c3e0aa31569bf21953/data/Burundi/Assembly/term-2015.csv"
           },
           {
             "end_date": "2015-04-30",
@@ -1621,7 +1621,7 @@
             "start_date": "2010",
             "slug": "2010",
             "csv": "data/Burundi/Assembly/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d9cf1c4/data/Burundi/Assembly/term-2010.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d9cf1c4a3622b3d7390de2bf3652a5433448236f/data/Burundi/Assembly/term-2010.csv"
           }
         ],
         "statement_count": 2905
@@ -1639,11 +1639,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Cabo_Verde/Assembly/sources",
         "popolo": "data/Cabo_Verde/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37e4fdb/data/Cabo_Verde/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37e4fdb98afdce3f1a6cd6de8de21e1f2cd6da45/data/Cabo_Verde/Assembly/ep-popolo-v1.0.json",
         "names": "data/Cabo_Verde/Assembly/names.csv",
         "lastmod": "1469383444",
         "person_count": 124,
-        "sha": "37e4fdb",
+        "sha": "37e4fdb98afdce3f1a6cd6de8de21e1f2cd6da45",
         "legislative_periods": [
           {
             "id": "term/9",
@@ -1651,7 +1651,7 @@
             "start_date": "2016-04-20",
             "slug": "9",
             "csv": "data/Cabo_Verde/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2131da6/data/Cabo_Verde/Assembly/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2131da66fb80e4d2b0f36265e820e5131e80eb9b/data/Cabo_Verde/Assembly/term-9.csv"
           },
           {
             "end_date": "2016-03-20",
@@ -1660,7 +1660,7 @@
             "start_date": "2011-03-11",
             "slug": "8",
             "csv": "data/Cabo_Verde/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cd9010d/data/Cabo_Verde/Assembly/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cd9010d1241337b6d7eec0cdd8ff0fef6700e4b4/data/Cabo_Verde/Assembly/term-8.csv"
           }
         ],
         "statement_count": 1967
@@ -1678,11 +1678,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Cambodia/National_Assembly/sources",
         "popolo": "data/Cambodia/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/15d084e/data/Cambodia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/15d084e9676e04e0dee14b2aeda193fb3d8156dd/data/Cambodia/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Cambodia/National_Assembly/names.csv",
         "lastmod": "1472104730",
         "person_count": 123,
-        "sha": "15d084e",
+        "sha": "15d084e9676e04e0dee14b2aeda193fb3d8156dd",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -1690,7 +1690,7 @@
             "start_date": "2013-09-23",
             "slug": "5",
             "csv": "data/Cambodia/National_Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/15d084e/data/Cambodia/National_Assembly/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/15d084e9676e04e0dee14b2aeda193fb3d8156dd/data/Cambodia/National_Assembly/term-5.csv"
           }
         ],
         "statement_count": 3210
@@ -1708,11 +1708,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Cameroon/Assembly/sources",
         "popolo": "data/Cameroon/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a3a106e/data/Cameroon/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a3a106e17f6b7d9a0fafd307e2500578086073c6/data/Cameroon/Assembly/ep-popolo-v1.0.json",
         "names": "data/Cameroon/Assembly/names.csv",
         "lastmod": "1469383479",
         "person_count": 964,
-        "sha": "a3a106e",
+        "sha": "a3a106e17f6b7d9a0fafd307e2500578086073c6",
         "legislative_periods": [
           {
             "id": "term/9",
@@ -1720,7 +1720,7 @@
             "start_date": "2013-10-29",
             "slug": "9",
             "csv": "data/Cameroon/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20bd8aa/data/Cameroon/Assembly/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20bd8aa5c71e0a0ab6e8bde8098e963d5acb1c1a/data/Cameroon/Assembly/term-9.csv"
           },
           {
             "end_date": "2013-07-22",
@@ -1729,7 +1729,7 @@
             "start_date": "2007",
             "slug": "8",
             "csv": "data/Cameroon/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/328acb8/data/Cameroon/Assembly/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/328acb852c9c92b4a8aa94598376dfa248d97365/data/Cameroon/Assembly/term-8.csv"
           },
           {
             "end_date": "2007",
@@ -1738,7 +1738,7 @@
             "start_date": "2002",
             "slug": "7",
             "csv": "data/Cameroon/Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1f58720/data/Cameroon/Assembly/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1f5872050a2cdef9def4270f2df08ebb9571747f/data/Cameroon/Assembly/term-7.csv"
           },
           {
             "end_date": "2002",
@@ -1747,7 +1747,7 @@
             "start_date": "1997",
             "slug": "6",
             "csv": "data/Cameroon/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1f58720/data/Cameroon/Assembly/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1f5872050a2cdef9def4270f2df08ebb9571747f/data/Cameroon/Assembly/term-6.csv"
           },
           {
             "end_date": "1997",
@@ -1756,7 +1756,7 @@
             "start_date": "1992",
             "slug": "5",
             "csv": "data/Cameroon/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1f58720/data/Cameroon/Assembly/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1f5872050a2cdef9def4270f2df08ebb9571747f/data/Cameroon/Assembly/term-5.csv"
           },
           {
             "end_date": "1992",
@@ -1765,7 +1765,7 @@
             "start_date": "1988",
             "slug": "4",
             "csv": "data/Cameroon/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/328acb8/data/Cameroon/Assembly/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/328acb852c9c92b4a8aa94598376dfa248d97365/data/Cameroon/Assembly/term-4.csv"
           },
           {
             "end_date": "1988",
@@ -1774,7 +1774,7 @@
             "start_date": "1983",
             "slug": "3",
             "csv": "data/Cameroon/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1f58720/data/Cameroon/Assembly/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1f5872050a2cdef9def4270f2df08ebb9571747f/data/Cameroon/Assembly/term-3.csv"
           },
           {
             "end_date": "1978",
@@ -1783,7 +1783,7 @@
             "start_date": "1973",
             "slug": "1",
             "csv": "data/Cameroon/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/328acb8/data/Cameroon/Assembly/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/328acb852c9c92b4a8aa94598376dfa248d97365/data/Cameroon/Assembly/term-1.csv"
           }
         ],
         "statement_count": 13140
@@ -1793,11 +1793,11 @@
         "slug": "Senate",
         "sources_directory": "data/Cameroon/Senate/sources",
         "popolo": "data/Cameroon/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8c447dc/data/Cameroon/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8c447dcea3786d595ccf7e0dc7b799fd69ea7d15/data/Cameroon/Senate/ep-popolo-v1.0.json",
         "names": "data/Cameroon/Senate/names.csv",
         "lastmod": "1469383484",
         "person_count": 100,
-        "sha": "8c447dc",
+        "sha": "8c447dcea3786d595ccf7e0dc7b799fd69ea7d15",
         "legislative_periods": [
           {
             "id": "term/9",
@@ -1805,7 +1805,7 @@
             "start_date": "2013",
             "slug": "9",
             "csv": "data/Cameroon/Senate/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/328acb8/data/Cameroon/Senate/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/328acb852c9c92b4a8aa94598376dfa248d97365/data/Cameroon/Senate/term-9.csv"
           }
         ],
         "statement_count": 1335
@@ -1823,11 +1823,11 @@
         "slug": "Commons",
         "sources_directory": "data/Canada/Commons/sources",
         "popolo": "data/Canada/Commons/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b4b74a1/data/Canada/Commons/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b4b74a1f7d7b059787ddd8c3187101309f3df13f/data/Canada/Commons/ep-popolo-v1.0.json",
         "names": "data/Canada/Commons/names.csv",
         "lastmod": "1471501332",
         "person_count": 537,
-        "sha": "b4b74a1",
+        "sha": "b4b74a1f7d7b059787ddd8c3187101309f3df13f",
         "legislative_periods": [
           {
             "id": "term/42",
@@ -1836,7 +1836,7 @@
             "wikidata": "Q21157957",
             "slug": "42",
             "csv": "data/Canada/Commons/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b4b74a1/data/Canada/Commons/term-42.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b4b74a1f7d7b059787ddd8c3187101309f3df13f/data/Canada/Commons/term-42.csv"
           },
           {
             "end_date": "2015-08-02",
@@ -1846,7 +1846,7 @@
             "wikidata": "Q2816776",
             "slug": "41",
             "csv": "data/Canada/Commons/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a362ae/data/Canada/Commons/term-41.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a362aed01c4c175ba90b94143e83bb6f5284140/data/Canada/Commons/term-41.csv"
           }
         ],
         "statement_count": 37049
@@ -1864,11 +1864,11 @@
         "slug": "Legislative-Assembly",
         "sources_directory": "data/Cayman_Islands/Legislative_Assembly/sources",
         "popolo": "data/Cayman_Islands/Legislative_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ea90989/data/Cayman_Islands/Legislative_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ea9098986da3e7b9de7dd440bdcbeac450ac0f3b/data/Cayman_Islands/Legislative_Assembly/ep-popolo-v1.0.json",
         "names": "data/Cayman_Islands/Legislative_Assembly/names.csv",
         "lastmod": "1470415359",
         "person_count": 18,
-        "sha": "ea90989",
+        "sha": "ea9098986da3e7b9de7dd440bdcbeac450ac0f3b",
         "legislative_periods": [
           {
             "id": "term/2013",
@@ -1876,7 +1876,7 @@
             "start_date": "2013",
             "slug": "2013",
             "csv": "data/Cayman_Islands/Legislative_Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aabc648/data/Cayman_Islands/Legislative_Assembly/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aabc6480ccf3e5bd173fd80bf3f75cc113eff898/data/Cayman_Islands/Legislative_Assembly/term-2013.csv"
           }
         ],
         "statement_count": 711
@@ -1894,11 +1894,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Chad/Assembly/sources",
         "popolo": "data/Chad/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5033595/data/Chad/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/50335954d24c6884dc1817c5d643212613bf52f3/data/Chad/Assembly/ep-popolo-v1.0.json",
         "names": "data/Chad/Assembly/names.csv",
         "lastmod": "1469383496",
         "person_count": 191,
-        "sha": "5033595",
+        "sha": "50335954d24c6884dc1817c5d643212613bf52f3",
         "legislative_periods": [
           {
             "id": "term/3",
@@ -1906,7 +1906,7 @@
             "start_date": "2011-06-23",
             "slug": "3",
             "csv": "data/Chad/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3d9c70/data/Chad/Assembly/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3d9c706f5545ba2cb9e523ebc6ba1394bd086ee/data/Chad/Assembly/term-3.csv"
           }
         ],
         "statement_count": 2587
@@ -1924,11 +1924,11 @@
         "slug": "Deputies",
         "sources_directory": "data/Chile/Deputies/sources",
         "popolo": "data/Chile/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2cdd841/data/Chile/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2cdd841b8ea7b63a7c1a7020308da9fa7affc173/data/Chile/Deputies/ep-popolo-v1.0.json",
         "names": "data/Chile/Deputies/names.csv",
         "lastmod": "1471340225",
         "person_count": 375,
-        "sha": "2cdd841",
+        "sha": "2cdd841b8ea7b63a7c1a7020308da9fa7affc173",
         "legislative_periods": [
           {
             "end_date": "2018-03-10",
@@ -1937,7 +1937,7 @@
             "start_date": "2014-03-11",
             "slug": "8",
             "csv": "data/Chile/Deputies/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0cbc026/data/Chile/Deputies/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0cbc0268e850bbb90d06d41d64280fc41035abcd/data/Chile/Deputies/term-8.csv"
           },
           {
             "end_date": "2014-03-10",
@@ -1946,7 +1946,7 @@
             "start_date": "2010-03-11",
             "slug": "6",
             "csv": "data/Chile/Deputies/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a43a70/data/Chile/Deputies/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a43a705b7644716568d1ca5833e9f13421228a4/data/Chile/Deputies/term-6.csv"
           },
           {
             "end_date": "2010-03-10",
@@ -1955,7 +1955,7 @@
             "start_date": "2006-03-11",
             "slug": "5",
             "csv": "data/Chile/Deputies/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a43a70/data/Chile/Deputies/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a43a705b7644716568d1ca5833e9f13421228a4/data/Chile/Deputies/term-5.csv"
           },
           {
             "end_date": "2006-03-10",
@@ -1964,7 +1964,7 @@
             "start_date": "2002-03-11",
             "slug": "4",
             "csv": "data/Chile/Deputies/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a43a70/data/Chile/Deputies/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a43a705b7644716568d1ca5833e9f13421228a4/data/Chile/Deputies/term-4.csv"
           },
           {
             "end_date": "2002-03-10",
@@ -1973,7 +1973,7 @@
             "start_date": "1998-03-11",
             "slug": "3",
             "csv": "data/Chile/Deputies/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a43a70/data/Chile/Deputies/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a43a705b7644716568d1ca5833e9f13421228a4/data/Chile/Deputies/term-3.csv"
           },
           {
             "end_date": "1998-03-10",
@@ -1982,7 +1982,7 @@
             "start_date": "1994-03-11",
             "slug": "2",
             "csv": "data/Chile/Deputies/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a43a70/data/Chile/Deputies/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a43a705b7644716568d1ca5833e9f13421228a4/data/Chile/Deputies/term-2.csv"
           },
           {
             "end_date": "1994-03-10",
@@ -1991,7 +1991,7 @@
             "start_date": "1990-03-11",
             "slug": "1",
             "csv": "data/Chile/Deputies/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a43a70/data/Chile/Deputies/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a43a705b7644716568d1ca5833e9f13421228a4/data/Chile/Deputies/term-1.csv"
           }
         ],
         "statement_count": 17642
@@ -2009,11 +2009,11 @@
         "slug": "Congress",
         "sources_directory": "data/China/Congress/sources",
         "popolo": "data/China/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7604952/data/China/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/760495262d32c6f9475471b872474fa438c5a1f2/data/China/Congress/ep-popolo-v1.0.json",
         "names": "data/China/Congress/names.csv",
         "lastmod": "1469383503",
         "person_count": 2956,
-        "sha": "7604952",
+        "sha": "760495262d32c6f9475471b872474fa438c5a1f2",
         "legislative_periods": [
           {
             "id": "term/12",
@@ -2021,7 +2021,7 @@
             "start_date": "2013-03-05",
             "slug": "12",
             "csv": "data/China/Congress/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0345a48/data/China/Congress/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0345a4889f286077972bbe86643d2100cbd54177/data/China/Congress/term-12.csv"
           }
         ],
         "statement_count": 29864
@@ -2039,11 +2039,11 @@
         "slug": "Representatives",
         "sources_directory": "data/Colombia/Representatives/sources",
         "popolo": "data/Colombia/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d22e133/data/Colombia/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d22e1337e2be7926c3f565ef239f58fd19324969/data/Colombia/Representatives/ep-popolo-v1.0.json",
         "names": "data/Colombia/Representatives/names.csv",
         "lastmod": "1470990316",
         "person_count": 168,
-        "sha": "d22e133",
+        "sha": "d22e1337e2be7926c3f565ef239f58fd19324969",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -2051,7 +2051,7 @@
             "start_date": "2014-07-20",
             "slug": "2014",
             "csv": "data/Colombia/Representatives/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e148d09/data/Colombia/Representatives/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e148d09a66d15e72cda422c084ae6b63dc3e570d/data/Colombia/Representatives/term-2014.csv"
           }
         ],
         "statement_count": 4745
@@ -2061,11 +2061,11 @@
         "slug": "Senate",
         "sources_directory": "data/Colombia/Senate/sources",
         "popolo": "data/Colombia/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb7d868/data/Colombia/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb7d868f1b546d78803dbeaf8b63e41d851ec3b1/data/Colombia/Senate/ep-popolo-v1.0.json",
         "names": "data/Colombia/Senate/names.csv",
         "lastmod": "1471403548",
         "person_count": 101,
-        "sha": "eb7d868",
+        "sha": "eb7d868f1b546d78803dbeaf8b63e41d851ec3b1",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -2073,7 +2073,7 @@
             "start_date": "2014-07-20",
             "slug": "2014",
             "csv": "data/Colombia/Senate/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8e591d8/data/Colombia/Senate/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8e591d8a2ae29560e3b57783487c52311a360013/data/Colombia/Senate/term-2014.csv"
           }
         ],
         "statement_count": 4936
@@ -2091,11 +2091,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Comoros/Assembly/sources",
         "popolo": "data/Comoros/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/67e993d/data/Comoros/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/67e993d5001e1883501fb83b0d09697617573315/data/Comoros/Assembly/ep-popolo-v1.0.json",
         "names": "data/Comoros/Assembly/names.csv",
         "lastmod": "1469383518",
         "person_count": 24,
-        "sha": "67e993d",
+        "sha": "67e993d5001e1883501fb83b0d09697617573315",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -2103,7 +2103,7 @@
             "start_date": "2015-04-03",
             "slug": "2015",
             "csv": "data/Comoros/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed2db8/data/Comoros/Assembly/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed2db8bbaa9f9cf554757ca4d748d07a7c6790d/data/Comoros/Assembly/term-2015.csv"
           }
         ],
         "statement_count": 771
@@ -2121,11 +2121,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Congo-Brazzaville/Assembly/sources",
         "popolo": "data/Congo-Brazzaville/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2a10542/data/Congo-Brazzaville/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2a105426f8ecaa0e8f140ad0cb1011fb2b21ffd0/data/Congo-Brazzaville/Assembly/ep-popolo-v1.0.json",
         "names": "data/Congo-Brazzaville/Assembly/names.csv",
         "lastmod": "1469383525",
         "person_count": 122,
-        "sha": "2a10542",
+        "sha": "2a105426f8ecaa0e8f140ad0cb1011fb2b21ffd0",
         "legislative_periods": [
           {
             "id": "term/13",
@@ -2133,7 +2133,7 @@
             "start_date": "2012-09-05",
             "slug": "13",
             "csv": "data/Congo-Brazzaville/Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4ae0017/data/Congo-Brazzaville/Assembly/term-13.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4ae00172d44ffa52ebd99772ba9f5c147a7829da/data/Congo-Brazzaville/Assembly/term-13.csv"
           }
         ],
         "statement_count": 2672
@@ -2151,11 +2151,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Congo-Kinshasa/Assembly/sources",
         "popolo": "data/Congo-Kinshasa/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3b24771/data/Congo-Kinshasa/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3b247718a723e8154290c0da5853f724c268da0c/data/Congo-Kinshasa/Assembly/ep-popolo-v1.0.json",
         "names": "data/Congo-Kinshasa/Assembly/names.csv",
         "lastmod": "1470416719",
         "person_count": 498,
-        "sha": "3b24771",
+        "sha": "3b247718a723e8154290c0da5853f724c268da0c",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -2163,7 +2163,7 @@
             "start_date": "2012-02-16",
             "slug": "2012",
             "csv": "data/Congo-Kinshasa/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4708746/data/Congo-Kinshasa/Assembly/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47087463bdf1ecbad42a9792df0c2b1b89b90353/data/Congo-Kinshasa/Assembly/term-2012.csv"
           }
         ],
         "statement_count": 6859
@@ -2181,11 +2181,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Cook_Islands/Parliament/sources",
         "popolo": "data/Cook_Islands/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/73edf0a/data/Cook_Islands/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/73edf0a8f5e6a711517757405a5a0c791c3116ad/data/Cook_Islands/Parliament/ep-popolo-v1.0.json",
         "names": "data/Cook_Islands/Parliament/names.csv",
         "lastmod": "1470406245",
         "person_count": 49,
-        "sha": "73edf0a",
+        "sha": "73edf0a8f5e6a711517757405a5a0c791c3116ad",
         "legislative_periods": [
           {
             "id": "term/14",
@@ -2193,7 +2193,7 @@
             "start_date": "2014",
             "slug": "14",
             "csv": "data/Cook_Islands/Parliament/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/10f8114/data/Cook_Islands/Parliament/term-14.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/10f8114ad0630edb7161b07bd51942b2c52a2d30/data/Cook_Islands/Parliament/term-14.csv"
           },
           {
             "end_date": "2014-04-17",
@@ -2202,7 +2202,7 @@
             "start_date": "2011-02-18",
             "slug": "13",
             "csv": "data/Cook_Islands/Parliament/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8967442e/data/Cook_Islands/Parliament/term-13.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8967442eb4df41fa7caf4b368384d9f67f85ceea/data/Cook_Islands/Parliament/term-13.csv"
           },
           {
             "end_date": "2010-09-24",
@@ -2211,7 +2211,7 @@
             "start_date": "2006",
             "slug": "12",
             "csv": "data/Cook_Islands/Parliament/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e53b65b/data/Cook_Islands/Parliament/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e53b65b967e1f0aef92f6eeeed517224483d1f3b/data/Cook_Islands/Parliament/term-12.csv"
           }
         ],
         "statement_count": 2367
@@ -2229,11 +2229,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Costa_Rica/Assembly/sources",
         "popolo": "data/Costa_Rica/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ce71b1/data/Costa_Rica/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ce71b186b69056a005f86d1be0adff0ad3b3d7f/data/Costa_Rica/Assembly/ep-popolo-v1.0.json",
         "names": "data/Costa_Rica/Assembly/names.csv",
         "lastmod": "1469850208",
         "person_count": 57,
-        "sha": "5ce71b1",
+        "sha": "5ce71b186b69056a005f86d1be0adff0ad3b3d7f",
         "legislative_periods": [
           {
             "end_date": "2018-04-30",
@@ -2242,7 +2242,7 @@
             "start_date": "2014-05-01",
             "slug": "2014",
             "csv": "data/Costa_Rica/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/085df36/data/Costa_Rica/Assembly/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/085df367dcd8319e828107a845256595fddb335c/data/Costa_Rica/Assembly/term-2014.csv"
           }
         ],
         "statement_count": 2082
@@ -2260,11 +2260,11 @@
         "slug": "Sabor",
         "sources_directory": "data/Croatia/Sabor/sources",
         "popolo": "data/Croatia/Sabor/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5509d66/data/Croatia/Sabor/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5509d6676b8ef418d585a436f609fe8b6954290d/data/Croatia/Sabor/ep-popolo-v1.0.json",
         "names": "data/Croatia/Sabor/names.csv",
         "lastmod": "1472099930",
         "person_count": 287,
-        "sha": "5509d66",
+        "sha": "5509d6676b8ef418d585a436f609fe8b6954290d",
         "legislative_periods": [
           {
             "id": "term/8",
@@ -2272,7 +2272,7 @@
             "start_date": "2015-12-28",
             "slug": "8",
             "csv": "data/Croatia/Sabor/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/672c0a2/data/Croatia/Sabor/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/672c0a201b372c107fc686643cfa8f72b667094a/data/Croatia/Sabor/term-8.csv"
           },
           {
             "end_date": "2015-09-28",
@@ -2281,7 +2281,7 @@
             "start_date": "2011-12-22",
             "slug": "7",
             "csv": "data/Croatia/Sabor/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0600433/data/Croatia/Sabor/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0600433190d8889828e6f87c4a629383e791471d/data/Croatia/Sabor/term-7.csv"
           }
         ],
         "statement_count": 9813
@@ -2299,11 +2299,11 @@
         "slug": "Estates",
         "sources_directory": "data/Curacao/Estates/sources",
         "popolo": "data/Curacao/Estates/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/897ab02/data/Curacao/Estates/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/897ab0246523a71fc1e27365b497172ec4a76e83/data/Curacao/Estates/ep-popolo-v1.0.json",
         "names": "data/Curacao/Estates/names.csv",
         "lastmod": "1469383583",
         "person_count": 21,
-        "sha": "897ab02",
+        "sha": "897ab0246523a71fc1e27365b497172ec4a76e83",
         "legislative_periods": [
           {
             "id": "term/2",
@@ -2311,7 +2311,7 @@
             "start_date": "2012-09-11",
             "slug": "2",
             "csv": "data/Curacao/Estates/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/86188ca/data/Curacao/Estates/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/86188ca53e2567e0a1376e4820d2684b3730bb8e/data/Curacao/Estates/term-2.csv"
           }
         ],
         "statement_count": 522
@@ -2329,11 +2329,11 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Cyprus/House_of_Representatives/sources",
         "popolo": "data/Cyprus/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ce3d92/data/Cyprus/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ce3d922dcdf17892bb497eb32b3aa4597014767/data/Cyprus/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Cyprus/House_of_Representatives/names.csv",
         "lastmod": "1472087762",
         "person_count": 91,
-        "sha": "1ce3d92",
+        "sha": "1ce3d922dcdf17892bb497eb32b3aa4597014767",
         "legislative_periods": [
           {
             "id": "term/11",
@@ -2341,7 +2341,7 @@
             "start_date": "2016-06-02",
             "slug": "11",
             "csv": "data/Cyprus/House_of_Representatives/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e6c65e6/data/Cyprus/House_of_Representatives/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e6c65e62f36d35d7acfa0beca5e71b60c5b0a79a/data/Cyprus/House_of_Representatives/term-11.csv"
           },
           {
             "end_date": "2016-04-14",
@@ -2350,7 +2350,7 @@
             "start_date": "2011-06-02",
             "slug": "10",
             "csv": "data/Cyprus/House_of_Representatives/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74fbe96/data/Cyprus/House_of_Representatives/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/74fbe962b10733b7ef07b9444183c60fb9827ba6/data/Cyprus/House_of_Representatives/term-10.csv"
           }
         ],
         "statement_count": 5449
@@ -2368,11 +2368,11 @@
         "slug": "Deputies",
         "sources_directory": "data/Czech_Republic/Deputies/sources",
         "popolo": "data/Czech_Republic/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2fda306/data/Czech_Republic/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2fda306e47c6114631d910fa10551625d235fadb/data/Czech_Republic/Deputies/ep-popolo-v1.0.json",
         "names": "data/Czech_Republic/Deputies/names.csv",
         "lastmod": "1472099625",
         "person_count": 893,
-        "sha": "2fda306",
+        "sha": "2fda306e47c6114631d910fa10551625d235fadb",
         "legislative_periods": [
           {
             "id": "term/7",
@@ -2380,7 +2380,7 @@
             "start_date": "2013-10-26",
             "slug": "7",
             "csv": "data/Czech_Republic/Deputies/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4290041/data/Czech_Republic/Deputies/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/42900418f78a27525fa939246b439e9bbd11734c/data/Czech_Republic/Deputies/term-7.csv"
           },
           {
             "end_date": "2013-08-28",
@@ -2389,7 +2389,7 @@
             "start_date": "2010-05-29",
             "slug": "6",
             "csv": "data/Czech_Republic/Deputies/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4290041/data/Czech_Republic/Deputies/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/42900418f78a27525fa939246b439e9bbd11734c/data/Czech_Republic/Deputies/term-6.csv"
           },
           {
             "end_date": "2010-06-03",
@@ -2398,7 +2398,7 @@
             "start_date": "2006-06-03",
             "slug": "5",
             "csv": "data/Czech_Republic/Deputies/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ea69b2d/data/Czech_Republic/Deputies/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ea69b2db60db883eabfc249544848d84f6b5a72d/data/Czech_Republic/Deputies/term-5.csv"
           },
           {
             "end_date": "2006-06-15",
@@ -2407,7 +2407,7 @@
             "start_date": "2002-06-15",
             "slug": "4",
             "csv": "data/Czech_Republic/Deputies/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1d49588/data/Czech_Republic/Deputies/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1d4958844756aa60c16fe6200c7e163396156863/data/Czech_Republic/Deputies/term-4.csv"
           },
           {
             "end_date": "2002-06-20",
@@ -2416,7 +2416,7 @@
             "start_date": "1998-06-20",
             "slug": "3",
             "csv": "data/Czech_Republic/Deputies/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4290041/data/Czech_Republic/Deputies/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/42900418f78a27525fa939246b439e9bbd11734c/data/Czech_Republic/Deputies/term-3.csv"
           },
           {
             "end_date": "1998-06-19",
@@ -2425,7 +2425,7 @@
             "start_date": "1996-06-01",
             "slug": "2",
             "csv": "data/Czech_Republic/Deputies/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ea69b2d/data/Czech_Republic/Deputies/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ea69b2db60db883eabfc249544848d84f6b5a72d/data/Czech_Republic/Deputies/term-2.csv"
           },
           {
             "end_date": "1996-06-06",
@@ -2434,7 +2434,7 @@
             "start_date": "1992-06-06",
             "slug": "1",
             "csv": "data/Czech_Republic/Deputies/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ea69b2d/data/Czech_Republic/Deputies/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ea69b2db60db883eabfc249544848d84f6b5a72d/data/Czech_Republic/Deputies/term-1.csv"
           }
         ],
         "statement_count": 153370
@@ -2452,11 +2452,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Ivory_Coast/Assembly/sources",
         "popolo": "data/Ivory_Coast/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/84ebd2a/data/Ivory_Coast/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/84ebd2a5ac443702f898a0485e09127c52fdb2f6/data/Ivory_Coast/Assembly/ep-popolo-v1.0.json",
         "names": "data/Ivory_Coast/Assembly/names.csv",
         "lastmod": "1469384200",
         "person_count": 241,
-        "sha": "84ebd2a",
+        "sha": "84ebd2a5ac443702f898a0485e09127c52fdb2f6",
         "legislative_periods": [
           {
             "id": "term/2.2",
@@ -2464,7 +2464,7 @@
             "start_date": "2012-03-12",
             "slug": "2.2",
             "csv": "data/Ivory_Coast/Assembly/term-2.2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/113211d/data/Ivory_Coast/Assembly/term-2.2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/113211d6715ec0c6dd56d04ce17017e593ddcbd5/data/Ivory_Coast/Assembly/term-2.2.csv"
           }
         ],
         "statement_count": 4271
@@ -2482,11 +2482,11 @@
         "slug": "Folketing",
         "sources_directory": "data/Denmark/Folketing/sources",
         "popolo": "data/Denmark/Folketing/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6c575b3/data/Denmark/Folketing/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6c575b3452276fbede80955fefd0b0ee6325e483/data/Denmark/Folketing/ep-popolo-v1.0.json",
         "names": "data/Denmark/Folketing/names.csv",
         "lastmod": "1471534982",
         "person_count": 613,
-        "sha": "6c575b3",
+        "sha": "6c575b3452276fbede80955fefd0b0ee6325e483",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -2494,7 +2494,7 @@
             "start_date": "2015-06-20",
             "slug": "2015",
             "csv": "data/Denmark/Folketing/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6c6388a/data/Denmark/Folketing/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6c6388a9a89c1a8df7155dec9939e9495efe4ffd/data/Denmark/Folketing/term-2015.csv"
           },
           {
             "end_date": "2015-06-19",
@@ -2503,7 +2503,7 @@
             "start_date": "2011-09-15",
             "slug": "2011",
             "csv": "data/Denmark/Folketing/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d211ba/data/Denmark/Folketing/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d211ba83b98cb4fb674807e279bdbfcbf8745b8/data/Denmark/Folketing/term-2011.csv"
           },
           {
             "end_date": "2011-09-14",
@@ -2512,7 +2512,7 @@
             "start_date": "2007-11-13",
             "slug": "2007",
             "csv": "data/Denmark/Folketing/term-2007.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d211ba/data/Denmark/Folketing/term-2007.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d211ba83b98cb4fb674807e279bdbfcbf8745b8/data/Denmark/Folketing/term-2007.csv"
           },
           {
             "end_date": "2007-11-12",
@@ -2521,7 +2521,7 @@
             "start_date": "2005-02-08",
             "slug": "2005",
             "csv": "data/Denmark/Folketing/term-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d211ba/data/Denmark/Folketing/term-2005.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d211ba83b98cb4fb674807e279bdbfcbf8745b8/data/Denmark/Folketing/term-2005.csv"
           },
           {
             "end_date": "2005-02-07",
@@ -2530,7 +2530,7 @@
             "start_date": "2001-11-20",
             "slug": "2001",
             "csv": "data/Denmark/Folketing/term-2001.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d211ba/data/Denmark/Folketing/term-2001.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d211ba83b98cb4fb674807e279bdbfcbf8745b8/data/Denmark/Folketing/term-2001.csv"
           },
           {
             "end_date": "2001-11-19",
@@ -2539,7 +2539,7 @@
             "start_date": "1998-11-03",
             "slug": "1998",
             "csv": "data/Denmark/Folketing/term-1998.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2dba738/data/Denmark/Folketing/term-1998.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2dba738654be3cc5309f2d9b96b5726869fe135f/data/Denmark/Folketing/term-1998.csv"
           },
           {
             "end_date": "1998-11-02",
@@ -2548,7 +2548,7 @@
             "start_date": "1994-09-21",
             "slug": "1994",
             "csv": "data/Denmark/Folketing/term-1994.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d211ba/data/Denmark/Folketing/term-1994.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d211ba83b98cb4fb674807e279bdbfcbf8745b8/data/Denmark/Folketing/term-1994.csv"
           },
           {
             "end_date": "1994-09-20",
@@ -2557,7 +2557,7 @@
             "start_date": "1990-12-12",
             "slug": "1990",
             "csv": "data/Denmark/Folketing/term-1990.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d211ba/data/Denmark/Folketing/term-1990.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d211ba83b98cb4fb674807e279bdbfcbf8745b8/data/Denmark/Folketing/term-1990.csv"
           }
         ],
         "statement_count": 40070
@@ -2575,11 +2575,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Djibouti/Assembly/sources",
         "popolo": "data/Djibouti/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/074a8f1/data/Djibouti/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/074a8f113d455d32a5d91c2f22291607d53601c6/data/Djibouti/Assembly/ep-popolo-v1.0.json",
         "names": "data/Djibouti/Assembly/names.csv",
         "lastmod": "1469383621",
         "person_count": 65,
-        "sha": "074a8f1",
+        "sha": "074a8f113d455d32a5d91c2f22291607d53601c6",
         "legislative_periods": [
           {
             "id": "term/6",
@@ -2587,7 +2587,7 @@
             "start_date": "2013-03-05",
             "slug": "6",
             "csv": "data/Djibouti/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dfe56e2/data/Djibouti/Assembly/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dfe56e242be3f70e40d4ebb562e237f2bd80e97f/data/Djibouti/Assembly/term-6.csv"
           }
         ],
         "statement_count": 825
@@ -2605,11 +2605,11 @@
         "slug": "House-of-Assembly",
         "sources_directory": "data/Dominica/House_of_Assembly/sources",
         "popolo": "data/Dominica/House_of_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cf93d09/data/Dominica/House_of_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cf93d0955e873151d04a62baef8899f3d6bb6a8a/data/Dominica/House_of_Assembly/ep-popolo-v1.0.json",
         "names": "data/Dominica/House_of_Assembly/names.csv",
         "lastmod": "1469383627",
         "person_count": 21,
-        "sha": "cf93d09",
+        "sha": "cf93d0955e873151d04a62baef8899f3d6bb6a8a",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -2617,7 +2617,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/Dominica/House_of_Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c7d9c92/data/Dominica/House_of_Assembly/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c7d9c925e3bf0558f0eb2e1d0e5cdef1f0428485/data/Dominica/House_of_Assembly/term-2014.csv"
           }
         ],
         "statement_count": 520
@@ -2635,11 +2635,11 @@
         "slug": "Diputados",
         "sources_directory": "data/Dominican_Republic/Diputados/sources",
         "popolo": "data/Dominican_Republic/Diputados/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1bdb936/data/Dominican_Republic/Diputados/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1bdb936b65cff60facc43ae425b3edff80b89441/data/Dominican_Republic/Diputados/ep-popolo-v1.0.json",
         "names": "data/Dominican_Republic/Diputados/names.csv",
         "lastmod": "1469806255",
         "person_count": 190,
-        "sha": "1bdb936",
+        "sha": "1bdb936b65cff60facc43ae425b3edff80b89441",
         "legislative_periods": [
           {
             "end_date": "2016-08-15",
@@ -2648,7 +2648,7 @@
             "start_date": "2010",
             "slug": "2010",
             "csv": "data/Dominican_Republic/Diputados/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1bdb936/data/Dominican_Republic/Diputados/term-2010.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1bdb936b65cff60facc43ae425b3edff80b89441/data/Dominican_Republic/Diputados/term-2010.csv"
           }
         ],
         "statement_count": 3777
@@ -2666,11 +2666,11 @@
         "slug": "Asamblea",
         "sources_directory": "data/Ecuador/Asamblea/sources",
         "popolo": "data/Ecuador/Asamblea/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0bea93c/data/Ecuador/Asamblea/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0bea93c9a0cca5dcfc84f37324ff35b70cffe281/data/Ecuador/Asamblea/ep-popolo-v1.0.json",
         "names": "data/Ecuador/Asamblea/names.csv",
         "lastmod": "1471997102",
         "person_count": 140,
-        "sha": "0bea93c",
+        "sha": "0bea93c9a0cca5dcfc84f37324ff35b70cffe281",
         "legislative_periods": [
           {
             "id": "term/2013",
@@ -2678,7 +2678,7 @@
             "start_date": "2013-05-14",
             "slug": "2013",
             "csv": "data/Ecuador/Asamblea/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0b326e2/data/Ecuador/Asamblea/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0b326e2f2f2c67bdccc627eded1e94092c41061e/data/Ecuador/Asamblea/term-2013.csv"
           }
         ],
         "statement_count": 4369
@@ -2696,11 +2696,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Egypt/Parliament/sources",
         "popolo": "data/Egypt/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0470b97/data/Egypt/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0470b97ec2f1f3045c6d47fc5d9b4c505fc5b247/data/Egypt/Parliament/ep-popolo-v1.0.json",
         "names": "data/Egypt/Parliament/names.csv",
         "lastmod": "1471245281",
         "person_count": 600,
-        "sha": "0470b97",
+        "sha": "0470b97ec2f1f3045c6d47fc5d9b4c505fc5b247",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -2708,7 +2708,7 @@
             "start_date": "2016-01-10",
             "slug": "2015",
             "csv": "data/Egypt/Parliament/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0470b97/data/Egypt/Parliament/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0470b97ec2f1f3045c6d47fc5d9b4c505fc5b247/data/Egypt/Parliament/term-2015.csv"
           }
         ],
         "statement_count": 7098
@@ -2726,11 +2726,11 @@
         "slug": "Legislative-Assembly",
         "sources_directory": "data/El_Salvador/Legislative_Assembly/sources",
         "popolo": "data/El_Salvador/Legislative_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9c6ba38/data/El_Salvador/Legislative_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9c6ba38a284943690503ce8a56e409f0c328cab2/data/El_Salvador/Legislative_Assembly/ep-popolo-v1.0.json",
         "names": "data/El_Salvador/Legislative_Assembly/names.csv",
         "lastmod": "1469383666",
         "person_count": 84,
-        "sha": "9c6ba38",
+        "sha": "9c6ba38a284943690503ce8a56e409f0c328cab2",
         "legislative_periods": [
           {
             "end_date": "2018",
@@ -2739,7 +2739,7 @@
             "start_date": "2015-05-14",
             "slug": "2015-2018",
             "csv": "data/El_Salvador/Legislative_Assembly/term-2015-2018.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1f39282/data/El_Salvador/Legislative_Assembly/term-2015-2018.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1f392827b805f12e718d2db08d8df2c234d7a805/data/El_Salvador/Legislative_Assembly/term-2015-2018.csv"
           }
         ],
         "statement_count": 1897
@@ -2757,11 +2757,11 @@
         "slug": "Riigikogu",
         "sources_directory": "data/Estonia/Riigikogu/sources",
         "popolo": "data/Estonia/Riigikogu/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c160641/data/Estonia/Riigikogu/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c160641e17a102120e3b461c9b59d3abb1138ec7/data/Estonia/Riigikogu/ep-popolo-v1.0.json",
         "names": "data/Estonia/Riigikogu/names.csv",
         "lastmod": "1471258258",
         "person_count": 193,
-        "sha": "c160641",
+        "sha": "c160641e17a102120e3b461c9b59d3abb1138ec7",
         "legislative_periods": [
           {
             "id": "term/13",
@@ -2770,7 +2770,7 @@
             "wikidata": "Q20530392",
             "slug": "13",
             "csv": "data/Estonia/Riigikogu/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b025d28/data/Estonia/Riigikogu/term-13.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b025d28f9c398ab5bcf9d2f1a1383ff2fe91b8a1/data/Estonia/Riigikogu/term-13.csv"
           },
           {
             "end_date": "2015-03-23",
@@ -2780,7 +2780,7 @@
             "wikidata": "Q967549",
             "slug": "12",
             "csv": "data/Estonia/Riigikogu/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b025d28/data/Estonia/Riigikogu/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b025d28f9c398ab5bcf9d2f1a1383ff2fe91b8a1/data/Estonia/Riigikogu/term-12.csv"
           }
         ],
         "statement_count": 16209
@@ -2798,11 +2798,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Falkland_Islands/Assembly/sources",
         "popolo": "data/Falkland_Islands/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2463fe5/data/Falkland_Islands/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2463fe56a7eac4ae8f7897f0fa44de05ca14659a/data/Falkland_Islands/Assembly/ep-popolo-v1.0.json",
         "names": "data/Falkland_Islands/Assembly/names.csv",
         "lastmod": "1470460635",
         "person_count": 49,
-        "sha": "2463fe5",
+        "sha": "2463fe56a7eac4ae8f7897f0fa44de05ca14659a",
         "legislative_periods": [
           {
             "end_date": "2017",
@@ -2811,7 +2811,7 @@
             "start_date": "2013-11-07",
             "slug": "2013",
             "csv": "data/Falkland_Islands/Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be7c9cc/data/Falkland_Islands/Assembly/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be7c9cc554976d25be12cd644dd25f35b77c9ea9/data/Falkland_Islands/Assembly/term-2013.csv"
           },
           {
             "end_date": "2013",
@@ -2820,7 +2820,7 @@
             "start_date": "2009",
             "slug": "2009",
             "csv": "data/Falkland_Islands/Assembly/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be7c9cc/data/Falkland_Islands/Assembly/term-2009.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be7c9cc554976d25be12cd644dd25f35b77c9ea9/data/Falkland_Islands/Assembly/term-2009.csv"
           },
           {
             "end_date": "2009",
@@ -2829,7 +2829,7 @@
             "start_date": "2005",
             "slug": "2005",
             "csv": "data/Falkland_Islands/Assembly/term-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a11dbc4/data/Falkland_Islands/Assembly/term-2005.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a11dbc43965e210cc7fd0670eb07642798ec5eec/data/Falkland_Islands/Assembly/term-2005.csv"
           },
           {
             "end_date": "2005",
@@ -2838,7 +2838,7 @@
             "start_date": "2001",
             "slug": "2001",
             "csv": "data/Falkland_Islands/Assembly/term-2001.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9be8b81/data/Falkland_Islands/Assembly/term-2001.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9be8b8127e01b1cb0bca2b1db48b47af22e2faf1/data/Falkland_Islands/Assembly/term-2001.csv"
           },
           {
             "end_date": "2001",
@@ -2847,7 +2847,7 @@
             "start_date": "1997",
             "slug": "1997",
             "csv": "data/Falkland_Islands/Assembly/term-1997.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9be8b81/data/Falkland_Islands/Assembly/term-1997.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9be8b8127e01b1cb0bca2b1db48b47af22e2faf1/data/Falkland_Islands/Assembly/term-1997.csv"
           },
           {
             "end_date": "1997",
@@ -2856,7 +2856,7 @@
             "start_date": "1993",
             "slug": "1993",
             "csv": "data/Falkland_Islands/Assembly/term-1993.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9be8b81/data/Falkland_Islands/Assembly/term-1993.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9be8b8127e01b1cb0bca2b1db48b47af22e2faf1/data/Falkland_Islands/Assembly/term-1993.csv"
           },
           {
             "end_date": "1993",
@@ -2865,7 +2865,7 @@
             "start_date": "1989",
             "slug": "1989",
             "csv": "data/Falkland_Islands/Assembly/term-1989.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9be8b81/data/Falkland_Islands/Assembly/term-1989.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9be8b8127e01b1cb0bca2b1db48b47af22e2faf1/data/Falkland_Islands/Assembly/term-1989.csv"
           },
           {
             "end_date": "1989",
@@ -2874,7 +2874,7 @@
             "start_date": "1985",
             "slug": "1985",
             "csv": "data/Falkland_Islands/Assembly/term-1985.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9be8b81/data/Falkland_Islands/Assembly/term-1985.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9be8b8127e01b1cb0bca2b1db48b47af22e2faf1/data/Falkland_Islands/Assembly/term-1985.csv"
           },
           {
             "end_date": "1985",
@@ -2883,7 +2883,7 @@
             "start_date": "1981",
             "slug": "1981",
             "csv": "data/Falkland_Islands/Assembly/term-1981.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d592dd3/data/Falkland_Islands/Assembly/term-1981.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d592dd3a755cfd2d660c66a0ceea35c6b5ee6810/data/Falkland_Islands/Assembly/term-1981.csv"
           },
           {
             "end_date": "1981",
@@ -2892,7 +2892,7 @@
             "start_date": "1977",
             "slug": "1977",
             "csv": "data/Falkland_Islands/Assembly/term-1977.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ae8e532/data/Falkland_Islands/Assembly/term-1977.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ae8e5320987af90005f813b9f863031a997b78e6/data/Falkland_Islands/Assembly/term-1977.csv"
           }
         ],
         "statement_count": 2027
@@ -2910,11 +2910,11 @@
         "slug": "Logting",
         "sources_directory": "data/Faroe_Islands/Logting/sources",
         "popolo": "data/Faroe_Islands/Logting/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/04f594a/data/Faroe_Islands/Logting/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/04f594a923a3b76d7b3d244132deb5dfbc759a14/data/Faroe_Islands/Logting/ep-popolo-v1.0.json",
         "names": "data/Faroe_Islands/Logting/names.csv",
         "lastmod": "1471347917",
         "person_count": 104,
-        "sha": "04f594a",
+        "sha": "04f594a923a3b76d7b3d244132deb5dfbc759a14",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -2922,7 +2922,7 @@
             "start_date": "2015-09-01",
             "slug": "2015",
             "csv": "data/Faroe_Islands/Logting/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2c82e9a/data/Faroe_Islands/Logting/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2c82e9a9c14df5c8921ede8c48ff9f4bc3dbfed3/data/Faroe_Islands/Logting/term-2015.csv"
           },
           {
             "end_date": "2015-09-01",
@@ -2931,7 +2931,7 @@
             "start_date": "2011-10-29",
             "slug": "2011",
             "csv": "data/Faroe_Islands/Logting/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2c82e9a/data/Faroe_Islands/Logting/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2c82e9a9c14df5c8921ede8c48ff9f4bc3dbfed3/data/Faroe_Islands/Logting/term-2011.csv"
           },
           {
             "end_date": "2011-10-29",
@@ -2940,7 +2940,7 @@
             "start_date": "2008-01-19",
             "slug": "2008",
             "csv": "data/Faroe_Islands/Logting/term-2008.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2c82e9a/data/Faroe_Islands/Logting/term-2008.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2c82e9a9c14df5c8921ede8c48ff9f4bc3dbfed3/data/Faroe_Islands/Logting/term-2008.csv"
           },
           {
             "end_date": "2008-01-19",
@@ -2949,7 +2949,7 @@
             "start_date": "2004",
             "slug": "2004",
             "csv": "data/Faroe_Islands/Logting/term-2004.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2c82e9a/data/Faroe_Islands/Logting/term-2004.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2c82e9a9c14df5c8921ede8c48ff9f4bc3dbfed3/data/Faroe_Islands/Logting/term-2004.csv"
           },
           {
             "end_date": "2004",
@@ -2958,7 +2958,7 @@
             "start_date": "2002",
             "slug": "2002",
             "csv": "data/Faroe_Islands/Logting/term-2002.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/007547d/data/Faroe_Islands/Logting/term-2002.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/007547d714b196f7f6332b5add2b8402b387b5c7/data/Faroe_Islands/Logting/term-2002.csv"
           },
           {
             "end_date": "2002",
@@ -2967,7 +2967,7 @@
             "start_date": "1998",
             "slug": "1998",
             "csv": "data/Faroe_Islands/Logting/term-1998.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/007547d/data/Faroe_Islands/Logting/term-1998.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/007547d714b196f7f6332b5add2b8402b387b5c7/data/Faroe_Islands/Logting/term-1998.csv"
           },
           {
             "end_date": "1998",
@@ -2976,7 +2976,7 @@
             "start_date": "1994",
             "slug": "1994",
             "csv": "data/Faroe_Islands/Logting/term-1994.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/007547d/data/Faroe_Islands/Logting/term-1994.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/007547d714b196f7f6332b5add2b8402b387b5c7/data/Faroe_Islands/Logting/term-1994.csv"
           },
           {
             "end_date": "1994",
@@ -2985,7 +2985,7 @@
             "start_date": "1990",
             "slug": "1990",
             "csv": "data/Faroe_Islands/Logting/term-1990.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/007547d/data/Faroe_Islands/Logting/term-1990.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/007547d714b196f7f6332b5add2b8402b387b5c7/data/Faroe_Islands/Logting/term-1990.csv"
           }
         ],
         "statement_count": 7362
@@ -3003,11 +3003,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Fiji/Parliament/sources",
         "popolo": "data/Fiji/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f15ed0f/data/Fiji/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f15ed0f24fd1b555ac5f53a49bfc8ccea696b0ee/data/Fiji/Parliament/ep-popolo-v1.0.json",
         "names": "data/Fiji/Parliament/names.csv",
         "lastmod": "1469383704",
         "person_count": 54,
-        "sha": "f15ed0f",
+        "sha": "f15ed0f24fd1b555ac5f53a49bfc8ccea696b0ee",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -3015,7 +3015,7 @@
             "start_date": "2014-10-06",
             "slug": "2014",
             "csv": "data/Fiji/Parliament/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bc017e8/data/Fiji/Parliament/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bc017e86d63713d7226a0d758aa47a1914351d00/data/Fiji/Parliament/term-2014.csv"
           }
         ],
         "statement_count": 897
@@ -3033,11 +3033,11 @@
         "slug": "Eduskunta",
         "sources_directory": "data/Finland/Eduskunta/sources",
         "popolo": "data/Finland/Eduskunta/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47157bc/data/Finland/Eduskunta/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47157bc43d33662158300219ca8eba2dccc13b04/data/Finland/Eduskunta/ep-popolo-v1.0.json",
         "names": "data/Finland/Eduskunta/names.csv",
         "lastmod": "1472085793",
         "person_count": 494,
-        "sha": "47157bc",
+        "sha": "47157bc43d33662158300219ca8eba2dccc13b04",
         "legislative_periods": [
           {
             "end_date": "2019",
@@ -3046,7 +3046,7 @@
             "start_date": "2015-04-28",
             "slug": "37",
             "csv": "data/Finland/Eduskunta/term-37.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47157bc/data/Finland/Eduskunta/term-37.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47157bc43d33662158300219ca8eba2dccc13b04/data/Finland/Eduskunta/term-37.csv"
           },
           {
             "end_date": "2015-03-14",
@@ -3055,7 +3055,7 @@
             "start_date": "2011-04-20",
             "slug": "36",
             "csv": "data/Finland/Eduskunta/term-36.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aaa0477/data/Finland/Eduskunta/term-36.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aaa047713a14e0fed252cb7a8a272c9d9cb45414/data/Finland/Eduskunta/term-36.csv"
           },
           {
             "end_date": "2011-04-19",
@@ -3064,7 +3064,7 @@
             "start_date": "2007-03-21",
             "slug": "35",
             "csv": "data/Finland/Eduskunta/term-35.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aaa0477/data/Finland/Eduskunta/term-35.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aaa047713a14e0fed252cb7a8a272c9d9cb45414/data/Finland/Eduskunta/term-35.csv"
           },
           {
             "end_date": "2007-03-20",
@@ -3073,7 +3073,7 @@
             "start_date": "2003-03-19",
             "slug": "34",
             "csv": "data/Finland/Eduskunta/term-34.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aaa0477/data/Finland/Eduskunta/term-34.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aaa047713a14e0fed252cb7a8a272c9d9cb45414/data/Finland/Eduskunta/term-34.csv"
           },
           {
             "end_date": "2003-03-18",
@@ -3082,7 +3082,7 @@
             "start_date": "1999-03-24",
             "slug": "33",
             "csv": "data/Finland/Eduskunta/term-33.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132/data/Finland/Eduskunta/term-33.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132c626bf367a61c1da2f8390707f50feb7d/data/Finland/Eduskunta/term-33.csv"
           },
           {
             "end_date": "1999-03-23",
@@ -3091,7 +3091,7 @@
             "start_date": "1995-03-24",
             "slug": "32",
             "csv": "data/Finland/Eduskunta/term-32.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132/data/Finland/Eduskunta/term-32.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132c626bf367a61c1da2f8390707f50feb7d/data/Finland/Eduskunta/term-32.csv"
           },
           {
             "end_date": "1995-03-23",
@@ -3100,7 +3100,7 @@
             "start_date": "1991-03-22",
             "slug": "31",
             "csv": "data/Finland/Eduskunta/term-31.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132/data/Finland/Eduskunta/term-31.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132c626bf367a61c1da2f8390707f50feb7d/data/Finland/Eduskunta/term-31.csv"
           },
           {
             "end_date": "1991-03-21",
@@ -3109,7 +3109,7 @@
             "start_date": "1987-03-21",
             "slug": "30",
             "csv": "data/Finland/Eduskunta/term-30.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132/data/Finland/Eduskunta/term-30.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132c626bf367a61c1da2f8390707f50feb7d/data/Finland/Eduskunta/term-30.csv"
           },
           {
             "end_date": "1987-03-20",
@@ -3118,7 +3118,7 @@
             "start_date": "1983-03-26",
             "slug": "29",
             "csv": "data/Finland/Eduskunta/term-29.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132/data/Finland/Eduskunta/term-29.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132c626bf367a61c1da2f8390707f50feb7d/data/Finland/Eduskunta/term-29.csv"
           },
           {
             "end_date": "1983-03-25",
@@ -3127,7 +3127,7 @@
             "start_date": "1979-03-24",
             "slug": "28",
             "csv": "data/Finland/Eduskunta/term-28.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132/data/Finland/Eduskunta/term-28.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132c626bf367a61c1da2f8390707f50feb7d/data/Finland/Eduskunta/term-28.csv"
           },
           {
             "end_date": "1979-03-23",
@@ -3136,7 +3136,7 @@
             "start_date": "1975-09-27",
             "slug": "27",
             "csv": "data/Finland/Eduskunta/term-27.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132/data/Finland/Eduskunta/term-27.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132c626bf367a61c1da2f8390707f50feb7d/data/Finland/Eduskunta/term-27.csv"
           },
           {
             "end_date": "1975-09-26",
@@ -3145,7 +3145,7 @@
             "start_date": "1972-01-22",
             "slug": "26",
             "csv": "data/Finland/Eduskunta/term-26.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132/data/Finland/Eduskunta/term-26.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132c626bf367a61c1da2f8390707f50feb7d/data/Finland/Eduskunta/term-26.csv"
           },
           {
             "end_date": "1972-01-21",
@@ -3154,7 +3154,7 @@
             "start_date": "1970-03-23",
             "slug": "25",
             "csv": "data/Finland/Eduskunta/term-25.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132/data/Finland/Eduskunta/term-25.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/508c132c626bf367a61c1da2f8390707f50feb7d/data/Finland/Eduskunta/term-25.csv"
           }
         ],
         "statement_count": 38497
@@ -3172,11 +3172,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/France/National_Assembly/sources",
         "popolo": "data/France/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ec83b8/data/France/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ec83b830bd72f3f93da0b797e2bc00e88c11a28/data/France/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/France/National_Assembly/names.csv",
         "lastmod": "1470597759",
         "person_count": 1053,
-        "sha": "5ec83b8",
+        "sha": "5ec83b830bd72f3f93da0b797e2bc00e88c11a28",
         "legislative_periods": [
           {
             "id": "term/14",
@@ -3185,7 +3185,7 @@
             "wikidata": "Q3570385",
             "slug": "14",
             "csv": "data/France/National_Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7aed5d3/data/France/National_Assembly/term-14.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7aed5d32b39d058db3fd6e04df2027d47831c5eb/data/France/National_Assembly/term-14.csv"
           },
           {
             "end_date": "2012-06-19",
@@ -3195,7 +3195,7 @@
             "wikidata": "Q3025921",
             "slug": "13",
             "csv": "data/France/National_Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7aed5d3/data/France/National_Assembly/term-13.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7aed5d32b39d058db3fd6e04df2027d47831c5eb/data/France/National_Assembly/term-13.csv"
           },
           {
             "end_date": "2007-06-19",
@@ -3205,7 +3205,7 @@
             "wikidata": "Q3570376",
             "slug": "12",
             "csv": "data/France/National_Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7aed5d3/data/France/National_Assembly/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7aed5d32b39d058db3fd6e04df2027d47831c5eb/data/France/National_Assembly/term-12.csv"
           }
         ],
         "statement_count": 89858
@@ -3223,11 +3223,11 @@
         "slug": "Assembly",
         "sources_directory": "data/French_Polynesia/Assembly/sources",
         "popolo": "data/French_Polynesia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/12bfd3d/data/French_Polynesia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/12bfd3d9fcc93578eb8dd0aa90429a30b386c49c/data/French_Polynesia/Assembly/ep-popolo-v1.0.json",
         "names": "data/French_Polynesia/Assembly/names.csv",
         "lastmod": "1470991068",
         "person_count": 59,
-        "sha": "12bfd3d",
+        "sha": "12bfd3d9fcc93578eb8dd0aa90429a30b386c49c",
         "legislative_periods": [
           {
             "id": "term/2013",
@@ -3235,7 +3235,7 @@
             "start_date": "2013-05-17",
             "slug": "2013",
             "csv": "data/French_Polynesia/Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/59a7038/data/French_Polynesia/Assembly/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/59a70381f8e3a4e81bea0b9f7607788e9a20640e/data/French_Polynesia/Assembly/term-2013.csv"
           }
         ],
         "statement_count": 1679
@@ -3253,11 +3253,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Gabon/Assembly/sources",
         "popolo": "data/Gabon/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7125e9a/data/Gabon/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7125e9a76f7c19dc45d189d79184e2778e9a4697/data/Gabon/Assembly/ep-popolo-v1.0.json",
         "names": "data/Gabon/Assembly/names.csv",
         "lastmod": "1469383742",
         "person_count": 114,
-        "sha": "7125e9a",
+        "sha": "7125e9a76f7c19dc45d189d79184e2778e9a4697",
         "legislative_periods": [
           {
             "id": "term/12",
@@ -3265,7 +3265,7 @@
             "start_date": "2012-02-27",
             "slug": "12",
             "csv": "data/Gabon/Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/670bab1/data/Gabon/Assembly/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/670bab1d42f12646248c1d5cf0fca7b70e75bfad/data/Gabon/Assembly/term-12.csv"
           }
         ],
         "statement_count": 1735
@@ -3283,11 +3283,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Gambia/National_Assembly/sources",
         "popolo": "data/Gambia/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f21f500/data/Gambia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f21f500f7e90fbfaa057f17ca3233f9382a5dd2a/data/Gambia/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Gambia/National_Assembly/names.csv",
         "lastmod": "1469383745",
         "person_count": 53,
-        "sha": "f21f500",
+        "sha": "f21f500f7e90fbfaa057f17ca3233f9382a5dd2a",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -3295,7 +3295,7 @@
             "start_date": "2012-04-20",
             "slug": "2012",
             "csv": "data/Gambia/National_Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/17b9585/data/Gambia/National_Assembly/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/17b95857a76d13aad7c93d824df4ff03dd83f84f/data/Gambia/National_Assembly/term-2012.csv"
           }
         ],
         "statement_count": 1296
@@ -3313,11 +3313,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Georgia/Parliament/sources",
         "popolo": "data/Georgia/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cff97e1/data/Georgia/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cff97e1381b36979f87566eebfb984e008550fff/data/Georgia/Parliament/ep-popolo-v1.0.json",
         "names": "data/Georgia/Parliament/names.csv",
         "lastmod": "1470270258",
         "person_count": 148,
-        "sha": "cff97e1",
+        "sha": "cff97e1381b36979f87566eebfb984e008550fff",
         "legislative_periods": [
           {
             "end_date": "2016-10-01",
@@ -3326,7 +3326,7 @@
             "start_date": "2012-10-20",
             "slug": "8",
             "csv": "data/Georgia/Parliament/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640fac/data/Georgia/Parliament/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0640facb22f61f56e76789b3a7c809f443df15de/data/Georgia/Parliament/term-8.csv"
           }
         ],
         "statement_count": 4320
@@ -3344,11 +3344,11 @@
         "slug": "Bundestag",
         "sources_directory": "data/Germany/Bundestag/sources",
         "popolo": "data/Germany/Bundestag/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c111c90/data/Germany/Bundestag/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c111c90b845bb4c8c87d9ef60f6f5a046ae5a0aa/data/Germany/Bundestag/ep-popolo-v1.0.json",
         "names": "data/Germany/Bundestag/names.csv",
         "lastmod": "1470562308",
         "person_count": 3814,
-        "sha": "c111c90",
+        "sha": "c111c90b845bb4c8c87d9ef60f6f5a046ae5a0aa",
         "legislative_periods": [
           {
             "id": "term/18",
@@ -3357,7 +3357,7 @@
             "wikidata": "Q15081430",
             "slug": "18",
             "csv": "data/Germany/Bundestag/term-18.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5b9ce7b/data/Germany/Bundestag/term-18.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5b9ce7b6da0aeabc974c63a2829a8778d8d63d92/data/Germany/Bundestag/term-18.csv"
           },
           {
             "end_date": "2013-10-22",
@@ -3367,7 +3367,7 @@
             "wikidata": "Q15081429",
             "slug": "17",
             "csv": "data/Germany/Bundestag/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5b9ce7b/data/Germany/Bundestag/term-17.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5b9ce7b6da0aeabc974c63a2829a8778d8d63d92/data/Germany/Bundestag/term-17.csv"
           },
           {
             "end_date": "2009-10-27",
@@ -3377,7 +3377,7 @@
             "wikidata": "Q15081428",
             "slug": "16",
             "csv": "data/Germany/Bundestag/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5b9ce7b/data/Germany/Bundestag/term-16.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5b9ce7b6da0aeabc974c63a2829a8778d8d63d92/data/Germany/Bundestag/term-16.csv"
           },
           {
             "end_date": "2005-10-18",
@@ -3387,7 +3387,7 @@
             "wikidata": "Q15081427",
             "slug": "15",
             "csv": "data/Germany/Bundestag/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4/data/Germany/Bundestag/term-15.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4fcff3225fed92a5625545b9bbb1913f75/data/Germany/Bundestag/term-15.csv"
           },
           {
             "end_date": "2002-10-17",
@@ -3397,7 +3397,7 @@
             "wikidata": "Q15081426",
             "slug": "14",
             "csv": "data/Germany/Bundestag/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4/data/Germany/Bundestag/term-14.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4fcff3225fed92a5625545b9bbb1913f75/data/Germany/Bundestag/term-14.csv"
           },
           {
             "end_date": "1998-10-26",
@@ -3407,7 +3407,7 @@
             "wikidata": "Q15081424",
             "slug": "13",
             "csv": "data/Germany/Bundestag/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4/data/Germany/Bundestag/term-13.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4fcff3225fed92a5625545b9bbb1913f75/data/Germany/Bundestag/term-13.csv"
           },
           {
             "end_date": "1994-11-10",
@@ -3417,7 +3417,7 @@
             "wikidata": "Q15081421",
             "slug": "12",
             "csv": "data/Germany/Bundestag/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4/data/Germany/Bundestag/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4fcff3225fed92a5625545b9bbb1913f75/data/Germany/Bundestag/term-12.csv"
           },
           {
             "end_date": "1990-12-20",
@@ -3427,7 +3427,7 @@
             "wikidata": "Q15741572",
             "slug": "11",
             "csv": "data/Germany/Bundestag/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4/data/Germany/Bundestag/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4fcff3225fed92a5625545b9bbb1913f75/data/Germany/Bundestag/term-11.csv"
           },
           {
             "end_date": "1987-02-18",
@@ -3437,7 +3437,7 @@
             "wikidata": "Q15741566",
             "slug": "10",
             "csv": "data/Germany/Bundestag/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4/data/Germany/Bundestag/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4fcff3225fed92a5625545b9bbb1913f75/data/Germany/Bundestag/term-10.csv"
           },
           {
             "end_date": "1983-03-29",
@@ -3447,7 +3447,7 @@
             "wikidata": "Q15781093",
             "slug": "9",
             "csv": "data/Germany/Bundestag/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4/data/Germany/Bundestag/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4fcff3225fed92a5625545b9bbb1913f75/data/Germany/Bundestag/term-9.csv"
           },
           {
             "end_date": "1980-11-04",
@@ -3457,7 +3457,7 @@
             "wikidata": "Q15781086",
             "slug": "8",
             "csv": "data/Germany/Bundestag/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4/data/Germany/Bundestag/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4fcff3225fed92a5625545b9bbb1913f75/data/Germany/Bundestag/term-8.csv"
           },
           {
             "end_date": "1976-12-14",
@@ -3467,7 +3467,7 @@
             "wikidata": "Q15781078",
             "slug": "7",
             "csv": "data/Germany/Bundestag/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4/data/Germany/Bundestag/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4fcff3225fed92a5625545b9bbb1913f75/data/Germany/Bundestag/term-7.csv"
           },
           {
             "end_date": "1972-12-13",
@@ -3477,7 +3477,7 @@
             "wikidata": "Q15644627",
             "slug": "6",
             "csv": "data/Germany/Bundestag/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4/data/Germany/Bundestag/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/54d20f4fcff3225fed92a5625545b9bbb1913f75/data/Germany/Bundestag/term-6.csv"
           },
           {
             "end_date": "1969-10-20",
@@ -3487,7 +3487,7 @@
             "wikidata": "Q15781067",
             "slug": "5",
             "csv": "data/Germany/Bundestag/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1845669/data/Germany/Bundestag/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/18456696bb653d238739516d6abbbb1ee3712f55/data/Germany/Bundestag/term-5.csv"
           },
           {
             "end_date": "1965-10-19",
@@ -3497,7 +3497,7 @@
             "wikidata": "Q15781058",
             "slug": "4",
             "csv": "data/Germany/Bundestag/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c111c90/data/Germany/Bundestag/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c111c90b845bb4c8c87d9ef60f6f5a046ae5a0aa/data/Germany/Bundestag/term-4.csv"
           },
           {
             "end_date": "1961-10-17",
@@ -3507,7 +3507,7 @@
             "wikidata": "Q15781041",
             "slug": "3",
             "csv": "data/Germany/Bundestag/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c111c90/data/Germany/Bundestag/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c111c90b845bb4c8c87d9ef60f6f5a046ae5a0aa/data/Germany/Bundestag/term-3.csv"
           },
           {
             "end_date": "1957-10-15",
@@ -3517,7 +3517,7 @@
             "wikidata": "Q7443318",
             "slug": "2",
             "csv": "data/Germany/Bundestag/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c111c90/data/Germany/Bundestag/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c111c90b845bb4c8c87d9ef60f6f5a046ae5a0aa/data/Germany/Bundestag/term-2.csv"
           },
           {
             "end_date": "1953-10-06",
@@ -3527,7 +3527,7 @@
             "wikidata": "Q5453045",
             "slug": "1",
             "csv": "data/Germany/Bundestag/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1845669/data/Germany/Bundestag/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/18456696bb653d238739516d6abbbb1ee3712f55/data/Germany/Bundestag/term-1.csv"
           }
         ],
         "statement_count": 293018
@@ -3545,11 +3545,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Ghana/Parliament/sources",
         "popolo": "data/Ghana/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bdd4c6c/data/Ghana/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bdd4c6ce84c0694f88fb9b808faaae17e105b106/data/Ghana/Parliament/ep-popolo-v1.0.json",
         "names": "data/Ghana/Parliament/names.csv",
         "lastmod": "1470491169",
         "person_count": 272,
-        "sha": "bdd4c6c",
+        "sha": "bdd4c6ce84c0694f88fb9b808faaae17e105b106",
         "legislative_periods": [
           {
             "id": "term/6",
@@ -3557,7 +3557,7 @@
             "start_date": "2013-01-07",
             "slug": "6",
             "csv": "data/Ghana/Parliament/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d8fe2f4/data/Ghana/Parliament/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d8fe2f46f0d9a36cd6428b8f35e008fcc222d9c1/data/Ghana/Parliament/term-6.csv"
           }
         ],
         "statement_count": 5786
@@ -3575,11 +3575,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Gibraltar/Parliament/sources",
         "popolo": "data/Gibraltar/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9c2f1ac/data/Gibraltar/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9c2f1ac088a102737bba4cddb803dcc5e5777322/data/Gibraltar/Parliament/ep-popolo-v1.0.json",
         "names": "data/Gibraltar/Parliament/names.csv",
         "lastmod": "1469922014",
         "person_count": 83,
-        "sha": "9c2f1ac",
+        "sha": "9c2f1ac088a102737bba4cddb803dcc5e5777322",
         "legislative_periods": [
           {
             "end_date": "2015-10-20",
@@ -3588,7 +3588,7 @@
             "start_date": "2011-12-21",
             "slug": "12",
             "csv": "data/Gibraltar/Parliament/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/10fc9ed/data/Gibraltar/Parliament/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/10fc9ede77d8d8678503d0ce2d9d8b09267719f6/data/Gibraltar/Parliament/term-12.csv"
           },
           {
             "end_date": "2011-11-03",
@@ -3597,7 +3597,7 @@
             "start_date": "2007-11-08",
             "slug": "11",
             "csv": "data/Gibraltar/Parliament/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/10fc9ed/data/Gibraltar/Parliament/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/10fc9ede77d8d8678503d0ce2d9d8b09267719f6/data/Gibraltar/Parliament/term-11.csv"
           },
           {
             "end_date": "2007-09-07",
@@ -3606,7 +3606,7 @@
             "start_date": "2003-12-18",
             "slug": "10",
             "csv": "data/Gibraltar/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/10fc9ed/data/Gibraltar/Parliament/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/10fc9ede77d8d8678503d0ce2d9d8b09267719f6/data/Gibraltar/Parliament/term-10.csv"
           },
           {
             "end_date": "2003-10-24",
@@ -3615,7 +3615,7 @@
             "start_date": "2000-02-23",
             "slug": "9",
             "csv": "data/Gibraltar/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aa4f421/data/Gibraltar/Parliament/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aa4f4219cf2b965df2452f1220135ccd70351703/data/Gibraltar/Parliament/term-9.csv"
           },
           {
             "end_date": "2000",
@@ -3624,7 +3624,7 @@
             "start_date": "1996",
             "slug": "8",
             "csv": "data/Gibraltar/Parliament/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aa4f421/data/Gibraltar/Parliament/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aa4f4219cf2b965df2452f1220135ccd70351703/data/Gibraltar/Parliament/term-8.csv"
           },
           {
             "end_date": "1996",
@@ -3633,7 +3633,7 @@
             "start_date": "1992",
             "slug": "7",
             "csv": "data/Gibraltar/Parliament/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71abace/data/Gibraltar/Parliament/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71abace9ffc383a917702572fad5d09f2951556e/data/Gibraltar/Parliament/term-7.csv"
           },
           {
             "end_date": "1992",
@@ -3642,7 +3642,7 @@
             "start_date": "1988",
             "slug": "6",
             "csv": "data/Gibraltar/Parliament/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71abace/data/Gibraltar/Parliament/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71abace9ffc383a917702572fad5d09f2951556e/data/Gibraltar/Parliament/term-6.csv"
           },
           {
             "end_date": "1988",
@@ -3651,7 +3651,7 @@
             "start_date": "1984",
             "slug": "5",
             "csv": "data/Gibraltar/Parliament/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71abace/data/Gibraltar/Parliament/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71abace9ffc383a917702572fad5d09f2951556e/data/Gibraltar/Parliament/term-5.csv"
           },
           {
             "end_date": "1984",
@@ -3660,7 +3660,7 @@
             "start_date": "1980",
             "slug": "4",
             "csv": "data/Gibraltar/Parliament/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71abace/data/Gibraltar/Parliament/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71abace9ffc383a917702572fad5d09f2951556e/data/Gibraltar/Parliament/term-4.csv"
           },
           {
             "end_date": "1980",
@@ -3669,7 +3669,7 @@
             "start_date": "1976",
             "slug": "3",
             "csv": "data/Gibraltar/Parliament/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71abace/data/Gibraltar/Parliament/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71abace9ffc383a917702572fad5d09f2951556e/data/Gibraltar/Parliament/term-3.csv"
           },
           {
             "end_date": "1976",
@@ -3678,7 +3678,7 @@
             "start_date": "1972",
             "slug": "2",
             "csv": "data/Gibraltar/Parliament/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71abace/data/Gibraltar/Parliament/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71abace9ffc383a917702572fad5d09f2951556e/data/Gibraltar/Parliament/term-2.csv"
           },
           {
             "end_date": "1972",
@@ -3687,7 +3687,7 @@
             "start_date": "1969",
             "slug": "1",
             "csv": "data/Gibraltar/Parliament/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71abace/data/Gibraltar/Parliament/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71abace9ffc383a917702572fad5d09f2951556e/data/Gibraltar/Parliament/term-1.csv"
           }
         ],
         "statement_count": 2939
@@ -3705,11 +3705,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Greece/Parliament/sources",
         "popolo": "data/Greece/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2abd0a2/data/Greece/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2abd0a2e85232f00d3b5c38348fc29e9de9ed5c5/data/Greece/Parliament/ep-popolo-v1.0.json",
         "names": "data/Greece/Parliament/names.csv",
         "lastmod": "1471965520",
         "person_count": 1783,
-        "sha": "2abd0a2",
+        "sha": "2abd0a2e85232f00d3b5c38348fc29e9de9ed5c5",
         "legislative_periods": [
           {
             "id": "term/17",
@@ -3717,7 +3717,7 @@
             "start_date": "2015-09-20",
             "slug": "17",
             "csv": "data/Greece/Parliament/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bc2ec2b/data/Greece/Parliament/term-17.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bc2ec2b7d4069556a54118d3594f37a8444a18d6/data/Greece/Parliament/term-17.csv"
           },
           {
             "end_date": "2015-08-28",
@@ -3726,7 +3726,7 @@
             "start_date": "2015-01-25",
             "slug": "16",
             "csv": "data/Greece/Parliament/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a680c1e/data/Greece/Parliament/term-16.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a680c1e09f9a7dc65b1e709bcc3dc9a9d6f9d0e2/data/Greece/Parliament/term-16.csv"
           },
           {
             "end_date": "2014-12-31",
@@ -3735,7 +3735,7 @@
             "start_date": "2012-06-17",
             "slug": "15",
             "csv": "data/Greece/Parliament/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/77f418d/data/Greece/Parliament/term-15.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/77f418d62bb8decdfb4c320f9854ae37204115a2/data/Greece/Parliament/term-15.csv"
           },
           {
             "end_date": "2012-05-19",
@@ -3744,7 +3744,7 @@
             "start_date": "2012-05-06",
             "slug": "14",
             "csv": "data/Greece/Parliament/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/77f418d/data/Greece/Parliament/term-14.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/77f418d62bb8decdfb4c320f9854ae37204115a2/data/Greece/Parliament/term-14.csv"
           },
           {
             "end_date": "2012-04-11",
@@ -3753,7 +3753,7 @@
             "start_date": "2009-10-04",
             "slug": "13",
             "csv": "data/Greece/Parliament/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa6cf2e/data/Greece/Parliament/term-13.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa6cf2e3ac1d4ae9d71eccc3f7595146e21dcb73/data/Greece/Parliament/term-13.csv"
           },
           {
             "end_date": "2009-09-07",
@@ -3762,7 +3762,7 @@
             "start_date": "2007-09-16",
             "slug": "12",
             "csv": "data/Greece/Parliament/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c68e162/data/Greece/Parliament/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c68e1621d20e8bb030a7d6bc1bc87c05aec636a1/data/Greece/Parliament/term-12.csv"
           },
           {
             "end_date": "2007-08-18",
@@ -3771,7 +3771,7 @@
             "start_date": "2004-03-07",
             "slug": "11",
             "csv": "data/Greece/Parliament/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa6cf2e/data/Greece/Parliament/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa6cf2e3ac1d4ae9d71eccc3f7595146e21dcb73/data/Greece/Parliament/term-11.csv"
           },
           {
             "end_date": "2004-02-11",
@@ -3780,7 +3780,7 @@
             "start_date": "2000-04-09",
             "slug": "10",
             "csv": "data/Greece/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa6cf2e/data/Greece/Parliament/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa6cf2e3ac1d4ae9d71eccc3f7595146e21dcb73/data/Greece/Parliament/term-10.csv"
           },
           {
             "end_date": "2000-03-14",
@@ -3789,7 +3789,7 @@
             "start_date": "1996-09-22",
             "slug": "9",
             "csv": "data/Greece/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa6cf2e/data/Greece/Parliament/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa6cf2e3ac1d4ae9d71eccc3f7595146e21dcb73/data/Greece/Parliament/term-9.csv"
           },
           {
             "end_date": "1996-08-24",
@@ -3798,7 +3798,7 @@
             "start_date": "1993-10-10",
             "slug": "8",
             "csv": "data/Greece/Parliament/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2abd0a2/data/Greece/Parliament/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2abd0a2e85232f00d3b5c38348fc29e9de9ed5c5/data/Greece/Parliament/term-8.csv"
           },
           {
             "end_date": "1993-09-11",
@@ -3807,7 +3807,7 @@
             "start_date": "1990-04-08",
             "slug": "7",
             "csv": "data/Greece/Parliament/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2abd0a2/data/Greece/Parliament/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2abd0a2e85232f00d3b5c38348fc29e9de9ed5c5/data/Greece/Parliament/term-7.csv"
           },
           {
             "end_date": "1990-03-12",
@@ -3816,7 +3816,7 @@
             "start_date": "1989-11-05",
             "slug": "6",
             "csv": "data/Greece/Parliament/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2abd0a2/data/Greece/Parliament/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2abd0a2e85232f00d3b5c38348fc29e9de9ed5c5/data/Greece/Parliament/term-6.csv"
           },
           {
             "end_date": "1989-10-12",
@@ -3825,7 +3825,7 @@
             "start_date": "1989-06-18",
             "slug": "5",
             "csv": "data/Greece/Parliament/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2abd0a2/data/Greece/Parliament/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2abd0a2e85232f00d3b5c38348fc29e9de9ed5c5/data/Greece/Parliament/term-5.csv"
           },
           {
             "end_date": "1989-06-02",
@@ -3834,7 +3834,7 @@
             "start_date": "1985-06-02",
             "slug": "4",
             "csv": "data/Greece/Parliament/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa6cf2e/data/Greece/Parliament/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa6cf2e3ac1d4ae9d71eccc3f7595146e21dcb73/data/Greece/Parliament/term-4.csv"
           },
           {
             "end_date": "1985-05-07",
@@ -3843,7 +3843,7 @@
             "start_date": "1981-10-18",
             "slug": "3",
             "csv": "data/Greece/Parliament/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa6cf2e/data/Greece/Parliament/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa6cf2e3ac1d4ae9d71eccc3f7595146e21dcb73/data/Greece/Parliament/term-3.csv"
           },
           {
             "end_date": "1981-09-19",
@@ -3852,7 +3852,7 @@
             "start_date": "1977-11-20",
             "slug": "2",
             "csv": "data/Greece/Parliament/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb76249/data/Greece/Parliament/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb7624932b290214637932bdcd12a9be59084a95/data/Greece/Parliament/term-2.csv"
           },
           {
             "end_date": "1977-10-22",
@@ -3861,7 +3861,7 @@
             "start_date": "1974-11-17",
             "slug": "1",
             "csv": "data/Greece/Parliament/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab78a15/data/Greece/Parliament/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab78a15dfd93635f4fa9a8dc3932dff6f7f62b5c/data/Greece/Parliament/term-1.csv"
           }
         ],
         "statement_count": 66492
@@ -3879,11 +3879,11 @@
         "slug": "Inatsisartut",
         "sources_directory": "data/Greenland/Inatsisartut/sources",
         "popolo": "data/Greenland/Inatsisartut/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4b4576e/data/Greenland/Inatsisartut/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4b4576e925c866f699b5679c50e98e564aea4669/data/Greenland/Inatsisartut/ep-popolo-v1.0.json",
         "names": "data/Greenland/Inatsisartut/names.csv",
         "lastmod": "1470822667",
         "person_count": 149,
-        "sha": "4b4576e",
+        "sha": "4b4576e925c866f699b5679c50e98e564aea4669",
         "legislative_periods": [
           {
             "id": "term/12",
@@ -3891,7 +3891,7 @@
             "start_date": "2014-11-28",
             "slug": "12",
             "csv": "data/Greenland/Inatsisartut/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fe66cc4/data/Greenland/Inatsisartut/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fe66cc4e9c042264576d577a7e1e2dee727866dc/data/Greenland/Inatsisartut/term-12.csv"
           },
           {
             "end_date": "2014-11-27",
@@ -3900,7 +3900,7 @@
             "start_date": "2013-03-12",
             "slug": "11",
             "csv": "data/Greenland/Inatsisartut/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fe96cb2/data/Greenland/Inatsisartut/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fe96cb2a53fc97e47650986e68f6969c7d7ec823/data/Greenland/Inatsisartut/term-11.csv"
           },
           {
             "end_date": "2013-03-11",
@@ -3909,7 +3909,7 @@
             "start_date": "2009-06-02",
             "slug": "10",
             "csv": "data/Greenland/Inatsisartut/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fe96cb2/data/Greenland/Inatsisartut/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fe96cb2a53fc97e47650986e68f6969c7d7ec823/data/Greenland/Inatsisartut/term-10.csv"
           },
           {
             "end_date": "2009-06-01",
@@ -3918,7 +3918,7 @@
             "start_date": "2005-11-15",
             "slug": "9",
             "csv": "data/Greenland/Inatsisartut/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d/data/Greenland/Inatsisartut/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d34dc6bf438e825fe05856a8497d50ad52/data/Greenland/Inatsisartut/term-9.csv"
           },
           {
             "end_date": "2005-11-14",
@@ -3927,7 +3927,7 @@
             "start_date": "2002-12-03",
             "slug": "8",
             "csv": "data/Greenland/Inatsisartut/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d/data/Greenland/Inatsisartut/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d34dc6bf438e825fe05856a8497d50ad52/data/Greenland/Inatsisartut/term-8.csv"
           },
           {
             "end_date": "2002-12-02",
@@ -3936,7 +3936,7 @@
             "start_date": "1999-02-16",
             "slug": "7",
             "csv": "data/Greenland/Inatsisartut/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d/data/Greenland/Inatsisartut/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d34dc6bf438e825fe05856a8497d50ad52/data/Greenland/Inatsisartut/term-7.csv"
           },
           {
             "end_date": "1999-02-15",
@@ -3945,7 +3945,7 @@
             "start_date": "1995-03-04",
             "slug": "6",
             "csv": "data/Greenland/Inatsisartut/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d/data/Greenland/Inatsisartut/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d34dc6bf438e825fe05856a8497d50ad52/data/Greenland/Inatsisartut/term-6.csv"
           },
           {
             "end_date": "1995-03-03",
@@ -3954,7 +3954,7 @@
             "start_date": "1991-03-05",
             "slug": "5",
             "csv": "data/Greenland/Inatsisartut/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d/data/Greenland/Inatsisartut/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d34dc6bf438e825fe05856a8497d50ad52/data/Greenland/Inatsisartut/term-5.csv"
           },
           {
             "end_date": "1991-03-04",
@@ -3963,7 +3963,7 @@
             "start_date": "1987-05-26",
             "slug": "4",
             "csv": "data/Greenland/Inatsisartut/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d/data/Greenland/Inatsisartut/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d34dc6bf438e825fe05856a8497d50ad52/data/Greenland/Inatsisartut/term-4.csv"
           },
           {
             "end_date": "1987-05-25",
@@ -3972,7 +3972,7 @@
             "start_date": "1984-06-06",
             "slug": "3",
             "csv": "data/Greenland/Inatsisartut/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d/data/Greenland/Inatsisartut/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d34dc6bf438e825fe05856a8497d50ad52/data/Greenland/Inatsisartut/term-3.csv"
           },
           {
             "end_date": "1984-06-05",
@@ -3981,7 +3981,7 @@
             "start_date": "1983-04-12",
             "slug": "2",
             "csv": "data/Greenland/Inatsisartut/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d/data/Greenland/Inatsisartut/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d34dc6bf438e825fe05856a8497d50ad52/data/Greenland/Inatsisartut/term-2.csv"
           },
           {
             "end_date": "1983-04-11",
@@ -3990,7 +3990,7 @@
             "start_date": "1979-04-04",
             "slug": "1",
             "csv": "data/Greenland/Inatsisartut/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d/data/Greenland/Inatsisartut/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69e536d34dc6bf438e825fe05856a8497d50ad52/data/Greenland/Inatsisartut/term-1.csv"
           }
         ],
         "statement_count": 5789
@@ -4008,11 +4008,11 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Grenada/House_of_Representatives/sources",
         "popolo": "data/Grenada/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/89ceef1/data/Grenada/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/89ceef1247d01ab7d315397d5563f4d8ce1fb804/data/Grenada/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Grenada/House_of_Representatives/names.csv",
         "lastmod": "1469383996",
         "person_count": 15,
-        "sha": "89ceef1",
+        "sha": "89ceef1247d01ab7d315397d5563f4d8ce1fb804",
         "legislative_periods": [
           {
             "id": "term/2013",
@@ -4020,7 +4020,7 @@
             "start_date": "2013-03-27",
             "slug": "2013",
             "csv": "data/Grenada/House_of_Representatives/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9483733/data/Grenada/House_of_Representatives/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/94837337f7dbdd0e2f8df55405847751b3229144/data/Grenada/House_of_Representatives/term-2013.csv"
           }
         ],
         "statement_count": 389
@@ -4038,11 +4038,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Guam/Parliament/sources",
         "popolo": "data/Guam/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fa5afe/data/Guam/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fa5afe98f2c1ff1769cebff9d3f56c63500080d/data/Guam/Parliament/ep-popolo-v1.0.json",
         "names": "data/Guam/Parliament/names.csv",
         "lastmod": "1469302344",
         "person_count": 28,
-        "sha": "9fa5afe",
+        "sha": "9fa5afe98f2c1ff1769cebff9d3f56c63500080d",
         "legislative_periods": [
           {
             "id": "term/33",
@@ -4050,7 +4050,7 @@
             "start_date": "2015-02-16",
             "slug": "33",
             "csv": "data/Guam/Parliament/term-33.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75a93bc/data/Guam/Parliament/term-33.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75a93bcc3a714ebbd559f2abe79ccc332c66ff50/data/Guam/Parliament/term-33.csv"
           },
           {
             "end_date": "2015-01-02",
@@ -4059,7 +4059,7 @@
             "start_date": "2013-01-11",
             "slug": "32",
             "csv": "data/Guam/Parliament/term-32.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f19e2da/data/Guam/Parliament/term-32.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f19e2da42b14b3a1ddd2aa8684c0849ab8aa000a/data/Guam/Parliament/term-32.csv"
           },
           {
             "end_date": "2013-01-04",
@@ -4068,7 +4068,7 @@
             "start_date": "2011-02-21",
             "slug": "31",
             "csv": "data/Guam/Parliament/term-31.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f19e2da/data/Guam/Parliament/term-31.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f19e2da42b14b3a1ddd2aa8684c0849ab8aa000a/data/Guam/Parliament/term-31.csv"
           },
           {
             "end_date": "2010-12-22",
@@ -4077,7 +4077,7 @@
             "start_date": "2009-02-16",
             "slug": "30",
             "csv": "data/Guam/Parliament/term-30.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75a93bc/data/Guam/Parliament/term-30.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75a93bcc3a714ebbd559f2abe79ccc332c66ff50/data/Guam/Parliament/term-30.csv"
           }
         ],
         "statement_count": 1205
@@ -4095,11 +4095,11 @@
         "slug": "Congress",
         "sources_directory": "data/Guatemala/Congress/sources",
         "popolo": "data/Guatemala/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/180a785/data/Guatemala/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/180a785212b8bc052e02f6dc0453a8a711ce211c/data/Guatemala/Congress/ep-popolo-v1.0.json",
         "names": "data/Guatemala/Congress/names.csv",
         "lastmod": "1469671817",
         "person_count": 244,
-        "sha": "180a785",
+        "sha": "180a785212b8bc052e02f6dc0453a8a711ce211c",
         "legislative_periods": [
           {
             "end_date": "2020-01-14",
@@ -4109,7 +4109,7 @@
             "wikidata": "Q23051910",
             "slug": "8",
             "csv": "data/Guatemala/Congress/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/180a785/data/Guatemala/Congress/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/180a785212b8bc052e02f6dc0453a8a711ce211c/data/Guatemala/Congress/term-8.csv"
           },
           {
             "end_date": "2016-01-14",
@@ -4119,7 +4119,7 @@
             "wikidata": "Q16644987",
             "slug": "7",
             "csv": "data/Guatemala/Congress/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4de1144/data/Guatemala/Congress/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4de11443c2af322df823fae491a867bc197a981c/data/Guatemala/Congress/term-7.csv"
           }
         ],
         "statement_count": 5576
@@ -4137,11 +4137,11 @@
         "slug": "States",
         "sources_directory": "data/Guernsey/States/sources",
         "popolo": "data/Guernsey/States/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/560ea7a/data/Guernsey/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/560ea7a491e45e59d290210f036f8f62571663fd/data/Guernsey/States/ep-popolo-v1.0.json",
         "names": "data/Guernsey/States/names.csv",
         "lastmod": "1470227769",
         "person_count": 49,
-        "sha": "560ea7a",
+        "sha": "560ea7a491e45e59d290210f036f8f62571663fd",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -4149,7 +4149,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Guernsey/States/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/145fb27/data/Guernsey/States/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/145fb27181efe040e91fba081c7f7703d29b591d/data/Guernsey/States/term-2012.csv"
           }
         ],
         "statement_count": 1306
@@ -4167,11 +4167,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Guinea-Bissau/Assembly/sources",
         "popolo": "data/Guinea-Bissau/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f3e04ef/data/Guinea-Bissau/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f3e04effe72e76a831e245bc6558aea074ead033/data/Guinea-Bissau/Assembly/ep-popolo-v1.0.json",
         "names": "data/Guinea-Bissau/Assembly/names.csv",
         "lastmod": "1469384010",
         "person_count": 100,
-        "sha": "f3e04ef",
+        "sha": "f3e04effe72e76a831e245bc6558aea074ead033",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -4179,7 +4179,7 @@
             "start_date": "2014-06-16",
             "slug": "2014",
             "csv": "data/Guinea-Bissau/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/96d2c4b/data/Guinea-Bissau/Assembly/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/96d2c4bbe72d9477204c5e40f623b073460a24b9/data/Guinea-Bissau/Assembly/term-2014.csv"
           }
         ],
         "statement_count": 1394
@@ -4197,11 +4197,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Guyana/National_Assembly/sources",
         "popolo": "data/Guyana/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fb1c14b/data/Guyana/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fb1c14b39b27d09030d917096d9acadb9225a436/data/Guyana/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Guyana/National_Assembly/names.csv",
         "lastmod": "1469384014",
         "person_count": 55,
-        "sha": "fb1c14b",
+        "sha": "fb1c14b39b27d09030d917096d9acadb9225a436",
         "legislative_periods": [
           {
             "id": "term/11",
@@ -4209,7 +4209,7 @@
             "start_date": "2015-06-10",
             "slug": "11",
             "csv": "data/Guyana/National_Assembly/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bc130a4/data/Guyana/National_Assembly/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bc130a4399b422bc2913c095cafd9ec83c0c01da/data/Guyana/National_Assembly/term-11.csv"
           }
         ],
         "statement_count": 947
@@ -4227,11 +4227,11 @@
         "slug": "Deputies",
         "sources_directory": "data/Haiti/Deputies/sources",
         "popolo": "data/Haiti/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3653366/data/Haiti/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/365336614de027c0cb273371628c504c98b0d14c/data/Haiti/Deputies/ep-popolo-v1.0.json",
         "names": "data/Haiti/Deputies/names.csv",
         "lastmod": "1469384021",
         "person_count": 99,
-        "sha": "3653366",
+        "sha": "365336614de027c0cb273371628c504c98b0d14c",
         "legislative_periods": [
           {
             "end_date": "2015-01-12",
@@ -4240,7 +4240,7 @@
             "start_date": "2011-05-14",
             "slug": "2011",
             "csv": "data/Haiti/Deputies/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e5597c3/data/Haiti/Deputies/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e5597c3e2c869187ec02b28132888c4c6502e0d2/data/Haiti/Deputies/term-2011.csv"
           }
         ],
         "statement_count": 1935
@@ -4258,11 +4258,11 @@
         "slug": "Congreso-Nacional",
         "sources_directory": "data/Honduras/Congreso_Nacional/sources",
         "popolo": "data/Honduras/Congreso_Nacional/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3551031/data/Honduras/Congreso_Nacional/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/35510317a4cc0183cbef4ad2d1058bb9d0b1719f/data/Honduras/Congreso_Nacional/ep-popolo-v1.0.json",
         "names": "data/Honduras/Congreso_Nacional/names.csv",
         "lastmod": "1469310554",
         "person_count": 129,
-        "sha": "3551031",
+        "sha": "35510317a4cc0183cbef4ad2d1058bb9d0b1719f",
         "legislative_periods": [
           {
             "end_date": "2018",
@@ -4271,7 +4271,7 @@
             "start_date": "2014-01-21",
             "slug": "8",
             "csv": "data/Honduras/Congreso_Nacional/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e94940a/data/Honduras/Congreso_Nacional/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e94940a29ff9fa05444b6d1032871151db47f9e7/data/Honduras/Congreso_Nacional/term-8.csv"
           }
         ],
         "statement_count": 2073
@@ -4289,11 +4289,11 @@
         "slug": "Legislative-Council",
         "sources_directory": "data/Hong_Kong/Legislative_Council/sources",
         "popolo": "data/Hong_Kong/Legislative_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4b1d67/data/Hong_Kong/Legislative_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4b1d676ffadaaec111941add9b8c14a29364463/data/Hong_Kong/Legislative_Council/ep-popolo-v1.0.json",
         "names": "data/Hong_Kong/Legislative_Council/names.csv",
         "lastmod": "1470936514",
         "person_count": 71,
-        "sha": "a4b1d67",
+        "sha": "a4b1d676ffadaaec111941add9b8c14a29364463",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -4301,7 +4301,7 @@
             "start_date": "2012-09-12",
             "slug": "5",
             "csv": "data/Hong_Kong/Legislative_Council/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7f86904/data/Hong_Kong/Legislative_Council/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7f869040e3b684681564aa991d9fcebd2851a9ad/data/Hong_Kong/Legislative_Council/term-5.csv"
           }
         ],
         "statement_count": 5848
@@ -4319,11 +4319,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Hungary/Assembly/sources",
         "popolo": "data/Hungary/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/89bd340/data/Hungary/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/89bd34020faeb06f231ff858b9c1588674b408db/data/Hungary/Assembly/ep-popolo-v1.0.json",
         "names": "data/Hungary/Assembly/names.csv",
         "lastmod": "1472088489",
         "person_count": 199,
-        "sha": "89bd340",
+        "sha": "89bd34020faeb06f231ff858b9c1588674b408db",
         "legislative_periods": [
           {
             "id": "term/40",
@@ -4331,7 +4331,7 @@
             "start_date": "2014-05-10",
             "slug": "40",
             "csv": "data/Hungary/Assembly/term-40.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f02c3a0/data/Hungary/Assembly/term-40.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f02c3a08b42dca6342f5c783e92905ef46ee4e0c/data/Hungary/Assembly/term-40.csv"
           }
         ],
         "statement_count": 9956
@@ -4349,11 +4349,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Iceland/Assembly/sources",
         "popolo": "data/Iceland/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6581ac3/data/Iceland/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6581ac34621f3533bf7ba349f987fc006ed1cbac/data/Iceland/Assembly/ep-popolo-v1.0.json",
         "names": "data/Iceland/Assembly/names.csv",
         "lastmod": "1471574337",
         "person_count": 205,
-        "sha": "6581ac3",
+        "sha": "6581ac34621f3533bf7ba349f987fc006ed1cbac",
         "legislative_periods": [
           {
             "id": "term/2013",
@@ -4361,7 +4361,7 @@
             "start_date": "2013-04-27",
             "slug": "2013",
             "csv": "data/Iceland/Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ae95416/data/Iceland/Assembly/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ae954163ce5d65ba8914fa7318a58f9e0a825447/data/Iceland/Assembly/term-2013.csv"
           },
           {
             "end_date": "2013-04-27",
@@ -4370,7 +4370,7 @@
             "start_date": "2009",
             "slug": "2009",
             "csv": "data/Iceland/Assembly/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a1f38e7/data/Iceland/Assembly/term-2009.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a1f38e7551bb5bc392c5fbaac6ab607940bc2880/data/Iceland/Assembly/term-2009.csv"
           },
           {
             "end_date": "2009",
@@ -4379,7 +4379,7 @@
             "start_date": "2007",
             "slug": "2007",
             "csv": "data/Iceland/Assembly/term-2007.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/31667ca/data/Iceland/Assembly/term-2007.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/31667caf247a49db50231d2a82db31ee564e1f2c/data/Iceland/Assembly/term-2007.csv"
           },
           {
             "end_date": "2007",
@@ -4388,7 +4388,7 @@
             "start_date": "2003",
             "slug": "2003",
             "csv": "data/Iceland/Assembly/term-2003.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/31667ca/data/Iceland/Assembly/term-2003.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/31667caf247a49db50231d2a82db31ee564e1f2c/data/Iceland/Assembly/term-2003.csv"
           },
           {
             "end_date": "2003",
@@ -4397,7 +4397,7 @@
             "start_date": "1999",
             "slug": "1999",
             "csv": "data/Iceland/Assembly/term-1999.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/31667ca/data/Iceland/Assembly/term-1999.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/31667caf247a49db50231d2a82db31ee564e1f2c/data/Iceland/Assembly/term-1999.csv"
           },
           {
             "end_date": "1999",
@@ -4406,7 +4406,7 @@
             "start_date": "1995",
             "slug": "1995",
             "csv": "data/Iceland/Assembly/term-1995.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/31667ca/data/Iceland/Assembly/term-1995.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/31667caf247a49db50231d2a82db31ee564e1f2c/data/Iceland/Assembly/term-1995.csv"
           }
         ],
         "statement_count": 13545
@@ -4424,11 +4424,11 @@
         "slug": "Lok-Sabha",
         "sources_directory": "data/India/Lok_Sabha/sources",
         "popolo": "data/India/Lok_Sabha/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c219183/data/India/Lok_Sabha/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c2191833c241b03310f3580d0a6fcab3247ebe1c/data/India/Lok_Sabha/ep-popolo-v1.0.json",
         "names": "data/India/Lok_Sabha/names.csv",
         "lastmod": "1472101427",
         "person_count": 541,
-        "sha": "c219183",
+        "sha": "c2191833c241b03310f3580d0a6fcab3247ebe1c",
         "legislative_periods": [
           {
             "id": "term/16",
@@ -4436,7 +4436,7 @@
             "start_date": "2014-05-26",
             "slug": "16",
             "csv": "data/India/Lok_Sabha/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4153cb9/data/India/Lok_Sabha/term-16.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4153cb9c7f41bd93658ea30e7e5878c04404490d/data/India/Lok_Sabha/term-16.csv"
           }
         ],
         "statement_count": 38890
@@ -4454,11 +4454,11 @@
         "slug": "Council",
         "sources_directory": "data/Indonesia/Council/sources",
         "popolo": "data/Indonesia/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc52f9/data/Indonesia/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fc52f99e899ac1ad1fdd5e09ecaa48e590c559b/data/Indonesia/Council/ep-popolo-v1.0.json",
         "names": "data/Indonesia/Council/names.csv",
         "lastmod": "1471418495",
         "person_count": 578,
-        "sha": "9fc52f9",
+        "sha": "9fc52f99e899ac1ad1fdd5e09ecaa48e590c559b",
         "legislative_periods": [
           {
             "id": "term/18",
@@ -4466,7 +4466,7 @@
             "start_date": "2014-10-01",
             "slug": "18",
             "csv": "data/Indonesia/Council/term-18.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cfd5213/data/Indonesia/Council/term-18.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cfd5213870858dedcdeb6e25f22e38703f8bfb24/data/Indonesia/Council/term-18.csv"
           }
         ],
         "statement_count": 12550
@@ -4484,11 +4484,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Iran/Assembly/sources",
         "popolo": "data/Iran/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/11bf6f8/data/Iran/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/11bf6f8bc9c91150877d3fb196009a5c2097886c/data/Iran/Assembly/ep-popolo-v1.0.json",
         "names": "data/Iran/Assembly/names.csv",
         "lastmod": "1470796928",
         "person_count": 507,
-        "sha": "11bf6f8",
+        "sha": "11bf6f8bc9c91150877d3fb196009a5c2097886c",
         "legislative_periods": [
           {
             "id": "term/10",
@@ -4496,7 +4496,7 @@
             "start_date": "2016-05-28",
             "slug": "10",
             "csv": "data/Iran/Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/11bf6f8/data/Iran/Assembly/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/11bf6f8bc9c91150877d3fb196009a5c2097886c/data/Iran/Assembly/term-10.csv"
           },
           {
             "end_date": "2016-05-26",
@@ -4505,7 +4505,7 @@
             "start_date": "2012-05-27",
             "slug": "9",
             "csv": "data/Iran/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/11bf6f8/data/Iran/Assembly/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/11bf6f8bc9c91150877d3fb196009a5c2097886c/data/Iran/Assembly/term-9.csv"
           }
         ],
         "statement_count": 7926
@@ -4523,11 +4523,11 @@
         "slug": "Majlis",
         "sources_directory": "data/Iraq/Majlis/sources",
         "popolo": "data/Iraq/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aad4b62/data/Iraq/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aad4b62dd9f92f18e3d4921824c5f60787173682/data/Iraq/Majlis/ep-popolo-v1.0.json",
         "names": "data/Iraq/Majlis/names.csv",
         "lastmod": "1469384118",
         "person_count": 328,
-        "sha": "aad4b62",
+        "sha": "aad4b62dd9f92f18e3d4921824c5f60787173682",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -4535,7 +4535,7 @@
             "start_date": "2014-07-01",
             "slug": "2014",
             "csv": "data/Iraq/Majlis/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8143d7b/data/Iraq/Majlis/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8143d7bf91ffce97a8f1fe15515f72791254f915/data/Iraq/Majlis/term-2014.csv"
           }
         ],
         "statement_count": 4101
@@ -4553,11 +4553,11 @@
         "slug": "Dail",
         "sources_directory": "data/Ireland/Dail/sources",
         "popolo": "data/Ireland/Dail/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/68bb2b0/data/Ireland/Dail/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/68bb2b0c906a5c142cff610dfbff13becc59ddf0/data/Ireland/Dail/ep-popolo-v1.0.json",
         "names": "data/Ireland/Dail/names.csv",
         "lastmod": "1471995832",
         "person_count": 226,
-        "sha": "68bb2b0",
+        "sha": "68bb2b0c906a5c142cff610dfbff13becc59ddf0",
         "legislative_periods": [
           {
             "id": "term/32",
@@ -4565,7 +4565,7 @@
             "start_date": "2016-03-10",
             "slug": "32",
             "csv": "data/Ireland/Dail/term-32.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/119afb7/data/Ireland/Dail/term-32.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/119afb7dad01dd0f482b9afedcdd8ecef3705ae6/data/Ireland/Dail/term-32.csv"
           },
           {
             "end_date": "2016-03-02",
@@ -4574,7 +4574,7 @@
             "start_date": "2011-03-09",
             "slug": "31",
             "csv": "data/Ireland/Dail/term-31.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ec324a/data/Ireland/Dail/term-31.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ec324a644742f135f8a6b4a82cf2abefc6f91b4/data/Ireland/Dail/term-31.csv"
           }
         ],
         "statement_count": 13892
@@ -4592,11 +4592,11 @@
         "slug": "House-of-Keys",
         "sources_directory": "data/Isle_of_Man/House_of_Keys/sources",
         "popolo": "data/Isle_of_Man/House_of_Keys/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4950b0d/data/Isle_of_Man/House_of_Keys/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4950b0d3f60eae8881a6f87596a1ac6a97347603/data/Isle_of_Man/House_of_Keys/ep-popolo-v1.0.json",
         "names": "data/Isle_of_Man/House_of_Keys/names.csv",
         "lastmod": "1470510200",
         "person_count": 29,
-        "sha": "4950b0d",
+        "sha": "4950b0d3f60eae8881a6f87596a1ac6a97347603",
         "legislative_periods": [
           {
             "id": "term/2011",
@@ -4604,7 +4604,7 @@
             "start_date": "2011-10-04",
             "slug": "2011",
             "csv": "data/Isle_of_Man/House_of_Keys/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0269a48/data/Isle_of_Man/House_of_Keys/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0269a48c5756a838dc5979d1a67188bf6f8342b8/data/Isle_of_Man/House_of_Keys/term-2011.csv"
           }
         ],
         "statement_count": 1464
@@ -4622,11 +4622,11 @@
         "slug": "Knesset",
         "sources_directory": "data/Israel/Knesset/sources",
         "popolo": "data/Israel/Knesset/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4bd693c/data/Israel/Knesset/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4bd693c7f2960672c13534d4a3e5fe92ce9d5015/data/Israel/Knesset/ep-popolo-v1.0.json",
         "names": "data/Israel/Knesset/names.csv",
         "lastmod": "1471348493",
         "person_count": 933,
-        "sha": "4bd693c",
+        "sha": "4bd693c7f2960672c13534d4a3e5fe92ce9d5015",
         "legislative_periods": [
           {
             "end_date": "2016-06-01",
@@ -4635,7 +4635,7 @@
             "start_date": "2015-03-31",
             "slug": "20",
             "csv": "data/Israel/Knesset/term-20.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a/data/Israel/Knesset/term-20.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a93d6498c6f5be97f039817c0ce8a492ba/data/Israel/Knesset/term-20.csv"
           },
           {
             "end_date": "2015-03-31",
@@ -4644,7 +4644,7 @@
             "start_date": "2013-02-05",
             "slug": "19",
             "csv": "data/Israel/Knesset/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a/data/Israel/Knesset/term-19.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a93d6498c6f5be97f039817c0ce8a492ba/data/Israel/Knesset/term-19.csv"
           },
           {
             "end_date": "2013-02-05",
@@ -4653,7 +4653,7 @@
             "start_date": "2009-02-24",
             "slug": "18",
             "csv": "data/Israel/Knesset/term-18.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a/data/Israel/Knesset/term-18.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a93d6498c6f5be97f039817c0ce8a492ba/data/Israel/Knesset/term-18.csv"
           },
           {
             "end_date": "2009-02-24",
@@ -4662,7 +4662,7 @@
             "start_date": "2006-04-17",
             "slug": "17",
             "csv": "data/Israel/Knesset/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a/data/Israel/Knesset/term-17.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a93d6498c6f5be97f039817c0ce8a492ba/data/Israel/Knesset/term-17.csv"
           },
           {
             "end_date": "2006-04-17",
@@ -4671,7 +4671,7 @@
             "start_date": "2003-02-17",
             "slug": "16",
             "csv": "data/Israel/Knesset/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a/data/Israel/Knesset/term-16.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a93d6498c6f5be97f039817c0ce8a492ba/data/Israel/Knesset/term-16.csv"
           },
           {
             "end_date": "2003-02-17",
@@ -4680,7 +4680,7 @@
             "start_date": "1999-06-07",
             "slug": "15",
             "csv": "data/Israel/Knesset/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a/data/Israel/Knesset/term-15.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a93d6498c6f5be97f039817c0ce8a492ba/data/Israel/Knesset/term-15.csv"
           },
           {
             "end_date": "1999-06-07",
@@ -4689,7 +4689,7 @@
             "start_date": "1996-06-17",
             "slug": "14",
             "csv": "data/Israel/Knesset/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a/data/Israel/Knesset/term-14.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a93d6498c6f5be97f039817c0ce8a492ba/data/Israel/Knesset/term-14.csv"
           },
           {
             "end_date": "1996-06-17",
@@ -4698,7 +4698,7 @@
             "start_date": "1992-07-13",
             "slug": "13",
             "csv": "data/Israel/Knesset/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a/data/Israel/Knesset/term-13.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a93d6498c6f5be97f039817c0ce8a492ba/data/Israel/Knesset/term-13.csv"
           },
           {
             "end_date": "1992-07-13",
@@ -4707,7 +4707,7 @@
             "start_date": "1988-11-21",
             "slug": "12",
             "csv": "data/Israel/Knesset/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a/data/Israel/Knesset/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f28d4a93d6498c6f5be97f039817c0ce8a492ba/data/Israel/Knesset/term-12.csv"
           },
           {
             "end_date": "1988-11-21",
@@ -4716,7 +4716,7 @@
             "start_date": "1984-08-13",
             "slug": "11",
             "csv": "data/Israel/Knesset/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1dd33e7/data/Israel/Knesset/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1dd33e7d327aeabc909d62c765ebf6a7cf329598/data/Israel/Knesset/term-11.csv"
           },
           {
             "end_date": "1984-08-13",
@@ -4725,7 +4725,7 @@
             "start_date": "1981-07-20",
             "slug": "10",
             "csv": "data/Israel/Knesset/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1dd33e7/data/Israel/Knesset/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1dd33e7d327aeabc909d62c765ebf6a7cf329598/data/Israel/Knesset/term-10.csv"
           },
           {
             "end_date": "1981-07-20",
@@ -4734,7 +4734,7 @@
             "start_date": "1977-06-13",
             "slug": "9",
             "csv": "data/Israel/Knesset/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1dd33e7/data/Israel/Knesset/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1dd33e7d327aeabc909d62c765ebf6a7cf329598/data/Israel/Knesset/term-9.csv"
           },
           {
             "end_date": "1977-06-13",
@@ -4743,7 +4743,7 @@
             "start_date": "1974-01-21",
             "slug": "8",
             "csv": "data/Israel/Knesset/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70e3d47/data/Israel/Knesset/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70e3d476a5db69ffd64364ad5e1c592b1b91716b/data/Israel/Knesset/term-8.csv"
           },
           {
             "end_date": "1974-01-21",
@@ -4752,7 +4752,7 @@
             "start_date": "1969-11-17",
             "slug": "7",
             "csv": "data/Israel/Knesset/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70e3d47/data/Israel/Knesset/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70e3d476a5db69ffd64364ad5e1c592b1b91716b/data/Israel/Knesset/term-7.csv"
           },
           {
             "end_date": "1969-11-17",
@@ -4761,7 +4761,7 @@
             "start_date": "1965-11-22",
             "slug": "6",
             "csv": "data/Israel/Knesset/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70e3d47/data/Israel/Knesset/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70e3d476a5db69ffd64364ad5e1c592b1b91716b/data/Israel/Knesset/term-6.csv"
           },
           {
             "end_date": "1965-11-22",
@@ -4770,7 +4770,7 @@
             "start_date": "1961-09-04",
             "slug": "5",
             "csv": "data/Israel/Knesset/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70e3d47/data/Israel/Knesset/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70e3d476a5db69ffd64364ad5e1c592b1b91716b/data/Israel/Knesset/term-5.csv"
           },
           {
             "end_date": "1961-09-04",
@@ -4779,7 +4779,7 @@
             "start_date": "1959-11-30",
             "slug": "4",
             "csv": "data/Israel/Knesset/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1dd33e7/data/Israel/Knesset/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1dd33e7d327aeabc909d62c765ebf6a7cf329598/data/Israel/Knesset/term-4.csv"
           },
           {
             "end_date": "1959-11-30",
@@ -4788,7 +4788,7 @@
             "start_date": "1955-08-15",
             "slug": "3",
             "csv": "data/Israel/Knesset/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1dd33e7/data/Israel/Knesset/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1dd33e7d327aeabc909d62c765ebf6a7cf329598/data/Israel/Knesset/term-3.csv"
           },
           {
             "end_date": "1955-08-15",
@@ -4797,7 +4797,7 @@
             "start_date": "1951-08-20",
             "slug": "2",
             "csv": "data/Israel/Knesset/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1dd33e7/data/Israel/Knesset/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1dd33e7d327aeabc909d62c765ebf6a7cf329598/data/Israel/Knesset/term-2.csv"
           },
           {
             "end_date": "1951-08-20",
@@ -4806,7 +4806,7 @@
             "start_date": "1949-02-14",
             "slug": "1",
             "csv": "data/Israel/Knesset/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1dd33e7/data/Israel/Knesset/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1dd33e7d327aeabc909d62c765ebf6a7cf329598/data/Israel/Knesset/term-1.csv"
           }
         ],
         "statement_count": 82097
@@ -4824,11 +4824,11 @@
         "slug": "House",
         "sources_directory": "data/Italy/House/sources",
         "popolo": "data/Italy/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f54f16a/data/Italy/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f54f16ad07a7404eb71c8e33bbc03874a33a6503/data/Italy/House/ep-popolo-v1.0.json",
         "names": "data/Italy/House/names.csv",
         "lastmod": "1470566630",
         "person_count": 664,
-        "sha": "f54f16a",
+        "sha": "f54f16ad07a7404eb71c8e33bbc03874a33a6503",
         "legislative_periods": [
           {
             "id": "term/17",
@@ -4836,7 +4836,7 @@
             "start_date": "2013-03-19",
             "slug": "17",
             "csv": "data/Italy/House/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/784eccf/data/Italy/House/term-17.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/784eccf67a353fee37e5f47ffcdf99238f72ee3a/data/Italy/House/term-17.csv"
           }
         ],
         "statement_count": 45207
@@ -4846,11 +4846,11 @@
         "slug": "Senate",
         "sources_directory": "data/Italy/Senate/sources",
         "popolo": "data/Italy/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2437971/data/Italy/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/243797166b4fd9dc9cb765e9c4168b5afd687972/data/Italy/Senate/ep-popolo-v1.0.json",
         "names": "data/Italy/Senate/names.csv",
         "lastmod": "1471411888",
         "person_count": 322,
-        "sha": "2437971",
+        "sha": "243797166b4fd9dc9cb765e9c4168b5afd687972",
         "legislative_periods": [
           {
             "id": "term/17",
@@ -4858,7 +4858,7 @@
             "start_date": "2013-03-15",
             "slug": "17",
             "csv": "data/Italy/Senate/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2437971/data/Italy/Senate/term-17.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/243797166b4fd9dc9cb765e9c4168b5afd687972/data/Italy/Senate/term-17.csv"
           }
         ],
         "statement_count": 21935
@@ -4876,11 +4876,11 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Jamaica/House_of_Representatives/sources",
         "popolo": "data/Jamaica/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7efd/data/Jamaica/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7efd4c2be9813c1532683356876833004d974/data/Jamaica/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Jamaica/House_of_Representatives/names.csv",
         "lastmod": "1472090954",
         "person_count": 81,
-        "sha": "75b7efd",
+        "sha": "75b7efd4c2be9813c1532683356876833004d974",
         "legislative_periods": [
           {
             "id": "term/2016",
@@ -4888,7 +4888,7 @@
             "start_date": "2016-03-10",
             "slug": "2016",
             "csv": "data/Jamaica/House_of_Representatives/term-2016.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7efd/data/Jamaica/House_of_Representatives/term-2016.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75b7efd4c2be9813c1532683356876833004d974/data/Jamaica/House_of_Representatives/term-2016.csv"
           },
           {
             "end_date": "2016-02-25",
@@ -4897,7 +4897,7 @@
             "start_date": "2012-01-17",
             "slug": "2011",
             "csv": "data/Jamaica/House_of_Representatives/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/89a37ec/data/Jamaica/House_of_Representatives/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/89a37ec14cc678ccd5772d65bc464a3be162a9fc/data/Jamaica/House_of_Representatives/term-2011.csv"
           }
         ],
         "statement_count": 3182
@@ -4915,11 +4915,11 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Japan/House_of_Representatives/sources",
         "popolo": "data/Japan/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7d4ea7d/data/Japan/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7d4ea7dbe8547efddd5388d491fb2bb66c9b8886/data/Japan/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Japan/House_of_Representatives/names.csv",
         "lastmod": "1471480281",
         "person_count": 477,
-        "sha": "7d4ea7d",
+        "sha": "7d4ea7dbe8547efddd5388d491fb2bb66c9b8886",
         "legislative_periods": [
           {
             "id": "term/46",
@@ -4927,7 +4927,7 @@
             "start_date": "2014-12-14",
             "slug": "46",
             "csv": "data/Japan/House_of_Representatives/term-46.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e1c447/data/Japan/House_of_Representatives/term-46.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e1c4470354c18487a48d730eb81330f5a09f3aa/data/Japan/House_of_Representatives/term-46.csv"
           }
         ],
         "statement_count": 24210
@@ -4945,11 +4945,11 @@
         "slug": "States",
         "sources_directory": "data/Jersey/States/sources",
         "popolo": "data/Jersey/States/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7352b16/data/Jersey/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7352b16b4074964bc98ff25d1043b70978da9ca4/data/Jersey/States/ep-popolo-v1.0.json",
         "names": "data/Jersey/States/names.csv",
         "lastmod": "1469384206",
         "person_count": 61,
-        "sha": "7352b16",
+        "sha": "7352b16b4074964bc98ff25d1043b70978da9ca4",
         "legislative_periods": [
           {
             "id": "term/2011",
@@ -4957,7 +4957,7 @@
             "start_date": "2014-11-03",
             "slug": "2011",
             "csv": "data/Jersey/States/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4bce540/data/Jersey/States/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4bce54087613b97944c587f7f6cc27796c41f091/data/Jersey/States/term-2011.csv"
           }
         ],
         "statement_count": 1638
@@ -4975,11 +4975,11 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Jordan/House_of_Representatives/sources",
         "popolo": "data/Jordan/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9ca7a16/data/Jordan/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9ca7a1645451c9116bd3249273295fbf5116521d/data/Jordan/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Jordan/House_of_Representatives/names.csv",
         "lastmod": "1469384209",
         "person_count": 150,
-        "sha": "9ca7a16",
+        "sha": "9ca7a1645451c9116bd3249273295fbf5116521d",
         "legislative_periods": [
           {
             "id": "term/2013",
@@ -4987,7 +4987,7 @@
             "start_date": "2013-02-10",
             "slug": "2013",
             "csv": "data/Jordan/House_of_Representatives/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/55872b7/data/Jordan/House_of_Representatives/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/55872b73fbb85d5bb3a028898baae87b7b18562b/data/Jordan/House_of_Representatives/term-2013.csv"
           }
         ],
         "statement_count": 2023
@@ -5005,11 +5005,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Kazakhstan/Assembly/sources",
         "popolo": "data/Kazakhstan/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a472afa/data/Kazakhstan/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a472afae7daf7e066fbd70d2daba42b7ae77ae8b/data/Kazakhstan/Assembly/ep-popolo-v1.0.json",
         "names": "data/Kazakhstan/Assembly/names.csv",
         "lastmod": "1470143794",
         "person_count": 171,
-        "sha": "a472afa",
+        "sha": "a472afae7daf7e066fbd70d2daba42b7ae77ae8b",
         "legislative_periods": [
           {
             "id": "term/6",
@@ -5017,7 +5017,7 @@
             "start_date": "2016-03-25",
             "slug": "6",
             "csv": "data/Kazakhstan/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2e6a53f/data/Kazakhstan/Assembly/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2e6a53f04af0d391973e6e788115c8e0b9b3085c/data/Kazakhstan/Assembly/term-6.csv"
           },
           {
             "end_date": "2016-01-20",
@@ -5026,7 +5026,7 @@
             "start_date": "2012-01-15",
             "slug": "5",
             "csv": "data/Kazakhstan/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/afe5f27/data/Kazakhstan/Assembly/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/afe5f273443f1f087aac686702b57ca806d2126b/data/Kazakhstan/Assembly/term-5.csv"
           }
         ],
         "statement_count": 3932
@@ -5044,11 +5044,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Kenya/Assembly/sources",
         "popolo": "data/Kenya/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/388a2d5/data/Kenya/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/388a2d5e95c58b7bc52625b562c1c8a54c362af9/data/Kenya/Assembly/ep-popolo-v1.0.json",
         "names": "data/Kenya/Assembly/names.csv",
         "lastmod": "1471208185",
         "person_count": 355,
-        "sha": "388a2d5",
+        "sha": "388a2d5e95c58b7bc52625b562c1c8a54c362af9",
         "legislative_periods": [
           {
             "id": "term/11",
@@ -5056,7 +5056,7 @@
             "start_date": "2013-03-28",
             "slug": "11",
             "csv": "data/Kenya/Assembly/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/388a2d5/data/Kenya/Assembly/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/388a2d5e95c58b7bc52625b562c1c8a54c362af9/data/Kenya/Assembly/term-11.csv"
           }
         ],
         "statement_count": 10359
@@ -5074,11 +5074,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Kiribati/Parliament/sources",
         "popolo": "data/Kiribati/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75cb627/data/Kiribati/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75cb627dc13e4caf919a6fce4a36ca6a5682fa59/data/Kiribati/Parliament/ep-popolo-v1.0.json",
         "names": "data/Kiribati/Parliament/names.csv",
         "lastmod": "1470489540",
         "person_count": 62,
-        "sha": "75cb627",
+        "sha": "75cb627dc13e4caf919a6fce4a36ca6a5682fa59",
         "legislative_periods": [
           {
             "end_date": "2015-11-25",
@@ -5087,7 +5087,7 @@
             "start_date": "2011-11-25",
             "slug": "10",
             "csv": "data/Kiribati/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ee1326b/data/Kiribati/Parliament/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ee1326b9cd70fea41d2dcb5627da58176efb51af/data/Kiribati/Parliament/term-10.csv"
           },
           {
             "end_date": "2011-10-20",
@@ -5096,7 +5096,7 @@
             "start_date": "2007-09-17",
             "slug": "9",
             "csv": "data/Kiribati/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ee1326b/data/Kiribati/Parliament/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ee1326b9cd70fea41d2dcb5627da58176efb51af/data/Kiribati/Parliament/term-9.csv"
           }
         ],
         "statement_count": 2057
@@ -5114,11 +5114,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Kosovo/Assembly/sources",
         "popolo": "data/Kosovo/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a423073/data/Kosovo/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a423073957e3098d7399126d92b189776119af50/data/Kosovo/Assembly/ep-popolo-v1.0.json",
         "names": "data/Kosovo/Assembly/names.csv",
         "lastmod": "1469384225",
         "person_count": 399,
-        "sha": "a423073",
+        "sha": "a423073957e3098d7399126d92b189776119af50",
         "legislative_periods": [
           {
             "id": "term/chamber_2014-07-17",
@@ -5126,7 +5126,7 @@
             "start_date": "2014-07-17",
             "slug": "chamber_2014-07-17",
             "csv": "data/Kosovo/Assembly/term-chamber_2014-07-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab3e8b5/data/Kosovo/Assembly/term-chamber_2014-07-17.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab3e8b562e7e182d7efb11113f001019985cc33a/data/Kosovo/Assembly/term-chamber_2014-07-17.csv"
           },
           {
             "end_date": "2014-05-07",
@@ -5135,7 +5135,7 @@
             "start_date": "2010-12-12",
             "slug": "chamber_2010-12-12",
             "csv": "data/Kosovo/Assembly/term-chamber_2010-12-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab3e8b5/data/Kosovo/Assembly/term-chamber_2010-12-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab3e8b562e7e182d7efb11113f001019985cc33a/data/Kosovo/Assembly/term-chamber_2010-12-12.csv"
           },
           {
             "end_date": "2010-11-03",
@@ -5144,7 +5144,7 @@
             "start_date": "2007-12-13",
             "slug": "chamber_2007-12-13",
             "csv": "data/Kosovo/Assembly/term-chamber_2007-12-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab3e8b5/data/Kosovo/Assembly/term-chamber_2007-12-13.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab3e8b562e7e182d7efb11113f001019985cc33a/data/Kosovo/Assembly/term-chamber_2007-12-13.csv"
           },
           {
             "end_date": "2007-12-12",
@@ -5153,7 +5153,7 @@
             "start_date": "2004-11-23",
             "slug": "chamber_2004-11-23",
             "csv": "data/Kosovo/Assembly/term-chamber_2004-11-23.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab3e8b5/data/Kosovo/Assembly/term-chamber_2004-11-23.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab3e8b562e7e182d7efb11113f001019985cc33a/data/Kosovo/Assembly/term-chamber_2004-11-23.csv"
           },
           {
             "end_date": "2004-11-23",
@@ -5162,7 +5162,7 @@
             "start_date": "2001-11-17",
             "slug": "chamber_2001-11-17",
             "csv": "data/Kosovo/Assembly/term-chamber_2001-11-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab3e8b5/data/Kosovo/Assembly/term-chamber_2001-11-17.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab3e8b562e7e182d7efb11113f001019985cc33a/data/Kosovo/Assembly/term-chamber_2001-11-17.csv"
           }
         ],
         "statement_count": 9359
@@ -5180,11 +5180,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Kuwait/National_Assembly/sources",
         "popolo": "data/Kuwait/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6c14d22/data/Kuwait/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6c14d2205e5d444a644b9baae309a0a8db77843b/data/Kuwait/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Kuwait/National_Assembly/names.csv",
         "lastmod": "1470418617",
         "person_count": 45,
-        "sha": "6c14d22",
+        "sha": "6c14d2205e5d444a644b9baae309a0a8db77843b",
         "legislative_periods": [
           {
             "id": "term/14",
@@ -5192,7 +5192,7 @@
             "start_date": "2013-08-06",
             "slug": "14",
             "csv": "data/Kuwait/National_Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4e8b8d7/data/Kuwait/National_Assembly/term-14.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4e8b8d7150cb185367422fee24834af06dddf7c8/data/Kuwait/National_Assembly/term-14.csv"
           }
         ],
         "statement_count": 1346
@@ -5210,11 +5210,11 @@
         "slug": "Council",
         "sources_directory": "data/Kyrgyzstan/Council/sources",
         "popolo": "data/Kyrgyzstan/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d97409b/data/Kyrgyzstan/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d97409bdfdb5c000bd726612264c10fa0e019a74/data/Kyrgyzstan/Council/ep-popolo-v1.0.json",
         "names": "data/Kyrgyzstan/Council/names.csv",
         "lastmod": "1469384235",
         "person_count": 209,
-        "sha": "d97409b",
+        "sha": "d97409bdfdb5c000bd726612264c10fa0e019a74",
         "legislative_periods": [
           {
             "id": "term/6",
@@ -5222,7 +5222,7 @@
             "start_date": "2015-10-28",
             "slug": "6",
             "csv": "data/Kyrgyzstan/Council/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c8a03d9/data/Kyrgyzstan/Council/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c8a03d963392cfe93fa25cb50d6538d94e8f9c6c/data/Kyrgyzstan/Council/term-6.csv"
           },
           {
             "end_date": "2015-10-15",
@@ -5231,7 +5231,7 @@
             "start_date": "2010",
             "slug": "5",
             "csv": "data/Kyrgyzstan/Council/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ac53cd8/data/Kyrgyzstan/Council/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ac53cd87c7b281a3ecce65b5bcf7ff0268694872/data/Kyrgyzstan/Council/term-5.csv"
           }
         ],
         "statement_count": 3621
@@ -5249,11 +5249,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Laos/Assembly/sources",
         "popolo": "data/Laos/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ae574a/data/Laos/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ae574a11fa229b932eca90b4a750c4adb59d78b/data/Laos/Assembly/ep-popolo-v1.0.json",
         "names": "data/Laos/Assembly/names.csv",
         "lastmod": "1469385748",
         "person_count": 132,
-        "sha": "5ae574a",
+        "sha": "5ae574a11fa229b932eca90b4a750c4adb59d78b",
         "legislative_periods": [
           {
             "end_date": "2016-03-20",
@@ -5262,7 +5262,7 @@
             "start_date": "2011-06-15",
             "slug": "2011",
             "csv": "data/Laos/Assembly/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c0f7450/data/Laos/Assembly/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c0f74504df167546c77db68f0463ea785100b6c9/data/Laos/Assembly/term-2011.csv"
           }
         ],
         "statement_count": 1899
@@ -5280,11 +5280,11 @@
         "slug": "Saeima",
         "sources_directory": "data/Latvia/Saeima/sources",
         "popolo": "data/Latvia/Saeima/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c79f683/data/Latvia/Saeima/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c79f68357fe11c8b871ef91c7c0720b98a2b47ab/data/Latvia/Saeima/ep-popolo-v1.0.json",
         "names": "data/Latvia/Saeima/names.csv",
         "lastmod": "1470403750",
         "person_count": 203,
-        "sha": "c79f683",
+        "sha": "c79f68357fe11c8b871ef91c7c0720b98a2b47ab",
         "legislative_periods": [
           {
             "id": "term/12",
@@ -5293,7 +5293,7 @@
             "wikidata": "Q20557340",
             "slug": "12",
             "csv": "data/Latvia/Saeima/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/87e65f0/data/Latvia/Saeima/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/87e65f09286a5549fd00d78ab7669af30c30b1a4/data/Latvia/Saeima/term-12.csv"
           },
           {
             "end_date": "2014-11-03",
@@ -5303,7 +5303,7 @@
             "wikidata": "Q13098708",
             "slug": "11",
             "csv": "data/Latvia/Saeima/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5853736/data/Latvia/Saeima/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/585373645f4dfcb30fb34455dddc96808242a0df/data/Latvia/Saeima/term-11.csv"
           },
           {
             "end_date": "2011-10-16",
@@ -5313,7 +5313,7 @@
             "wikidata": "Q16347625",
             "slug": "10",
             "csv": "data/Latvia/Saeima/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5853736/data/Latvia/Saeima/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/585373645f4dfcb30fb34455dddc96808242a0df/data/Latvia/Saeima/term-10.csv"
           }
         ],
         "statement_count": 27059
@@ -5331,11 +5331,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Lebanon/Parliament/sources",
         "popolo": "data/Lebanon/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1e608d3/data/Lebanon/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1e608d3db85657729ac4b2e8576df5873bcf573a/data/Lebanon/Parliament/ep-popolo-v1.0.json",
         "names": "data/Lebanon/Parliament/names.csv",
         "lastmod": "1472105035",
         "person_count": 130,
-        "sha": "1e608d3",
+        "sha": "1e608d3db85657729ac4b2e8576df5873bcf573a",
         "legislative_periods": [
           {
             "end_date": "2017-06-20",
@@ -5344,7 +5344,7 @@
             "start_date": "2009-06-20",
             "slug": "2009",
             "csv": "data/Lebanon/Parliament/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1e608d3/data/Lebanon/Parliament/term-2009.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1e608d3db85657729ac4b2e8576df5873bcf573a/data/Lebanon/Parliament/term-2009.csv"
           }
         ],
         "statement_count": 7978
@@ -5362,11 +5362,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Lesotho/Assembly/sources",
         "popolo": "data/Lesotho/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1afcf70/data/Lesotho/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1afcf709c50aecd29602005d865f13419edcdcab/data/Lesotho/Assembly/ep-popolo-v1.0.json",
         "names": "data/Lesotho/Assembly/names.csv",
         "lastmod": "1469302753",
         "person_count": 120,
-        "sha": "1afcf70",
+        "sha": "1afcf709c50aecd29602005d865f13419edcdcab",
         "legislative_periods": [
           {
             "id": "term/9",
@@ -5374,7 +5374,7 @@
             "start_date": "2015-03-10",
             "slug": "9",
             "csv": "data/Lesotho/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/58cc9fb/data/Lesotho/Assembly/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/58cc9fb33e331fe6faa6db14cf9560e506d01b78/data/Lesotho/Assembly/term-9.csv"
           }
         ],
         "statement_count": 2182
@@ -5392,11 +5392,11 @@
         "slug": "House",
         "sources_directory": "data/Liberia/House/sources",
         "popolo": "data/Liberia/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cf86ee7/data/Liberia/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cf86ee74265c134480020d79d1191a2833772939/data/Liberia/House/ep-popolo-v1.0.json",
         "names": "data/Liberia/House/names.csv",
         "lastmod": "1469384289",
         "person_count": 73,
-        "sha": "cf86ee7",
+        "sha": "cf86ee74265c134480020d79d1191a2833772939",
         "legislative_periods": [
           {
             "id": "term/53",
@@ -5404,7 +5404,7 @@
             "start_date": "2012-01-09",
             "slug": "53",
             "csv": "data/Liberia/House/term-53.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/72a0b58/data/Liberia/House/term-53.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/72a0b5867587756a2d4cc06b4632485e4b6c74c1/data/Liberia/House/term-53.csv"
           }
         ],
         "statement_count": 2008
@@ -5422,11 +5422,11 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Libya/House_of_Representatives/sources",
         "popolo": "data/Libya/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c0a53fe/data/Libya/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c0a53fe7e6cb70f255759aadb25a77c849e790da/data/Libya/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Libya/House_of_Representatives/names.csv",
         "lastmod": "1469384295",
         "person_count": 189,
-        "sha": "c0a53fe",
+        "sha": "c0a53fe7e6cb70f255759aadb25a77c849e790da",
         "legislative_periods": [
           {
             "id": "term/1",
@@ -5434,7 +5434,7 @@
             "start_date": "2014-08-04",
             "slug": "1",
             "csv": "data/Libya/House_of_Representatives/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b96db40/data/Libya/House_of_Representatives/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b96db406dfd285f135e3d84c7e950557e63b2aa2/data/Libya/House_of_Representatives/term-1.csv"
           }
         ],
         "statement_count": 3087
@@ -5452,11 +5452,11 @@
         "slug": "Landtag",
         "sources_directory": "data/Liechtenstein/Landtag/sources",
         "popolo": "data/Liechtenstein/Landtag/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af1cd6e/data/Liechtenstein/Landtag/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af1cd6edf40ad08814600581d2e13e21a3b6f376/data/Liechtenstein/Landtag/ep-popolo-v1.0.json",
         "names": "data/Liechtenstein/Landtag/names.csv",
         "lastmod": "1471546192",
         "person_count": 51,
-        "sha": "af1cd6e",
+        "sha": "af1cd6edf40ad08814600581d2e13e21a3b6f376",
         "legislative_periods": [
           {
             "end_date": "2017",
@@ -5465,7 +5465,7 @@
             "start_date": "2013-03-27",
             "slug": "2013",
             "csv": "data/Liechtenstein/Landtag/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8551ecb/data/Liechtenstein/Landtag/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8551ecbfeaea75244b23734a9db92268e128bde8/data/Liechtenstein/Landtag/term-2013.csv"
           },
           {
             "end_date": "2013-02-02",
@@ -5474,7 +5474,7 @@
             "start_date": "2009-03-18",
             "slug": "2009",
             "csv": "data/Liechtenstein/Landtag/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8551ecb/data/Liechtenstein/Landtag/term-2009.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8551ecbfeaea75244b23734a9db92268e128bde8/data/Liechtenstein/Landtag/term-2009.csv"
           },
           {
             "end_date": "2009-02-07",
@@ -5483,7 +5483,7 @@
             "start_date": "2005-04-14",
             "slug": "2005",
             "csv": "data/Liechtenstein/Landtag/term-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3a4bed1/data/Liechtenstein/Landtag/term-2005.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3a4bed1fcd87d233f226f9889d784cce0534a492/data/Liechtenstein/Landtag/term-2005.csv"
           }
         ],
         "statement_count": 2639
@@ -5501,11 +5501,11 @@
         "slug": "Seimas",
         "sources_directory": "data/Lithuania/Seimas/sources",
         "popolo": "data/Lithuania/Seimas/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b620114/data/Lithuania/Seimas/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b62011443c6eb6d0acc0db8ead8461c0771aaa27/data/Lithuania/Seimas/ep-popolo-v1.0.json",
         "names": "data/Lithuania/Seimas/names.csv",
         "lastmod": "1472099280",
         "person_count": 150,
-        "sha": "b620114",
+        "sha": "b62011443c6eb6d0acc0db8ead8461c0771aaa27",
         "legislative_periods": [
           {
             "id": "term/11",
@@ -5513,7 +5513,7 @@
             "start_date": "2012-11-17",
             "slug": "11",
             "csv": "data/Lithuania/Seimas/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6a52d7d/data/Lithuania/Seimas/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6a52d7d9a1f033baa3ca349e37cd23292a69721d/data/Lithuania/Seimas/term-11.csv"
           }
         ],
         "statement_count": 15520
@@ -5531,11 +5531,11 @@
         "slug": "Chamber",
         "sources_directory": "data/Luxembourg/Chamber/sources",
         "popolo": "data/Luxembourg/Chamber/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37f9c9a/data/Luxembourg/Chamber/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37f9c9aa4d317f85f8ccbc4c73bdad4da8cc3ca4/data/Luxembourg/Chamber/ep-popolo-v1.0.json",
         "names": "data/Luxembourg/Chamber/names.csv",
         "lastmod": "1471959837",
         "person_count": 62,
-        "sha": "37f9c9a",
+        "sha": "37f9c9aa4d317f85f8ccbc4c73bdad4da8cc3ca4",
         "legislative_periods": [
           {
             "id": "term/2013",
@@ -5543,7 +5543,7 @@
             "start_date": "2013-11-13",
             "slug": "2013",
             "csv": "data/Luxembourg/Chamber/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c28ee77/data/Luxembourg/Chamber/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c28ee7764113aadbcd9e86879ea13c2130609a73/data/Luxembourg/Chamber/term-2013.csv"
           }
         ],
         "statement_count": 4072
@@ -5561,11 +5561,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Macao/Assembly/sources",
         "popolo": "data/Macao/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/236389b/data/Macao/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/236389b8fc40a5e726adf48f361ad73ab932ee42/data/Macao/Assembly/ep-popolo-v1.0.json",
         "names": "data/Macao/Assembly/names.csv",
         "lastmod": "1469384393",
         "person_count": 33,
-        "sha": "236389b",
+        "sha": "236389b8fc40a5e726adf48f361ad73ab932ee42",
         "legislative_periods": [
           {
             "end_date": "2017",
@@ -5574,7 +5574,7 @@
             "start_date": "2013",
             "slug": "10",
             "csv": "data/Macao/Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f6c878/data/Macao/Assembly/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f6c8784728d9b552d9e83f2ca44e5be0bc2dc35/data/Macao/Assembly/term-10.csv"
           }
         ],
         "statement_count": 1033
@@ -5592,11 +5592,11 @@
         "slug": "Sobranie",
         "sources_directory": "data/Macedonia/Sobranie/sources",
         "popolo": "data/Macedonia/Sobranie/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a55c99c/data/Macedonia/Sobranie/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a55c99c67b85b367d7b155726f681dfb7da9ea0b/data/Macedonia/Sobranie/ep-popolo-v1.0.json",
         "names": "data/Macedonia/Sobranie/names.csv",
         "lastmod": "1470774876",
         "person_count": 92,
-        "sha": "a55c99c",
+        "sha": "a55c99c67b85b367d7b155726f681dfb7da9ea0b",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -5604,7 +5604,7 @@
             "start_date": "2014-05-10",
             "slug": "2014",
             "csv": "data/Macedonia/Sobranie/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af6fa64/data/Macedonia/Sobranie/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af6fa64cf0df5c3c894de5b55c2512e6901d2f70/data/Macedonia/Sobranie/term-2014.csv"
           }
         ],
         "statement_count": 2493
@@ -5622,11 +5622,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Madagascar/Assembly/sources",
         "popolo": "data/Madagascar/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ac026b5/data/Madagascar/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ac026b5dca928299e2c8c001eaf0c35e466c13c3/data/Madagascar/Assembly/ep-popolo-v1.0.json",
         "names": "data/Madagascar/Assembly/names.csv",
         "lastmod": "1470665084",
         "person_count": 155,
-        "sha": "ac026b5",
+        "sha": "ac026b5dca928299e2c8c001eaf0c35e466c13c3",
         "legislative_periods": [
           {
             "end_date": "2018",
@@ -5635,7 +5635,7 @@
             "start_date": "2013-12-20",
             "slug": "2013",
             "csv": "data/Madagascar/Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ac026b5/data/Madagascar/Assembly/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ac026b5dca928299e2c8c001eaf0c35e466c13c3/data/Madagascar/Assembly/term-2013.csv"
           }
         ],
         "statement_count": 3065
@@ -5653,11 +5653,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Malawi/Assembly/sources",
         "popolo": "data/Malawi/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0f005d1/data/Malawi/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0f005d1dc2888b3c0971bfaa359ff87883301737/data/Malawi/Assembly/ep-popolo-v1.0.json",
         "names": "data/Malawi/Assembly/names.csv",
         "lastmod": "1469384402",
         "person_count": 193,
-        "sha": "0f005d1",
+        "sha": "0f005d1dc2888b3c0971bfaa359ff87883301737",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -5665,7 +5665,7 @@
             "start_date": "2014-06-19",
             "slug": "2014",
             "csv": "data/Malawi/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/acb977a/data/Malawi/Assembly/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/acb977a472973ee1e98caf64b10a630ebbcde6cb/data/Malawi/Assembly/term-2014.csv"
           }
         ],
         "statement_count": 2777
@@ -5683,11 +5683,11 @@
         "slug": "Dewan-Rakyat",
         "sources_directory": "data/Malaysia/Dewan_Rakyat/sources",
         "popolo": "data/Malaysia/Dewan_Rakyat/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bd3cad4/data/Malaysia/Dewan_Rakyat/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bd3cad4b30807202564e59226339797c2bf94506/data/Malaysia/Dewan_Rakyat/ep-popolo-v1.0.json",
         "names": "data/Malaysia/Dewan_Rakyat/names.csv",
         "lastmod": "1469385790",
         "person_count": 1152,
-        "sha": "bd3cad4",
+        "sha": "bd3cad4b30807202564e59226339797c2bf94506",
         "legislative_periods": [
           {
             "id": "term/13",
@@ -5695,7 +5695,7 @@
             "start_date": "2013-06-24",
             "slug": "13",
             "csv": "data/Malaysia/Dewan_Rakyat/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a4c1f6/data/Malaysia/Dewan_Rakyat/term-13.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a4c1f6baec4a1a9347aca94ef42731ca73a81b0/data/Malaysia/Dewan_Rakyat/term-13.csv"
           },
           {
             "end_date": "2013",
@@ -5704,7 +5704,7 @@
             "start_date": "2008",
             "slug": "12",
             "csv": "data/Malaysia/Dewan_Rakyat/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6/data/Malaysia/Dewan_Rakyat/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6145ad02b0ec104182ec0d8e183b2f9862/data/Malaysia/Dewan_Rakyat/term-12.csv"
           },
           {
             "end_date": "2008",
@@ -5713,7 +5713,7 @@
             "start_date": "2004",
             "slug": "11",
             "csv": "data/Malaysia/Dewan_Rakyat/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a4c1f6/data/Malaysia/Dewan_Rakyat/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a4c1f6baec4a1a9347aca94ef42731ca73a81b0/data/Malaysia/Dewan_Rakyat/term-11.csv"
           },
           {
             "end_date": "2004",
@@ -5722,7 +5722,7 @@
             "start_date": "1999",
             "slug": "10",
             "csv": "data/Malaysia/Dewan_Rakyat/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6/data/Malaysia/Dewan_Rakyat/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6145ad02b0ec104182ec0d8e183b2f9862/data/Malaysia/Dewan_Rakyat/term-10.csv"
           },
           {
             "end_date": "1999",
@@ -5731,7 +5731,7 @@
             "start_date": "1995",
             "slug": "9",
             "csv": "data/Malaysia/Dewan_Rakyat/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6/data/Malaysia/Dewan_Rakyat/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6145ad02b0ec104182ec0d8e183b2f9862/data/Malaysia/Dewan_Rakyat/term-9.csv"
           },
           {
             "end_date": "1995",
@@ -5740,7 +5740,7 @@
             "start_date": "1990",
             "slug": "8",
             "csv": "data/Malaysia/Dewan_Rakyat/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6/data/Malaysia/Dewan_Rakyat/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6145ad02b0ec104182ec0d8e183b2f9862/data/Malaysia/Dewan_Rakyat/term-8.csv"
           },
           {
             "end_date": "1990",
@@ -5749,7 +5749,7 @@
             "start_date": "1986",
             "slug": "7",
             "csv": "data/Malaysia/Dewan_Rakyat/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6/data/Malaysia/Dewan_Rakyat/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6145ad02b0ec104182ec0d8e183b2f9862/data/Malaysia/Dewan_Rakyat/term-7.csv"
           },
           {
             "end_date": "1986",
@@ -5758,7 +5758,7 @@
             "start_date": "1982",
             "slug": "6",
             "csv": "data/Malaysia/Dewan_Rakyat/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6/data/Malaysia/Dewan_Rakyat/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6145ad02b0ec104182ec0d8e183b2f9862/data/Malaysia/Dewan_Rakyat/term-6.csv"
           },
           {
             "end_date": "1982",
@@ -5767,7 +5767,7 @@
             "start_date": "1978",
             "slug": "5",
             "csv": "data/Malaysia/Dewan_Rakyat/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6/data/Malaysia/Dewan_Rakyat/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6145ad02b0ec104182ec0d8e183b2f9862/data/Malaysia/Dewan_Rakyat/term-5.csv"
           },
           {
             "end_date": "1978",
@@ -5776,7 +5776,7 @@
             "start_date": "1974",
             "slug": "4",
             "csv": "data/Malaysia/Dewan_Rakyat/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6/data/Malaysia/Dewan_Rakyat/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6145ad02b0ec104182ec0d8e183b2f9862/data/Malaysia/Dewan_Rakyat/term-4.csv"
           },
           {
             "end_date": "1974",
@@ -5785,7 +5785,7 @@
             "start_date": "1969",
             "slug": "3",
             "csv": "data/Malaysia/Dewan_Rakyat/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6/data/Malaysia/Dewan_Rakyat/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6145ad02b0ec104182ec0d8e183b2f9862/data/Malaysia/Dewan_Rakyat/term-3.csv"
           },
           {
             "end_date": "1969",
@@ -5794,7 +5794,7 @@
             "start_date": "1964",
             "slug": "2",
             "csv": "data/Malaysia/Dewan_Rakyat/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7c579b3/data/Malaysia/Dewan_Rakyat/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7c579b32f402f0fc5f35f8d81cd062bb6a9ffbb2/data/Malaysia/Dewan_Rakyat/term-2.csv"
           },
           {
             "end_date": "1964",
@@ -5803,7 +5803,7 @@
             "start_date": "1959",
             "slug": "1",
             "csv": "data/Malaysia/Dewan_Rakyat/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6/data/Malaysia/Dewan_Rakyat/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be6ddc6145ad02b0ec104182ec0d8e183b2f9862/data/Malaysia/Dewan_Rakyat/term-1.csv"
           }
         ],
         "statement_count": 47826
@@ -5821,11 +5821,11 @@
         "slug": "Majlis",
         "sources_directory": "data/Maldives/Majlis/sources",
         "popolo": "data/Maldives/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dd2046c/data/Maldives/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dd2046ca2e2f5b90f561a3684746f2c7ecfd6975/data/Maldives/Majlis/ep-popolo-v1.0.json",
         "names": "data/Maldives/Majlis/names.csv",
         "lastmod": "1469384447",
         "person_count": 85,
-        "sha": "dd2046c",
+        "sha": "dd2046ca2e2f5b90f561a3684746f2c7ecfd6975",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -5833,7 +5833,7 @@
             "start_date": "2014-05-28",
             "slug": "2014",
             "csv": "data/Maldives/Majlis/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e58b9bf/data/Maldives/Majlis/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e58b9bf71ba53eafd6861b6b6f6dc38636822998/data/Maldives/Majlis/term-2014.csv"
           }
         ],
         "statement_count": 1266
@@ -5851,11 +5851,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Mali/Assembly/sources",
         "popolo": "data/Mali/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa68f03/data/Mali/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa68f036f0ecdce0cfce3510c55b91f384c556ac/data/Mali/Assembly/ep-popolo-v1.0.json",
         "names": "data/Mali/Assembly/names.csv",
         "lastmod": "1469384453",
         "person_count": 142,
-        "sha": "fa68f03",
+        "sha": "fa68f036f0ecdce0cfce3510c55b91f384c556ac",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -5863,7 +5863,7 @@
             "start_date": "2014-01-01",
             "slug": "2014",
             "csv": "data/Mali/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ed725d0/data/Mali/Assembly/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ed725d06548ddde4b367d44e1fede10e384c3d13/data/Mali/Assembly/term-2014.csv"
           }
         ],
         "statement_count": 2454
@@ -5881,11 +5881,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Malta/Assembly/sources",
         "popolo": "data/Malta/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3226cce/data/Malta/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3226ccee1731725c2322f86d332b92a74f11ebbd/data/Malta/Assembly/ep-popolo-v1.0.json",
         "names": "data/Malta/Assembly/names.csv",
         "lastmod": "1470055320",
         "person_count": 71,
-        "sha": "3226cce",
+        "sha": "3226ccee1731725c2322f86d332b92a74f11ebbd",
         "legislative_periods": [
           {
             "id": "term/12",
@@ -5893,7 +5893,7 @@
             "start_date": "2013-04-06",
             "slug": "12",
             "csv": "data/Malta/Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6936251/data/Malta/Assembly/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/693625156273ac10184bde85fa26ca15d1f510bc/data/Malta/Assembly/term-12.csv"
           }
         ],
         "statement_count": 2793
@@ -5911,11 +5911,11 @@
         "slug": "Nitijela",
         "sources_directory": "data/Marshall_Islands/Nitijela/sources",
         "popolo": "data/Marshall_Islands/Nitijela/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6c0d66b/data/Marshall_Islands/Nitijela/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6c0d66ba4a6262eb0c3bfdfcd5ac2c076c4cde6f/data/Marshall_Islands/Nitijela/ep-popolo-v1.0.json",
         "names": "data/Marshall_Islands/Nitijela/names.csv",
         "lastmod": "1469384462",
         "person_count": 33,
-        "sha": "6c0d66b",
+        "sha": "6c0d66ba4a6262eb0c3bfdfcd5ac2c076c4cde6f",
         "legislative_periods": [
           {
             "end_date": "2015-11-30",
@@ -5924,7 +5924,7 @@
             "start_date": "2012-01-03",
             "slug": "2012",
             "csv": "data/Marshall_Islands/Nitijela/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cd740df/data/Marshall_Islands/Nitijela/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cd740dfb9630ef83be901a6cfd68d7dc4d17a99e/data/Marshall_Islands/Nitijela/term-2012.csv"
           }
         ],
         "statement_count": 547
@@ -5942,11 +5942,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Mauritania/National_Assembly/sources",
         "popolo": "data/Mauritania/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c82a06f/data/Mauritania/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c82a06fc616f1b6c37ec666dfcfa89795259d64c/data/Mauritania/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Mauritania/National_Assembly/names.csv",
         "lastmod": "1469384467",
         "person_count": 147,
-        "sha": "c82a06f",
+        "sha": "c82a06fc616f1b6c37ec666dfcfa89795259d64c",
         "legislative_periods": [
           {
             "id": "term/12",
@@ -5954,7 +5954,7 @@
             "start_date": "2013-12-21",
             "slug": "12",
             "csv": "data/Mauritania/National_Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e14d68/data/Mauritania/National_Assembly/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e14d68fb8ac95033e092abc1b2a60c8d03a2d7d/data/Mauritania/National_Assembly/term-12.csv"
           }
         ],
         "statement_count": 1899
@@ -5972,11 +5972,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Mauritius/National_Assembly/sources",
         "popolo": "data/Mauritius/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c48212c/data/Mauritius/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c48212c2e6dec15f9bdd62e8eb9563777a0d0d8b/data/Mauritius/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Mauritius/National_Assembly/names.csv",
         "lastmod": "1469384473",
         "person_count": 62,
-        "sha": "c48212c",
+        "sha": "c48212c2e6dec15f9bdd62e8eb9563777a0d0d8b",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -5984,7 +5984,7 @@
             "start_date": "2014-12-10",
             "slug": "2014",
             "csv": "data/Mauritius/National_Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/48071d9/data/Mauritius/National_Assembly/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/48071d984c351045f3ddf7e210f315adf1730806/data/Mauritius/National_Assembly/term-2014.csv"
           }
         ],
         "statement_count": 1019
@@ -6002,11 +6002,11 @@
         "slug": "Deputies",
         "sources_directory": "data/Mexico/Deputies/sources",
         "popolo": "data/Mexico/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1400578/data/Mexico/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1400578d29e8a094c48c14a34b5ae4a9712e8809/data/Mexico/Deputies/ep-popolo-v1.0.json",
         "names": "data/Mexico/Deputies/names.csv",
         "lastmod": "1472106242",
         "person_count": 1025,
-        "sha": "1400578",
+        "sha": "1400578d29e8a094c48c14a34b5ae4a9712e8809",
         "legislative_periods": [
           {
             "id": "term/63",
@@ -6014,7 +6014,7 @@
             "start_date": "2015-09-01",
             "slug": "63",
             "csv": "data/Mexico/Deputies/term-63.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1400578/data/Mexico/Deputies/term-63.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1400578d29e8a094c48c14a34b5ae4a9712e8809/data/Mexico/Deputies/term-63.csv"
           },
           {
             "end_date": "2015-08-31",
@@ -6023,7 +6023,7 @@
             "start_date": "2012-09-01",
             "slug": "62",
             "csv": "data/Mexico/Deputies/term-62.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b1cdf3b/data/Mexico/Deputies/term-62.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b1cdf3beb94ac5a9c0eb1bf42cebcf539ce267ca/data/Mexico/Deputies/term-62.csv"
           }
         ],
         "statement_count": 30301
@@ -6041,11 +6041,11 @@
         "slug": "Congress",
         "sources_directory": "data/Micronesia/Congress/sources",
         "popolo": "data/Micronesia/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6fcf25/data/Micronesia/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6fcf2520f2d9a03e07b28123e2c206e9781477f/data/Micronesia/Congress/ep-popolo-v1.0.json",
         "names": "data/Micronesia/Congress/names.csv",
         "lastmod": "1470223136",
         "person_count": 24,
-        "sha": "a6fcf25",
+        "sha": "a6fcf2520f2d9a03e07b28123e2c206e9781477f",
         "legislative_periods": [
           {
             "id": "term/19",
@@ -6053,7 +6053,7 @@
             "start_date": "2015-05-11",
             "slug": "19",
             "csv": "data/Micronesia/Congress/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a252553/data/Micronesia/Congress/term-19.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a252553ab39499ca94ab13e6f27bc0ff7a38ab9c/data/Micronesia/Congress/term-19.csv"
           },
           {
             "end_date": "2015-05-10",
@@ -6062,7 +6062,7 @@
             "start_date": "2013-05-11",
             "slug": "18",
             "csv": "data/Micronesia/Congress/term-18.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a252553/data/Micronesia/Congress/term-18.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a252553ab39499ca94ab13e6f27bc0ff7a38ab9c/data/Micronesia/Congress/term-18.csv"
           },
           {
             "end_date": "2013-05-10",
@@ -6071,7 +6071,7 @@
             "start_date": "2011-05-11",
             "slug": "17",
             "csv": "data/Micronesia/Congress/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a252553/data/Micronesia/Congress/term-17.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a252553ab39499ca94ab13e6f27bc0ff7a38ab9c/data/Micronesia/Congress/term-17.csv"
           }
         ],
         "statement_count": 1118
@@ -6089,11 +6089,11 @@
         "slug": "Parlamentul",
         "sources_directory": "data/Moldova/Parlamentul/sources",
         "popolo": "data/Moldova/Parlamentul/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9c0eaa7/data/Moldova/Parlamentul/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9c0eaa7028531b2b686c042b741a24e9266e0038/data/Moldova/Parlamentul/ep-popolo-v1.0.json",
         "names": "data/Moldova/Parlamentul/names.csv",
         "lastmod": "1471395229",
         "person_count": 115,
-        "sha": "9c0eaa7",
+        "sha": "9c0eaa7028531b2b686c042b741a24e9266e0038",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -6101,7 +6101,7 @@
             "start_date": "2014-12-29",
             "slug": "2014",
             "csv": "data/Moldova/Parlamentul/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9727404/data/Moldova/Parlamentul/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/97274049efc5c98b54b193a48f5648476164304e/data/Moldova/Parlamentul/term-2014.csv"
           }
         ],
         "statement_count": 5821
@@ -6119,11 +6119,11 @@
         "slug": "Council",
         "sources_directory": "data/Monaco/Council/sources",
         "popolo": "data/Monaco/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5277d81/data/Monaco/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5277d81e334977401334681e3606021273037f3b/data/Monaco/Council/ep-popolo-v1.0.json",
         "names": "data/Monaco/Council/names.csv",
         "lastmod": "1469384486",
         "person_count": 50,
-        "sha": "5277d81",
+        "sha": "5277d81e334977401334681e3606021273037f3b",
         "legislative_periods": [
           {
             "end_date": "2018",
@@ -6132,7 +6132,7 @@
             "start_date": "2013-02-21",
             "slug": "2013",
             "csv": "data/Monaco/Council/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d76f877/data/Monaco/Council/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d76f877c498d62dcad70defb4d90869366261030/data/Monaco/Council/term-2013.csv"
           },
           {
             "end_date": "2013",
@@ -6141,7 +6141,7 @@
             "start_date": "2008",
             "slug": "2008",
             "csv": "data/Monaco/Council/term-2008.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d76f877/data/Monaco/Council/term-2008.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d76f877c498d62dcad70defb4d90869366261030/data/Monaco/Council/term-2008.csv"
           },
           {
             "end_date": "2008",
@@ -6150,7 +6150,7 @@
             "start_date": "2003",
             "slug": "2003",
             "csv": "data/Monaco/Council/term-2003.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d76f877/data/Monaco/Council/term-2003.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d76f877c498d62dcad70defb4d90869366261030/data/Monaco/Council/term-2003.csv"
           }
         ],
         "statement_count": 1059
@@ -6168,11 +6168,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Mongolia/Assembly/sources",
         "popolo": "data/Mongolia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69eee22/data/Mongolia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69eee22c82a07f47a27e0642e75a869c0be1c35f/data/Mongolia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Mongolia/Assembly/names.csv",
         "lastmod": "1470234638",
         "person_count": 117,
-        "sha": "69eee22",
+        "sha": "69eee22c82a07f47a27e0642e75a869c0be1c35f",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -6180,7 +6180,7 @@
             "start_date": "2012-06-28",
             "slug": "2012",
             "csv": "data/Mongolia/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/21dc073/data/Mongolia/Assembly/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/21dc073cee0ee1f61ddc499abad8004e73d879dc/data/Mongolia/Assembly/term-2012.csv"
           },
           {
             "end_date": "2012-06-28",
@@ -6189,7 +6189,7 @@
             "start_date": "2008-07-23",
             "slug": "2008",
             "csv": "data/Mongolia/Assembly/term-2008.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e339e1/data/Mongolia/Assembly/term-2008.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e339e10ec597d1aee0fdf1a023466bd6342661a/data/Mongolia/Assembly/term-2008.csv"
           }
         ],
         "statement_count": 4993
@@ -6207,11 +6207,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Montenegro/Assembly/sources",
         "popolo": "data/Montenegro/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fe618f6/data/Montenegro/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fe618f6f38a431fd127ad8f637d21232c11cb945/data/Montenegro/Assembly/ep-popolo-v1.0.json",
         "names": "data/Montenegro/Assembly/names.csv",
         "lastmod": "1471998962",
         "person_count": 82,
-        "sha": "fe618f6",
+        "sha": "fe618f6f38a431fd127ad8f637d21232c11cb945",
         "legislative_periods": [
           {
             "end_date": "2015",
@@ -6220,7 +6220,7 @@
             "start_date": "2012-11-06",
             "slug": "25",
             "csv": "data/Montenegro/Assembly/term-25.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dd8dddc/data/Montenegro/Assembly/term-25.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dd8dddc3843afc2317b62af2e4f84ac9c89c920d/data/Montenegro/Assembly/term-25.csv"
           }
         ],
         "statement_count": 2313
@@ -6238,11 +6238,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Montserrat/Assembly/sources",
         "popolo": "data/Montserrat/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/153bbb1/data/Montserrat/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/153bbb16cac66bee803ff759247d2dcfe36eb83f/data/Montserrat/Assembly/ep-popolo-v1.0.json",
         "names": "data/Montserrat/Assembly/names.csv",
         "lastmod": "1469384500",
         "person_count": 9,
-        "sha": "153bbb1",
+        "sha": "153bbb16cac66bee803ff759247d2dcfe36eb83f",
         "legislative_periods": [
           {
             "id": "term/1",
@@ -6250,7 +6250,7 @@
             "start_date": "2014",
             "slug": "1",
             "csv": "data/Montserrat/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8102167/data/Montserrat/Assembly/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/81021671b24406cd8a294609ba39da470e58bcb4/data/Montserrat/Assembly/term-1.csv"
           }
         ],
         "statement_count": 224
@@ -6268,11 +6268,11 @@
         "slug": "House",
         "sources_directory": "data/Morocco/House/sources",
         "popolo": "data/Morocco/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fb0624b/data/Morocco/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fb0624be1afeca5404f8e579ebdc2fa66ece088c/data/Morocco/House/ep-popolo-v1.0.json",
         "names": "data/Morocco/House/names.csv",
         "lastmod": "1469384505",
         "person_count": 401,
-        "sha": "fb0624b",
+        "sha": "fb0624be1afeca5404f8e579ebdc2fa66ece088c",
         "legislative_periods": [
           {
             "end_date": "2016",
@@ -6281,7 +6281,7 @@
             "start_date": "2011-12-19",
             "slug": "9",
             "csv": "data/Morocco/House/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c276e53/data/Morocco/House/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c276e536aeabcc17e230e5ab08f8fb34f7f3712e/data/Morocco/House/term-9.csv"
           }
         ],
         "statement_count": 5397
@@ -6299,11 +6299,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Mozambique/Assembly/sources",
         "popolo": "data/Mozambique/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/56bbc77/data/Mozambique/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/56bbc77a9ca524d1085a732038c11df3d0be3ab6/data/Mozambique/Assembly/ep-popolo-v1.0.json",
         "names": "data/Mozambique/Assembly/names.csv",
         "lastmod": "1469384540",
         "person_count": 250,
-        "sha": "56bbc77",
+        "sha": "56bbc77a9ca524d1085a732038c11df3d0be3ab6",
         "legislative_periods": [
           {
             "id": "term/8",
@@ -6311,7 +6311,7 @@
             "start_date": "2015-01-12",
             "slug": "8",
             "csv": "data/Mozambique/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d480c6e/data/Mozambique/Assembly/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d480c6e7efa554d21743e5fb43315ccd5dbe83cb/data/Mozambique/Assembly/term-8.csv"
           }
         ],
         "statement_count": 3353
@@ -6329,11 +6329,11 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Myanmar/House_of_Representatives/sources",
         "popolo": "data/Myanmar/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c923367/data/Myanmar/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c92336738e5a0db58a63aded72b8e999cd857657/data/Myanmar/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Myanmar/House_of_Representatives/names.csv",
         "lastmod": "1469384562",
         "person_count": 314,
-        "sha": "c923367",
+        "sha": "c92336738e5a0db58a63aded72b8e999cd857657",
         "legislative_periods": [
           {
             "id": "term/1",
@@ -6341,7 +6341,7 @@
             "start_date": "2011-01-31",
             "slug": "1",
             "csv": "data/Myanmar/House_of_Representatives/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eee3e62/data/Myanmar/House_of_Representatives/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eee3e62aa529dd2550c9d45418faf40c6745ea3b/data/Myanmar/House_of_Representatives/term-1.csv"
           }
         ],
         "statement_count": 5165
@@ -6359,11 +6359,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Nagorno_Karabakh/Assembly/sources",
         "popolo": "data/Nagorno_Karabakh/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2c3022/data/Nagorno_Karabakh/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2c302298e1c1949102487daa37d35bb298e159a/data/Nagorno_Karabakh/Assembly/ep-popolo-v1.0.json",
         "names": "data/Nagorno_Karabakh/Assembly/names.csv",
         "lastmod": "1469384796",
         "person_count": 33,
-        "sha": "b2c3022",
+        "sha": "b2c302298e1c1949102487daa37d35bb298e159a",
         "legislative_periods": [
           {
             "id": "term/6",
@@ -6371,7 +6371,7 @@
             "start_date": "2015-05-21",
             "slug": "6",
             "csv": "data/Nagorno_Karabakh/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eac9a60/data/Nagorno_Karabakh/Assembly/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eac9a60ffd90305584c7ee9f42c0a93de3c9b834/data/Nagorno_Karabakh/Assembly/term-6.csv"
           }
         ],
         "statement_count": 1366
@@ -6389,11 +6389,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Namibia/Assembly/sources",
         "popolo": "data/Namibia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d2fe694/data/Namibia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d2fe69426e09baecf17cae92103ff3adf84faea1/data/Namibia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Namibia/Assembly/names.csv",
         "lastmod": "1471203543",
         "person_count": 267,
-        "sha": "d2fe694",
+        "sha": "d2fe69426e09baecf17cae92103ff3adf84faea1",
         "legislative_periods": [
           {
             "end_date": "2020",
@@ -6402,7 +6402,7 @@
             "start_date": "2015-03-20",
             "slug": "6",
             "csv": "data/Namibia/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef4aaed/data/Namibia/Assembly/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ef4aaedcca5f8ddc8764256a6bf4c4f67593cb53/data/Namibia/Assembly/term-6.csv"
           },
           {
             "end_date": "2015-03-19",
@@ -6411,7 +6411,7 @@
             "start_date": "2010-03-19",
             "slug": "5",
             "csv": "data/Namibia/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a87b179/data/Namibia/Assembly/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a87b1796e8b50624f9106a97aff43f78960694bd/data/Namibia/Assembly/term-5.csv"
           },
           {
             "end_date": "2010-03-19",
@@ -6420,7 +6420,7 @@
             "start_date": "2005-03-20",
             "slug": "4",
             "csv": "data/Namibia/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a87b179/data/Namibia/Assembly/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a87b1796e8b50624f9106a97aff43f78960694bd/data/Namibia/Assembly/term-4.csv"
           },
           {
             "end_date": "2005",
@@ -6429,7 +6429,7 @@
             "start_date": "2000",
             "slug": "3",
             "csv": "data/Namibia/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a87b179/data/Namibia/Assembly/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a87b1796e8b50624f9106a97aff43f78960694bd/data/Namibia/Assembly/term-3.csv"
           },
           {
             "end_date": "2000",
@@ -6438,7 +6438,7 @@
             "start_date": "1995",
             "slug": "2",
             "csv": "data/Namibia/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a87b179/data/Namibia/Assembly/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a87b1796e8b50624f9106a97aff43f78960694bd/data/Namibia/Assembly/term-2.csv"
           },
           {
             "end_date": "1995",
@@ -6447,7 +6447,7 @@
             "start_date": "1990",
             "slug": "1",
             "csv": "data/Namibia/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a87b179/data/Namibia/Assembly/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a87b1796e8b50624f9106a97aff43f78960694bd/data/Namibia/Assembly/term-1.csv"
           },
           {
             "end_date": "1990",
@@ -6456,7 +6456,7 @@
             "start_date": "1989",
             "slug": "0",
             "csv": "data/Namibia/Assembly/term-0.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a87b179/data/Namibia/Assembly/term-0.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a87b1796e8b50624f9106a97aff43f78960694bd/data/Namibia/Assembly/term-0.csv"
           }
         ],
         "statement_count": 9733
@@ -6466,11 +6466,11 @@
         "slug": "Council",
         "sources_directory": "data/Namibia/Council/sources",
         "popolo": "data/Namibia/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f39f52/data/Namibia/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f39f529a8ba5f455f4b2e5eedf5e070675d6e11/data/Namibia/Council/ep-popolo-v1.0.json",
         "names": "data/Namibia/Council/names.csv",
         "lastmod": "1469384817",
         "person_count": 115,
-        "sha": "4f39f52",
+        "sha": "4f39f529a8ba5f455f4b2e5eedf5e070675d6e11",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -6478,7 +6478,7 @@
             "start_date": "2015-12-18",
             "slug": "5",
             "csv": "data/Namibia/Council/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcb12c5/data/Namibia/Council/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcb12c5c9f97f352969a39e3929516e0e2a55faa/data/Namibia/Council/term-5.csv"
           },
           {
             "end_date": "2015-12-17",
@@ -6487,7 +6487,7 @@
             "start_date": "2010",
             "slug": "4",
             "csv": "data/Namibia/Council/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcb12c5/data/Namibia/Council/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcb12c5c9f97f352969a39e3929516e0e2a55faa/data/Namibia/Council/term-4.csv"
           },
           {
             "end_date": "2010",
@@ -6496,7 +6496,7 @@
             "start_date": "2004",
             "slug": "3",
             "csv": "data/Namibia/Council/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcb12c5/data/Namibia/Council/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fcb12c5c9f97f352969a39e3929516e0e2a55faa/data/Namibia/Council/term-3.csv"
           },
           {
             "end_date": "2004",
@@ -6505,7 +6505,7 @@
             "start_date": "1998",
             "slug": "2",
             "csv": "data/Namibia/Council/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5d43c06/data/Namibia/Council/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5d43c06dafb2373045a6fc6ec3fefe75041b4e23/data/Namibia/Council/term-2.csv"
           },
           {
             "end_date": "1998",
@@ -6514,7 +6514,7 @@
             "start_date": "1993",
             "slug": "1",
             "csv": "data/Namibia/Council/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5d43c06/data/Namibia/Council/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5d43c06dafb2373045a6fc6ec3fefe75041b4e23/data/Namibia/Council/term-1.csv"
           }
         ],
         "statement_count": 2072
@@ -6532,11 +6532,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Nauru/Parliament/sources",
         "popolo": "data/Nauru/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a3ddb9d/data/Nauru/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a3ddb9d1cc43fa351e99ca33a612f383b6a85efb/data/Nauru/Parliament/ep-popolo-v1.0.json",
         "names": "data/Nauru/Parliament/names.csv",
         "lastmod": "1470268205",
         "person_count": 33,
-        "sha": "a3ddb9d",
+        "sha": "a3ddb9d1cc43fa351e99ca33a612f383b6a85efb",
         "legislative_periods": [
           {
             "id": "term/22",
@@ -6544,7 +6544,7 @@
             "start_date": "2016-07-11",
             "slug": "22",
             "csv": "data/Nauru/Parliament/term-22.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3f4e8f0/data/Nauru/Parliament/term-22.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3f4e8f0e39735c97183438c602c4cc7f3d113594/data/Nauru/Parliament/term-22.csv"
           },
           {
             "end_date": "2016-05-14",
@@ -6553,7 +6553,7 @@
             "start_date": "2013-06-11",
             "slug": "21",
             "csv": "data/Nauru/Parliament/term-21.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0adedd7/data/Nauru/Parliament/term-21.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0adedd7391cdbad36954970ebdcd7e1a5c9fa7af/data/Nauru/Parliament/term-21.csv"
           },
           {
             "end_date": "2013-05-23",
@@ -6562,7 +6562,7 @@
             "start_date": "2010-06-22",
             "slug": "20",
             "csv": "data/Nauru/Parliament/term-20.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8da20f0/data/Nauru/Parliament/term-20.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8da20f0c2442ace9358e2544e429da0d7e8422dd/data/Nauru/Parliament/term-20.csv"
           },
           {
             "end_date": "2010-05-23",
@@ -6571,7 +6571,7 @@
             "start_date": "2000-06-19",
             "slug": "19",
             "csv": "data/Nauru/Parliament/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8da20f0/data/Nauru/Parliament/term-19.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8da20f0c2442ace9358e2544e429da0d7e8422dd/data/Nauru/Parliament/term-19.csv"
           }
         ],
         "statement_count": 2513
@@ -6589,11 +6589,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Nepal/Assembly/sources",
         "popolo": "data/Nepal/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/77764e4/data/Nepal/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/77764e41b76dc677ba6db13b6f20e4151d5fd93a/data/Nepal/Assembly/ep-popolo-v1.0.json",
         "names": "data/Nepal/Assembly/names.csv",
         "lastmod": "1471372156",
         "person_count": 550,
-        "sha": "77764e4",
+        "sha": "77764e41b76dc677ba6db13b6f20e4151d5fd93a",
         "legislative_periods": [
           {
             "id": "term/ca2",
@@ -6601,7 +6601,7 @@
             "start_date": "2014-01-22",
             "slug": "ca2",
             "csv": "data/Nepal/Assembly/term-ca2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/618393a/data/Nepal/Assembly/term-ca2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/618393a9bc755b6521dd771ff6fd5aa0c07419d7/data/Nepal/Assembly/term-ca2.csv"
           }
         ],
         "statement_count": 12811
@@ -6619,11 +6619,11 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Netherlands/House_of_Representatives/sources",
         "popolo": "data/Netherlands/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a3cd1db/data/Netherlands/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a3cd1db3a34c8f76e8106ba592ebeab913790d34/data/Netherlands/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Netherlands/House_of_Representatives/names.csv",
         "lastmod": "1471473084",
         "person_count": 190,
-        "sha": "a3cd1db",
+        "sha": "a3cd1db3a34c8f76e8106ba592ebeab913790d34",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -6631,7 +6631,7 @@
             "start_date": "2012-09-20",
             "slug": "2012",
             "csv": "data/Netherlands/House_of_Representatives/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f718aa2/data/Netherlands/House_of_Representatives/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f718aa24f2feb12bd4b7505e62372f71a8b9be25/data/Netherlands/House_of_Representatives/term-2012.csv"
           }
         ],
         "statement_count": 16165
@@ -6649,11 +6649,11 @@
         "slug": "Congress",
         "sources_directory": "data/New_Caledonia/Congress/sources",
         "popolo": "data/New_Caledonia/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3b55c40/data/New_Caledonia/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3b55c408bf9835573130c5c845fb94649a9242ee/data/New_Caledonia/Congress/ep-popolo-v1.0.json",
         "names": "data/New_Caledonia/Congress/names.csv",
         "lastmod": "1470412063",
         "person_count": 56,
-        "sha": "3b55c40",
+        "sha": "3b55c408bf9835573130c5c845fb94649a9242ee",
         "legislative_periods": [
           {
             "id": "term/4",
@@ -6661,7 +6661,7 @@
             "start_date": "2014",
             "slug": "4",
             "csv": "data/New_Caledonia/Congress/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3b55c40/data/New_Caledonia/Congress/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3b55c408bf9835573130c5c845fb94649a9242ee/data/New_Caledonia/Congress/term-4.csv"
           }
         ],
         "statement_count": 1690
@@ -6679,11 +6679,11 @@
         "slug": "House",
         "sources_directory": "data/New_Zealand/House/sources",
         "popolo": "data/New_Zealand/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b488c72/data/New_Zealand/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b488c72a4db5586b09c55ecd78a192217f7dfb52/data/New_Zealand/House/ep-popolo-v1.0.json",
         "names": "data/New_Zealand/House/names.csv",
         "lastmod": "1471452168",
         "person_count": 230,
-        "sha": "b488c72",
+        "sha": "b488c72a4db5586b09c55ecd78a192217f7dfb52",
         "legislative_periods": [
           {
             "id": "term/51",
@@ -6692,7 +6692,7 @@
             "wikidata": "Q4640115",
             "slug": "51",
             "csv": "data/New_Zealand/House/term-51.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/13bae8a/data/New_Zealand/House/term-51.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/13bae8a160c01c4ad3f360d36acfb1c0e42cb768/data/New_Zealand/House/term-51.csv"
           },
           {
             "end_date": "2014-09-19",
@@ -6702,7 +6702,7 @@
             "wikidata": "Q4120749",
             "slug": "50",
             "csv": "data/New_Zealand/House/term-50.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02d4521/data/New_Zealand/House/term-50.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02d4521e73a30e0c16b8cb956e77d5ef86c1d24e/data/New_Zealand/House/term-50.csv"
           },
           {
             "end_date": "2011-10-20",
@@ -6712,7 +6712,7 @@
             "wikidata": "Q11812120",
             "slug": "49",
             "csv": "data/New_Zealand/House/term-49.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02d4521/data/New_Zealand/House/term-49.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02d4521e73a30e0c16b8cb956e77d5ef86c1d24e/data/New_Zealand/House/term-49.csv"
           },
           {
             "end_date": "2008-10-03",
@@ -6722,7 +6722,7 @@
             "wikidata": "Q4638695",
             "slug": "48",
             "csv": "data/New_Zealand/House/term-48.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02d4521/data/New_Zealand/House/term-48.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02d4521e73a30e0c16b8cb956e77d5ef86c1d24e/data/New_Zealand/House/term-48.csv"
           }
         ],
         "statement_count": 16640
@@ -6740,11 +6740,11 @@
         "slug": "Asamblea",
         "sources_directory": "data/Nicaragua/Asamblea/sources",
         "popolo": "data/Nicaragua/Asamblea/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ae3b985/data/Nicaragua/Asamblea/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ae3b985f70d1945603882cc0aa46821314dfce61/data/Nicaragua/Asamblea/ep-popolo-v1.0.json",
         "names": "data/Nicaragua/Asamblea/names.csv",
         "lastmod": "1469384862",
         "person_count": 90,
-        "sha": "ae3b985",
+        "sha": "ae3b985f70d1945603882cc0aa46821314dfce61",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -6752,7 +6752,7 @@
             "start_date": "2012-01-09",
             "slug": "2012",
             "csv": "data/Nicaragua/Asamblea/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ffe5d82/data/Nicaragua/Asamblea/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ffe5d82b98642ff3d08119573480163fd9404078/data/Nicaragua/Asamblea/term-2012.csv"
           }
         ],
         "statement_count": 2195
@@ -6770,11 +6770,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Niger/Assembly/sources",
         "popolo": "data/Niger/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f8c58be/data/Niger/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f8c58bead6887b85f781a2b1fa271fef081dc8c1/data/Niger/Assembly/ep-popolo-v1.0.json",
         "names": "data/Niger/Assembly/names.csv",
         "lastmod": "1469384868",
         "person_count": 113,
-        "sha": "f8c58be",
+        "sha": "f8c58bead6887b85f781a2b1fa271fef081dc8c1",
         "legislative_periods": [
           {
             "id": "term/7.1",
@@ -6782,7 +6782,7 @@
             "start_date": "2011-10-06",
             "slug": "7.1",
             "csv": "data/Niger/Assembly/term-7.1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be1e6cb/data/Niger/Assembly/term-7.1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be1e6cbace4bbd2c8e4f05099a64ab1a46057017/data/Niger/Assembly/term-7.1.csv"
           }
         ],
         "statement_count": 1421
@@ -6800,11 +6800,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Nigeria/Assembly/sources",
         "popolo": "data/Nigeria/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47ae37f/data/Nigeria/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47ae37f5e77c417b8e329ccfa61f299680cee76d/data/Nigeria/Assembly/ep-popolo-v1.0.json",
         "names": "data/Nigeria/Assembly/names.csv",
         "lastmod": "1469384875",
         "person_count": 362,
-        "sha": "47ae37f",
+        "sha": "47ae37f5e77c417b8e329ccfa61f299680cee76d",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -6812,7 +6812,7 @@
             "start_date": "2015-06-09",
             "slug": "2015",
             "csv": "data/Nigeria/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6ac4370/data/Nigeria/Assembly/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6ac43705911a04512e9f890f49e793c1465ab8a9/data/Nigeria/Assembly/term-2015.csv"
           }
         ],
         "statement_count": 5963
@@ -6830,11 +6830,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Niue/Assembly/sources",
         "popolo": "data/Niue/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7fe55a7/data/Niue/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7fe55a7ccafdc1cc3344881c02d6dbcf79ecf935/data/Niue/Assembly/ep-popolo-v1.0.json",
         "names": "data/Niue/Assembly/names.csv",
         "lastmod": "1472010135",
         "person_count": 20,
-        "sha": "7fe55a7",
+        "sha": "7fe55a7ccafdc1cc3344881c02d6dbcf79ecf935",
         "legislative_periods": [
           {
             "id": "term/15",
@@ -6842,7 +6842,7 @@
             "start_date": "2014-04-23",
             "slug": "15",
             "csv": "data/Niue/Assembly/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dae655b/data/Niue/Assembly/term-15.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dae655bc6aef1a19ed3776f98344ca0725d42c82/data/Niue/Assembly/term-15.csv"
           }
         ],
         "statement_count": 948
@@ -6860,11 +6860,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Norfolk_Island/Assembly/sources",
         "popolo": "data/Norfolk_Island/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/284cdea/data/Norfolk_Island/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/284cdea8981f70a9591f11200202d3eaa4dc3663/data/Norfolk_Island/Assembly/ep-popolo-v1.0.json",
         "names": "data/Norfolk_Island/Assembly/names.csv",
         "lastmod": "1469384888",
         "person_count": 9,
-        "sha": "284cdea",
+        "sha": "284cdea8981f70a9591f11200202d3eaa4dc3663",
         "legislative_periods": [
           {
             "end_date": "2015-06-17",
@@ -6873,7 +6873,7 @@
             "start_date": "2013-03-20",
             "slug": "14",
             "csv": "data/Norfolk_Island/Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/93ab0bf/data/Norfolk_Island/Assembly/term-14.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/93ab0bf41670b041de58ba8878f0184b01178e4f/data/Norfolk_Island/Assembly/term-14.csv"
           }
         ],
         "statement_count": 472
@@ -6891,11 +6891,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/North_Korea/National_Assembly/sources",
         "popolo": "data/North_Korea/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/915e553/data/North_Korea/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/915e553b2b93ccfbdbd350f209f55299aed02ee4/data/North_Korea/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/North_Korea/National_Assembly/names.csv",
         "lastmod": "1472107792",
         "person_count": 687,
-        "sha": "915e553",
+        "sha": "915e553b2b93ccfbdbd350f209f55299aed02ee4",
         "legislative_periods": [
           {
             "id": "term/13",
@@ -6903,7 +6903,7 @@
             "start_date": "2014-03-09",
             "slug": "13",
             "csv": "data/North_Korea/National_Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db2673e/data/North_Korea/National_Assembly/term-13.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db2673e1fac0abb00dae7bd794f6e391ca90d890/data/North_Korea/National_Assembly/term-13.csv"
           }
         ],
         "statement_count": 12816
@@ -6921,11 +6921,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Northern_Cyprus/Assembly/sources",
         "popolo": "data/Northern_Cyprus/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aedd6b4/data/Northern_Cyprus/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aedd6b415143b0808c088a5b18c23f8069343db2/data/Northern_Cyprus/Assembly/ep-popolo-v1.0.json",
         "names": "data/Northern_Cyprus/Assembly/names.csv",
         "lastmod": "1469385802",
         "person_count": 50,
-        "sha": "aedd6b4",
+        "sha": "aedd6b415143b0808c088a5b18c23f8069343db2",
         "legislative_periods": [
           {
             "id": "term/14",
@@ -6933,7 +6933,7 @@
             "start_date": "2013-08-12",
             "slug": "14",
             "csv": "data/Northern_Cyprus/Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e1d590b/data/Northern_Cyprus/Assembly/term-14.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e1d590b5a0bca8609b92e0f1b6d8c24558b4951f/data/Northern_Cyprus/Assembly/term-14.csv"
           }
         ],
         "statement_count": 1785
@@ -6951,11 +6951,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Northern_Ireland/Assembly/sources",
         "popolo": "data/Northern_Ireland/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7c5a1e2/data/Northern_Ireland/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7c5a1e2da4ac61e6761058126eef7a1922e9f9bb/data/Northern_Ireland/Assembly/ep-popolo-v1.0.json",
         "names": "data/Northern_Ireland/Assembly/names.csv",
         "lastmod": "1472011675",
         "person_count": 271,
-        "sha": "7c5a1e2",
+        "sha": "7c5a1e2da4ac61e6761058126eef7a1922e9f9bb",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -6964,7 +6964,7 @@
             "wikidata": "Q24050037",
             "slug": "5",
             "csv": "data/Northern_Ireland/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66d26b6/data/Northern_Ireland/Assembly/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66d26b60111e2a83c87c3b6aa52dc7ea5eb698bf/data/Northern_Ireland/Assembly/term-5.csv"
           },
           {
             "end_date": "2016-03-24",
@@ -6974,7 +6974,7 @@
             "wikidata": "Q21124329",
             "slug": "4",
             "csv": "data/Northern_Ireland/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66d26b6/data/Northern_Ireland/Assembly/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66d26b60111e2a83c87c3b6aa52dc7ea5eb698bf/data/Northern_Ireland/Assembly/term-4.csv"
           },
           {
             "end_date": "2011-03-24",
@@ -6984,7 +6984,7 @@
             "wikidata": "Q21128152",
             "slug": "3",
             "csv": "data/Northern_Ireland/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8077c2a/data/Northern_Ireland/Assembly/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8077c2a9048c08cd2214303380e84d8f6e0aafdd/data/Northern_Ireland/Assembly/term-3.csv"
           },
           {
             "end_date": "2007-01-30",
@@ -6994,7 +6994,7 @@
             "wikidata": "Q21128144",
             "slug": "2",
             "csv": "data/Northern_Ireland/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8077c2a/data/Northern_Ireland/Assembly/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8077c2a9048c08cd2214303380e84d8f6e0aafdd/data/Northern_Ireland/Assembly/term-2.csv"
           },
           {
             "end_date": "2003-04-28",
@@ -7004,7 +7004,7 @@
             "wikidata": "Q21128140",
             "slug": "1",
             "csv": "data/Northern_Ireland/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c831685/data/Northern_Ireland/Assembly/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c83168549bcd25ca57b836c9cace36017ef7f698/data/Northern_Ireland/Assembly/term-1.csv"
           }
         ],
         "statement_count": 16305
@@ -7022,11 +7022,11 @@
         "slug": "House",
         "sources_directory": "data/Northern_Mariana_Islands/House/sources",
         "popolo": "data/Northern_Mariana_Islands/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/63685dd/data/Northern_Mariana_Islands/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/63685dd043e61036d0abcd1482a4a74f0cbf08da/data/Northern_Mariana_Islands/House/ep-popolo-v1.0.json",
         "names": "data/Northern_Mariana_Islands/House/names.csv",
         "lastmod": "1470220335",
         "person_count": 20,
-        "sha": "63685dd",
+        "sha": "63685dd043e61036d0abcd1482a4a74f0cbf08da",
         "legislative_periods": [
           {
             "id": "term/19",
@@ -7034,7 +7034,7 @@
             "start_date": "2014",
             "slug": "19",
             "csv": "data/Northern_Mariana_Islands/House/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/018fffb/data/Northern_Mariana_Islands/House/term-19.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/018fffb38bb7fc0a70a2fc1e2822339b77ed983a/data/Northern_Mariana_Islands/House/term-19.csv"
           }
         ],
         "statement_count": 840
@@ -7052,11 +7052,11 @@
         "slug": "Storting",
         "sources_directory": "data/Norway/Storting/sources",
         "popolo": "data/Norway/Storting/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8921f2f/data/Norway/Storting/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8921f2fc7a707848648650c7e6a979de463e13fc/data/Norway/Storting/ep-popolo-v1.0.json",
         "names": "data/Norway/Storting/names.csv",
         "lastmod": "1472104133",
         "person_count": 1141,
-        "sha": "8921f2f",
+        "sha": "8921f2fc7a707848648650c7e6a979de463e13fc",
         "legislative_periods": [
           {
             "end_date": "2017-09-30",
@@ -7065,7 +7065,7 @@
             "start_date": "2013-10-01",
             "slug": "2013-2017",
             "csv": "data/Norway/Storting/term-2013-2017.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7f62f54/data/Norway/Storting/term-2013-2017.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7f62f5422fceadfa3072856de0ba7d5b2b7f7c7a/data/Norway/Storting/term-2013-2017.csv"
           },
           {
             "end_date": "2013-09-30",
@@ -7074,7 +7074,7 @@
             "start_date": "2009-10-01",
             "slug": "2009-2013",
             "csv": "data/Norway/Storting/term-2009-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7f62f54/data/Norway/Storting/term-2009-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7f62f5422fceadfa3072856de0ba7d5b2b7f7c7a/data/Norway/Storting/term-2009-2013.csv"
           },
           {
             "end_date": "2009-09-30",
@@ -7083,7 +7083,7 @@
             "start_date": "2005-10-01",
             "slug": "2005-2009",
             "csv": "data/Norway/Storting/term-2005-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7f62f54/data/Norway/Storting/term-2005-2009.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7f62f5422fceadfa3072856de0ba7d5b2b7f7c7a/data/Norway/Storting/term-2005-2009.csv"
           },
           {
             "end_date": "2005-09-30",
@@ -7092,7 +7092,7 @@
             "start_date": "2001-10-01",
             "slug": "2001-2005",
             "csv": "data/Norway/Storting/term-2001-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a74b372/data/Norway/Storting/term-2001-2005.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a74b3729809c1620b03efe10912a526399f79b1e/data/Norway/Storting/term-2001-2005.csv"
           },
           {
             "end_date": "2001-09-30",
@@ -7101,7 +7101,7 @@
             "start_date": "1997-10-01",
             "slug": "1997-2001",
             "csv": "data/Norway/Storting/term-1997-2001.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a74b372/data/Norway/Storting/term-1997-2001.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a74b3729809c1620b03efe10912a526399f79b1e/data/Norway/Storting/term-1997-2001.csv"
           },
           {
             "end_date": "1997-09-30",
@@ -7110,7 +7110,7 @@
             "start_date": "1993-10-01",
             "slug": "1993-97",
             "csv": "data/Norway/Storting/term-1993-97.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f07392a/data/Norway/Storting/term-1993-97.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f07392af5c8f62c184f647251dce24c3184c0962/data/Norway/Storting/term-1993-97.csv"
           },
           {
             "end_date": "1993-09-30",
@@ -7119,7 +7119,7 @@
             "start_date": "1989-10-01",
             "slug": "1989-93",
             "csv": "data/Norway/Storting/term-1989-93.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/57dca95/data/Norway/Storting/term-1989-93.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/57dca955a189c2525b63c05b295f2380382d58c2/data/Norway/Storting/term-1989-93.csv"
           },
           {
             "end_date": "1989-09-30",
@@ -7128,7 +7128,7 @@
             "start_date": "1985-10-01",
             "slug": "1985-89",
             "csv": "data/Norway/Storting/term-1985-89.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/57dca95/data/Norway/Storting/term-1985-89.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/57dca955a189c2525b63c05b295f2380382d58c2/data/Norway/Storting/term-1985-89.csv"
           },
           {
             "end_date": "1985-09-30",
@@ -7137,7 +7137,7 @@
             "start_date": "1981-10-01",
             "slug": "1981-85",
             "csv": "data/Norway/Storting/term-1981-85.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/57dca95/data/Norway/Storting/term-1981-85.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/57dca955a189c2525b63c05b295f2380382d58c2/data/Norway/Storting/term-1981-85.csv"
           },
           {
             "end_date": "1981-09-30",
@@ -7146,7 +7146,7 @@
             "start_date": "1977-10-01",
             "slug": "1977-81",
             "csv": "data/Norway/Storting/term-1977-81.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/57dca95/data/Norway/Storting/term-1977-81.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/57dca955a189c2525b63c05b295f2380382d58c2/data/Norway/Storting/term-1977-81.csv"
           },
           {
             "end_date": "1977-09-30",
@@ -7155,7 +7155,7 @@
             "start_date": "1973-10-01",
             "slug": "1973-77",
             "csv": "data/Norway/Storting/term-1973-77.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8921f2f/data/Norway/Storting/term-1973-77.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8921f2fc7a707848648650c7e6a979de463e13fc/data/Norway/Storting/term-1973-77.csv"
           },
           {
             "end_date": "1973-09-30",
@@ -7164,7 +7164,7 @@
             "start_date": "1969-10-01",
             "slug": "1969-73",
             "csv": "data/Norway/Storting/term-1969-73.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fbd3ca5/data/Norway/Storting/term-1969-73.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fbd3ca5d6cc66a95457abf3fd15390abf13470bb/data/Norway/Storting/term-1969-73.csv"
           },
           {
             "end_date": "1969-09-30",
@@ -7173,7 +7173,7 @@
             "start_date": "1965-10-01",
             "slug": "1965-69",
             "csv": "data/Norway/Storting/term-1965-69.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8921f2f/data/Norway/Storting/term-1965-69.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8921f2fc7a707848648650c7e6a979de463e13fc/data/Norway/Storting/term-1965-69.csv"
           },
           {
             "end_date": "1965-09-30",
@@ -7182,7 +7182,7 @@
             "start_date": "1961-10-01",
             "slug": "1961-65",
             "csv": "data/Norway/Storting/term-1961-65.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8921f2f/data/Norway/Storting/term-1961-65.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8921f2fc7a707848648650c7e6a979de463e13fc/data/Norway/Storting/term-1961-65.csv"
           },
           {
             "end_date": "1961-09-30",
@@ -7191,7 +7191,7 @@
             "start_date": "1958-01-11",
             "slug": "1958-61",
             "csv": "data/Norway/Storting/term-1958-61.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8a32c7d/data/Norway/Storting/term-1958-61.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8a32c7d2181e2946851797daffaca748acd993cf/data/Norway/Storting/term-1958-61.csv"
           },
           {
             "end_date": "1958-01-10",
@@ -7200,7 +7200,7 @@
             "start_date": "1954-01-11",
             "slug": "1954-57",
             "csv": "data/Norway/Storting/term-1954-57.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8a32c7d/data/Norway/Storting/term-1954-57.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8a32c7d2181e2946851797daffaca748acd993cf/data/Norway/Storting/term-1954-57.csv"
           },
           {
             "end_date": "1954-01-10",
@@ -7209,7 +7209,7 @@
             "start_date": "1950-01-11",
             "slug": "1950-53",
             "csv": "data/Norway/Storting/term-1950-53.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8a32c7d/data/Norway/Storting/term-1950-53.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8a32c7d2181e2946851797daffaca748acd993cf/data/Norway/Storting/term-1950-53.csv"
           },
           {
             "end_date": "1950-01-10",
@@ -7218,7 +7218,7 @@
             "start_date": "1945-12-04",
             "slug": "1945-49",
             "csv": "data/Norway/Storting/term-1945-49.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d146a71/data/Norway/Storting/term-1945-49.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d146a716cb6cbc73e3a3eee747300f88065d86fe/data/Norway/Storting/term-1945-49.csv"
           }
         ],
         "statement_count": 79285
@@ -7236,11 +7236,11 @@
         "slug": "Majlis",
         "sources_directory": "data/Oman/Majlis/sources",
         "popolo": "data/Oman/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2a73313/data/Oman/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2a733133f704f017d86d11239c3c0acf1a8778b6/data/Oman/Majlis/ep-popolo-v1.0.json",
         "names": "data/Oman/Majlis/names.csv",
         "lastmod": "1469384923",
         "person_count": 84,
-        "sha": "2a73313",
+        "sha": "2a733133f704f017d86d11239c3c0acf1a8778b6",
         "legislative_periods": [
           {
             "end_date": "2015-10-28",
@@ -7249,7 +7249,7 @@
             "start_date": "2011-10-31",
             "slug": "7",
             "csv": "data/Oman/Majlis/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aea0138/data/Oman/Majlis/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aea0138d4503e5c487ac5b4e3e46cf713dce140a/data/Oman/Majlis/term-7.csv"
           }
         ],
         "statement_count": 1514
@@ -7267,11 +7267,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Pakistan/Assembly/sources",
         "popolo": "data/Pakistan/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/173d7a3/data/Pakistan/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/173d7a32e2ce4fca9fc350bd433a673da33413cd/data/Pakistan/Assembly/ep-popolo-v1.0.json",
         "names": "data/Pakistan/Assembly/names.csv",
         "lastmod": "1471246365",
         "person_count": 347,
-        "sha": "173d7a3",
+        "sha": "173d7a32e2ce4fca9fc350bd433a673da33413cd",
         "legislative_periods": [
           {
             "id": "term/14",
@@ -7279,7 +7279,7 @@
             "start_date": "2013-06-01",
             "slug": "14",
             "csv": "data/Pakistan/Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e9ed9ec/data/Pakistan/Assembly/term-14.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e9ed9ecb5a49b40b0c5636d6ebc474b02ac8316c/data/Pakistan/Assembly/term-14.csv"
           }
         ],
         "statement_count": 12893
@@ -7297,11 +7297,11 @@
         "slug": "House-of-Delegates",
         "sources_directory": "data/Palau/House_of_Delegates/sources",
         "popolo": "data/Palau/House_of_Delegates/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5591f2e/data/Palau/House_of_Delegates/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5591f2e98d05a49d2080157e9896ff85571b179b/data/Palau/House_of_Delegates/ep-popolo-v1.0.json",
         "names": "data/Palau/House_of_Delegates/names.csv",
         "lastmod": "1470511550",
         "person_count": 16,
-        "sha": "5591f2e",
+        "sha": "5591f2e98d05a49d2080157e9896ff85571b179b",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -7309,7 +7309,7 @@
             "start_date": "2013-01-17",
             "slug": "2012",
             "csv": "data/Palau/House_of_Delegates/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/668b5fd/data/Palau/House_of_Delegates/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/668b5fdb6c2288f01bb23410efe788e7782e5470/data/Palau/House_of_Delegates/term-2012.csv"
           }
         ],
         "statement_count": 625
@@ -7327,11 +7327,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Panama/Assembly/sources",
         "popolo": "data/Panama/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b389d31/data/Panama/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b389d31503add9b3c154d94b69f739c885b9ad9b/data/Panama/Assembly/ep-popolo-v1.0.json",
         "names": "data/Panama/Assembly/names.csv",
         "lastmod": "1469385853",
         "person_count": 74,
-        "sha": "b389d31",
+        "sha": "b389d31503add9b3c154d94b69f739c885b9ad9b",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -7339,7 +7339,7 @@
             "start_date": "2014-07-01",
             "slug": "2014",
             "csv": "data/Panama/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b389d31/data/Panama/Assembly/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b389d31503add9b3c154d94b69f739c885b9ad9b/data/Panama/Assembly/term-2014.csv"
           }
         ],
         "statement_count": 1715
@@ -7357,11 +7357,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Papua_New_Guinea/Parliament/sources",
         "popolo": "data/Papua_New_Guinea/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/10c47c4/data/Papua_New_Guinea/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/10c47c43ecb3454b9439419d4886557ad0136474/data/Papua_New_Guinea/Parliament/ep-popolo-v1.0.json",
         "names": "data/Papua_New_Guinea/Parliament/names.csv",
         "lastmod": "1470455163",
         "person_count": 111,
-        "sha": "10c47c4",
+        "sha": "10c47c43ecb3454b9439419d4886557ad0136474",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -7369,7 +7369,7 @@
             "start_date": "2012-08-03",
             "slug": "2012",
             "csv": "data/Papua_New_Guinea/Parliament/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6b5a9f/data/Papua_New_Guinea/Parliament/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6b5a9f6622e8d909cc996b7258ed8cd2e3fe455/data/Papua_New_Guinea/Parliament/term-2012.csv"
           }
         ],
         "statement_count": 3431
@@ -7387,11 +7387,11 @@
         "slug": "Deputies",
         "sources_directory": "data/Paraguay/Deputies/sources",
         "popolo": "data/Paraguay/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/62ba4a3/data/Paraguay/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/62ba4a308a922d1c813a3facae86e55a5972d5f4/data/Paraguay/Deputies/ep-popolo-v1.0.json",
         "names": "data/Paraguay/Deputies/names.csv",
         "lastmod": "1469384995",
         "person_count": 80,
-        "sha": "62ba4a3",
+        "sha": "62ba4a308a922d1c813a3facae86e55a5972d5f4",
         "legislative_periods": [
           {
             "id": "term/2013",
@@ -7399,7 +7399,7 @@
             "start_date": "2013-04-21",
             "slug": "2013",
             "csv": "data/Paraguay/Deputies/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e0e17f5/data/Paraguay/Deputies/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e0e17f5b7f75190777f449da85b51ded860ef502/data/Paraguay/Deputies/term-2013.csv"
           }
         ],
         "statement_count": 2176
@@ -7417,11 +7417,11 @@
         "slug": "Congreso",
         "sources_directory": "data/Peru/Congreso/sources",
         "popolo": "data/Peru/Congreso/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b15cc3/data/Peru/Congreso/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b15cc3c74cf1f4c0193efb097cddf0be050406f/data/Peru/Congreso/ep-popolo-v1.0.json",
         "names": "data/Peru/Congreso/names.csv",
         "lastmod": "1471998601",
         "person_count": 127,
-        "sha": "8b15cc3",
+        "sha": "8b15cc3c74cf1f4c0193efb097cddf0be050406f",
         "legislative_periods": [
           {
             "end_date": "2016-07-26",
@@ -7430,7 +7430,7 @@
             "start_date": "2011-07-27",
             "slug": "2011",
             "csv": "data/Peru/Congreso/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/55f827c/data/Peru/Congreso/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/55f827c0023fae882046b4cf6e221b18443831b2/data/Peru/Congreso/term-2011.csv"
           }
         ],
         "statement_count": 6858
@@ -7448,11 +7448,11 @@
         "slug": "House",
         "sources_directory": "data/Philippines/House/sources",
         "popolo": "data/Philippines/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cc8e493/data/Philippines/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cc8e493bfe9da0b2cbb3fef6f7c28162a748419b/data/Philippines/House/ep-popolo-v1.0.json",
         "names": "data/Philippines/House/names.csv",
         "lastmod": "1472097448",
         "person_count": 295,
-        "sha": "cc8e493",
+        "sha": "cc8e493bfe9da0b2cbb3fef6f7c28162a748419b",
         "legislative_periods": [
           {
             "end_date": "2016-06-30",
@@ -7461,7 +7461,7 @@
             "start_date": "2013-06-30",
             "slug": "16",
             "csv": "data/Philippines/House/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37291f4/data/Philippines/House/term-16.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37291f4dd3671068f14f6109ff8bac4437aa9eff/data/Philippines/House/term-16.csv"
           }
         ],
         "statement_count": 8720
@@ -7479,11 +7479,11 @@
         "slug": "Island-Council",
         "sources_directory": "data/Pitcairn/Island_Council/sources",
         "popolo": "data/Pitcairn/Island_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/474a140/data/Pitcairn/Island_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/474a1403ea7b7b9544536965df13d614167e6e21/data/Pitcairn/Island_Council/ep-popolo-v1.0.json",
         "names": "data/Pitcairn/Island_Council/names.csv",
         "lastmod": "1470236501",
         "person_count": 12,
-        "sha": "474a140",
+        "sha": "474a1403ea7b7b9544536965df13d614167e6e21",
         "legislative_periods": [
           {
             "id": "term/2013",
@@ -7491,7 +7491,7 @@
             "start_date": "2013-11-12",
             "slug": "2013",
             "csv": "data/Pitcairn/Island_Council/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/53115ee/data/Pitcairn/Island_Council/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/53115ee59c4d3d04a3d68004daf58570afa5ae6a/data/Pitcairn/Island_Council/term-2013.csv"
           },
           {
             "end_date": "2013-11-11",
@@ -7500,7 +7500,7 @@
             "start_date": "2011-12-12",
             "slug": "2011",
             "csv": "data/Pitcairn/Island_Council/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bda86b9/data/Pitcairn/Island_Council/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bda86b91d30febed094ad852df918f1787c34013/data/Pitcairn/Island_Council/term-2011.csv"
           },
           {
             "end_date": "2011-12-11",
@@ -7509,7 +7509,7 @@
             "start_date": "2009-12-11",
             "slug": "2009",
             "csv": "data/Pitcairn/Island_Council/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bda86b9/data/Pitcairn/Island_Council/term-2009.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bda86b91d30febed094ad852df918f1787c34013/data/Pitcairn/Island_Council/term-2009.csv"
           }
         ],
         "statement_count": 652
@@ -7527,11 +7527,11 @@
         "slug": "Sejm",
         "sources_directory": "data/Poland/Sejm/sources",
         "popolo": "data/Poland/Sejm/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a90971/data/Poland/Sejm/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a909711ad986eb97e25ff511de1efeab5f0f984/data/Poland/Sejm/ep-popolo-v1.0.json",
         "names": "data/Poland/Sejm/names.csv",
         "lastmod": "1471706508",
         "person_count": 2180,
-        "sha": "9a90971",
+        "sha": "9a909711ad986eb97e25ff511de1efeab5f0f984",
         "legislative_periods": [
           {
             "id": "term/8",
@@ -7539,7 +7539,7 @@
             "start_date": "2015-11-12",
             "slug": "8",
             "csv": "data/Poland/Sejm/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a90971/data/Poland/Sejm/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a909711ad986eb97e25ff511de1efeab5f0f984/data/Poland/Sejm/term-8.csv"
           },
           {
             "end_date": "2015-11-11",
@@ -7548,7 +7548,7 @@
             "start_date": "2011-11-08",
             "slug": "7",
             "csv": "data/Poland/Sejm/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ee7775b/data/Poland/Sejm/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ee7775bfb00a30d0e3277eb9c38711ae8ba8ccc1/data/Poland/Sejm/term-7.csv"
           },
           {
             "end_date": "2011-11-07",
@@ -7557,7 +7557,7 @@
             "start_date": "2007-11-05",
             "slug": "6",
             "csv": "data/Poland/Sejm/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/383f572/data/Poland/Sejm/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/383f5729c4902a3f366e26b540a54de8fe29e2d2/data/Poland/Sejm/term-6.csv"
           },
           {
             "end_date": "2007-11-04",
@@ -7566,7 +7566,7 @@
             "start_date": "2005-10-19",
             "slug": "5",
             "csv": "data/Poland/Sejm/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c487473/data/Poland/Sejm/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c487473df3e0d29e6ee1d10132f2ced64cca2d72/data/Poland/Sejm/term-5.csv"
           },
           {
             "end_date": "2005-10-18",
@@ -7575,7 +7575,7 @@
             "start_date": "2001-10-19",
             "slug": "4",
             "csv": "data/Poland/Sejm/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c487473/data/Poland/Sejm/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c487473df3e0d29e6ee1d10132f2ced64cca2d72/data/Poland/Sejm/term-4.csv"
           },
           {
             "end_date": "2001-10-18",
@@ -7584,7 +7584,7 @@
             "start_date": "1997-10-20",
             "slug": "3",
             "csv": "data/Poland/Sejm/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c487473/data/Poland/Sejm/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c487473df3e0d29e6ee1d10132f2ced64cca2d72/data/Poland/Sejm/term-3.csv"
           },
           {
             "end_date": "1997-10-19",
@@ -7593,7 +7593,7 @@
             "start_date": "1993-09-19",
             "slug": "2",
             "csv": "data/Poland/Sejm/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c487473/data/Poland/Sejm/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c487473df3e0d29e6ee1d10132f2ced64cca2d72/data/Poland/Sejm/term-2.csv"
           },
           {
             "end_date": "1993-09-18",
@@ -7602,7 +7602,7 @@
             "start_date": "1991-11-25",
             "slug": "1",
             "csv": "data/Poland/Sejm/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c487473/data/Poland/Sejm/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c487473df3e0d29e6ee1d10132f2ced64cca2d72/data/Poland/Sejm/term-1.csv"
           }
         ],
         "statement_count": 123298
@@ -7620,11 +7620,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Portugal/Assembly/sources",
         "popolo": "data/Portugal/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/86699c9/data/Portugal/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/86699c9386feb57b5fe95672a09c155068778cf7/data/Portugal/Assembly/ep-popolo-v1.0.json",
         "names": "data/Portugal/Assembly/names.csv",
         "lastmod": "1472105627",
         "person_count": 1272,
-        "sha": "86699c9",
+        "sha": "86699c9386feb57b5fe95672a09c155068778cf7",
         "legislative_periods": [
           {
             "id": "term/13",
@@ -7632,7 +7632,7 @@
             "start_date": "2015-10-23",
             "slug": "13",
             "csv": "data/Portugal/Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c769fc2/data/Portugal/Assembly/term-13.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c769fc24f464e3d018c168fa481de3408feb80fb/data/Portugal/Assembly/term-13.csv"
           },
           {
             "end_date": "2015-10-22",
@@ -7641,7 +7641,7 @@
             "start_date": "2011-06-20",
             "slug": "12",
             "csv": "data/Portugal/Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d/data/Portugal/Assembly/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d2b5a020ed931f92ddef57a0eed8336c22/data/Portugal/Assembly/term-12.csv"
           },
           {
             "end_date": "2011-06-19",
@@ -7650,7 +7650,7 @@
             "start_date": "2009-10-15",
             "slug": "11",
             "csv": "data/Portugal/Assembly/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d/data/Portugal/Assembly/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d2b5a020ed931f92ddef57a0eed8336c22/data/Portugal/Assembly/term-11.csv"
           },
           {
             "end_date": "2009-09-14",
@@ -7659,7 +7659,7 @@
             "start_date": "2005-03-10",
             "slug": "10",
             "csv": "data/Portugal/Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d/data/Portugal/Assembly/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d2b5a020ed931f92ddef57a0eed8336c22/data/Portugal/Assembly/term-10.csv"
           },
           {
             "end_date": "2005-03-09",
@@ -7668,7 +7668,7 @@
             "start_date": "2002-04-05",
             "slug": "9",
             "csv": "data/Portugal/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d/data/Portugal/Assembly/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d2b5a020ed931f92ddef57a0eed8336c22/data/Portugal/Assembly/term-9.csv"
           },
           {
             "end_date": "2002-04-04",
@@ -7677,7 +7677,7 @@
             "start_date": "1999-10-25",
             "slug": "8",
             "csv": "data/Portugal/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d/data/Portugal/Assembly/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d2b5a020ed931f92ddef57a0eed8336c22/data/Portugal/Assembly/term-8.csv"
           },
           {
             "end_date": "1999-10-14",
@@ -7686,7 +7686,7 @@
             "start_date": "1995-10-27",
             "slug": "7",
             "csv": "data/Portugal/Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d/data/Portugal/Assembly/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d2b5a020ed931f92ddef57a0eed8336c22/data/Portugal/Assembly/term-7.csv"
           },
           {
             "end_date": "1995-10-26",
@@ -7695,7 +7695,7 @@
             "start_date": "1991-11-04",
             "slug": "6",
             "csv": "data/Portugal/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d/data/Portugal/Assembly/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d2b5a020ed931f92ddef57a0eed8336c22/data/Portugal/Assembly/term-6.csv"
           },
           {
             "end_date": "1991-11-03",
@@ -7704,7 +7704,7 @@
             "start_date": "1987-08-13",
             "slug": "5",
             "csv": "data/Portugal/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d/data/Portugal/Assembly/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d2b5a020ed931f92ddef57a0eed8336c22/data/Portugal/Assembly/term-5.csv"
           },
           {
             "end_date": "1987-08-12",
@@ -7713,7 +7713,7 @@
             "start_date": "1985-11-04",
             "slug": "4",
             "csv": "data/Portugal/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d/data/Portugal/Assembly/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d2b5a020ed931f92ddef57a0eed8336c22/data/Portugal/Assembly/term-4.csv"
           },
           {
             "end_date": "1985-11-03",
@@ -7722,7 +7722,7 @@
             "start_date": "1983-05-31",
             "slug": "3",
             "csv": "data/Portugal/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d/data/Portugal/Assembly/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d2b5a020ed931f92ddef57a0eed8336c22/data/Portugal/Assembly/term-3.csv"
           },
           {
             "end_date": "1983-05-30",
@@ -7731,7 +7731,7 @@
             "start_date": "1980-01-03",
             "slug": "2",
             "csv": "data/Portugal/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d/data/Portugal/Assembly/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d2b5a020ed931f92ddef57a0eed8336c22/data/Portugal/Assembly/term-2.csv"
           },
           {
             "end_date": "1980-01-02",
@@ -7740,7 +7740,7 @@
             "start_date": "1976-03-06",
             "slug": "1",
             "csv": "data/Portugal/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d/data/Portugal/Assembly/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6e982d2b5a020ed931f92ddef57a0eed8336c22/data/Portugal/Assembly/term-1.csv"
           }
         ],
         "statement_count": 40528
@@ -7758,11 +7758,11 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Puerto_Rico/House_of_Representatives/sources",
         "popolo": "data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cebc1ae/data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cebc1ae83d8a30b18e195dbdbc2441524f50043b/data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Puerto_Rico/House_of_Representatives/names.csv",
         "lastmod": "1469385054",
         "person_count": 53,
-        "sha": "cebc1ae",
+        "sha": "cebc1ae83d8a30b18e195dbdbc2441524f50043b",
         "legislative_periods": [
           {
             "end_date": "2017-01-08",
@@ -7771,7 +7771,7 @@
             "start_date": "2013-01-14",
             "slug": "29",
             "csv": "data/Puerto_Rico/House_of_Representatives/term-29.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/09e3423/data/Puerto_Rico/House_of_Representatives/term-29.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/09e3423798ad623c84b82c3deb3cc0ea2113f67e/data/Puerto_Rico/House_of_Representatives/term-29.csv"
           }
         ],
         "statement_count": 3083
@@ -7789,11 +7789,11 @@
         "slug": "Deputies",
         "sources_directory": "data/Romania/Deputies/sources",
         "popolo": "data/Romania/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/88207c4/data/Romania/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/88207c46f272a03bfbbe1fe90bf65101e2bf712a/data/Romania/Deputies/ep-popolo-v1.0.json",
         "names": "data/Romania/Deputies/names.csv",
         "lastmod": "1471597828",
         "person_count": 417,
-        "sha": "88207c4",
+        "sha": "88207c46f272a03bfbbe1fe90bf65101e2bf712a",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -7801,7 +7801,7 @@
             "start_date": "2012-12-12",
             "slug": "2012",
             "csv": "data/Romania/Deputies/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/88207c4/data/Romania/Deputies/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/88207c46f272a03bfbbe1fe90bf65101e2bf712a/data/Romania/Deputies/term-2012.csv"
           }
         ],
         "statement_count": 22215
@@ -7819,11 +7819,11 @@
         "slug": "Duma",
         "sources_directory": "data/Russia/Duma/sources",
         "popolo": "data/Russia/Duma/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/39b15f8/data/Russia/Duma/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/39b15f8ac24914a3a45a4a441b3244ae2895c25b/data/Russia/Duma/ep-popolo-v1.0.json",
         "names": "data/Russia/Duma/names.csv",
         "lastmod": "1472095696",
         "person_count": 469,
-        "sha": "39b15f8",
+        "sha": "39b15f8ac24914a3a45a4a441b3244ae2895c25b",
         "legislative_periods": [
           {
             "id": "term/6",
@@ -7831,7 +7831,7 @@
             "start_date": "2011-12-04",
             "slug": "6",
             "csv": "data/Russia/Duma/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b99d6e9/data/Russia/Duma/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b99d6e9db69f6b598233d7f495c16058ed9f48b9/data/Russia/Duma/term-6.csv"
           }
         ],
         "statement_count": 19703
@@ -7849,11 +7849,11 @@
         "slug": "Deputies",
         "sources_directory": "data/Rwanda/Deputies/sources",
         "popolo": "data/Rwanda/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0f4ad10/data/Rwanda/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0f4ad10e830c83b1a07c1187ca2e530af2af1c70/data/Rwanda/Deputies/ep-popolo-v1.0.json",
         "names": "data/Rwanda/Deputies/names.csv",
         "lastmod": "1469385073",
         "person_count": 77,
-        "sha": "0f4ad10",
+        "sha": "0f4ad10e830c83b1a07c1187ca2e530af2af1c70",
         "legislative_periods": [
           {
             "id": "term/3",
@@ -7861,7 +7861,7 @@
             "start_date": "2013-10-05",
             "slug": "3",
             "csv": "data/Rwanda/Deputies/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/49c42cd/data/Rwanda/Deputies/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/49c42cd1cb268efed4bab007af049831c44944de/data/Rwanda/Deputies/term-3.csv"
           }
         ],
         "statement_count": 1740
@@ -7879,11 +7879,11 @@
         "slug": "Council",
         "sources_directory": "data/Saint_Barthelemy/Council/sources",
         "popolo": "data/Saint_Barthelemy/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8bffee1/data/Saint_Barthelemy/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8bffee10a83e47d6b213027b6c4734504dd7745f/data/Saint_Barthelemy/Council/ep-popolo-v1.0.json",
         "names": "data/Saint_Barthelemy/Council/names.csv",
         "lastmod": "1469385080",
         "person_count": 19,
-        "sha": "8bffee1",
+        "sha": "8bffee10a83e47d6b213027b6c4734504dd7745f",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -7891,7 +7891,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Saint_Barthelemy/Council/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/131d002/data/Saint_Barthelemy/Council/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/131d0025b51a8e9670a6d22d47dbc0684cf27ed1/data/Saint_Barthelemy/Council/term-2012.csv"
           }
         ],
         "statement_count": 333
@@ -7909,11 +7909,11 @@
         "slug": "Legislative-Council",
         "sources_directory": "data/Saint_Helena/Legislative_Council/sources",
         "popolo": "data/Saint_Helena/Legislative_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e596988/data/Saint_Helena/Legislative_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e5969882cd0f1a428dfbdaead420ab40bb5af6bc/data/Saint_Helena/Legislative_Council/ep-popolo-v1.0.json",
         "names": "data/Saint_Helena/Legislative_Council/names.csv",
         "lastmod": "1469385086",
         "person_count": 12,
-        "sha": "e596988",
+        "sha": "e5969882cd0f1a428dfbdaead420ab40bb5af6bc",
         "legislative_periods": [
           {
             "id": "term/2013",
@@ -7921,7 +7921,7 @@
             "start_date": "2013-07-17",
             "slug": "2013",
             "csv": "data/Saint_Helena/Legislative_Council/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/63b2e3e/data/Saint_Helena/Legislative_Council/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/63b2e3ed2ce7c6d37d6062cf0f0b3a3aa801a881/data/Saint_Helena/Legislative_Council/term-2013.csv"
           }
         ],
         "statement_count": 538
@@ -7939,11 +7939,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Saint_Kitts_and_Nevis/Assembly/sources",
         "popolo": "data/Saint_Kitts_and_Nevis/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f269562/data/Saint_Kitts_and_Nevis/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f2695624e7c8d066bbc0778d2417d0733c319ba2/data/Saint_Kitts_and_Nevis/Assembly/ep-popolo-v1.0.json",
         "names": "data/Saint_Kitts_and_Nevis/Assembly/names.csv",
         "lastmod": "1471201024",
         "person_count": 30,
-        "sha": "f269562",
+        "sha": "f2695624e7c8d066bbc0778d2417d0733c319ba2",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -7951,7 +7951,7 @@
             "start_date": "2015-05-14",
             "slug": "2015",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/09e2a9e/data/Saint_Kitts_and_Nevis/Assembly/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/09e2a9e0b06a1877783e96ebc60111427b167235/data/Saint_Kitts_and_Nevis/Assembly/term-2015.csv"
           },
           {
             "end_date": "2015-01-16",
@@ -7960,7 +7960,7 @@
             "start_date": "2010-03-10",
             "slug": "2010",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/09e2a9e/data/Saint_Kitts_and_Nevis/Assembly/term-2010.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/09e2a9e0b06a1877783e96ebc60111427b167235/data/Saint_Kitts_and_Nevis/Assembly/term-2010.csv"
           },
           {
             "end_date": "2010",
@@ -7969,7 +7969,7 @@
             "start_date": "2004-10-26",
             "slug": "2004",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-2004.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/30ee36a/data/Saint_Kitts_and_Nevis/Assembly/term-2004.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/30ee36a4c334c378e5627a05f103fa4b62ca0395/data/Saint_Kitts_and_Nevis/Assembly/term-2004.csv"
           },
           {
             "end_date": "2004",
@@ -7978,7 +7978,7 @@
             "start_date": "2000",
             "slug": "2000",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-2000.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/30ee36a/data/Saint_Kitts_and_Nevis/Assembly/term-2000.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/30ee36a4c334c378e5627a05f103fa4b62ca0395/data/Saint_Kitts_and_Nevis/Assembly/term-2000.csv"
           },
           {
             "end_date": "2000",
@@ -7987,7 +7987,7 @@
             "start_date": "1995",
             "slug": "1995",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-1995.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/30ee36a/data/Saint_Kitts_and_Nevis/Assembly/term-1995.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/30ee36a4c334c378e5627a05f103fa4b62ca0395/data/Saint_Kitts_and_Nevis/Assembly/term-1995.csv"
           },
           {
             "end_date": "1995",
@@ -7996,7 +7996,7 @@
             "start_date": "1993",
             "slug": "1993",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-1993.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/30ee36a/data/Saint_Kitts_and_Nevis/Assembly/term-1993.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/30ee36a4c334c378e5627a05f103fa4b62ca0395/data/Saint_Kitts_and_Nevis/Assembly/term-1993.csv"
           },
           {
             "end_date": "1993",
@@ -8005,7 +8005,7 @@
             "start_date": "1989",
             "slug": "1989",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-1989.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/30ee36a/data/Saint_Kitts_and_Nevis/Assembly/term-1989.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/30ee36a4c334c378e5627a05f103fa4b62ca0395/data/Saint_Kitts_and_Nevis/Assembly/term-1989.csv"
           },
           {
             "end_date": "1989",
@@ -8014,7 +8014,7 @@
             "start_date": "1984",
             "slug": "1984",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-1984.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/30ee36a/data/Saint_Kitts_and_Nevis/Assembly/term-1984.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/30ee36a4c334c378e5627a05f103fa4b62ca0395/data/Saint_Kitts_and_Nevis/Assembly/term-1984.csv"
           }
         ],
         "statement_count": 1550
@@ -8032,11 +8032,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Saint_Lucia/Assembly/sources",
         "popolo": "data/Saint_Lucia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4bd63d9/data/Saint_Lucia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4bd63d9e03a9a15a8eee1857ec877d5fe89fae5d/data/Saint_Lucia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Saint_Lucia/Assembly/names.csv",
         "lastmod": "1471012608",
         "person_count": 23,
-        "sha": "4bd63d9",
+        "sha": "4bd63d9e03a9a15a8eee1857ec877d5fe89fae5d",
         "legislative_periods": [
           {
             "end_date": "2016-06-05",
@@ -8045,7 +8045,7 @@
             "start_date": "2012-01-05",
             "slug": "9",
             "csv": "data/Saint_Lucia/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0787cf5/data/Saint_Lucia/Assembly/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0787cf5c002a89c6ba3eb3298691cb5d734f88cd/data/Saint_Lucia/Assembly/term-9.csv"
           },
           {
             "end_date": "2011-11-27",
@@ -8054,7 +8054,7 @@
             "start_date": "2007-01-09",
             "slug": "8",
             "csv": "data/Saint_Lucia/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/020d40a/data/Saint_Lucia/Assembly/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/020d40a55c99bbddfd436dd766855c2943341aaf/data/Saint_Lucia/Assembly/term-8.csv"
           }
         ],
         "statement_count": 1712
@@ -8072,11 +8072,11 @@
         "slug": "Council",
         "sources_directory": "data/Saint_Martin/Council/sources",
         "popolo": "data/Saint_Martin/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/04c8445/data/Saint_Martin/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/04c84452cde4e1a316c73c1831de2a1b2bf4dd77/data/Saint_Martin/Council/ep-popolo-v1.0.json",
         "names": "data/Saint_Martin/Council/names.csv",
         "lastmod": "1469385101",
         "person_count": 23,
-        "sha": "04c8445",
+        "sha": "04c84452cde4e1a316c73c1831de2a1b2bf4dd77",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -8084,7 +8084,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Saint_Martin/Council/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c56a394/data/Saint_Martin/Council/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c56a3948cc2ebe20624e2d1dfee623e9d172a3d2/data/Saint_Martin/Council/term-2012.csv"
           }
         ],
         "statement_count": 371
@@ -8102,11 +8102,11 @@
         "slug": "Territorial-Council",
         "sources_directory": "data/Saint_Pierre_and_Miquelon/Territorial_Council/sources",
         "popolo": "data/Saint_Pierre_and_Miquelon/Territorial_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6fdc6cb/data/Saint_Pierre_and_Miquelon/Territorial_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6fdc6cbf23fbd808e377ff07c5da55665d5c9dde/data/Saint_Pierre_and_Miquelon/Territorial_Council/ep-popolo-v1.0.json",
         "names": "data/Saint_Pierre_and_Miquelon/Territorial_Council/names.csv",
         "lastmod": "1469385108",
         "person_count": 31,
-        "sha": "6fdc6cb",
+        "sha": "6fdc6cbf23fbd808e377ff07c5da55665d5c9dde",
         "legislative_periods": [
           {
             "end_date": "2017",
@@ -8115,7 +8115,7 @@
             "start_date": "2012-03",
             "slug": "2012",
             "csv": "data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a17069/data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a17069e70b7814a095a85c8a0f4ecb47e5b51ac/data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2012.csv"
           },
           {
             "end_date": "2012-03",
@@ -8124,7 +8124,7 @@
             "start_date": "2006-03",
             "slug": "2006",
             "csv": "data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2006.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a17069/data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2006.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a17069e70b7814a095a85c8a0f4ecb47e5b51ac/data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2006.csv"
           }
         ],
         "statement_count": 709
@@ -8142,11 +8142,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Saint_Vincent_and_the_Grenadines/Assembly/sources",
         "popolo": "data/Saint_Vincent_and_the_Grenadines/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3f5c59b/data/Saint_Vincent_and_the_Grenadines/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3f5c59b30fc2416409dc962eb9bb58caddbdae63/data/Saint_Vincent_and_the_Grenadines/Assembly/ep-popolo-v1.0.json",
         "names": "data/Saint_Vincent_and_the_Grenadines/Assembly/names.csv",
         "lastmod": "1469385114",
         "person_count": 15,
-        "sha": "3f5c59b",
+        "sha": "3f5c59b30fc2416409dc962eb9bb58caddbdae63",
         "legislative_periods": [
           {
             "end_date": "2015-11-07",
@@ -8155,7 +8155,7 @@
             "start_date": "2010-12-30",
             "slug": "8",
             "csv": "data/Saint_Vincent_and_the_Grenadines/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fe649c3/data/Saint_Vincent_and_the_Grenadines/Assembly/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fe649c3f0523e4871887c45eb85b855ff2494023/data/Saint_Vincent_and_the_Grenadines/Assembly/term-8.csv"
           }
         ],
         "statement_count": 404
@@ -8173,11 +8173,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Samoa/Parliament/sources",
         "popolo": "data/Samoa/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/607bbc9/data/Samoa/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/607bbc9f1e710a603817b5ba3dc126186918b207/data/Samoa/Parliament/ep-popolo-v1.0.json",
         "names": "data/Samoa/Parliament/names.csv",
         "lastmod": "1470235208",
         "person_count": 49,
-        "sha": "607bbc9",
+        "sha": "607bbc9f1e710a603817b5ba3dc126186918b207",
         "legislative_periods": [
           {
             "end_date": "2016-01-29",
@@ -8186,7 +8186,7 @@
             "start_date": "2011-03-18",
             "slug": "15",
             "csv": "data/Samoa/Parliament/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1637b7e/data/Samoa/Parliament/term-15.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1637b7eff2ae081bebb632f72780d36c021cba05/data/Samoa/Parliament/term-15.csv"
           }
         ],
         "statement_count": 1757
@@ -8204,11 +8204,11 @@
         "slug": "Council",
         "sources_directory": "data/San_Marino/Council/sources",
         "popolo": "data/San_Marino/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f3cdb4d/data/San_Marino/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f3cdb4dedfb358d76048fb148bed84d537ce2e7a/data/San_Marino/Council/ep-popolo-v1.0.json",
         "names": "data/San_Marino/Council/names.csv",
         "lastmod": "1471021734",
         "person_count": 62,
-        "sha": "f3cdb4d",
+        "sha": "f3cdb4dedfb358d76048fb148bed84d537ce2e7a",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -8216,7 +8216,7 @@
             "start_date": "2012-12-26",
             "slug": "2012",
             "csv": "data/San_Marino/Council/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8ada51f/data/San_Marino/Council/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8ada51f4bb47e4b950aeb417acca9c76c29c33bb/data/San_Marino/Council/term-2012.csv"
           }
         ],
         "statement_count": 3626
@@ -8234,11 +8234,11 @@
         "slug": "Chief-Pleas",
         "sources_directory": "data/Sark/Chief_Pleas/sources",
         "popolo": "data/Sark/Chief_Pleas/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/022199c/data/Sark/Chief_Pleas/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/022199c8695a1c087a7400629f1bf49e0a92976c/data/Sark/Chief_Pleas/ep-popolo-v1.0.json",
         "names": "data/Sark/Chief_Pleas/names.csv",
         "lastmod": "1469385120",
         "person_count": 46,
-        "sha": "022199c",
+        "sha": "022199c8695a1c087a7400629f1bf49e0a92976c",
         "legislative_periods": [
           {
             "end_date": "2017",
@@ -8247,7 +8247,7 @@
             "start_date": "2015",
             "slug": "2015",
             "csv": "data/Sark/Chief_Pleas/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c3911f/data/Sark/Chief_Pleas/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c3911f1249d20e9104b216a5241f48d6141e256/data/Sark/Chief_Pleas/term-2015.csv"
           },
           {
             "end_date": "2015",
@@ -8256,7 +8256,7 @@
             "start_date": "2013",
             "slug": "2013",
             "csv": "data/Sark/Chief_Pleas/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c3911f/data/Sark/Chief_Pleas/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c3911f1249d20e9104b216a5241f48d6141e256/data/Sark/Chief_Pleas/term-2013.csv"
           },
           {
             "end_date": "2013",
@@ -8265,7 +8265,7 @@
             "start_date": "2011",
             "slug": "2011",
             "csv": "data/Sark/Chief_Pleas/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c3911f/data/Sark/Chief_Pleas/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c3911f1249d20e9104b216a5241f48d6141e256/data/Sark/Chief_Pleas/term-2011.csv"
           },
           {
             "end_date": "2011",
@@ -8274,7 +8274,7 @@
             "start_date": "2009",
             "slug": "2009",
             "csv": "data/Sark/Chief_Pleas/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c3911f/data/Sark/Chief_Pleas/term-2009.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c3911f1249d20e9104b216a5241f48d6141e256/data/Sark/Chief_Pleas/term-2009.csv"
           }
         ],
         "statement_count": 1195
@@ -8292,11 +8292,11 @@
         "slug": "Shura",
         "sources_directory": "data/Saudi_Arabia/Shura/sources",
         "popolo": "data/Saudi_Arabia/Shura/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2def6bd/data/Saudi_Arabia/Shura/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2def6bdf7ed64baf7e01803cb3b8d5e53e9b2221/data/Saudi_Arabia/Shura/ep-popolo-v1.0.json",
         "names": "data/Saudi_Arabia/Shura/names.csv",
         "lastmod": "1469385128",
         "person_count": 148,
-        "sha": "2def6bd",
+        "sha": "2def6bdf7ed64baf7e01803cb3b8d5e53e9b2221",
         "legislative_periods": [
           {
             "id": "term/6",
@@ -8304,7 +8304,7 @@
             "start_date": "2013-02-24",
             "slug": "6",
             "csv": "data/Saudi_Arabia/Shura/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a26c70c/data/Saudi_Arabia/Shura/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a26c70c20735cce4e29a1fbc14dae43602fcf461/data/Saudi_Arabia/Shura/term-6.csv"
           }
         ],
         "statement_count": 1959
@@ -8322,11 +8322,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Scotland/Parliament/sources",
         "popolo": "data/Scotland/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4fbd94/data/Scotland/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4fbd9425966c73f195233520b7cbf3aa5189562/data/Scotland/Parliament/ep-popolo-v1.0.json",
         "names": "data/Scotland/Parliament/names.csv",
         "lastmod": "1470972176",
         "person_count": 301,
-        "sha": "a4fbd94",
+        "sha": "a4fbd9425966c73f195233520b7cbf3aa5189562",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -8334,7 +8334,7 @@
             "start_date": "2016-05-05",
             "slug": "5",
             "csv": "data/Scotland/Parliament/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4fbd94/data/Scotland/Parliament/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4fbd9425966c73f195233520b7cbf3aa5189562/data/Scotland/Parliament/term-5.csv"
           },
           {
             "end_date": "2016-03-24",
@@ -8343,7 +8343,7 @@
             "start_date": "2011-05-06",
             "slug": "4",
             "csv": "data/Scotland/Parliament/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4fbd94/data/Scotland/Parliament/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4fbd9425966c73f195233520b7cbf3aa5189562/data/Scotland/Parliament/term-4.csv"
           },
           {
             "end_date": "2011-05-04",
@@ -8352,7 +8352,7 @@
             "start_date": "2007-05-03",
             "slug": "3",
             "csv": "data/Scotland/Parliament/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4fbd94/data/Scotland/Parliament/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4fbd9425966c73f195233520b7cbf3aa5189562/data/Scotland/Parliament/term-3.csv"
           },
           {
             "end_date": "2007-04-02",
@@ -8361,7 +8361,7 @@
             "start_date": "2003-05-01",
             "slug": "2",
             "csv": "data/Scotland/Parliament/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4fbd94/data/Scotland/Parliament/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a4fbd9425966c73f195233520b7cbf3aa5189562/data/Scotland/Parliament/term-2.csv"
           },
           {
             "end_date": "2003-03-31",
@@ -8370,7 +8370,7 @@
             "start_date": "1999-05-06",
             "slug": "1",
             "csv": "data/Scotland/Parliament/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd329e9/data/Scotland/Parliament/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd329e9e07f96b62a3ec1f3b67e5ac7e8caeca90/data/Scotland/Parliament/term-1.csv"
           }
         ],
         "statement_count": 19129
@@ -8388,11 +8388,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Senegal/Assembly/sources",
         "popolo": "data/Senegal/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d941031/data/Senegal/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d941031822d2f6603c7f973bec3cc30248f132c7/data/Senegal/Assembly/ep-popolo-v1.0.json",
         "names": "data/Senegal/Assembly/names.csv",
         "lastmod": "1469385195",
         "person_count": 149,
-        "sha": "d941031",
+        "sha": "d941031822d2f6603c7f973bec3cc30248f132c7",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -8400,7 +8400,7 @@
             "start_date": "2012-07-30",
             "slug": "2012",
             "csv": "data/Senegal/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/29a7738/data/Senegal/Assembly/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/29a77381b541e7a76eec7e881623451d6efbe92e/data/Senegal/Assembly/term-2012.csv"
           }
         ],
         "statement_count": 2211
@@ -8418,11 +8418,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Serbia/National_Assembly/sources",
         "popolo": "data/Serbia/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af918fa/data/Serbia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af918faeff47a339e431824f62c59c63c54a734b/data/Serbia/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Serbia/National_Assembly/names.csv",
         "lastmod": "1472083198",
         "person_count": 391,
-        "sha": "af918fa",
+        "sha": "af918faeff47a339e431824f62c59c63c54a734b",
         "legislative_periods": [
           {
             "id": "term/11",
@@ -8430,7 +8430,7 @@
             "start_date": "2016-06-03",
             "slug": "11",
             "csv": "data/Serbia/National_Assembly/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af918fa/data/Serbia/National_Assembly/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af918faeff47a339e431824f62c59c63c54a734b/data/Serbia/National_Assembly/term-11.csv"
           },
           {
             "end_date": "2016-06-03",
@@ -8439,7 +8439,7 @@
             "start_date": "2014-05-16",
             "slug": "10",
             "csv": "data/Serbia/National_Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af918fa/data/Serbia/National_Assembly/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af918faeff47a339e431824f62c59c63c54a734b/data/Serbia/National_Assembly/term-10.csv"
           }
         ],
         "statement_count": 8112
@@ -8457,11 +8457,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Seychelles/Assembly/sources",
         "popolo": "data/Seychelles/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7970c07/data/Seychelles/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7970c074fef2c117045de7d613fce90f454a01b2/data/Seychelles/Assembly/ep-popolo-v1.0.json",
         "names": "data/Seychelles/Assembly/names.csv",
         "lastmod": "1469385206",
         "person_count": 32,
-        "sha": "7970c07",
+        "sha": "7970c074fef2c117045de7d613fce90f454a01b2",
         "legislative_periods": [
           {
             "id": "term/2011",
@@ -8469,7 +8469,7 @@
             "start_date": "2011-10-11",
             "slug": "2011",
             "csv": "data/Seychelles/Assembly/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6baa026/data/Seychelles/Assembly/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6baa026d856764aeaaebc3f454fdde9fc1e32680/data/Seychelles/Assembly/term-2011.csv"
           }
         ],
         "statement_count": 776
@@ -8487,11 +8487,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Sierra_Leone/Parliament/sources",
         "popolo": "data/Sierra_Leone/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f30e52f/data/Sierra_Leone/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f30e52f3f061dcfa83aad4560d4332cae8f714ed/data/Sierra_Leone/Parliament/ep-popolo-v1.0.json",
         "names": "data/Sierra_Leone/Parliament/names.csv",
         "lastmod": "1469385211",
         "person_count": 124,
-        "sha": "f30e52f",
+        "sha": "f30e52f3f061dcfa83aad4560d4332cae8f714ed",
         "legislative_periods": [
           {
             "id": "term/2-4",
@@ -8499,7 +8499,7 @@
             "start_date": "2012-12-07",
             "slug": "2-4",
             "csv": "data/Sierra_Leone/Parliament/term-2-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0c40a52/data/Sierra_Leone/Parliament/term-2-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0c40a52d94537013fffa1778765fa1bf5577c937/data/Sierra_Leone/Parliament/term-2-4.csv"
           }
         ],
         "statement_count": 1722
@@ -8517,11 +8517,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Singapore/Parliament/sources",
         "popolo": "data/Singapore/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75f682d/data/Singapore/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75f682d2cd30c3c16b892e7b2a6aa526faf00b93/data/Singapore/Parliament/ep-popolo-v1.0.json",
         "names": "data/Singapore/Parliament/names.csv",
         "lastmod": "1471267501",
         "person_count": 403,
-        "sha": "75f682d",
+        "sha": "75f682d2cd30c3c16b892e7b2a6aa526faf00b93",
         "legislative_periods": [
           {
             "id": "term/13",
@@ -8529,7 +8529,7 @@
             "start_date": "2016-01-15",
             "slug": "13",
             "csv": "data/Singapore/Parliament/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75f682d/data/Singapore/Parliament/term-13.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75f682d2cd30c3c16b892e7b2a6aa526faf00b93/data/Singapore/Parliament/term-13.csv"
           },
           {
             "end_date": "2015-08-25",
@@ -8538,7 +8538,7 @@
             "start_date": "2011-10-10",
             "slug": "12",
             "csv": "data/Singapore/Parliament/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75f682d/data/Singapore/Parliament/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75f682d2cd30c3c16b892e7b2a6aa526faf00b93/data/Singapore/Parliament/term-12.csv"
           },
           {
             "end_date": "2011-04-19",
@@ -8547,7 +8547,7 @@
             "start_date": "2006-11-02",
             "slug": "11",
             "csv": "data/Singapore/Parliament/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/56d89eb/data/Singapore/Parliament/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/56d89ebf0beff86de08dc93d872b734d907b84be/data/Singapore/Parliament/term-11.csv"
           },
           {
             "end_date": "2006-04-19",
@@ -8556,7 +8556,7 @@
             "start_date": "2002-03-25",
             "slug": "10",
             "csv": "data/Singapore/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/56d89eb/data/Singapore/Parliament/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/56d89ebf0beff86de08dc93d872b734d907b84be/data/Singapore/Parliament/term-10.csv"
           },
           {
             "end_date": "2001-10-17",
@@ -8565,7 +8565,7 @@
             "start_date": "1997-05-26",
             "slug": "9",
             "csv": "data/Singapore/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/56d89eb/data/Singapore/Parliament/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/56d89ebf0beff86de08dc93d872b734d907b84be/data/Singapore/Parliament/term-9.csv"
           },
           {
             "end_date": "1996-12-15",
@@ -8574,7 +8574,7 @@
             "start_date": "1992-01-06",
             "slug": "8",
             "csv": "data/Singapore/Parliament/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/56d89eb/data/Singapore/Parliament/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/56d89ebf0beff86de08dc93d872b734d907b84be/data/Singapore/Parliament/term-8.csv"
           },
           {
             "end_date": "1991-08-13",
@@ -8583,7 +8583,7 @@
             "start_date": "1989-01-09",
             "slug": "7",
             "csv": "data/Singapore/Parliament/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/56d89eb/data/Singapore/Parliament/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/56d89ebf0beff86de08dc93d872b734d907b84be/data/Singapore/Parliament/term-7.csv"
           },
           {
             "end_date": "1988-08-16",
@@ -8592,7 +8592,7 @@
             "start_date": "1985-02-25",
             "slug": "6",
             "csv": "data/Singapore/Parliament/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/56d89eb/data/Singapore/Parliament/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/56d89ebf0beff86de08dc93d872b734d907b84be/data/Singapore/Parliament/term-6.csv"
           },
           {
             "end_date": "1984-12-03",
@@ -8601,7 +8601,7 @@
             "start_date": "1981-02-03",
             "slug": "5",
             "csv": "data/Singapore/Parliament/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f7ea40/data/Singapore/Parliament/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f7ea402d28dc0aa0ebf3dd44ca84f4c6b565e36/data/Singapore/Parliament/term-5.csv"
           },
           {
             "end_date": "1980-12-04",
@@ -8610,7 +8610,7 @@
             "start_date": "1977-02-07",
             "slug": "4",
             "csv": "data/Singapore/Parliament/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f7ea40/data/Singapore/Parliament/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f7ea402d28dc0aa0ebf3dd44ca84f4c6b565e36/data/Singapore/Parliament/term-4.csv"
           },
           {
             "end_date": "1976-12-06",
@@ -8619,7 +8619,7 @@
             "start_date": "1972-10-12",
             "slug": "3",
             "csv": "data/Singapore/Parliament/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f7ea40/data/Singapore/Parliament/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f7ea402d28dc0aa0ebf3dd44ca84f4c6b565e36/data/Singapore/Parliament/term-3.csv"
           },
           {
             "end_date": "1972-08-16",
@@ -8628,7 +8628,7 @@
             "start_date": "1968-05-06",
             "slug": "2",
             "csv": "data/Singapore/Parliament/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f7ea40/data/Singapore/Parliament/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f7ea402d28dc0aa0ebf3dd44ca84f4c6b565e36/data/Singapore/Parliament/term-2.csv"
           },
           {
             "end_date": "1968-02-08",
@@ -8637,7 +8637,7 @@
             "start_date": "1965-12-08",
             "slug": "1",
             "csv": "data/Singapore/Parliament/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f7ea40/data/Singapore/Parliament/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f7ea402d28dc0aa0ebf3dd44ca84f4c6b565e36/data/Singapore/Parliament/term-1.csv"
           }
         ],
         "statement_count": 15429
@@ -8655,11 +8655,11 @@
         "slug": "Estates",
         "sources_directory": "data/Sint_Maarten/Estates/sources",
         "popolo": "data/Sint_Maarten/Estates/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37e1ed4/data/Sint_Maarten/Estates/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37e1ed44c020da28cd14edc36d14a1206083f40b/data/Sint_Maarten/Estates/ep-popolo-v1.0.json",
         "names": "data/Sint_Maarten/Estates/names.csv",
         "lastmod": "1469385223",
         "person_count": 17,
-        "sha": "37e1ed4",
+        "sha": "37e1ed44c020da28cd14edc36d14a1206083f40b",
         "legislative_periods": [
           {
             "id": "term/2",
@@ -8667,7 +8667,7 @@
             "start_date": "2014",
             "slug": "2",
             "csv": "data/Sint_Maarten/Estates/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b56da29/data/Sint_Maarten/Estates/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b56da29f5f8e1330780869ae0013095adcb413cc/data/Sint_Maarten/Estates/term-2.csv"
           }
         ],
         "statement_count": 692
@@ -8685,11 +8685,11 @@
         "slug": "National-Council",
         "sources_directory": "data/Slovakia/National_Council/sources",
         "popolo": "data/Slovakia/National_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aa7122f/data/Slovakia/National_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aa7122f590f5c5ab9d2c2ebf5ad4f49c96cf032f/data/Slovakia/National_Council/ep-popolo-v1.0.json",
         "names": "data/Slovakia/National_Council/names.csv",
         "lastmod": "1471345348",
         "person_count": 526,
-        "sha": "aa7122f",
+        "sha": "aa7122f590f5c5ab9d2c2ebf5ad4f49c96cf032f",
         "legislative_periods": [
           {
             "id": "term/6",
@@ -8697,7 +8697,7 @@
             "start_date": "2012-03-11",
             "slug": "6",
             "csv": "data/Slovakia/National_Council/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8693c2d/data/Slovakia/National_Council/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8693c2d2e57307804bc12106a58cc8bb21d428be/data/Slovakia/National_Council/term-6.csv"
           },
           {
             "end_date": "2012-03-10",
@@ -8706,7 +8706,7 @@
             "start_date": "2010-06-13",
             "slug": "5",
             "csv": "data/Slovakia/National_Council/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8693c2d/data/Slovakia/National_Council/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8693c2d2e57307804bc12106a58cc8bb21d428be/data/Slovakia/National_Council/term-5.csv"
           },
           {
             "end_date": "2010-06-12",
@@ -8715,7 +8715,7 @@
             "start_date": "2006-06-17",
             "slug": "4",
             "csv": "data/Slovakia/National_Council/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8693c2d/data/Slovakia/National_Council/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8693c2d2e57307804bc12106a58cc8bb21d428be/data/Slovakia/National_Council/term-4.csv"
           },
           {
             "end_date": "2006-06-16",
@@ -8724,7 +8724,7 @@
             "start_date": "2002-09-22",
             "slug": "3",
             "csv": "data/Slovakia/National_Council/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2a28ecb/data/Slovakia/National_Council/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2a28ecb4d902ca69db5ec594bd9041a1b3adaafa/data/Slovakia/National_Council/term-3.csv"
           },
           {
             "end_date": "2002-09-21",
@@ -8733,7 +8733,7 @@
             "start_date": "1998-09-26",
             "slug": "2",
             "csv": "data/Slovakia/National_Council/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3f1e80b/data/Slovakia/National_Council/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3f1e80bcb72ab7454267295b2d771774fb7770b4/data/Slovakia/National_Council/term-2.csv"
           }
         ],
         "statement_count": 35302
@@ -8751,11 +8751,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Slovenia/National_Assembly/sources",
         "popolo": "data/Slovenia/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ee08b39/data/Slovenia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ee08b39c29056c4a1c3691c46b117d95c881aa8a/data/Slovenia/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Slovenia/National_Assembly/names.csv",
         "lastmod": "1469385228",
         "person_count": 91,
-        "sha": "ee08b39",
+        "sha": "ee08b39c29056c4a1c3691c46b117d95c881aa8a",
         "legislative_periods": [
           {
             "id": "term/7",
@@ -8763,7 +8763,7 @@
             "start_date": "2014-08-01",
             "slug": "7",
             "csv": "data/Slovenia/National_Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/460dab0/data/Slovenia/National_Assembly/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/460dab0e80c346441bb94a9f1b3cde703e3c24c3/data/Slovenia/National_Assembly/term-7.csv"
           }
         ],
         "statement_count": 6923
@@ -8781,11 +8781,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Solomon_Islands/Parliament/sources",
         "popolo": "data/Solomon_Islands/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0954e58/data/Solomon_Islands/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0954e58dea508d88b6b3f27b585e817754393b41/data/Solomon_Islands/Parliament/ep-popolo-v1.0.json",
         "names": "data/Solomon_Islands/Parliament/names.csv",
         "lastmod": "1470227375",
         "person_count": 50,
-        "sha": "0954e58",
+        "sha": "0954e58dea508d88b6b3f27b585e817754393b41",
         "legislative_periods": [
           {
             "id": "term/10",
@@ -8793,7 +8793,7 @@
             "start_date": "2014-12-09",
             "slug": "10",
             "csv": "data/Solomon_Islands/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ec2febe/data/Solomon_Islands/Parliament/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ec2febe4ed50a39c72bdb6e2c1dc73602231e488/data/Solomon_Islands/Parliament/term-10.csv"
           }
         ],
         "statement_count": 2373
@@ -8811,11 +8811,11 @@
         "slug": "Lower",
         "sources_directory": "data/Somalia/Lower/sources",
         "popolo": "data/Somalia/Lower/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0e9d8e6/data/Somalia/Lower/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0e9d8e691f10a3cc53629273d2eead084feed3c6/data/Somalia/Lower/ep-popolo-v1.0.json",
         "names": "data/Somalia/Lower/names.csv",
         "lastmod": "1469385401",
         "person_count": 204,
-        "sha": "0e9d8e6",
+        "sha": "0e9d8e691f10a3cc53629273d2eead084feed3c6",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -8823,7 +8823,7 @@
             "start_date": "2012-08-20",
             "slug": "2012",
             "csv": "data/Somalia/Lower/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1fbe923/data/Somalia/Lower/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1fbe9236f393581271ceee95b24fb762414602cb/data/Somalia/Lower/term-2012.csv"
           }
         ],
         "statement_count": 2297
@@ -8841,11 +8841,11 @@
         "slug": "Representatives",
         "sources_directory": "data/Somaliland/Representatives/sources",
         "popolo": "data/Somaliland/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/99760e8/data/Somaliland/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/99760e8fba47290aed07286fff4f63b1cdb4f1cc/data/Somaliland/Representatives/ep-popolo-v1.0.json",
         "names": "data/Somaliland/Representatives/names.csv",
         "lastmod": "1469385319",
         "person_count": 82,
-        "sha": "99760e8",
+        "sha": "99760e8fba47290aed07286fff4f63b1cdb4f1cc",
         "legislative_periods": [
           {
             "id": "term/2005",
@@ -8853,7 +8853,7 @@
             "start_date": "2005-09-29",
             "slug": "2005",
             "csv": "data/Somaliland/Representatives/term-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d609454/data/Somaliland/Representatives/term-2005.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d609454bf9eac7d203a166b34a700c2a26870836/data/Somaliland/Representatives/term-2005.csv"
           }
         ],
         "statement_count": 946
@@ -8871,11 +8871,11 @@
         "slug": "Assembly",
         "sources_directory": "data/South_Africa/Assembly/sources",
         "popolo": "data/South_Africa/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6cfac0d/data/South_Africa/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6cfac0dde24b3d4aa3180253791f0a2c792d2fd6/data/South_Africa/Assembly/ep-popolo-v1.0.json",
         "names": "data/South_Africa/Assembly/names.csv",
         "lastmod": "1470724639",
         "person_count": 400,
-        "sha": "6cfac0d",
+        "sha": "6cfac0dde24b3d4aa3180253791f0a2c792d2fd6",
         "legislative_periods": [
           {
             "id": "term/26",
@@ -8883,7 +8883,7 @@
             "start_date": "2014-05-21",
             "slug": "26",
             "csv": "data/South_Africa/Assembly/term-26.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ed79c0b/data/South_Africa/Assembly/term-26.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ed79c0b19ff9a838628e7ef109400d45ed418fcf/data/South_Africa/Assembly/term-26.csv"
           }
         ],
         "statement_count": 11606
@@ -8901,11 +8901,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/South_Korea/National_Assembly/sources",
         "popolo": "data/South_Korea/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd10cda/data/South_Korea/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd10cdab5fe883556e3b723423337963f8044900/data/South_Korea/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/South_Korea/National_Assembly/names.csv",
         "lastmod": "1470223066",
         "person_count": 298,
-        "sha": "fd10cda",
+        "sha": "fd10cdab5fe883556e3b723423337963f8044900",
         "legislative_periods": [
           {
             "end_date": "2016-05-29",
@@ -8914,7 +8914,7 @@
             "start_date": "2012-05-30",
             "slug": "19",
             "csv": "data/South_Korea/National_Assembly/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2e82b0d/data/South_Korea/National_Assembly/term-19.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2e82b0dcfd562a29a893441e420ecefa48df5bd1/data/South_Korea/National_Assembly/term-19.csv"
           }
         ],
         "statement_count": 15709
@@ -8932,11 +8932,11 @@
         "slug": "Parliament",
         "sources_directory": "data/South_Ossetia/Parliament/sources",
         "popolo": "data/South_Ossetia/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f1a79c/data/South_Ossetia/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f1a79cd3bdd7f6df30e900e5dc09d13a2d09836/data/South_Ossetia/Parliament/ep-popolo-v1.0.json",
         "names": "data/South_Ossetia/Parliament/names.csv",
         "lastmod": "1469385339",
         "person_count": 34,
-        "sha": "8f1a79c",
+        "sha": "8f1a79cd3bdd7f6df30e900e5dc09d13a2d09836",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -8944,7 +8944,7 @@
             "start_date": "2014-06-09",
             "slug": "2014",
             "csv": "data/South_Ossetia/Parliament/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/044afe6/data/South_Ossetia/Parliament/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/044afe664f633e7b20cdb988cfdf3ad2adb138bb/data/South_Ossetia/Parliament/term-2014.csv"
           }
         ],
         "statement_count": 439
@@ -8962,11 +8962,11 @@
         "slug": "Assembly",
         "sources_directory": "data/South_Sudan/Assembly/sources",
         "popolo": "data/South_Sudan/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/07abd98/data/South_Sudan/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/07abd98519ea3208943fce5c1020adcc86bc98db/data/South_Sudan/Assembly/ep-popolo-v1.0.json",
         "names": "data/South_Sudan/Assembly/names.csv",
         "lastmod": "1469385344",
         "person_count": 167,
-        "sha": "07abd98",
+        "sha": "07abd98519ea3208943fce5c1020adcc86bc98db",
         "legislative_periods": [
           {
             "id": "term/1",
@@ -8974,7 +8974,7 @@
             "start_date": "2011-07-09",
             "slug": "1",
             "csv": "data/South_Sudan/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d89886a/data/South_Sudan/Assembly/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d89886a4cfba54613d635be69ed863478f202166/data/South_Sudan/Assembly/term-1.csv"
           }
         ],
         "statement_count": 2618
@@ -8992,11 +8992,11 @@
         "slug": "Congress",
         "sources_directory": "data/Spain/Congress/sources",
         "popolo": "data/Spain/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf78fcc/data/Spain/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf78fcce51109dc0c0219e5a3816d7ba5cb068d5/data/Spain/Congress/ep-popolo-v1.0.json",
         "names": "data/Spain/Congress/names.csv",
         "lastmod": "1469385350",
         "person_count": 621,
-        "sha": "bf78fcc",
+        "sha": "bf78fcce51109dc0c0219e5a3816d7ba5cb068d5",
         "legislative_periods": [
           {
             "id": "term/11",
@@ -9004,7 +9004,7 @@
             "start_date": "2016-01-13",
             "slug": "11",
             "csv": "data/Spain/Congress/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e8d2fb8/data/Spain/Congress/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e8d2fb8acc6ea31a672df2c1a76712cf0f55d672/data/Spain/Congress/term-11.csv"
           },
           {
             "end_date": "2015-10-27",
@@ -9013,7 +9013,7 @@
             "start_date": "2011-11-28",
             "slug": "10",
             "csv": "data/Spain/Congress/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e8d2fb8/data/Spain/Congress/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e8d2fb8acc6ea31a672df2c1a76712cf0f55d672/data/Spain/Congress/term-10.csv"
           }
         ],
         "statement_count": 32142
@@ -9031,11 +9031,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Sri_Lanka/Parliament/sources",
         "popolo": "data/Sri_Lanka/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ef9b19/data/Sri_Lanka/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ef9b193c1fdea5cfe5a9bba3568c4340a6cc2b7/data/Sri_Lanka/Parliament/ep-popolo-v1.0.json",
         "names": "data/Sri_Lanka/Parliament/names.csv",
         "lastmod": "1471314946",
         "person_count": 228,
-        "sha": "1ef9b19",
+        "sha": "1ef9b193c1fdea5cfe5a9bba3568c4340a6cc2b7",
         "legislative_periods": [
           {
             "id": "term/15",
@@ -9043,7 +9043,7 @@
             "start_date": "2015-09-01",
             "slug": "15",
             "csv": "data/Sri_Lanka/Parliament/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ef9b19/data/Sri_Lanka/Parliament/term-15.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ef9b193c1fdea5cfe5a9bba3568c4340a6cc2b7/data/Sri_Lanka/Parliament/term-15.csv"
           }
         ],
         "statement_count": 8998
@@ -9061,11 +9061,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Suriname/Assembly/sources",
         "popolo": "data/Suriname/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a3095e1/data/Suriname/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a3095e13fecdccc5296fe1528394311fe960c169/data/Suriname/Assembly/ep-popolo-v1.0.json",
         "names": "data/Suriname/Assembly/names.csv",
         "lastmod": "1470994534",
         "person_count": 87,
-        "sha": "a3095e1",
+        "sha": "a3095e13fecdccc5296fe1528394311fe960c169",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -9073,7 +9073,7 @@
             "start_date": "2015-06-30",
             "slug": "2015",
             "csv": "data/Suriname/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1e993b9/data/Suriname/Assembly/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1e993b9b7d61f85325bf37c1fffdbaf3ade442b6/data/Suriname/Assembly/term-2015.csv"
           },
           {
             "end_date": "2015-06-30",
@@ -9082,7 +9082,7 @@
             "start_date": "2010",
             "slug": "2010",
             "csv": "data/Suriname/Assembly/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b07233f/data/Suriname/Assembly/term-2010.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b07233fdfd0215d4ef2de156ba8b4c1455a8ba31/data/Suriname/Assembly/term-2010.csv"
           }
         ],
         "statement_count": 3304
@@ -9100,11 +9100,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Swaziland/Assembly/sources",
         "popolo": "data/Swaziland/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4ae1e83/data/Swaziland/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4ae1e836f1c124dfbfb3347465aadf266a266650/data/Swaziland/Assembly/ep-popolo-v1.0.json",
         "names": "data/Swaziland/Assembly/names.csv",
         "lastmod": "1469385361",
         "person_count": 93,
-        "sha": "4ae1e83",
+        "sha": "4ae1e836f1c124dfbfb3347465aadf266a266650",
         "legislative_periods": [
           {
             "id": "term/10",
@@ -9112,7 +9112,7 @@
             "start_date": "2013-08-17",
             "slug": "10",
             "csv": "data/Swaziland/Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8ecc83a/data/Swaziland/Assembly/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8ecc83a0bb2ef59cf4f266ac6ed872c442f3eead/data/Swaziland/Assembly/term-10.csv"
           },
           {
             "end_date": "2013-09-19",
@@ -9121,7 +9121,7 @@
             "start_date": "2008-10-10",
             "slug": "9",
             "csv": "data/Swaziland/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a505443/data/Swaziland/Assembly/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a50544396aadc037ec054242b908be5671118b2b/data/Swaziland/Assembly/term-9.csv"
           }
         ],
         "statement_count": 1250
@@ -9139,11 +9139,11 @@
         "slug": "Riksdag",
         "sources_directory": "data/Sweden/Riksdag/sources",
         "popolo": "data/Sweden/Riksdag/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a34fa4/data/Sweden/Riksdag/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a34fa4047a18566717c4682f8e4f1690efe4acd/data/Sweden/Riksdag/ep-popolo-v1.0.json",
         "names": "data/Sweden/Riksdag/names.csv",
         "lastmod": "1472109925",
         "person_count": 1619,
-        "sha": "4a34fa4",
+        "sha": "4a34fa4047a18566717c4682f8e4f1690efe4acd",
         "legislative_periods": [
           {
             "end_date": "2018-09-24",
@@ -9152,7 +9152,7 @@
             "start_date": "2014-09-29",
             "slug": "2014",
             "csv": "data/Sweden/Riksdag/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/539691c/data/Sweden/Riksdag/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/539691c631c876ba6604ea06c95df7b7f33d93af/data/Sweden/Riksdag/term-2014.csv"
           },
           {
             "end_date": "2014-09-29",
@@ -9161,7 +9161,7 @@
             "start_date": "2010-10-04",
             "slug": "2010",
             "csv": "data/Sweden/Riksdag/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6ac79a/data/Sweden/Riksdag/term-2010.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6ac79ae4aeaee2cdcd48043aac76c2b71075605/data/Sweden/Riksdag/term-2010.csv"
           },
           {
             "end_date": "2010-10-04",
@@ -9170,7 +9170,7 @@
             "start_date": "2006-10-02",
             "slug": "2006",
             "csv": "data/Sweden/Riksdag/term-2006.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6ac79a/data/Sweden/Riksdag/term-2006.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6ac79ae4aeaee2cdcd48043aac76c2b71075605/data/Sweden/Riksdag/term-2006.csv"
           },
           {
             "end_date": "2006-10-02",
@@ -9179,7 +9179,7 @@
             "start_date": "2002-09-30",
             "slug": "2002",
             "csv": "data/Sweden/Riksdag/term-2002.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6ac79a/data/Sweden/Riksdag/term-2002.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6ac79ae4aeaee2cdcd48043aac76c2b71075605/data/Sweden/Riksdag/term-2002.csv"
           },
           {
             "end_date": "2002-09-30",
@@ -9188,7 +9188,7 @@
             "start_date": "1998-10-05",
             "slug": "1998",
             "csv": "data/Sweden/Riksdag/term-1998.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6ac79a/data/Sweden/Riksdag/term-1998.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6ac79ae4aeaee2cdcd48043aac76c2b71075605/data/Sweden/Riksdag/term-1998.csv"
           },
           {
             "end_date": "1998-10-05",
@@ -9197,7 +9197,7 @@
             "start_date": "1994-10-03",
             "slug": "1994",
             "csv": "data/Sweden/Riksdag/term-1994.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6ac79a/data/Sweden/Riksdag/term-1994.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6ac79ae4aeaee2cdcd48043aac76c2b71075605/data/Sweden/Riksdag/term-1994.csv"
           },
           {
             "end_date": "1994-10-03",
@@ -9206,7 +9206,7 @@
             "start_date": "1991-09-30",
             "slug": "1991",
             "csv": "data/Sweden/Riksdag/term-1991.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6ac79a/data/Sweden/Riksdag/term-1991.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6ac79ae4aeaee2cdcd48043aac76c2b71075605/data/Sweden/Riksdag/term-1991.csv"
           },
           {
             "end_date": "1991-09-30",
@@ -9215,7 +9215,7 @@
             "start_date": "1988-10-03",
             "slug": "1988",
             "csv": "data/Sweden/Riksdag/term-1988.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6ac79a/data/Sweden/Riksdag/term-1988.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b6ac79ae4aeaee2cdcd48043aac76c2b71075605/data/Sweden/Riksdag/term-1988.csv"
           },
           {
             "end_date": "1988-10-03",
@@ -9224,7 +9224,7 @@
             "start_date": "1985-09-30",
             "slug": "1985",
             "csv": "data/Sweden/Riksdag/term-1985.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f60050/data/Sweden/Riksdag/term-1985.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f600503105a8183a3c4eeda9e5d6506f90ce1a2/data/Sweden/Riksdag/term-1985.csv"
           },
           {
             "end_date": "1985-09-30",
@@ -9233,7 +9233,7 @@
             "start_date": "1982-10-04",
             "slug": "1982",
             "csv": "data/Sweden/Riksdag/term-1982.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f60050/data/Sweden/Riksdag/term-1982.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f600503105a8183a3c4eeda9e5d6506f90ce1a2/data/Sweden/Riksdag/term-1982.csv"
           },
           {
             "end_date": "1982-10-04",
@@ -9242,7 +9242,7 @@
             "start_date": "1979-10-01",
             "slug": "1979",
             "csv": "data/Sweden/Riksdag/term-1979.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f60050/data/Sweden/Riksdag/term-1979.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f600503105a8183a3c4eeda9e5d6506f90ce1a2/data/Sweden/Riksdag/term-1979.csv"
           },
           {
             "end_date": "1979-10-01",
@@ -9251,7 +9251,7 @@
             "start_date": "1976-10-04",
             "slug": "1976",
             "csv": "data/Sweden/Riksdag/term-1976.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f60050/data/Sweden/Riksdag/term-1976.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f600503105a8183a3c4eeda9e5d6506f90ce1a2/data/Sweden/Riksdag/term-1976.csv"
           }
         ],
         "statement_count": 96285
@@ -9269,11 +9269,11 @@
         "slug": "National-Council",
         "sources_directory": "data/Switzerland/National_Council/sources",
         "popolo": "data/Switzerland/National_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/97ace3c/data/Switzerland/National_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/97ace3c19275126a00d9540e73211500e292e326/data/Switzerland/National_Council/ep-popolo-v1.0.json",
         "names": "data/Switzerland/National_Council/names.csv",
         "lastmod": "1472109591",
         "person_count": 1216,
-        "sha": "97ace3c",
+        "sha": "97ace3c19275126a00d9540e73211500e292e326",
         "legislative_periods": [
           {
             "end_date": "2019-11-29",
@@ -9282,7 +9282,7 @@
             "start_date": "2015-11-30",
             "slug": "50",
             "csv": "data/Switzerland/National_Council/term-50.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/712f4b7/data/Switzerland/National_Council/term-50.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/712f4b7b0e218cd961d6148a83b4210dad8bfb55/data/Switzerland/National_Council/term-50.csv"
           },
           {
             "end_date": "2015-11-29",
@@ -9291,7 +9291,7 @@
             "start_date": "2011-12-05",
             "slug": "49",
             "csv": "data/Switzerland/National_Council/term-49.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/712f4b7/data/Switzerland/National_Council/term-49.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/712f4b7b0e218cd961d6148a83b4210dad8bfb55/data/Switzerland/National_Council/term-49.csv"
           },
           {
             "end_date": "2011-12-02",
@@ -9300,7 +9300,7 @@
             "start_date": "2007-12-03",
             "slug": "48",
             "csv": "data/Switzerland/National_Council/term-48.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0438920/data/Switzerland/National_Council/term-48.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/043892087ca8712ceefebcf0176eadd1a280bfe7/data/Switzerland/National_Council/term-48.csv"
           },
           {
             "end_date": "2007-11-30",
@@ -9309,7 +9309,7 @@
             "start_date": "2003-12-01",
             "slug": "47",
             "csv": "data/Switzerland/National_Council/term-47.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51d1521/data/Switzerland/National_Council/term-47.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51d1521e5dddd1cbb991aea39257a0847ff6118b/data/Switzerland/National_Council/term-47.csv"
           },
           {
             "end_date": "2003-11-30",
@@ -9318,7 +9318,7 @@
             "start_date": "1999-12-06",
             "slug": "46",
             "csv": "data/Switzerland/National_Council/term-46.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51d1521/data/Switzerland/National_Council/term-46.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51d1521e5dddd1cbb991aea39257a0847ff6118b/data/Switzerland/National_Council/term-46.csv"
           },
           {
             "end_date": "1999-11-30",
@@ -9327,7 +9327,7 @@
             "start_date": "1995-12-04",
             "slug": "45",
             "csv": "data/Switzerland/National_Council/term-45.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/50ff620/data/Switzerland/National_Council/term-45.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/50ff620e47445497a41b9edced07f4e797322e2e/data/Switzerland/National_Council/term-45.csv"
           },
           {
             "end_date": "1995-12-03",
@@ -9336,7 +9336,7 @@
             "start_date": "1991-11-25",
             "slug": "44",
             "csv": "data/Switzerland/National_Council/term-44.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/50ff620/data/Switzerland/National_Council/term-44.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/50ff620e47445497a41b9edced07f4e797322e2e/data/Switzerland/National_Council/term-44.csv"
           },
           {
             "end_date": "1991-11-24",
@@ -9345,7 +9345,7 @@
             "start_date": "1987-11-30",
             "slug": "43",
             "csv": "data/Switzerland/National_Council/term-43.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/50ff620/data/Switzerland/National_Council/term-43.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/50ff620e47445497a41b9edced07f4e797322e2e/data/Switzerland/National_Council/term-43.csv"
           },
           {
             "end_date": "1987-11-29",
@@ -9354,7 +9354,7 @@
             "start_date": "1983-11-28",
             "slug": "42",
             "csv": "data/Switzerland/National_Council/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/50ff620/data/Switzerland/National_Council/term-42.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/50ff620e47445497a41b9edced07f4e797322e2e/data/Switzerland/National_Council/term-42.csv"
           },
           {
             "end_date": "1983-11-27",
@@ -9363,7 +9363,7 @@
             "start_date": "1979-11-26",
             "slug": "41",
             "csv": "data/Switzerland/National_Council/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51d1521/data/Switzerland/National_Council/term-41.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51d1521e5dddd1cbb991aea39257a0847ff6118b/data/Switzerland/National_Council/term-41.csv"
           },
           {
             "end_date": "1979-11-25",
@@ -9372,7 +9372,7 @@
             "start_date": "1975-12-01",
             "slug": "40",
             "csv": "data/Switzerland/National_Council/term-40.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51d1521/data/Switzerland/National_Council/term-40.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51d1521e5dddd1cbb991aea39257a0847ff6118b/data/Switzerland/National_Council/term-40.csv"
           },
           {
             "end_date": "1975-11-30",
@@ -9381,7 +9381,7 @@
             "start_date": "1971-11-29",
             "slug": "39",
             "csv": "data/Switzerland/National_Council/term-39.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51d1521/data/Switzerland/National_Council/term-39.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51d1521e5dddd1cbb991aea39257a0847ff6118b/data/Switzerland/National_Council/term-39.csv"
           },
           {
             "end_date": "1971-11-28",
@@ -9390,7 +9390,7 @@
             "start_date": "1967-12-04",
             "slug": "38",
             "csv": "data/Switzerland/National_Council/term-38.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51d1521/data/Switzerland/National_Council/term-38.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51d1521e5dddd1cbb991aea39257a0847ff6118b/data/Switzerland/National_Council/term-38.csv"
           },
           {
             "end_date": "1967-12-03",
@@ -9399,7 +9399,7 @@
             "start_date": "1963-12-02",
             "slug": "37",
             "csv": "data/Switzerland/National_Council/term-37.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51d1521/data/Switzerland/National_Council/term-37.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/51d1521e5dddd1cbb991aea39257a0847ff6118b/data/Switzerland/National_Council/term-37.csv"
           }
         ],
         "statement_count": 63652
@@ -9417,11 +9417,11 @@
         "slug": "Majlis",
         "sources_directory": "data/Syria/Majlis/sources",
         "popolo": "data/Syria/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b22bbb3/data/Syria/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b22bbb36beb1ac1467cf88c80938fc0a8cf425e3/data/Syria/Majlis/ep-popolo-v1.0.json",
         "names": "data/Syria/Majlis/names.csv",
         "lastmod": "1469385485",
         "person_count": 274,
-        "sha": "b22bbb3",
+        "sha": "b22bbb36beb1ac1467cf88c80938fc0a8cf425e3",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -9429,7 +9429,7 @@
             "start_date": "2012-05-24",
             "slug": "2012",
             "csv": "data/Syria/Majlis/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d5b0308/data/Syria/Majlis/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d5b0308b90f8e4282664646e4c535d7d5c58a318/data/Syria/Majlis/term-2012.csv"
           }
         ],
         "statement_count": 4145
@@ -9447,11 +9447,11 @@
         "slug": "Legislative-Yuan",
         "sources_directory": "data/Taiwan/Legislative_Yuan/sources",
         "popolo": "data/Taiwan/Legislative_Yuan/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/30dda6a/data/Taiwan/Legislative_Yuan/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/30dda6af92a4cfe578bba57ba40bfde5e0d700df/data/Taiwan/Legislative_Yuan/ep-popolo-v1.0.json",
         "names": "data/Taiwan/Legislative_Yuan/names.csv",
         "lastmod": "1471558886",
         "person_count": 168,
-        "sha": "30dda6a",
+        "sha": "30dda6af92a4cfe578bba57ba40bfde5e0d700df",
         "legislative_periods": [
           {
             "id": "term/9",
@@ -9459,7 +9459,7 @@
             "start_date": "2016-01-16",
             "slug": "9",
             "csv": "data/Taiwan/Legislative_Yuan/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7612999/data/Taiwan/Legislative_Yuan/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/76129996f56661c8189dcb640e94df7ae69f2fa8/data/Taiwan/Legislative_Yuan/term-9.csv"
           },
           {
             "end_date": "2016-01-16",
@@ -9468,7 +9468,7 @@
             "start_date": "2012-02-01",
             "slug": "8",
             "csv": "data/Taiwan/Legislative_Yuan/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2bf9902/data/Taiwan/Legislative_Yuan/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2bf99021d28e30aa65324b8d24df37f730a02c0b/data/Taiwan/Legislative_Yuan/term-8.csv"
           }
         ],
         "statement_count": 7608
@@ -9486,11 +9486,11 @@
         "slug": "Representatives",
         "sources_directory": "data/Tajikistan/Representatives/sources",
         "popolo": "data/Tajikistan/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d9a1e3/data/Tajikistan/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d9a1e332401c32ec5716d5878bc8fdfc2c4126b/data/Tajikistan/Representatives/ep-popolo-v1.0.json",
         "names": "data/Tajikistan/Representatives/names.csv",
         "lastmod": "1469385512",
         "person_count": 62,
-        "sha": "2d9a1e3",
+        "sha": "2d9a1e332401c32ec5716d5878bc8fdfc2c4126b",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -9498,7 +9498,7 @@
             "start_date": "2015-03-17",
             "slug": "2015",
             "csv": "data/Tajikistan/Representatives/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/86623d0/data/Tajikistan/Representatives/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/86623d0b2ac585ce1a717d1cbd47949c77accea0/data/Tajikistan/Representatives/term-2015.csv"
           }
         ],
         "statement_count": 973
@@ -9516,11 +9516,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Tanzania/Assembly/sources",
         "popolo": "data/Tanzania/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/149a34d/data/Tanzania/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/149a34d52190dc5425034ce69fcbb2f7407c2987/data/Tanzania/Assembly/ep-popolo-v1.0.json",
         "names": "data/Tanzania/Assembly/names.csv",
         "lastmod": "1469385519",
         "person_count": 889,
-        "sha": "149a34d",
+        "sha": "149a34d52190dc5425034ce69fcbb2f7407c2987",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -9528,7 +9528,7 @@
             "start_date": "2015-11-17",
             "slug": "5",
             "csv": "data/Tanzania/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/707dbe5/data/Tanzania/Assembly/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/707dbe59e0579929c63f70ee76c4097d54ddf606/data/Tanzania/Assembly/term-5.csv"
           },
           {
             "end_date": "2015-06-18",
@@ -9537,7 +9537,7 @@
             "start_date": "2010-10-31",
             "slug": "4",
             "csv": "data/Tanzania/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/090f322/data/Tanzania/Assembly/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/090f322409452d00fa2c1cba9c487ff86971d6fd/data/Tanzania/Assembly/term-4.csv"
           },
           {
             "end_date": "2010-10-30",
@@ -9546,7 +9546,7 @@
             "start_date": "2005-10-30",
             "slug": "3",
             "csv": "data/Tanzania/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f3df858/data/Tanzania/Assembly/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f3df858daf0e678803087642de71cbf1c38b4936/data/Tanzania/Assembly/term-3.csv"
           },
           {
             "end_date": "2005-10-29",
@@ -9555,7 +9555,7 @@
             "start_date": "2000-10-29",
             "slug": "2",
             "csv": "data/Tanzania/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f3df858/data/Tanzania/Assembly/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f3df858daf0e678803087642de71cbf1c38b4936/data/Tanzania/Assembly/term-2.csv"
           }
         ],
         "statement_count": 26280
@@ -9573,11 +9573,11 @@
         "slug": "National-Legislative-Assembly",
         "sources_directory": "data/Thailand/National_Legislative_Assembly/sources",
         "popolo": "data/Thailand/National_Legislative_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/72b13ce/data/Thailand/National_Legislative_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/72b13ce7602200fe2189d46b5c55141f5d742c31/data/Thailand/National_Legislative_Assembly/ep-popolo-v1.0.json",
         "names": "data/Thailand/National_Legislative_Assembly/names.csv",
         "lastmod": "1471020598",
         "person_count": 220,
-        "sha": "72b13ce",
+        "sha": "72b13ce7602200fe2189d46b5c55141f5d742c31",
         "legislative_periods": [
           {
             "id": "term/2557",
@@ -9585,7 +9585,7 @@
             "start_date": "2014-08-07",
             "slug": "2557",
             "csv": "data/Thailand/National_Legislative_Assembly/term-2557.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a076d2/data/Thailand/National_Legislative_Assembly/term-2557.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a076d295f59ace6a36d608f19214f814fff3537/data/Thailand/National_Legislative_Assembly/term-2557.csv"
           }
         ],
         "statement_count": 3811
@@ -9603,11 +9603,11 @@
         "slug": "Parlamento",
         "sources_directory": "data/Timor_Leste/Parlamento/sources",
         "popolo": "data/Timor_Leste/Parlamento/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a94142/data/Timor_Leste/Parlamento/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a94142da4ebabf5f94d537b227b553e8150921a/data/Timor_Leste/Parlamento/ep-popolo-v1.0.json",
         "names": "data/Timor_Leste/Parlamento/names.csv",
         "lastmod": "1469385525",
         "person_count": 65,
-        "sha": "0a94142",
+        "sha": "0a94142da4ebabf5f94d537b227b553e8150921a",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -9615,7 +9615,7 @@
             "start_date": "2012-07-30",
             "slug": "2012",
             "csv": "data/Timor_Leste/Parlamento/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cd40511/data/Timor_Leste/Parlamento/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cd405117bffe66271d53007ffb0d10cdb99d5757/data/Timor_Leste/Parlamento/term-2012.csv"
           }
         ],
         "statement_count": 1223
@@ -9633,11 +9633,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Togo/Assembly/sources",
         "popolo": "data/Togo/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6c97019/data/Togo/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6c9701932975251618e9303e734c814d3640a97b/data/Togo/Assembly/ep-popolo-v1.0.json",
         "names": "data/Togo/Assembly/names.csv",
         "lastmod": "1470997857",
         "person_count": 91,
-        "sha": "6c97019",
+        "sha": "6c9701932975251618e9303e734c814d3640a97b",
         "legislative_periods": [
           {
             "id": "term/2013",
@@ -9645,7 +9645,7 @@
             "start_date": "2013-08-20",
             "slug": "2013",
             "csv": "data/Togo/Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d6ce70/data/Togo/Assembly/term-2013.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d6ce70e623cd2ee7a44dbe5f20ff4747de9cae4/data/Togo/Assembly/term-2013.csv"
           }
         ],
         "statement_count": 1871
@@ -9663,11 +9663,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Tonga/Assembly/sources",
         "popolo": "data/Tonga/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d1ebaf/data/Tonga/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d1ebaffdc2a4832b31948893e4ae9cf41559e17/data/Tonga/Assembly/ep-popolo-v1.0.json",
         "names": "data/Tonga/Assembly/names.csv",
         "lastmod": "1469385536",
         "person_count": 26,
-        "sha": "4d1ebaf",
+        "sha": "4d1ebaffdc2a4832b31948893e4ae9cf41559e17",
         "legislative_periods": [
           {
             "end_date": "2018",
@@ -9676,7 +9676,7 @@
             "start_date": "2014-12-29",
             "slug": "2015",
             "csv": "data/Tonga/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/790cfb8/data/Tonga/Assembly/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/790cfb83411af7b2111f40fb9a7e10540038e53f/data/Tonga/Assembly/term-2015.csv"
           }
         ],
         "statement_count": 537
@@ -9694,11 +9694,11 @@
         "slug": "Supreme-Council",
         "sources_directory": "data/Transnistria/Supreme_Council/sources",
         "popolo": "data/Transnistria/Supreme_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6fc9159/data/Transnistria/Supreme_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6fc91594d580a2f3bafa342cc68979f7050f96a9/data/Transnistria/Supreme_Council/ep-popolo-v1.0.json",
         "names": "data/Transnistria/Supreme_Council/names.csv",
         "lastmod": "1469385541",
         "person_count": 65,
-        "sha": "6fc9159",
+        "sha": "6fc91594d580a2f3bafa342cc68979f7050f96a9",
         "legislative_periods": [
           {
             "id": "term/6",
@@ -9706,7 +9706,7 @@
             "start_date": "2015-12-23",
             "slug": "6",
             "csv": "data/Transnistria/Supreme_Council/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7e18835/data/Transnistria/Supreme_Council/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7e18835d0097c6841ce2f04633deae19c03d9346/data/Transnistria/Supreme_Council/term-6.csv"
           },
           {
             "end_date": "2015",
@@ -9715,7 +9715,7 @@
             "start_date": "2010",
             "slug": "5",
             "csv": "data/Transnistria/Supreme_Council/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d0298d/data/Transnistria/Supreme_Council/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d0298d2f27a0964ecb092dfedfe35b2700fcbd0/data/Transnistria/Supreme_Council/term-5.csv"
           }
         ],
         "statement_count": 1080
@@ -9733,11 +9733,11 @@
         "slug": "Representatives",
         "sources_directory": "data/Trinidad_and_Tobago/Representatives/sources",
         "popolo": "data/Trinidad_and_Tobago/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b5ad5aa/data/Trinidad_and_Tobago/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b5ad5aaf12ea1639e9fa08e10d6f4dfa1285afbd/data/Trinidad_and_Tobago/Representatives/ep-popolo-v1.0.json",
         "names": "data/Trinidad_and_Tobago/Representatives/names.csv",
         "lastmod": "1469385547",
         "person_count": 42,
-        "sha": "b5ad5aa",
+        "sha": "b5ad5aaf12ea1639e9fa08e10d6f4dfa1285afbd",
         "legislative_periods": [
           {
             "id": "term/11",
@@ -9745,7 +9745,7 @@
             "start_date": "2015-09-23",
             "slug": "11",
             "csv": "data/Trinidad_and_Tobago/Representatives/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/820aa9f/data/Trinidad_and_Tobago/Representatives/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/820aa9fe5cbbe33103d15f2de1d4075243245252/data/Trinidad_and_Tobago/Representatives/term-11.csv"
           }
         ],
         "statement_count": 949
@@ -9755,11 +9755,11 @@
         "slug": "Senate",
         "sources_directory": "data/Trinidad_and_Tobago/Senate/sources",
         "popolo": "data/Trinidad_and_Tobago/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3931ea0/data/Trinidad_and_Tobago/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3931ea039c3735f97fd06eb07da439c0ffddfd3d/data/Trinidad_and_Tobago/Senate/ep-popolo-v1.0.json",
         "names": "data/Trinidad_and_Tobago/Senate/names.csv",
         "lastmod": "1469385557",
         "person_count": 31,
-        "sha": "3931ea0",
+        "sha": "3931ea039c3735f97fd06eb07da439c0ffddfd3d",
         "legislative_periods": [
           {
             "id": "term/11",
@@ -9767,7 +9767,7 @@
             "start_date": "2015-09-23",
             "slug": "11",
             "csv": "data/Trinidad_and_Tobago/Senate/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/820aa9f/data/Trinidad_and_Tobago/Senate/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/820aa9fe5cbbe33103d15f2de1d4075243245252/data/Trinidad_and_Tobago/Senate/term-11.csv"
           }
         ],
         "statement_count": 511
@@ -9785,11 +9785,11 @@
         "slug": "Majlis",
         "sources_directory": "data/Tunisia/Majlis/sources",
         "popolo": "data/Tunisia/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/abf9522/data/Tunisia/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/abf9522ed3306e002c1f5acc70a9774fac85eadc/data/Tunisia/Majlis/ep-popolo-v1.0.json",
         "names": "data/Tunisia/Majlis/names.csv",
         "lastmod": "1471516921",
         "person_count": 220,
-        "sha": "abf9522",
+        "sha": "abf9522ed3306e002c1f5acc70a9774fac85eadc",
         "legislative_periods": [
           {
             "id": "term/1",
@@ -9797,7 +9797,7 @@
             "start_date": "2014-12-02",
             "slug": "1",
             "csv": "data/Tunisia/Majlis/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ab1778/data/Tunisia/Majlis/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ab177827dcb5ee7ba65446a0729e0338b111588/data/Tunisia/Majlis/term-1.csv"
           }
         ],
         "statement_count": 4770
@@ -9815,11 +9815,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Turkey/Assembly/sources",
         "popolo": "data/Turkey/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1a7d1d3/data/Turkey/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1a7d1d38ad085e77ce1d7d70784b2f7e3d5ea946/data/Turkey/Assembly/ep-popolo-v1.0.json",
         "names": "data/Turkey/Assembly/names.csv",
         "lastmod": "1469386043",
         "person_count": 6907,
-        "sha": "1a7d1d3",
+        "sha": "1a7d1d38ad085e77ce1d7d70784b2f7e3d5ea946",
         "legislative_periods": [
           {
             "id": "term/26",
@@ -9827,7 +9827,7 @@
             "start_date": "2015-11-17",
             "slug": "26",
             "csv": "data/Turkey/Assembly/term-26.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713/data/Turkey/Assembly/term-26.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713d8b4b157ef867f7a219aef7337924565e/data/Turkey/Assembly/term-26.csv"
           },
           {
             "end_date": "2015-11-01",
@@ -9836,7 +9836,7 @@
             "start_date": "2015-06-23",
             "slug": "25",
             "csv": "data/Turkey/Assembly/term-25.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713/data/Turkey/Assembly/term-25.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713d8b4b157ef867f7a219aef7337924565e/data/Turkey/Assembly/term-25.csv"
           },
           {
             "end_date": "2015-06-07",
@@ -9845,7 +9845,7 @@
             "start_date": "2011-06-28",
             "slug": "24",
             "csv": "data/Turkey/Assembly/term-24.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713/data/Turkey/Assembly/term-24.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713d8b4b157ef867f7a219aef7337924565e/data/Turkey/Assembly/term-24.csv"
           },
           {
             "end_date": "2011-06-28",
@@ -9854,7 +9854,7 @@
             "start_date": "2007-07-23",
             "slug": "23",
             "csv": "data/Turkey/Assembly/term-23.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713/data/Turkey/Assembly/term-23.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713d8b4b157ef867f7a219aef7337924565e/data/Turkey/Assembly/term-23.csv"
           },
           {
             "end_date": "2007-07-23",
@@ -9863,7 +9863,7 @@
             "start_date": "2002-11-14",
             "slug": "22",
             "csv": "data/Turkey/Assembly/term-22.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713/data/Turkey/Assembly/term-22.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713d8b4b157ef867f7a219aef7337924565e/data/Turkey/Assembly/term-22.csv"
           },
           {
             "end_date": "2002-11-14",
@@ -9872,7 +9872,7 @@
             "start_date": "1999-04-18",
             "slug": "21",
             "csv": "data/Turkey/Assembly/term-21.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713/data/Turkey/Assembly/term-21.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713d8b4b157ef867f7a219aef7337924565e/data/Turkey/Assembly/term-21.csv"
           },
           {
             "end_date": "1999-04-18",
@@ -9881,7 +9881,7 @@
             "start_date": "1996-01-08",
             "slug": "20",
             "csv": "data/Turkey/Assembly/term-20.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713/data/Turkey/Assembly/term-20.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713d8b4b157ef867f7a219aef7337924565e/data/Turkey/Assembly/term-20.csv"
           },
           {
             "end_date": "1995-12-24",
@@ -9890,7 +9890,7 @@
             "start_date": "1991-11-06",
             "slug": "19",
             "csv": "data/Turkey/Assembly/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed8138/data/Turkey/Assembly/term-19.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed81381c1845ea07e578ca9d3146f9145901dca/data/Turkey/Assembly/term-19.csv"
           },
           {
             "end_date": "1991-10-20",
@@ -9899,7 +9899,7 @@
             "start_date": "1987-12-14",
             "slug": "18",
             "csv": "data/Turkey/Assembly/term-18.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed8138/data/Turkey/Assembly/term-18.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed81381c1845ea07e578ca9d3146f9145901dca/data/Turkey/Assembly/term-18.csv"
           },
           {
             "end_date": "1987-11-29",
@@ -9908,7 +9908,7 @@
             "start_date": "1983-11-24",
             "slug": "17",
             "csv": "data/Turkey/Assembly/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed8138/data/Turkey/Assembly/term-17.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed81381c1845ea07e578ca9d3146f9145901dca/data/Turkey/Assembly/term-17.csv"
           },
           {
             "end_date": "1980-09-12",
@@ -9917,7 +9917,7 @@
             "start_date": "1977-06-13",
             "slug": "16",
             "csv": "data/Turkey/Assembly/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed8138/data/Turkey/Assembly/term-16.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed81381c1845ea07e578ca9d3146f9145901dca/data/Turkey/Assembly/term-16.csv"
           },
           {
             "end_date": "1977-06-05",
@@ -9926,7 +9926,7 @@
             "start_date": "1973-10-24",
             "slug": "15",
             "csv": "data/Turkey/Assembly/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed8138/data/Turkey/Assembly/term-15.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed81381c1845ea07e578ca9d3146f9145901dca/data/Turkey/Assembly/term-15.csv"
           },
           {
             "end_date": "1973-10-14",
@@ -9935,7 +9935,7 @@
             "start_date": "1969-10-22",
             "slug": "14",
             "csv": "data/Turkey/Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed8138/data/Turkey/Assembly/term-14.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed81381c1845ea07e578ca9d3146f9145901dca/data/Turkey/Assembly/term-14.csv"
           },
           {
             "end_date": "1973-10-14",
@@ -9944,7 +9944,7 @@
             "start_date": "1965-10-22",
             "slug": "13",
             "csv": "data/Turkey/Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed8138/data/Turkey/Assembly/term-13.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed81381c1845ea07e578ca9d3146f9145901dca/data/Turkey/Assembly/term-13.csv"
           },
           {
             "end_date": "1973-10-14",
@@ -9953,7 +9953,7 @@
             "start_date": "1961-10-25",
             "slug": "12",
             "csv": "data/Turkey/Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed8138/data/Turkey/Assembly/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed81381c1845ea07e578ca9d3146f9145901dca/data/Turkey/Assembly/term-12.csv"
           },
           {
             "end_date": "1960-05-27",
@@ -9962,7 +9962,7 @@
             "start_date": "1957-11-01",
             "slug": "11",
             "csv": "data/Turkey/Assembly/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713/data/Turkey/Assembly/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713d8b4b157ef867f7a219aef7337924565e/data/Turkey/Assembly/term-11.csv"
           },
           {
             "end_date": "1957-11-01",
@@ -9971,7 +9971,7 @@
             "start_date": "1954-05-14",
             "slug": "10",
             "csv": "data/Turkey/Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713/data/Turkey/Assembly/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b13c713d8b4b157ef867f7a219aef7337924565e/data/Turkey/Assembly/term-10.csv"
           },
           {
             "end_date": "1954-05-14",
@@ -9980,7 +9980,7 @@
             "start_date": "1950-05-22",
             "slug": "9",
             "csv": "data/Turkey/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed8138/data/Turkey/Assembly/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed81381c1845ea07e578ca9d3146f9145901dca/data/Turkey/Assembly/term-9.csv"
           },
           {
             "end_date": "1950-05-22",
@@ -9989,7 +9989,7 @@
             "start_date": "1946-08-05",
             "slug": "8",
             "csv": "data/Turkey/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed8138/data/Turkey/Assembly/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed81381c1845ea07e578ca9d3146f9145901dca/data/Turkey/Assembly/term-8.csv"
           },
           {
             "end_date": "1946-08-05",
@@ -9998,7 +9998,7 @@
             "start_date": "1943-03-08",
             "slug": "7",
             "csv": "data/Turkey/Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed8138/data/Turkey/Assembly/term-7.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed81381c1845ea07e578ca9d3146f9145901dca/data/Turkey/Assembly/term-7.csv"
           },
           {
             "end_date": "1943-03-08",
@@ -10007,7 +10007,7 @@
             "start_date": "1939-04-03",
             "slug": "6",
             "csv": "data/Turkey/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed8138/data/Turkey/Assembly/term-6.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed81381c1845ea07e578ca9d3146f9145901dca/data/Turkey/Assembly/term-6.csv"
           },
           {
             "end_date": "1939-04-03",
@@ -10016,7 +10016,7 @@
             "start_date": "1935-03-01",
             "slug": "5",
             "csv": "data/Turkey/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed8138/data/Turkey/Assembly/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed81381c1845ea07e578ca9d3146f9145901dca/data/Turkey/Assembly/term-5.csv"
           },
           {
             "end_date": "1935-03-01",
@@ -10025,7 +10025,7 @@
             "start_date": "1931-05-04",
             "slug": "4",
             "csv": "data/Turkey/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed8138/data/Turkey/Assembly/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed81381c1845ea07e578ca9d3146f9145901dca/data/Turkey/Assembly/term-4.csv"
           },
           {
             "end_date": "1931-05-04",
@@ -10034,7 +10034,7 @@
             "start_date": "1927-05-01",
             "slug": "3",
             "csv": "data/Turkey/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed8138/data/Turkey/Assembly/term-3.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed81381c1845ea07e578ca9d3146f9145901dca/data/Turkey/Assembly/term-3.csv"
           },
           {
             "end_date": "1927-11-01",
@@ -10043,7 +10043,7 @@
             "start_date": "1923-08-11",
             "slug": "2",
             "csv": "data/Turkey/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9c8494a/data/Turkey/Assembly/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9c8494ab0b90f287c26d88a23593cfdad2babc3e/data/Turkey/Assembly/term-2.csv"
           },
           {
             "end_date": "1923-08-11",
@@ -10052,7 +10052,7 @@
             "start_date": "1920-04-23",
             "slug": "1",
             "csv": "data/Turkey/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed8138/data/Turkey/Assembly/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ed81381c1845ea07e578ca9d3146f9145901dca/data/Turkey/Assembly/term-1.csv"
           }
         ],
         "statement_count": 215121
@@ -10070,11 +10070,11 @@
         "slug": "Mejlis",
         "sources_directory": "data/Turkmenistan/Mejlis/sources",
         "popolo": "data/Turkmenistan/Mejlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f1dfeb/data/Turkmenistan/Mejlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f1dfeb11517572fca4c2f9de6006319a356bd93/data/Turkmenistan/Mejlis/ep-popolo-v1.0.json",
         "names": "data/Turkmenistan/Mejlis/names.csv",
         "lastmod": "1469385615",
         "person_count": 237,
-        "sha": "4f1dfeb",
+        "sha": "4f1dfeb11517572fca4c2f9de6006319a356bd93",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -10082,7 +10082,7 @@
             "start_date": "2014-01-07",
             "slug": "5",
             "csv": "data/Turkmenistan/Mejlis/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fedacb2/data/Turkmenistan/Mejlis/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fedacb2df1f5110d5775924965d42c61e3ca40b2/data/Turkmenistan/Mejlis/term-5.csv"
           },
           {
             "end_date": "2013",
@@ -10091,7 +10091,7 @@
             "start_date": "2009",
             "slug": "4",
             "csv": "data/Turkmenistan/Mejlis/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fedacb2/data/Turkmenistan/Mejlis/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fedacb2df1f5110d5775924965d42c61e3ca40b2/data/Turkmenistan/Mejlis/term-4.csv"
           }
         ],
         "statement_count": 4144
@@ -10109,11 +10109,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Turks_and_Caicos_Islands/Assembly/sources",
         "popolo": "data/Turks_and_Caicos_Islands/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/380cfde/data/Turks_and_Caicos_Islands/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/380cfde568745dc57b0ed9726afc93da91b06493/data/Turks_and_Caicos_Islands/Assembly/ep-popolo-v1.0.json",
         "names": "data/Turks_and_Caicos_Islands/Assembly/names.csv",
         "lastmod": "1469983386",
         "person_count": 18,
-        "sha": "380cfde",
+        "sha": "380cfde568745dc57b0ed9726afc93da91b06493",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -10121,7 +10121,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Turks_and_Caicos_Islands/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/87d677b/data/Turks_and_Caicos_Islands/Assembly/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/87d677b0758814ff8418a6c64354a2da9f01819a/data/Turks_and_Caicos_Islands/Assembly/term-2012.csv"
           }
         ],
         "statement_count": 562
@@ -10139,11 +10139,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Tuvalu/Parliament/sources",
         "popolo": "data/Tuvalu/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3d10291/data/Tuvalu/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3d10291923d705df7e14ba9f3f8c158945921d08/data/Tuvalu/Parliament/ep-popolo-v1.0.json",
         "names": "data/Tuvalu/Parliament/names.csv",
         "lastmod": "1471423721",
         "person_count": 27,
-        "sha": "3d10291",
+        "sha": "3d10291923d705df7e14ba9f3f8c158945921d08",
         "legislative_periods": [
           {
             "id": "term/11",
@@ -10151,7 +10151,7 @@
             "start_date": "2015-03-31",
             "slug": "11",
             "csv": "data/Tuvalu/Parliament/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e65432b/data/Tuvalu/Parliament/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e65432bc2e20752d09cd1e17f79b7f79d97cc08b/data/Tuvalu/Parliament/term-11.csv"
           },
           {
             "end_date": "2015-03-30",
@@ -10160,7 +10160,7 @@
             "start_date": "2010-09-16",
             "slug": "10",
             "csv": "data/Tuvalu/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e65432b/data/Tuvalu/Parliament/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e65432bc2e20752d09cd1e17f79b7f79d97cc08b/data/Tuvalu/Parliament/term-10.csv"
           },
           {
             "end_date": "2010-09-16",
@@ -10169,7 +10169,7 @@
             "start_date": "2006-08-03",
             "slug": "9",
             "csv": "data/Tuvalu/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b70e6ee/data/Tuvalu/Parliament/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b70e6ee28e3c59112bf0f91cf391ebb85e623f93/data/Tuvalu/Parliament/term-9.csv"
           }
         ],
         "statement_count": 1821
@@ -10187,11 +10187,11 @@
         "slug": "Legislature",
         "sources_directory": "data/US_Virgin_Islands/Legislature/sources",
         "popolo": "data/US_Virgin_Islands/Legislature/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cd69725/data/US_Virgin_Islands/Legislature/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cd697254a1cc87e24767c18f53e27736e5b6f447/data/US_Virgin_Islands/Legislature/ep-popolo-v1.0.json",
         "names": "data/US_Virgin_Islands/Legislature/names.csv",
         "lastmod": "1469385650",
         "person_count": 15,
-        "sha": "cd69725",
+        "sha": "cd697254a1cc87e24767c18f53e27736e5b6f447",
         "legislative_periods": [
           {
             "end_date": "2016-12-31",
@@ -10200,7 +10200,7 @@
             "start_date": "2015-01-12",
             "slug": "2014",
             "csv": "data/US_Virgin_Islands/Legislature/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5dcbaa3/data/US_Virgin_Islands/Legislature/term-2014.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5dcbaa3052f9a67307812772264665b7aa6dbeb3/data/US_Virgin_Islands/Legislature/term-2014.csv"
           }
         ],
         "statement_count": 660
@@ -10218,11 +10218,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Uganda/Parliament/sources",
         "popolo": "data/Uganda/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d281f26/data/Uganda/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d281f26fad349eede1326ba1f0c79bfcb7e4ab76/data/Uganda/Parliament/ep-popolo-v1.0.json",
         "names": "data/Uganda/Parliament/names.csv",
         "lastmod": "1471256037",
         "person_count": 647,
-        "sha": "d281f26",
+        "sha": "d281f26fad349eede1326ba1f0c79bfcb7e4ab76",
         "legislative_periods": [
           {
             "id": "term/10",
@@ -10230,7 +10230,7 @@
             "start_date": "2016-05-16",
             "slug": "10",
             "csv": "data/Uganda/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d281f26/data/Uganda/Parliament/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d281f26fad349eede1326ba1f0c79bfcb7e4ab76/data/Uganda/Parliament/term-10.csv"
           },
           {
             "end_date": "2016-05-13",
@@ -10239,7 +10239,7 @@
             "start_date": "2011-05-16",
             "slug": "9",
             "csv": "data/Uganda/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d281f26/data/Uganda/Parliament/term-9.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d281f26fad349eede1326ba1f0c79bfcb7e4ab76/data/Uganda/Parliament/term-9.csv"
           }
         ],
         "statement_count": 18041
@@ -10257,11 +10257,11 @@
         "slug": "Verkhovna-Rada",
         "sources_directory": "data/Ukraine/Verkhovna_Rada/sources",
         "popolo": "data/Ukraine/Verkhovna_Rada/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/98df6bc/data/Ukraine/Verkhovna_Rada/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/98df6bc1da8b761806533dad42fbdfb60abf6efb/data/Ukraine/Verkhovna_Rada/ep-popolo-v1.0.json",
         "names": "data/Ukraine/Verkhovna_Rada/names.csv",
         "lastmod": "1472009018",
         "person_count": 451,
-        "sha": "98df6bc",
+        "sha": "98df6bc1da8b761806533dad42fbdfb60abf6efb",
         "legislative_periods": [
           {
             "id": "term/8",
@@ -10269,7 +10269,7 @@
             "start_date": "2014-11-27",
             "slug": "8",
             "csv": "data/Ukraine/Verkhovna_Rada/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/08358cb/data/Ukraine/Verkhovna_Rada/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/08358cbf2c1e93e735984166afcefc7179c93ebb/data/Ukraine/Verkhovna_Rada/term-8.csv"
           }
         ],
         "statement_count": 21718
@@ -10287,11 +10287,11 @@
         "slug": "Federal-National-Council",
         "sources_directory": "data/United_Arab_Emirates/Federal_National_Council/sources",
         "popolo": "data/United_Arab_Emirates/Federal_National_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/46126f9/data/United_Arab_Emirates/Federal_National_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/46126f9a9ad0ffdd58978cc8b8ac63c64aa61738/data/United_Arab_Emirates/Federal_National_Council/ep-popolo-v1.0.json",
         "names": "data/United_Arab_Emirates/Federal_National_Council/names.csv",
         "lastmod": "1469385633",
         "person_count": 40,
-        "sha": "46126f9",
+        "sha": "46126f9a9ad0ffdd58978cc8b8ac63c64aa61738",
         "legislative_periods": [
           {
             "end_date": "2015-10-03",
@@ -10300,7 +10300,7 @@
             "start_date": "2011-11-15",
             "slug": "2011",
             "csv": "data/United_Arab_Emirates/Federal_National_Council/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7347172/data/United_Arab_Emirates/Federal_National_Council/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7347172781ade0e34a4752f35d2f81910e3efa64/data/United_Arab_Emirates/Federal_National_Council/term-2011.csv"
           }
         ],
         "statement_count": 709
@@ -10318,11 +10318,11 @@
         "slug": "Commons",
         "sources_directory": "data/UK/Commons/sources",
         "popolo": "data/UK/Commons/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba976cf/data/UK/Commons/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba976cf13824d27d09001503b0f252508d023ad8/data/UK/Commons/ep-popolo-v1.0.json",
         "names": "data/UK/Commons/names.csv",
         "lastmod": "1471516198",
         "person_count": 1341,
-        "sha": "ba976cf",
+        "sha": "ba976cf13824d27d09001503b0f252508d023ad8",
         "legislative_periods": [
           {
             "id": "term/56",
@@ -10331,7 +10331,7 @@
             "wikidata": "Q21084473",
             "slug": "56",
             "csv": "data/UK/Commons/term-56.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba976cf/data/UK/Commons/term-56.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba976cf13824d27d09001503b0f252508d023ad8/data/UK/Commons/term-56.csv"
           },
           {
             "end_date": "2015-03-30",
@@ -10341,7 +10341,7 @@
             "wikidata": "Q21084472",
             "slug": "55",
             "csv": "data/UK/Commons/term-55.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba976cf/data/UK/Commons/term-55.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba976cf13824d27d09001503b0f252508d023ad8/data/UK/Commons/term-55.csv"
           },
           {
             "end_date": "2010-04-12",
@@ -10351,7 +10351,7 @@
             "wikidata": "Q21084471",
             "slug": "54",
             "csv": "data/UK/Commons/term-54.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba976cf/data/UK/Commons/term-54.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba976cf13824d27d09001503b0f252508d023ad8/data/UK/Commons/term-54.csv"
           },
           {
             "end_date": "2005-04-11",
@@ -10361,7 +10361,7 @@
             "wikidata": "Q21084470",
             "slug": "53",
             "csv": "data/UK/Commons/term-53.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba976cf/data/UK/Commons/term-53.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba976cf13824d27d09001503b0f252508d023ad8/data/UK/Commons/term-53.csv"
           },
           {
             "end_date": "2001-05-14",
@@ -10371,7 +10371,7 @@
             "wikidata": "Q21084469",
             "slug": "52",
             "csv": "data/UK/Commons/term-52.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba976cf/data/UK/Commons/term-52.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba976cf13824d27d09001503b0f252508d023ad8/data/UK/Commons/term-52.csv"
           }
         ],
         "statement_count": 132572
@@ -10389,11 +10389,11 @@
         "slug": "House",
         "sources_directory": "data/United_States_of_America/House/sources",
         "popolo": "data/United_States_of_America/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e8/data/United_States_of_America/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e86e8a769f1a9e61704a0476f082a8fb15e/data/United_States_of_America/House/ep-popolo-v1.0.json",
         "names": "data/United_States_of_America/House/names.csv",
         "lastmod": "1470553794",
         "person_count": 1585,
-        "sha": "43485e8",
+        "sha": "43485e86e8a769f1a9e61704a0476f082a8fb15e",
         "legislative_periods": [
           {
             "id": "term/114",
@@ -10402,7 +10402,7 @@
             "wikidata": "Q16146771",
             "slug": "114",
             "csv": "data/United_States_of_America/House/term-114.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e8/data/United_States_of_America/House/term-114.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e86e8a769f1a9e61704a0476f082a8fb15e/data/United_States_of_America/House/term-114.csv"
           },
           {
             "end_date": "2015-01-03",
@@ -10412,7 +10412,7 @@
             "wikidata": "Q71871",
             "slug": "113",
             "csv": "data/United_States_of_America/House/term-113.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e8/data/United_States_of_America/House/term-113.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e86e8a769f1a9e61704a0476f082a8fb15e/data/United_States_of_America/House/term-113.csv"
           },
           {
             "end_date": "2013-01-03",
@@ -10422,7 +10422,7 @@
             "wikidata": "Q170447",
             "slug": "112",
             "csv": "data/United_States_of_America/House/term-112.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e8/data/United_States_of_America/House/term-112.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e86e8a769f1a9e61704a0476f082a8fb15e/data/United_States_of_America/House/term-112.csv"
           },
           {
             "end_date": "2011-01-03",
@@ -10432,7 +10432,7 @@
             "wikidata": "Q170375",
             "slug": "111",
             "csv": "data/United_States_of_America/House/term-111.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e8/data/United_States_of_America/House/term-111.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e86e8a769f1a9e61704a0476f082a8fb15e/data/United_States_of_America/House/term-111.csv"
           },
           {
             "end_date": "2009-01-03",
@@ -10442,7 +10442,7 @@
             "wikidata": "Q170018",
             "slug": "110",
             "csv": "data/United_States_of_America/House/term-110.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e8/data/United_States_of_America/House/term-110.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e86e8a769f1a9e61704a0476f082a8fb15e/data/United_States_of_America/House/term-110.csv"
           },
           {
             "end_date": "2007-01-03",
@@ -10452,7 +10452,7 @@
             "wikidata": "Q168778",
             "slug": "109",
             "csv": "data/United_States_of_America/House/term-109.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e8/data/United_States_of_America/House/term-109.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e86e8a769f1a9e61704a0476f082a8fb15e/data/United_States_of_America/House/term-109.csv"
           },
           {
             "end_date": "2005-01-03",
@@ -10462,7 +10462,7 @@
             "wikidata": "Q168504",
             "slug": "108",
             "csv": "data/United_States_of_America/House/term-108.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e8/data/United_States_of_America/House/term-108.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e86e8a769f1a9e61704a0476f082a8fb15e/data/United_States_of_America/House/term-108.csv"
           },
           {
             "end_date": "2003-01-03",
@@ -10472,7 +10472,7 @@
             "wikidata": "Q2057259",
             "slug": "107",
             "csv": "data/United_States_of_America/House/term-107.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e8/data/United_States_of_America/House/term-107.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e86e8a769f1a9e61704a0476f082a8fb15e/data/United_States_of_America/House/term-107.csv"
           },
           {
             "end_date": "2001-01-03",
@@ -10482,7 +10482,7 @@
             "wikidata": "Q3596897",
             "slug": "106",
             "csv": "data/United_States_of_America/House/term-106.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e8/data/United_States_of_America/House/term-106.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e86e8a769f1a9e61704a0476f082a8fb15e/data/United_States_of_America/House/term-106.csv"
           },
           {
             "end_date": "1999-01-03",
@@ -10492,7 +10492,7 @@
             "wikidata": "Q3596884",
             "slug": "105",
             "csv": "data/United_States_of_America/House/term-105.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e8/data/United_States_of_America/House/term-105.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e86e8a769f1a9e61704a0476f082a8fb15e/data/United_States_of_America/House/term-105.csv"
           },
           {
             "end_date": "1997-01-03",
@@ -10502,7 +10502,7 @@
             "wikidata": "Q3596857",
             "slug": "104",
             "csv": "data/United_States_of_America/House/term-104.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e8/data/United_States_of_America/House/term-104.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e86e8a769f1a9e61704a0476f082a8fb15e/data/United_States_of_America/House/term-104.csv"
           },
           {
             "end_date": "1995-01-03",
@@ -10512,7 +10512,7 @@
             "wikidata": "Q3556780",
             "slug": "103",
             "csv": "data/United_States_of_America/House/term-103.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e8/data/United_States_of_America/House/term-103.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e86e8a769f1a9e61704a0476f082a8fb15e/data/United_States_of_America/House/term-103.csv"
           },
           {
             "end_date": "1993-01-03",
@@ -10522,7 +10522,7 @@
             "wikidata": "Q347346",
             "slug": "102",
             "csv": "data/United_States_of_America/House/term-102.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e8/data/United_States_of_America/House/term-102.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e86e8a769f1a9e61704a0476f082a8fb15e/data/United_States_of_America/House/term-102.csv"
           },
           {
             "end_date": "1991-01-03",
@@ -10532,7 +10532,7 @@
             "wikidata": "Q4546373",
             "slug": "101",
             "csv": "data/United_States_of_America/House/term-101.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e8/data/United_States_of_America/House/term-101.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43485e86e8a769f1a9e61704a0476f082a8fb15e/data/United_States_of_America/House/term-101.csv"
           },
           {
             "end_date": "1989-01-03",
@@ -10542,7 +10542,7 @@
             "wikidata": "Q4546248",
             "slug": "100",
             "csv": "data/United_States_of_America/House/term-100.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e65ad7d/data/United_States_of_America/House/term-100.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e65ad7d2d329aabf4071c610aeb6a47f7a0a78fd/data/United_States_of_America/House/term-100.csv"
           },
           {
             "end_date": "1987-01-03",
@@ -10552,7 +10552,7 @@
             "wikidata": "Q4646349",
             "slug": "99",
             "csv": "data/United_States_of_America/House/term-99.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e71ae78/data/United_States_of_America/House/term-99.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e71ae7860cc6c5718ee4e78f9b49f7693d81f10d/data/United_States_of_America/House/term-99.csv"
           },
           {
             "end_date": "1983-01-03",
@@ -10562,7 +10562,7 @@
             "wikidata": "Q4646254",
             "slug": "98",
             "csv": "data/United_States_of_America/House/term-98.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e71ae78/data/United_States_of_America/House/term-98.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e71ae7860cc6c5718ee4e78f9b49f7693d81f10d/data/United_States_of_America/House/term-98.csv"
           },
           {
             "end_date": "1983-01-03",
@@ -10572,7 +10572,7 @@
             "wikidata": "Q4646187",
             "slug": "97",
             "csv": "data/United_States_of_America/House/term-97.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e65ad7d/data/United_States_of_America/House/term-97.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e65ad7d2d329aabf4071c610aeb6a47f7a0a78fd/data/United_States_of_America/House/term-97.csv"
           }
         ],
         "statement_count": 222543
@@ -10582,11 +10582,11 @@
         "slug": "Senate",
         "sources_directory": "data/United_States_of_America/Senate/sources",
         "popolo": "data/United_States_of_America/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70e834c/data/United_States_of_America/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70e834cd873f8843df923e17a559cca6f6ab961b/data/United_States_of_America/Senate/ep-popolo-v1.0.json",
         "names": "data/United_States_of_America/Senate/names.csv",
         "lastmod": "1472108584",
         "person_count": 310,
-        "sha": "70e834c",
+        "sha": "70e834cd873f8843df923e17a559cca6f6ab961b",
         "legislative_periods": [
           {
             "id": "term/114",
@@ -10595,7 +10595,7 @@
             "wikidata": "Q16146771",
             "slug": "114",
             "csv": "data/United_States_of_America/Senate/term-114.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b3587f1/data/United_States_of_America/Senate/term-114.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b3587f13e137ce4bff91a4e8f96939358edea98b/data/United_States_of_America/Senate/term-114.csv"
           },
           {
             "end_date": "2015-01-03",
@@ -10605,7 +10605,7 @@
             "wikidata": "Q71871",
             "slug": "113",
             "csv": "data/United_States_of_America/Senate/term-113.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b3587f1/data/United_States_of_America/Senate/term-113.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b3587f13e137ce4bff91a4e8f96939358edea98b/data/United_States_of_America/Senate/term-113.csv"
           },
           {
             "end_date": "2013-01-03",
@@ -10615,7 +10615,7 @@
             "wikidata": "Q170447",
             "slug": "112",
             "csv": "data/United_States_of_America/Senate/term-112.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b3587f1/data/United_States_of_America/Senate/term-112.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b3587f13e137ce4bff91a4e8f96939358edea98b/data/United_States_of_America/Senate/term-112.csv"
           },
           {
             "end_date": "2011-01-03",
@@ -10625,7 +10625,7 @@
             "wikidata": "Q170375",
             "slug": "111",
             "csv": "data/United_States_of_America/Senate/term-111.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70e834c/data/United_States_of_America/Senate/term-111.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70e834cd873f8843df923e17a559cca6f6ab961b/data/United_States_of_America/Senate/term-111.csv"
           },
           {
             "end_date": "2009-01-03",
@@ -10635,7 +10635,7 @@
             "wikidata": "Q170018",
             "slug": "110",
             "csv": "data/United_States_of_America/Senate/term-110.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70e834c/data/United_States_of_America/Senate/term-110.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70e834cd873f8843df923e17a559cca6f6ab961b/data/United_States_of_America/Senate/term-110.csv"
           },
           {
             "end_date": "2007-01-03",
@@ -10645,7 +10645,7 @@
             "wikidata": "Q168778",
             "slug": "109",
             "csv": "data/United_States_of_America/Senate/term-109.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70e834c/data/United_States_of_America/Senate/term-109.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70e834cd873f8843df923e17a559cca6f6ab961b/data/United_States_of_America/Senate/term-109.csv"
           },
           {
             "end_date": "2005-01-03",
@@ -10655,7 +10655,7 @@
             "wikidata": "Q168504",
             "slug": "108",
             "csv": "data/United_States_of_America/Senate/term-108.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fbfb3ed/data/United_States_of_America/Senate/term-108.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fbfb3ed6743f6cd7f7f3921ea4ee718e4778651a/data/United_States_of_America/Senate/term-108.csv"
           },
           {
             "end_date": "2003-01-03",
@@ -10665,7 +10665,7 @@
             "wikidata": "Q2057259",
             "slug": "107",
             "csv": "data/United_States_of_America/Senate/term-107.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fbfb3ed/data/United_States_of_America/Senate/term-107.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fbfb3ed6743f6cd7f7f3921ea4ee718e4778651a/data/United_States_of_America/Senate/term-107.csv"
           },
           {
             "end_date": "2001-01-03",
@@ -10675,7 +10675,7 @@
             "wikidata": "Q3596897",
             "slug": "106",
             "csv": "data/United_States_of_America/Senate/term-106.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fbfb3ed/data/United_States_of_America/Senate/term-106.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fbfb3ed6743f6cd7f7f3921ea4ee718e4778651a/data/United_States_of_America/Senate/term-106.csv"
           },
           {
             "end_date": "1999-01-03",
@@ -10685,7 +10685,7 @@
             "wikidata": "Q3596884",
             "slug": "105",
             "csv": "data/United_States_of_America/Senate/term-105.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fbfb3ed/data/United_States_of_America/Senate/term-105.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fbfb3ed6743f6cd7f7f3921ea4ee718e4778651a/data/United_States_of_America/Senate/term-105.csv"
           },
           {
             "end_date": "1997-01-03",
@@ -10695,7 +10695,7 @@
             "wikidata": "Q3596857",
             "slug": "104",
             "csv": "data/United_States_of_America/Senate/term-104.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296df5c/data/United_States_of_America/Senate/term-104.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296df5c9ef9b681e3ef79f864c580933a733d936/data/United_States_of_America/Senate/term-104.csv"
           },
           {
             "end_date": "1995-01-03",
@@ -10705,7 +10705,7 @@
             "wikidata": "Q3556780",
             "slug": "103",
             "csv": "data/United_States_of_America/Senate/term-103.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296df5c/data/United_States_of_America/Senate/term-103.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296df5c9ef9b681e3ef79f864c580933a733d936/data/United_States_of_America/Senate/term-103.csv"
           },
           {
             "end_date": "1993-01-03",
@@ -10715,7 +10715,7 @@
             "wikidata": "Q347346",
             "slug": "102",
             "csv": "data/United_States_of_America/Senate/term-102.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296df5c/data/United_States_of_America/Senate/term-102.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296df5c9ef9b681e3ef79f864c580933a733d936/data/United_States_of_America/Senate/term-102.csv"
           },
           {
             "end_date": "1991-01-03",
@@ -10725,7 +10725,7 @@
             "wikidata": "Q4546373",
             "slug": "101",
             "csv": "data/United_States_of_America/Senate/term-101.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296df5c/data/United_States_of_America/Senate/term-101.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296df5c9ef9b681e3ef79f864c580933a733d936/data/United_States_of_America/Senate/term-101.csv"
           },
           {
             "end_date": "1989-01-03",
@@ -10735,7 +10735,7 @@
             "wikidata": "Q4546248",
             "slug": "100",
             "csv": "data/United_States_of_America/Senate/term-100.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296df5c/data/United_States_of_America/Senate/term-100.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296df5c9ef9b681e3ef79f864c580933a733d936/data/United_States_of_America/Senate/term-100.csv"
           },
           {
             "end_date": "1987-01-03",
@@ -10745,7 +10745,7 @@
             "wikidata": "Q4646349",
             "slug": "99",
             "csv": "data/United_States_of_America/Senate/term-99.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296df5c/data/United_States_of_America/Senate/term-99.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296df5c9ef9b681e3ef79f864c580933a733d936/data/United_States_of_America/Senate/term-99.csv"
           },
           {
             "end_date": "1983-01-03",
@@ -10755,7 +10755,7 @@
             "wikidata": "Q4646254",
             "slug": "98",
             "csv": "data/United_States_of_America/Senate/term-98.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296df5c/data/United_States_of_America/Senate/term-98.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296df5c9ef9b681e3ef79f864c580933a733d936/data/United_States_of_America/Senate/term-98.csv"
           },
           {
             "end_date": "1983-01-03",
@@ -10765,7 +10765,7 @@
             "wikidata": "Q4646187",
             "slug": "97",
             "csv": "data/United_States_of_America/Senate/term-97.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296df5c/data/United_States_of_America/Senate/term-97.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/296df5c9ef9b681e3ef79f864c580933a733d936/data/United_States_of_America/Senate/term-97.csv"
           }
         ],
         "statement_count": 69077
@@ -10783,11 +10783,11 @@
         "slug": "Deputies",
         "sources_directory": "data/Uruguay/Deputies/sources",
         "popolo": "data/Uruguay/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/627603f/data/Uruguay/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/627603f92ea08a16c2d90147125599fa30bdbfa8/data/Uruguay/Deputies/ep-popolo-v1.0.json",
         "names": "data/Uruguay/Deputies/names.csv",
         "lastmod": "1469303711",
         "person_count": 106,
-        "sha": "627603f",
+        "sha": "627603f92ea08a16c2d90147125599fa30bdbfa8",
         "legislative_periods": [
           {
             "id": "term/48",
@@ -10795,7 +10795,7 @@
             "start_date": "2015-02-15",
             "slug": "48",
             "csv": "data/Uruguay/Deputies/term-48.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f38d525/data/Uruguay/Deputies/term-48.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f38d525ced70ce0bf8779228cb3fcd5b67675229/data/Uruguay/Deputies/term-48.csv"
           }
         ],
         "statement_count": 3457
@@ -10813,11 +10813,11 @@
         "slug": "Legislative-Chamber",
         "sources_directory": "data/Uzbekistan/Legislative_Chamber/sources",
         "popolo": "data/Uzbekistan/Legislative_Chamber/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/61b360b/data/Uzbekistan/Legislative_Chamber/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/61b360bbaaff9e42be2a969728f1a320278e495c/data/Uzbekistan/Legislative_Chamber/ep-popolo-v1.0.json",
         "names": "data/Uzbekistan/Legislative_Chamber/names.csv",
         "lastmod": "1469385655",
         "person_count": 147,
-        "sha": "61b360b",
+        "sha": "61b360bbaaff9e42be2a969728f1a320278e495c",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -10825,7 +10825,7 @@
             "start_date": "2015-01-12",
             "slug": "5",
             "csv": "data/Uzbekistan/Legislative_Chamber/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad11325/data/Uzbekistan/Legislative_Chamber/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ad11325e7f67cf8f4339dbcedf70bb8a9e377466/data/Uzbekistan/Legislative_Chamber/term-5.csv"
           }
         ],
         "statement_count": 2499
@@ -10843,11 +10843,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Vanuatu/Parliament/sources",
         "popolo": "data/Vanuatu/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/03f9050/data/Vanuatu/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/03f90500053c3e81305cc61e10ef461d9f073e5b/data/Vanuatu/Parliament/ep-popolo-v1.0.json",
         "names": "data/Vanuatu/Parliament/names.csv",
         "lastmod": "1470759221",
         "person_count": 95,
-        "sha": "03f9050",
+        "sha": "03f90500053c3e81305cc61e10ef461d9f073e5b",
         "legislative_periods": [
           {
             "id": "term/11",
@@ -10855,7 +10855,7 @@
             "start_date": "2016-02-11",
             "slug": "11",
             "csv": "data/Vanuatu/Parliament/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/19116db/data/Vanuatu/Parliament/term-11.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/19116db6f4cca62711866ff6fa22ccfe1c47efeb/data/Vanuatu/Parliament/term-11.csv"
           },
           {
             "end_date": "2015-11-24",
@@ -10864,7 +10864,7 @@
             "start_date": "2012-11-19",
             "slug": "10",
             "csv": "data/Vanuatu/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/03f9050/data/Vanuatu/Parliament/term-10.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/03f90500053c3e81305cc61e10ef461d9f073e5b/data/Vanuatu/Parliament/term-10.csv"
           }
         ],
         "statement_count": 2899
@@ -10882,11 +10882,11 @@
         "slug": "Pontifical-Commission",
         "sources_directory": "data/Vatican_City/Pontifical_Commission/sources",
         "popolo": "data/Vatican_City/Pontifical_Commission/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4db2973/data/Vatican_City/Pontifical_Commission/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4db2973d11919c25ee5c2d132f54fbbb0b9421fc/data/Vatican_City/Pontifical_Commission/ep-popolo-v1.0.json",
         "names": "data/Vatican_City/Pontifical_Commission/names.csv",
         "lastmod": "1470402510",
         "person_count": 7,
-        "sha": "4db2973",
+        "sha": "4db2973d11919c25ee5c2d132f54fbbb0b9421fc",
         "legislative_periods": [
           {
             "id": "term/2011",
@@ -10894,7 +10894,7 @@
             "start_date": "2011-10-01",
             "slug": "2011",
             "csv": "data/Vatican_City/Pontifical_Commission/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/89900b7/data/Vatican_City/Pontifical_Commission/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/89900b7b1ad4007550dc38965a932e784cbc1236/data/Vatican_City/Pontifical_Commission/term-2011.csv"
           }
         ],
         "statement_count": 1289
@@ -10912,11 +10912,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Venezuela/Assembly/sources",
         "popolo": "data/Venezuela/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/734104f/data/Venezuela/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/734104f3c680dcfa76a258a098e828029e4c1b8f/data/Venezuela/Assembly/ep-popolo-v1.0.json",
         "names": "data/Venezuela/Assembly/names.csv",
         "lastmod": "1471232566",
         "person_count": 279,
-        "sha": "734104f",
+        "sha": "734104f3c680dcfa76a258a098e828029e4c1b8f",
         "legislative_periods": [
           {
             "id": "term/2016",
@@ -10924,7 +10924,7 @@
             "start_date": "2016-01-05",
             "slug": "2016",
             "csv": "data/Venezuela/Assembly/term-2016.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cd8c538/data/Venezuela/Assembly/term-2016.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cd8c538d74a3c6f1583773e036a2e29325c2812b/data/Venezuela/Assembly/term-2016.csv"
           },
           {
             "end_date": "2016-01-04",
@@ -10933,7 +10933,7 @@
             "start_date": "2011-01-05",
             "slug": "2011",
             "csv": "data/Venezuela/Assembly/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f43931b/data/Venezuela/Assembly/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f43931b1709439108dedfcba32391f040c5ecc36/data/Venezuela/Assembly/term-2011.csv"
           }
         ],
         "statement_count": 6901
@@ -10951,11 +10951,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Vietnam/National_Assembly/sources",
         "popolo": "data/Vietnam/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3dc95a5/data/Vietnam/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3dc95a571d7e9ec7a98f804445889b562c7c48df/data/Vietnam/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Vietnam/National_Assembly/names.csv",
         "lastmod": "1472010604",
         "person_count": 492,
-        "sha": "3dc95a5",
+        "sha": "3dc95a571d7e9ec7a98f804445889b562c7c48df",
         "legislative_periods": [
           {
             "end_date": "2016-05-22",
@@ -10964,7 +10964,7 @@
             "start_date": "2011-07-25",
             "slug": "13",
             "csv": "data/Vietnam/National_Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70d2037/data/Vietnam/National_Assembly/term-13.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70d2037e424ba063390394514cf1e6e16e63ef7e/data/Vietnam/National_Assembly/term-13.csv"
           }
         ],
         "statement_count": 12165
@@ -10982,11 +10982,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Wales/Assembly/sources",
         "popolo": "data/Wales/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4feed7c/data/Wales/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4feed7cdcc10aef0e5a51f23207279da91d804cb/data/Wales/Assembly/ep-popolo-v1.0.json",
         "names": "data/Wales/Assembly/names.csv",
         "lastmod": "1471493651",
         "person_count": 85,
-        "sha": "4feed7c",
+        "sha": "4feed7cdcc10aef0e5a51f23207279da91d804cb",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -10994,7 +10994,7 @@
             "start_date": "2016-05-06",
             "slug": "5",
             "csv": "data/Wales/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4feed7c/data/Wales/Assembly/term-5.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4feed7cdcc10aef0e5a51f23207279da91d804cb/data/Wales/Assembly/term-5.csv"
           },
           {
             "end_date": "2016-04-06",
@@ -11003,7 +11003,7 @@
             "start_date": "2011-09-15",
             "slug": "4",
             "csv": "data/Wales/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1791e1b/data/Wales/Assembly/term-4.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1791e1be633e7f915ab65fcce51bd55395c1114b/data/Wales/Assembly/term-4.csv"
           }
         ],
         "statement_count": 5932
@@ -11021,11 +11021,11 @@
         "slug": "Territorial-Assembly",
         "sources_directory": "data/Wallis_and_Futuna/Territorial_Assembly/sources",
         "popolo": "data/Wallis_and_Futuna/Territorial_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b5d993c/data/Wallis_and_Futuna/Territorial_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b5d993cd7c6a8c78b2da70d87f276702e754efce/data/Wallis_and_Futuna/Territorial_Assembly/ep-popolo-v1.0.json",
         "names": "data/Wallis_and_Futuna/Territorial_Assembly/names.csv",
         "lastmod": "1469305478",
         "person_count": 20,
-        "sha": "b5d993c",
+        "sha": "b5d993cd7c6a8c78b2da70d87f276702e754efce",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -11033,7 +11033,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Wallis_and_Futuna/Territorial_Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ebb3865/data/Wallis_and_Futuna/Territorial_Assembly/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ebb38652c13d784a4940df7aafb9956abea5f8bf/data/Wallis_and_Futuna/Territorial_Assembly/term-2012.csv"
           }
         ],
         "statement_count": 470
@@ -11051,11 +11051,11 @@
         "slug": "Majlis",
         "sources_directory": "data/Yemen/Majlis/sources",
         "popolo": "data/Yemen/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cbeecf1/data/Yemen/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cbeecf196436a77e65f294d7644d2bb7704d4481/data/Yemen/Majlis/ep-popolo-v1.0.json",
         "names": "data/Yemen/Majlis/names.csv",
         "lastmod": "1469385674",
         "person_count": 302,
-        "sha": "cbeecf1",
+        "sha": "cbeecf196436a77e65f294d7644d2bb7704d4481",
         "legislative_periods": [
           {
             "id": "term/2003",
@@ -11063,7 +11063,7 @@
             "start_date": "2003-05-10",
             "slug": "2003",
             "csv": "data/Yemen/Majlis/term-2003.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/09613f4/data/Yemen/Majlis/term-2003.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/09613f4f1556bc7af6246a1da24ff8bb7f6c70db/data/Yemen/Majlis/term-2003.csv"
           }
         ],
         "statement_count": 5185
@@ -11081,11 +11081,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Zambia/Assembly/sources",
         "popolo": "data/Zambia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/81fbd1b/data/Zambia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/81fbd1b5a4627e0aa390f10135a5dd47e5a11022/data/Zambia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Zambia/Assembly/names.csv",
         "lastmod": "1470634147",
         "person_count": 148,
-        "sha": "81fbd1b",
+        "sha": "81fbd1b5a4627e0aa390f10135a5dd47e5a11022",
         "legislative_periods": [
           {
             "id": "term/2011",
@@ -11093,7 +11093,7 @@
             "start_date": "2011-10-06",
             "slug": "2011",
             "csv": "data/Zambia/Assembly/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2ff78d1/data/Zambia/Assembly/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2ff78d11e2a27acf39bfbb09b07835ef8adcd071/data/Zambia/Assembly/term-2011.csv"
           }
         ],
         "statement_count": 3838
@@ -11111,11 +11111,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Zimbabwe/Assembly/sources",
         "popolo": "data/Zimbabwe/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8256982/data/Zimbabwe/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/825698224929ec4b1ac21384430b7e1b1feb7c9b/data/Zimbabwe/Assembly/ep-popolo-v1.0.json",
         "names": "data/Zimbabwe/Assembly/names.csv",
         "lastmod": "1471998270",
         "person_count": 229,
-        "sha": "8256982",
+        "sha": "825698224929ec4b1ac21384430b7e1b1feb7c9b",
         "legislative_periods": [
           {
             "id": "term/8",
@@ -11123,7 +11123,7 @@
             "start_date": "2013-09-17",
             "slug": "8",
             "csv": "data/Zimbabwe/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0ba3144/data/Zimbabwe/Assembly/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0ba314442be693e3096c69e1c2a34e64fea63dac/data/Zimbabwe/Assembly/term-8.csv"
           }
         ],
         "statement_count": 5892
@@ -11133,11 +11133,11 @@
         "slug": "Senate",
         "sources_directory": "data/Zimbabwe/Senate/sources",
         "popolo": "data/Zimbabwe/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/85e7eac/data/Zimbabwe/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/85e7eaccaca37ca8e66c62076783a374ea894b59/data/Zimbabwe/Senate/ep-popolo-v1.0.json",
         "names": "data/Zimbabwe/Senate/names.csv",
         "lastmod": "1469385687",
         "person_count": 67,
-        "sha": "85e7eac",
+        "sha": "85e7eaccaca37ca8e66c62076783a374ea894b59",
         "legislative_periods": [
           {
             "id": "term/8",
@@ -11145,7 +11145,7 @@
             "start_date": "2013-09-17",
             "slug": "8",
             "csv": "data/Zimbabwe/Senate/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9076b10/data/Zimbabwe/Senate/term-8.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9076b10359b923c3b51197213dac11e747a82fb6/data/Zimbabwe/Senate/term-8.csv"
           }
         ],
         "statement_count": 1334
@@ -11163,11 +11163,11 @@
         "slug": "Lagting",
         "sources_directory": "data/Aland/Lagting/sources",
         "popolo": "data/Aland/Lagting/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f6aafcb/data/Aland/Lagting/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f6aafcb5479abbfaa8a32cf46ceab6b9a3cc3dda/data/Aland/Lagting/ep-popolo-v1.0.json",
         "names": "data/Aland/Lagting/names.csv",
         "lastmod": "1470658552",
         "person_count": 60,
-        "sha": "f6aafcb",
+        "sha": "f6aafcb5479abbfaa8a32cf46ceab6b9a3cc3dda",
         "legislative_periods": [
           {
             "end_date": "2019-10-31",
@@ -11176,7 +11176,7 @@
             "start_date": "2015-11-02",
             "slug": "2015",
             "csv": "data/Aland/Lagting/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6274b06/data/Aland/Lagting/term-2015.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6274b06a51dcd8ee3cf1f57879dbd89d1668bdd8/data/Aland/Lagting/term-2015.csv"
           },
           {
             "end_date": "2015",
@@ -11185,7 +11185,7 @@
             "start_date": "2011",
             "slug": "2011",
             "csv": "data/Aland/Lagting/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2a9e6f9/data/Aland/Lagting/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2a9e6f9ae533bf8eb6109a1e6c5451ce9f539cc2/data/Aland/Lagting/term-2011.csv"
           },
           {
             "end_date": "2011",
@@ -11194,7 +11194,7 @@
             "start_date": "2007",
             "slug": "2007",
             "csv": "data/Aland/Lagting/term-2007.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2a9e6f9/data/Aland/Lagting/term-2007.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2a9e6f9ae533bf8eb6109a1e6c5451ce9f539cc2/data/Aland/Lagting/term-2007.csv"
           }
         ],
         "statement_count": 3350

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -12,7 +12,7 @@ def file_to_commit_metadata(directories)
   # parse the output line-by-line. As a bonus this doesn't
   # unnecessarily invoke a shell.
   command = [
-    'git', '--no-pager', 'log', '--name-only', '--format=%h|%at',
+    'git', '--no-pager', 'log', '--name-only', '--format=%H|%at',
     '--', *directories,
   ]
   last_commit = {}


### PR DESCRIPTION
We recently hit a case where the short version doesn't work: Peru was pointing at https://github.com/everypolitician/everypolitician-data/commit/8b15cc3, but we have a clash between https://github.com/everypolitician/everypolitician-data/commit/8b15cc3c (which is what we need here) and https://github.com/everypolitician/everypolitician-data/commit/8b15cc39 

So instead switch to using the full version.