### PR TITLE
Split up OCD Lookup classes

### DIFF
--- a/lib/ocd_id.rb
+++ b/lib/ocd_id.rb
@@ -1,47 +1,50 @@
-class OcdId
-  attr_reader :ocd_ids
-  attr_reader :overrides
-  attr_reader :area_ids
+module OCD
+  class Lookup
+    class Plain
+      attr_reader :ocd_ids
+      attr_reader :overrides
+      attr_reader :area_ids
 
-  def initialize(ocd_ids, overrides, fuzzy)
-    @ocd_ids = ocd_ids
-    @overrides = overrides
-    @fuzzy = fuzzy
-    @area_ids = {}
-  end
+      def initialize(ocd_ids, overrides)
+        @ocd_ids = ocd_ids
+        @overrides = overrides
+        @area_ids = {}
+      end
 
-  def from_name(name)
-    area_ids[name] ||= area_id_from_name(name)
-  end
+      def from_name(name)
+        area_ids[name] ||= area_id_from_name(name)
+      end
 
-  private
+      private
 
-  def area_id_from_name(name)
-    area = override(name) || finder(name)
-    return if area.nil?
-    warn '  Matched Area %s to %s' % [name.yellow, area[:name].to_s.green] unless area[:name].include? " #{name} "
-    area[:id]
-  end
+      def area_id_from_name(name)
+        area = override(name) || find(name)
+        return if area.nil?
+        warn '  Matched Area %s to %s' % [name.yellow, area[:name].to_s.green] unless area[:name].include? " #{name} "
+        area[:id]
+      end
 
-  def override(name)
-    override_id = overrides[name]
-    return if override_id.nil?
-    { name: name, id: override_id }
-  end
+      def override(name)
+        override_id = overrides[name]
+        return if override_id.nil?
+        { name: name, id: override_id }
+      end
 
-  def finder(name)
-    if fuzzy?
-      fuzzer.find(name.to_s, must_match_at_least_one_word: true)
-    else
-      ocd_ids.find { |i| i[:name] == name }
+      def find(name)
+        ocd_ids.find { |i| i[:name] == name }
+      end
     end
-  end
 
-  def fuzzy?
-    @fuzzy
-  end
+    class Fuzzy < Plain
+      private
 
-  def fuzzer
-    @fuzzer ||= FuzzyMatch.new(ocd_ids, read: :name)
+      def find(name)
+        fuzzer.find(name.to_s, must_match_at_least_one_word: true)
+      end
+
+      def fuzzer
+        @fuzzer ||= FuzzyMatch.new(ocd_ids, read: :name)
+      end
+    end
   end
 end

--- a/lib/ocd_id.rb
+++ b/lib/ocd_id.rb
@@ -1,0 +1,47 @@
+class OcdId
+  attr_reader :ocd_ids
+  attr_reader :overrides
+  attr_reader :area_ids
+
+  def initialize(ocd_ids, overrides, fuzzy)
+    @ocd_ids = ocd_ids
+    @overrides = overrides
+    @fuzzy = fuzzy
+    @area_ids = {}
+  end
+
+  def from_name(name)
+    area_ids[name] ||= area_id_from_name(name)
+  end
+
+  private
+
+  def area_id_from_name(name)
+    area = override(name) || finder(name)
+    return if area.nil?
+    warn '  Matched Area %s to %s' % [name.yellow, area[:name].to_s.green] unless area[:name].include? " #{name} "
+    area[:id]
+  end
+
+  def override(name)
+    override_id = overrides[name]
+    return if override_id.nil?
+    { name: name, id: override_id }
+  end
+
+  def finder(name)
+    if fuzzy?
+      fuzzer.find(name.to_s, must_match_at_least_one_word: true)
+    else
+      ocd_ids.find { |i| i[:name] == name }
+    end
+  end
+
+  def fuzzy?
+    @fuzzy
+  end
+
+  def fuzzer
+    @fuzzer ||= FuzzyMatch.new(ocd_ids, read: :name)
+  end
+end

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -212,6 +212,10 @@ module Source
       %i(area area_id)
     end
 
+    def fuzzy_match?
+      i(:merge)[:fuzzy]
+    end
+
     def overrides
       return {} unless i(:merge)
       return {} unless i(:merge).key? :overrides

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -190,7 +190,7 @@ namespace :merge_sources do
       else
         # Generate IDs from names
         overrides_with_string_keys = Hash[area.overrides.map { |k, v| [k.to_s, v] }]
-        lookup_class = (area.merge_instructions || {})[:fuzzy] ? OCD::Lookup::Fuzzy : OCD::Lookup::Plain
+        lookup_class = area.fuzzy_match? ? OCD::Lookup::Fuzzy : OCD::Lookup::Plain
         ocd_ids = lookup_class.new(area.as_table, overrides_with_string_keys)
 
         merged_rows.select { |r| r[:area_id].nil? }.each do |r|

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -190,8 +190,8 @@ namespace :merge_sources do
       else
         # Generate IDs from names
         overrides_with_string_keys = Hash[area.overrides.map { |k, v| [k.to_s, v] }]
-        fuzzy = (area.merge_instructions || {})[:fuzzy]
-        ocd_ids = OcdId.new(area.as_table, overrides_with_string_keys, fuzzy)
+        lookup_class = (area.merge_instructions || {})[:fuzzy] ? OCD::Lookup::Fuzzy : OCD::Lookup::Plain
+        ocd_ids = lookup_class.new(area.as_table, overrides_with_string_keys)
 
         merged_rows.select { |r| r[:area_id].nil? }.each do |r|
           area = ocd_ids.from_name(r[:area])

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -6,54 +6,7 @@ require_relative '../lib/reconciliation'
 require_relative '../lib/remotesource'
 require_relative '../lib/source'
 require_relative '../lib/gender_balancer'
-
-class OcdId
-  attr_reader :ocd_ids
-  attr_reader :overrides
-  attr_reader :area_ids
-
-  def initialize(ocd_ids, overrides, fuzzy)
-    @ocd_ids = ocd_ids
-    @overrides = overrides
-    @fuzzy = fuzzy
-    @area_ids = {}
-  end
-
-  def from_name(name)
-    area_ids[name] ||= area_id_from_name(name)
-  end
-
-  private
-
-  def area_id_from_name(name)
-    area = override(name) || finder(name)
-    return if area.nil?
-    warn '  Matched Area %s to %s' % [name.yellow, area[:name].to_s.green] unless area[:name].include? " #{name} "
-    area[:id]
-  end
-
-  def override(name)
-    override_id = overrides[name]
-    return if override_id.nil?
-    { name: name, id: override_id }
-  end
-
-  def finder(name)
-    if fuzzy?
-      fuzzer.find(name.to_s, must_match_at_least_one_word: true)
-    else
-      ocd_ids.find { |i| i[:name] == name }
-    end
-  end
-
-  def fuzzy?
-    @fuzzy
-  end
-
-  def fuzzer
-    @fuzzer ||= FuzzyMatch.new(ocd_ids, read: :name)
-  end
-end
+require_relative '../lib/ocd_id'
 
 class String
   def tidy


### PR DESCRIPTION
Pull the OCD Lookup class to its own file, and split out separate classes for plain lookups and fuzzy lookups.

(flog drops from 430.5 → 428.7)