### PR TITLE
Fix broken date checking

### DIFF
--- a/rake_build/verify_source_data.rb
+++ b/rake_build/verify_source_data.rb
@@ -29,7 +29,7 @@ namespace :verify do
           # warn_once.("Short #{d} in #{r}", [d, r[:uuid]])
           next
         end
-        abort "Badly formatted #{d} in #{r}" unless r[d] =~ /^\d{4}-\d{2}-\d{2}$/
+        abort "Badly formatted #{d} (#{r[d]}) in #{r}" unless r[d] =~ /^\d{4}-\d{2}-\d{2}$/
         parsed_date = Date.parse(r[d]) rescue 'broken'
         abort "Invalid #{d} in #{r}" unless parsed_date.to_s == r[d]
       end

--- a/rake_build/verify_source_data.rb
+++ b/rake_build/verify_source_data.rb
@@ -19,7 +19,7 @@ namespace :verify do
   end
 
   task check_data: :load do
-    date_fields = @csv_headers.select { |k| k.include? '_date' }
+    date_fields = @csv_headers.select { |k| k.include? '_date' }.map(&:to_sym)
 
     @csv.each do |r|
       abort "No `name` in #{r}" if r[:name].to_s.empty?


### PR DESCRIPTION
The build process is meant to check that date fields have values that
actually look like dates. But it hasn't been working, because it’s been
looking for "date" columns by string, rather than symbol.