### PR TITLE
split Cabinet positions from Other Executive

### DIFF
--- a/bin/learn_position.rb
+++ b/bin/learn_position.rb
@@ -13,7 +13,7 @@ end
 
 (file = ARGV.shift) || abort("Usage: echo CSV | #{$PROGRAM_NAME} <filter file>")
 json = json_from(file)
-%i(self other_legislatures executive party other).each { |i| json[:include][i] ||= [] }
+%i(self other_legislatures cabinet executive party other).each { |i| json[:include][i] ||= [] }
 
 csv = Hash[ARGF.readlines.map { |l| l.chomp.split(',') }]
 
@@ -23,7 +23,8 @@ section_for = lambda do |r|
   return json[:include][:other] if res == 'Exclude'
   return json[:include][:self] if res == 'Self (keep)'
   return json[:include][:other_legislatures] if res == 'Other Legislature'
-  return json[:include][:executive] if res == 'Executive'
+  return json[:include][:cabinet] if res == 'Cabinet'
+  return json[:include][:executive] if res == 'Other Executive'
   return json[:include][:party] if res == 'Party'
   return json[:include][:other] if res == 'Other'
   raise "Unknown button: #{res}"

--- a/data/Estonia/Riigikogu/sources/manual/position-filter.json
+++ b/data/Estonia/Riigikogu/sources/manual/position-filter.json
@@ -18,102 +18,7 @@
       }
     ],
     "executive": [
-      {
-        "id": "Q12361541",
-        "name": "Environment Minister"
-      },
-      {
-        "id": "Q16405106",
-        "name": "Minister of Agriculture"
-      },
-      {
-        "id": "Q16402952",
-        "name": "Minister of Culture"
-      },
-      {
-        "id": "Q23005920",
-        "name": "Minister of Culture"
-      },
-      {
-        "id": "Q23725838",
-        "name": "Minister of Culture and Education"
-      },
-      {
-        "id": "Q3741249",
-        "name": "Minister of Defence"
-      },
-      {
-        "id": "Q21121665",
-        "name": "Minister of Economic Affairs and Communications"
-      },
-      {
-        "id": "Q16403845",
-        "name": "Minister of Economic Affairs and Infrastructure"
-      },
-      {
-        "id": "Q6866110",
-        "name": "Minister of Education and Research"
-      },
-      {
-        "id": "Q20933474",
-        "name": "Minister of Entrepreneurship"
-      },
-      {
-        "id": "Q21103025",
-        "name": "Minister of Finance"
-      },
-      {
-        "id": "Q1760777",
-        "name": "Minister of Foreign Affairs"
-      },
-      {
-        "id": "Q24058803",
-        "name": "Minister of Foreign Trade and Entrepreneurship"
-      },
-      {
-        "id": "Q24060082",
-        "name": "Minister of Health and Labour"
-      },
-      {
-        "id": "Q20528230",
-        "name": "Minister of Justice"
-      },
-      {
-        "id": "Q24061775",
-        "name": "Minister of Population and Ethnic Affairs"
-      },
-      {
-        "id": "Q20528404",
-        "name": "Minister of Public Administration"
-      },
-      {
-        "id": "Q23268238",
-        "name": "Minister of Regional Affairs"
-      },
-      {
-        "id": "Q24060239",
-        "name": "Minister of Rural Affairs"
-      },
-      {
-        "id": "Q16402881",
-        "name": "Minister of Social Affairs"
-      },
-      {
-        "id": "Q24060088",
-        "name": "Minister of Social Protection"
-      },
-      {
-        "id": "Q6866431",
-        "name": "Minister of the Interior"
-      },
-      {
-        "id": "Q737115",
-        "name": "Prime Minister of Estonia"
-      },
-      {
-        "id": "Q24067751",
-        "name": "minister without portfolio"
-      }
+
     ],
     "other": [
       {
@@ -128,6 +33,129 @@
         "id": "Q6627739",
         "name": "Mayor of Tartu"
       }
+    ],
+    "self": [
+
+    ],
+    "cabinet": [
+      {
+        "id": "Q16405106",
+        "name": "Minister of Agriculture",
+        "description": "Estonian cabinet position"
+      },
+      {
+        "id": "Q16402952",
+        "name": "Minister of Culture",
+        "description": "Estonian cabinet minister"
+      },
+      {
+        "id": "Q23725838",
+        "name": "Minister of Culture and Education",
+        "description": "Estonian cabinet minister"
+      },
+      {
+        "id": "Q3741249",
+        "name": "Minister of Defence",
+        "description": "in Estonia"
+      },
+      {
+        "id": "Q21121665",
+        "name": "Minister of Economic Affairs and Communications",
+        "description": "Estonian cabinet position"
+      },
+      {
+        "id": "Q16403845",
+        "name": "Minister of Economic Affairs and Infrastructure",
+        "description": "Estonian cabinet minister"
+      },
+      {
+        "id": "Q6866110",
+        "name": "Minister of Education and Research",
+        "description": "Estonian cabinet position"
+      },
+      {
+        "id": "Q20933474",
+        "name": "Minister of Entrepreneurship",
+        "description": "Estonian cabinet position"
+      },
+      {
+        "id": "Q21103025",
+        "name": "Minister of Finance",
+        "description": "Estonian finance minister"
+      },
+      {
+        "id": "Q1760777",
+        "name": "Minister of Foreign Affairs",
+        "description": "Minister of Foreign Affairs in Estonia"
+      },
+      {
+        "id": "Q24058803",
+        "name": "Minister of Foreign Trade and Entrepreneurship",
+        "description": "Estonian cabinet minister"
+      },
+      {
+        "id": "Q24060082",
+        "name": "Minister of Health and Labour",
+        "description": "Estonian cabinet minister"
+      },
+      {
+        "id": "Q20528230",
+        "name": "Minister of Justice",
+        "description": "Estonian Cabinet position"
+      },
+      {
+        "id": "Q24061775",
+        "name": "Minister of Population and Ethnic Affairs",
+        "description": "Estonian cabinet position"
+      },
+      {
+        "id": "Q20528404",
+        "name": "Minister of Public Administration",
+        "description": "Estonian cabinet position"
+      },
+      {
+        "id": "Q23268238",
+        "name": "Minister of Regional Affairs",
+        "description": "Estonian cabinet minister"
+      },
+      {
+        "id": "Q24060239",
+        "name": "Minister of Rural Affairs",
+        "description": "Estonian cabinet position"
+      },
+      {
+        "id": "Q16402881",
+        "name": "Minister of Social Affairs",
+        "description": "Estonian cabinet minister"
+      },
+      {
+        "id": "Q24060088",
+        "name": "Minister of Social Protection",
+        "description": "Estonian cabinet minister"
+      },
+      {
+        "id": "Q12361541",
+        "name": "Minister of the Environment",
+        "description": "Estonian cabinet minister"
+      },
+      {
+        "id": "Q6866431",
+        "name": "Minister of the Interior",
+        "description": "Estonian Minister of the Interior"
+      },
+      {
+        "id": "Q737115",
+        "name": "Prime Minister of Estonia",
+        "description": "position"
+      },
+      {
+        "id": "Q24067751",
+        "name": "minister without portfolio",
+        "description": "Estonian cabinet minister"
+      }
+    ],
+    "party": [
+
     ]
   },
   "unknown": {

--- a/data/Estonia/Riigikogu/unstable/stats.json
+++ b/data/Estonia/Riigikogu/unstable/stats.json
@@ -16,6 +16,6 @@
     "latest": "2015-03-01"
   },
   "positions": {
-    "executive": 24
+    "cabinet": 23
   }
 }

--- a/rake_build/generate_final_csvs.rb
+++ b/rake_build/generate_final_csvs.rb
@@ -125,7 +125,7 @@ namespace :term_csvs do
                     fs.each { |_, fs| fs.each { |f| f.delete :count } }
                   end
                 else
-                  { exclude: { self: [], other: [] }, include: { self: [], other_legislatures: [], executive: [], party: [], other: [] } }
+                  { exclude: { self: [], other: [] }, include: { self: [], other_legislatures: [], cabinet: [], executive: [], party: [], other: [] } }
                 end
 
     to_include = filter[:include].map { |_, fs| fs.map { |f| f[:id] } }.flatten.to_set

--- a/rake_build/generate_final_csvs.rb
+++ b/rake_build/generate_final_csvs.rb
@@ -130,7 +130,7 @@ namespace :term_csvs do
 
     to_include = filter[:include].map { |_, fs| fs.map { |f| f[:id] } }.flatten.to_set
     to_exclude = filter[:exclude].map { |_, fs| fs.map { |f| f[:id] } }.flatten.to_set
-    executive  = filter[:include][:executive].map { |p| p[:id] }.to_set
+    cabinet    = (filter[:include][:cabinet] || []).map { |p| p[:id] }.to_set
 
     want, unknown = @json[:persons].map do |p|
       (p[:identifiers] || []).select { |i| i[:scheme] == 'wikidata' }.map do |id|
@@ -149,7 +149,7 @@ namespace :term_csvs do
       end
     end.flatten(2).reject { |r| to_exclude.include? r[:position_id] }.partition { |r| to_include.include? r[:position_id] }
 
-    want.select { |p| executive.include? p[:position_id] }.select { |p| p[:start_date].nil? && p[:end_date].nil? }.each do |p|
+    want.select { |p| cabinet.include? p[:position_id] }.select { |p| p[:start_date].nil? && p[:end_date].nil? }.each do |p|
       warn "  ☇ No dates for #{p[:name]} (#{p[:wikidata]}) as #{p[:position]}"
     end
 

--- a/rake_build/generate_stats.rb
+++ b/rake_build/generate_stats.rb
@@ -20,9 +20,9 @@ namespace :stats do
 
     if POSITION_FILTER.file?
       posns = JSON.parse(POSITION_FILTER.read, symbolize_names: true)
-      executive_positions = posns[:include][:executive].count rescue 0
+      cabinet_positions = posns[:include][:cabinet].count rescue 0
     else
-      executive_positions = 0
+      cabinet_positions = 0
     end
 
     stats = {
@@ -43,7 +43,7 @@ namespace :stats do
         latest: latest_election || '',
       },
       positions: {
-        executive: executive_positions,
+        cabinet: cabinet_positions,
       },
     }
 

--- a/templates/position-filter.js
+++ b/templates/position-filter.js
@@ -14,7 +14,8 @@ jQuery(function($) {
   $("div#data p").prepend(button("Exclude"));
   $("div#data p").prepend(button("Other"));
   $("div#data p").prepend(button("Party"));
-  $("div#data p").prepend(button("Executive"));
+  $("div#data p").prepend(button("Other Executive"));
+  $("div#data p").prepend(button("Cabinet"));
   $("div#data p").prepend(button("Other Legislature"));
   $("div#data p").prepend(button("Self (keep)"));
   $("div#data p").prepend(button("Self (skip)"));


### PR DESCRIPTION
We want to start displaying information on Cabinet memberships. Currently,
however, these are grouped with other positions under the
'Executive' section. So we need to split out a separate 'Cabinet' position.

We then want to change the build report and stats generation to show
information solely about the Cabinet, not the other Executive positions.

Estonia has been rebuilt to show this in action.