### PR TITLE
Raise rubocop's TargetRubyVersion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   Exclude: 
     - 'data/**/*'
     - 'vendor/**/*'
+  TargetRubyVersion: 2.1
 
 Metrics/ClassLength:
   Max: 250
@@ -22,6 +23,6 @@ Metrics/PerceivedComplexity:
   Max: 8
 
 
-inherit_from: 
+inherit_from:
   - .rubocop_base.yml
   - .rubocop_todo.yml


### PR DESCRIPTION
we're now requiring Ruby 2.1 generally, so we should update Rubocop to
also target that (e.g. so that it's happier with default named
parameter syntax)