### PR TITLE
Add a 'type' column to positions.csv

### DIFF
--- a/lib/position/map.rb
+++ b/lib/position/map.rb
@@ -11,6 +11,10 @@ class PositionMap
     raw_json
   end
 
+  def type(pid)
+    type_lookup[pid]
+  end
+
   def include_ids
     to_json[:include].values.flatten.map { |p| p[:id] }.to_set
   end
@@ -46,5 +50,13 @@ class PositionMap
     # read with JSON5 to be more liberal about trailing commas.
     # But that doesn't have a 'symbolize_names' so rountrip through JSON
     JSON.parse(JSON5.parse(data).to_json, symbolize_names: true)
+  end
+
+  def type_lookup
+    @type ||= raw_json.values.flatten.flat_map do |i|
+      i.flat_map do |type, items|
+        items.map { |item| [item[:id], type] }
+      end
+    end.to_h
   end
 end

--- a/rake_build/generate_final_csvs.rb
+++ b/rake_build/generate_final_csvs.rb
@@ -125,9 +125,9 @@ namespace :term_csvs do
     end
 
     # Write positions.csv
-    csv_headers = %w(id name position start_date end_date).to_csv
+    csv_headers = %w(id name position start_date end_date type).to_csv
     csv_data = all_positions.select { |posn| position_map.include_ids.include? posn.id }.map do |posn|
-      [posn.person.id, posn.person.name, posn.label, posn.start_date, posn.end_date].to_csv
+      [posn.person.id, posn.person.name, posn.label, posn.start_date, posn.end_date, position_map.type(posn.id)].to_csv
     end
 
     POSITION_CSV.dirname.mkpath


### PR DESCRIPTION
This adds a new column to the `positions.csv` file telling us the 'type'
of position (cabinet, executive, other_legislatures, etc)

This then will let us select a subset of positions from it (e.g. the
Cabinet memberships someone has held)