### PR TITLE
Update mapping method in the UuidMapFile class

### DIFF
--- a/lib/uuid_map.rb
+++ b/lib/uuid_map.rb
@@ -17,8 +17,9 @@ class UuidMapFile
   end
 
   def mapping
-    raw = [@newfile, @oldfile].find(&:exist?).read
-    return {} if raw.empty?
+    file = [@newfile, @oldfile].find(&:exist?)
+    raw  = file.read unless file.nil?
+    return {} if file.nil? || raw.empty?
     Hash[Rcsv.parse(raw, row_as_hash: true, columns: {}).map { |r| [r['id'], r['uuid']] }]
   end
 

--- a/test/uuid_map_test.rb
+++ b/test/uuid_map_test.rb
@@ -14,6 +14,10 @@ def new_tempfile
 end
 
 describe 'UUID Mapper' do
+  it "has nothing if the file doesn't exist" do
+    UuidMapFile.new(Pathname.new('not/a/file')).mapping.must_be_empty
+  end
+
   it 'has nothing in an empty tempfile' do
     UuidMapFile.new(new_tempfile).mapping.must_be_empty
   end


### PR DESCRIPTION
The code that was used to migrate the id map files from `data-ids.csv`
to `idmap/data.csv` was throwing a rake error when adding a new
source and rebuilding the data with rake clean default, since there
was no @oldfile or @ newfile. Moving the .read down to the
Rcsv.parse call seemed to fix the error.

Thanks @chrismytton for the tip :D