### PR TITLE
Falklands data import

### DIFF
--- a/data/Falkland_Islands/Assembly/sources/instructions.json
+++ b/data/Falkland_Islands/Assembly/sources/instructions.json
@@ -4,7 +4,7 @@
       "file": "morph/wikipedia.csv",
       "create": {
         "from": "morph",
-        "scraper": "dracos/falkland-islands",
+        "scraper": "everypolitician-scrapers/falkland-islands",
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id, NULL as source FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org/",

--- a/data/Falkland_Islands/Assembly/sources/morph/wikipedia.csv
+++ b/data/Falkland_Islands/Assembly/sources/morph/wikipedia.csv
@@ -1,77 +1,77 @@
-source,name,area,area_id,wikiname,party,term,id
-,Adrian Bertrand Monk,East Falkland,ocd-division/country:fk/constituency:east-falkland,,Independent,1977,adrian_bertrand_monk
-,Andrea Clausen,Stanley,ocd-division/country:fk/constituency:stanley,Andrea Patricia Clausen,Independent,2005,andrea_clausen
-,Anthony Thomas Blake,Camp,ocd-division/country:fk/constituency:camp,,Independent,1981,anthony_thomas_blake
-,Anthony Thomas Blake,Camp,ocd-division/country:fk/constituency:camp,,Independent,1985,anthony_thomas_blake
-,Barry Elsby,Stanley,ocd-division/country:fk/constituency:stanley,Barry Elsby,Independent,2013,barry_elsby
-,Bill Luxton,Camp,ocd-division/country:fk/constituency:camp,Bill Luxton,Independent,1989,bill_luxton
-,Bill Luxton,Camp,ocd-division/country:fk/constituency:camp,Bill Luxton,Independent,1993,bill_luxton
-,Bill Luxton,Camp,ocd-division/country:fk/constituency:camp,Bill Luxton,Independent,1997,bill_luxton
-,Bill Luxton,Camp,ocd-division/country:fk/constituency:camp,Bill Luxton,Independent,2009,bill_luxton
-,"Charles Desmond Keenleyside, Jr",Stanley,ocd-division/country:fk/constituency:stanley,,Independent,1985,"charles_desmond_keenleyside,_jr"
-,Charles Keenleyside,Stanley,ocd-division/country:fk/constituency:stanley,,Independent,1993,charles_keenleyside
-,Darwin Lewis Clifton,Stanley,ocd-division/country:fk/constituency:stanley,,Independent,1985,darwin_lewis_clifton
-,Derek Stanley Evans,West Falkland,ocd-division/country:fk/constituency:west-falkland,,Independent,1977,derek_stanley_evans
-,Emma Edwards,Stanley,ocd-division/country:fk/constituency:stanley,Emma Edwards,Independent,2009,emma_edwards
-,Eric Goss,Camp,ocd-division/country:fk/constituency:camp,,Independent,1993,eric_goss
-,Gavin Short,Stanley,ocd-division/country:fk/constituency:stanley,Gavin Short,Independent,1989,gavin_short
-,Gavin Short,Stanley,ocd-division/country:fk/constituency:stanley,Gavin Short,Independent,2009,gavin_short
-,Gavin Short,Stanley,ocd-division/country:fk/constituency:stanley,Gavin Short,Independent,2013,gavin_short
-,"Gerrard ""Fred"" Robson",Stanley,ocd-division/country:fk/constituency:stanley,,Independent,1989,"gerrard_""fred""_robson"
-,Glenn Ross,Stanley,ocd-division/country:fk/constituency:stanley,Glenn Ross (politician),Independent,2009,glenn_ross
-,Harold Rowlands,Stanley,ocd-division/country:fk/constituency:stanley,,Independent,1989,harold_rowlands
-,Ian Hansen,Camp,ocd-division/country:fk/constituency:camp,Ian Hansen,Independent,2005,ian_hansen
-,Ian Hansen,Camp,ocd-division/country:fk/constituency:camp,Ian Hansen,Independent,2013,ian_hansen
-,Jan Cheek,Stanley,ocd-division/country:fk/constituency:stanley,Jan Cheek,Independent,1997,jan_cheek
-,Jan Cheek,Stanley,ocd-division/country:fk/constituency:stanley,Jan Cheek,Independent,2001,jan_cheek
-,Jan Cheek,Stanley,ocd-division/country:fk/constituency:stanley,Jan Cheek,Independent,2009,jan_cheek
-,Jan Cheek,Stanley,ocd-division/country:fk/constituency:stanley,Jan Cheek,Independent,2013,jan_cheek
-,Janet Robertson,Stanley,ocd-division/country:fk/constituency:stanley,Janet Robertson,Independent,2005,janet_robertson
-,John Birmingham,Stanley,ocd-division/country:fk/constituency:stanley,John Birmingham (politician),Independent,1997,john_birmingham
-,John Birmingham,Stanley,ocd-division/country:fk/constituency:stanley,John Birmingham (politician),Independent,2001,john_birmingham
-,John Cheek,Stanley,ocd-division/country:fk/constituency:stanley,,Independent,1993,john_cheek
-,John Edward Cheek,West Stanley,ocd-division/country:fk/constituency:west-stanley,,Independent,1981,john_edward_cheek
-,John Edward Cheek,Stanley,ocd-division/country:fk/constituency:stanley,,Independent,1985,john_edward_cheek
-,Kevin Kilmartin,Camp,ocd-division/country:fk/constituency:camp,,Independent,1989,kevin_kilmartin
-,Lewis Clifton,Stanley,ocd-division/country:fk/constituency:stanley,,Independent,1997,lewis_clifton
-,Lionel Geoffrey Blake,West Falkland,ocd-division/country:fk/constituency:west-falkland,,Independent,1981,lionel_geoffrey_blake
-,Lionel Geoffrey Blake,Camp,ocd-division/country:fk/constituency:camp,,Independent,1985,lionel_geoffrey_blake
-,Michael Poole,Stanley,ocd-division/country:fk/constituency:stanley,Michael Poole (politician),Independent,2013,michael_poole
-,Michael Rendell,Camp,ocd-division/country:fk/constituency:camp,Michael Rendell,Independent,2005,michael_rendell
-,Michael Summers,Stanley,ocd-division/country:fk/constituency:stanley,Mike Summers,Independent,2001,michael_summers
-,Mike Summers,Stanley,ocd-division/country:fk/constituency:stanley,Mike Summers,Independent,1997,mike_summers
-,Mike Summers,Stanley,ocd-division/country:fk/constituency:stanley,Mike Summers,Independent,2005,mike_summers
-,Mike Summers,Stanley,ocd-division/country:fk/constituency:stanley,Mike Summers,Independent,2013,mike_summers
-,Norma Edwards,Stanley,ocd-division/country:fk/constituency:stanley,,Independent,1985,norma_edwards
-,Norma Edwards,Camp,ocd-division/country:fk/constituency:camp,,Independent,1989,norma_edwards
-,Norma Edwards,Camp,ocd-division/country:fk/constituency:camp,,Independent,1993,norma_edwards
-,Norma Edwards,Camp,ocd-division/country:fk/constituency:camp,,Independent,1997,norma_edwards
-,Norma Edwards,Camp,ocd-division/country:fk/constituency:camp,,Independent,2001,norma_edwards
-,Philip Miller,Camp,ocd-division/country:fk/constituency:camp,,Independent,2001,philip_miller
-,Phyllis Rendell,Camp,ocd-division/country:fk/constituency:camp,Phyllis Rendell,Independent,2013,phyllis_rendell
-,Richard Cockwell,Camp,ocd-division/country:fk/constituency:camp,Richard Cockwell,Independent,1997,richard_cockwell
-,Richard Cockwell,Stanley,ocd-division/country:fk/constituency:stanley,Richard Cockwell,Independent,2001,richard_cockwell
-,Richard Cockwell,Stanley,ocd-division/country:fk/constituency:stanley,Richard Cockwell,Independent,2005,richard_cockwell
-,Richard Davies,Stanley,ocd-division/country:fk/constituency:stanley,,Independent,2005,richard_davies
-,Richard Sawle,Stanley,ocd-division/country:fk/constituency:stanley,Richard Sawle,Independent,2009,richard_sawle
-,Richard Stevens,Camp,ocd-division/country:fk/constituency:camp,Richard Stevens (Falkland Islands politician),Independent,1993,richard_stevens
-,Richard Stevens,Camp,ocd-division/country:fk/constituency:camp,Richard James Stevens,Independent,2005,richard_stevens
-,Robin Myles Lee,Camp,ocd-division/country:fk/constituency:camp,,Independent,1985,robin_myles_lee
-,Roger Edwards,Camp,ocd-division/country:fk/constituency:camp,Roger Edwards (politician),Independent,2001,roger_edwards
-,Roger Edwards,Camp,ocd-division/country:fk/constituency:camp,Roger Anthony Edwards,Independent,2009,roger_edwards
-,Roger Edwards,Camp,ocd-division/country:fk/constituency:camp,Roger Edwards (politician),Independent,2013,roger_edwards
-,Ron Binnie,Camp,ocd-division/country:fk/constituency:camp,,Independent,1989,ron_binnie
-,Ronald Eric Binnie,East Falkland,ocd-division/country:fk/constituency:east-falkland,,Independent,1981,ronald_eric_binnie
-,Sharon Halford,Stanley,ocd-division/country:fk/constituency:stanley,Sharon Halford,Independent,1993,sharon_halford
-,Sharon Halford,Stanley,ocd-division/country:fk/constituency:stanley,Sharon Halford,Independent,1997,sharon_halford
-,Sharon Halford,Camp,ocd-division/country:fk/constituency:camp,Sharon Halford,Independent,2009,sharon_halford
-,Stephen Luxton,Stanley,ocd-division/country:fk/constituency:stanley,,Independent,2001,stephen_luxton
-,Stuart Barrett Wallace,West Stanley,ocd-division/country:fk/constituency:west-stanley,,Independent,1977,stuart_barrett_wallace
-,Terence John Peck,Stanley,ocd-division/country:fk/constituency:stanley,Terence John Peck,Independent,1981,terence_john_peck
-,Terry Peck,Stanley,ocd-division/country:fk/constituency:stanley,Terry Peck,Independent,1989,terry_peck
-,Timothy John Durose Miller,Camp,ocd-division/country:fk/constituency:camp,,Independent,1977,timothy_john_durose_miller
-,Timothy John Durose Miller,Camp,ocd-division/country:fk/constituency:camp,,Independent,1985,timothy_john_durose_miller
-,Wendy Teggart,Stanley,ocd-division/country:fk/constituency:stanley,,Independent,1993,wendy_teggart
-,William Edward Bowles,Stanley,ocd-division/country:fk/constituency:stanley,,Independent,1977,william_edward_bowles
-,William Henry,East Stanley,ocd-division/country:fk/constituency:east-stanley,,Independent,1977,william_henry
-,William Henry Goss,East Stanley,ocd-division/country:fk/constituency:east-stanley,,Independent,1981,william_henry_goss
+area,party,source,wikiname,area_id,term,name,id
+East Falkland,Independent,,,ocd-division/country:fk/constituency:east-falkland,1977,Adrian Bertrand Monk,adrian_bertrand_monk
+Stanley,Independent,,Andrea Patricia Clausen,ocd-division/country:fk/constituency:stanley,2005,Andrea Clausen,andrea_clausen
+Camp,Independent,,,ocd-division/country:fk/constituency:camp,1981,Anthony Thomas Blake,anthony_thomas_blake
+Camp,Independent,,,ocd-division/country:fk/constituency:camp,1985,Anthony Thomas Blake,anthony_thomas_blake
+Stanley,Independent,,Barry Elsby,ocd-division/country:fk/constituency:stanley,2013,Barry Elsby,barry_elsby
+Camp,Independent,,Bill Luxton,ocd-division/country:fk/constituency:camp,1989,Bill Luxton,bill_luxton
+Camp,Independent,,Bill Luxton,ocd-division/country:fk/constituency:camp,1993,Bill Luxton,bill_luxton
+Camp,Independent,,Bill Luxton,ocd-division/country:fk/constituency:camp,1997,Bill Luxton,bill_luxton
+Camp,Independent,,Bill Luxton,ocd-division/country:fk/constituency:camp,2009,Bill Luxton,bill_luxton
+Stanley,Independent,,,ocd-division/country:fk/constituency:stanley,1985,"Charles Desmond Keenleyside, Jr","charles_desmond_keenleyside,_jr"
+Stanley,Independent,,,ocd-division/country:fk/constituency:stanley,1993,Charles Keenleyside,charles_keenleyside
+Stanley,Independent,,,ocd-division/country:fk/constituency:stanley,1985,Darwin Lewis Clifton,darwin_lewis_clifton
+West Falkland,Independent,,,ocd-division/country:fk/constituency:west-falkland,1977,Derek Stanley Evans,derek_stanley_evans
+Stanley,Independent,,Emma Edwards,ocd-division/country:fk/constituency:stanley,2009,Emma Edwards,emma_edwards
+Camp,Independent,,,ocd-division/country:fk/constituency:camp,1993,Eric Goss,eric_goss
+Stanley,Independent,,Gavin Short,ocd-division/country:fk/constituency:stanley,1989,Gavin Short,gavin_short
+Stanley,Independent,,Gavin Short,ocd-division/country:fk/constituency:stanley,2009,Gavin Short,gavin_short
+Stanley,Independent,,Gavin Short,ocd-division/country:fk/constituency:stanley,2013,Gavin Short,gavin_short
+Stanley,Independent,,,ocd-division/country:fk/constituency:stanley,1989,"Gerrard ""Fred"" Robson","gerrard_""fred""_robson"
+Stanley,Independent,,Glenn Ross (politician),ocd-division/country:fk/constituency:stanley,2009,Glenn Ross,glenn_ross
+Stanley,Independent,,,ocd-division/country:fk/constituency:stanley,1989,Harold Rowlands,harold_rowlands
+Camp,Independent,,Ian Hansen,ocd-division/country:fk/constituency:camp,2005,Ian Hansen,ian_hansen
+Camp,Independent,,Ian Hansen,ocd-division/country:fk/constituency:camp,2013,Ian Hansen,ian_hansen
+Stanley,Independent,,Jan Cheek,ocd-division/country:fk/constituency:stanley,1997,Jan Cheek,jan_cheek
+Stanley,Independent,,Jan Cheek,ocd-division/country:fk/constituency:stanley,2001,Jan Cheek,jan_cheek
+Stanley,Independent,,Jan Cheek,ocd-division/country:fk/constituency:stanley,2009,Jan Cheek,jan_cheek
+Stanley,Independent,,Jan Cheek,ocd-division/country:fk/constituency:stanley,2013,Jan Cheek,jan_cheek
+Stanley,Independent,,Janet Robertson,ocd-division/country:fk/constituency:stanley,2005,Janet Robertson,janet_robertson
+Stanley,Independent,,John Birmingham (politician),ocd-division/country:fk/constituency:stanley,1997,John Birmingham,john_birmingham
+Stanley,Independent,,John Birmingham (politician),ocd-division/country:fk/constituency:stanley,2001,John Birmingham,john_birmingham
+Stanley,Independent,,,ocd-division/country:fk/constituency:stanley,1993,John Cheek,john_cheek
+West Stanley,Independent,,,ocd-division/country:fk/constituency:west-stanley,1981,John Edward Cheek,john_edward_cheek
+Stanley,Independent,,,ocd-division/country:fk/constituency:stanley,1985,John Edward Cheek,john_edward_cheek
+Camp,Independent,,,ocd-division/country:fk/constituency:camp,1989,Kevin Kilmartin,kevin_kilmartin
+Stanley,Independent,,,ocd-division/country:fk/constituency:stanley,1997,Lewis Clifton,lewis_clifton
+West Falkland,Independent,,,ocd-division/country:fk/constituency:west-falkland,1981,Lionel Geoffrey Blake,lionel_geoffrey_blake
+Camp,Independent,,,ocd-division/country:fk/constituency:camp,1985,Lionel Geoffrey Blake,lionel_geoffrey_blake
+Stanley,Independent,,Michael Poole (politician),ocd-division/country:fk/constituency:stanley,2013,Michael Poole,michael_poole
+Camp,Independent,,Michael Rendell,ocd-division/country:fk/constituency:camp,2005,Michael Rendell,michael_rendell
+Stanley,Independent,,Mike Summers,ocd-division/country:fk/constituency:stanley,2001,Michael Summers,michael_summers
+Stanley,Independent,,Mike Summers,ocd-division/country:fk/constituency:stanley,1997,Mike Summers,mike_summers
+Stanley,Independent,,Mike Summers,ocd-division/country:fk/constituency:stanley,2005,Mike Summers,mike_summers
+Stanley,Independent,,Mike Summers,ocd-division/country:fk/constituency:stanley,2013,Mike Summers,mike_summers
+Stanley,Independent,,,ocd-division/country:fk/constituency:stanley,1985,Norma Edwards,norma_edwards
+Camp,Independent,,,ocd-division/country:fk/constituency:camp,1989,Norma Edwards,norma_edwards
+Camp,Independent,,,ocd-division/country:fk/constituency:camp,1993,Norma Edwards,norma_edwards
+Camp,Independent,,,ocd-division/country:fk/constituency:camp,1997,Norma Edwards,norma_edwards
+Camp,Independent,,,ocd-division/country:fk/constituency:camp,2001,Norma Edwards,norma_edwards
+Camp,Independent,,,ocd-division/country:fk/constituency:camp,2001,Philip Miller,philip_miller
+Camp,Independent,,Phyllis Rendell,ocd-division/country:fk/constituency:camp,2013,Phyllis Rendell,phyllis_rendell
+Camp,Independent,,Richard Cockwell,ocd-division/country:fk/constituency:camp,1997,Richard Cockwell,richard_cockwell
+Stanley,Independent,,Richard Cockwell,ocd-division/country:fk/constituency:stanley,2001,Richard Cockwell,richard_cockwell
+Stanley,Independent,,Richard Cockwell,ocd-division/country:fk/constituency:stanley,2005,Richard Cockwell,richard_cockwell
+Stanley,Independent,,,ocd-division/country:fk/constituency:stanley,2005,Richard Davies,richard_davies
+Stanley,Independent,,Richard Sawle,ocd-division/country:fk/constituency:stanley,2009,Richard Sawle,richard_sawle
+Camp,Independent,,Richard Stevens (Falkland Islands politician),ocd-division/country:fk/constituency:camp,1993,Richard Stevens,richard_stevens
+Camp,Independent,,Richard James Stevens,ocd-division/country:fk/constituency:camp,2005,Richard Stevens,richard_stevens
+Camp,Independent,,,ocd-division/country:fk/constituency:camp,1985,Robin Myles Lee,robin_myles_lee
+Camp,Independent,,Roger Edwards (politician),ocd-division/country:fk/constituency:camp,2001,Roger Edwards,roger_edwards
+Camp,Independent,,Roger Anthony Edwards,ocd-division/country:fk/constituency:camp,2009,Roger Edwards,roger_edwards
+Camp,Independent,,Roger Edwards (politician),ocd-division/country:fk/constituency:camp,2013,Roger Edwards,roger_edwards
+Camp,Independent,,,ocd-division/country:fk/constituency:camp,1989,Ron Binnie,ron_binnie
+East Falkland,Independent,,,ocd-division/country:fk/constituency:east-falkland,1981,Ronald Eric Binnie,ronald_eric_binnie
+Stanley,Independent,,Sharon Halford,ocd-division/country:fk/constituency:stanley,1993,Sharon Halford,sharon_halford
+Stanley,Independent,,Sharon Halford,ocd-division/country:fk/constituency:stanley,1997,Sharon Halford,sharon_halford
+Camp,Independent,,Sharon Halford,ocd-division/country:fk/constituency:camp,2009,Sharon Halford,sharon_halford
+Stanley,Independent,,,ocd-division/country:fk/constituency:stanley,2001,Stephen Luxton,stephen_luxton
+West Stanley,Independent,,,ocd-division/country:fk/constituency:west-stanley,1977,Stuart Barrett Wallace,stuart_barrett_wallace
+Stanley,Independent,,Terence John Peck,ocd-division/country:fk/constituency:stanley,1981,Terence John Peck,terence_john_peck
+Stanley,Independent,,Terry Peck,ocd-division/country:fk/constituency:stanley,1989,Terry Peck,terry_peck
+Camp,Independent,,,ocd-division/country:fk/constituency:camp,1977,Timothy John Durose Miller,timothy_john_durose_miller
+Camp,Independent,,,ocd-division/country:fk/constituency:camp,1985,Timothy John Durose Miller,timothy_john_durose_miller
+Stanley,Independent,,,ocd-division/country:fk/constituency:stanley,1993,Wendy Teggart,wendy_teggart
+Stanley,Independent,,,ocd-division/country:fk/constituency:stanley,1977,William Edward Bowles,william_edward_bowles
+East Stanley,Independent,,,ocd-division/country:fk/constituency:east-stanley,1977,William Henry,william_henry
+East Stanley,Independent,,,ocd-division/country:fk/constituency:east-stanley,1981,William Henry Goss,william_henry_goss

--- a/data/Falkland_Islands/Assembly/unstable/positions.csv
+++ b/data/Falkland_Islands/Assembly/unstable/positions.csv
@@ -1,1 +1,1 @@
-id,name,position,start_date,end_date
+id,name,position,start_date,end_date,type

--- a/data/Falkland_Islands/Assembly/unstable/stats.json
+++ b/data/Falkland_Islands/Assembly/unstable/stats.json
@@ -16,6 +16,6 @@
     "latest": "2013-11-07"
   },
   "positions": {
-    "executive": 0
+    "cabinet": 0
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/everypolitician/everypolitician-data/issues/16432

Because of a change in the wikipedia page table layout, the scraper was pulling in members called 'Nonpartisan'.

The scraper has been amended -- and also moved to morph.io/everypolitician-scrapers/... -- and the instructions file has been updated.