### PR TITLE
Run pull request cleaner on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: ruby
+script: bundle exec rake test
 rvm:
   - 2.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: ruby
 script: bundle exec rake test
 rvm:
   - 2.3.1
+env:
+  global:
+    secure: ZCQVQdKDUyPY/BM1FYriv6h+rNF+PqQETnj5FwU/jQKNz8utvaUVjXD/pIMwEmO5orzng5/MnZvErkr2+JZBs+0JghXWtjDxQHxJzfBTZJnaiAY9hWZBC9Kgbl1/mJvUvK132W5GzQ5xS9lw/pyKFGRba9A7rfoYFfkaJKmgq1U=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-script: bundle exec rake test
+script: bundle exec rake test close_old_pull_requests
 rvm:
   - 2.3.1
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 script: bundle exec rake test close_old_pull_requests
+cache: bundler
 rvm:
   - 2.3.1
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'json5'
 gem 'slop', '~> 3.6.0' # tied to pry version
 gem 'rcsv'
 gem 'require_all'
+gem 'close_old_pull_requests', git: 'https://github.com/everypolitician/close_old_pull_requests', branch: 'master'
 
 group :test do
   gem 'minitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,14 @@ GIT
       rcsv
       twitter_username_extractor
 
+GIT
+  remote: https://github.com/everypolitician/close_old_pull_requests
+  revision: ea9fe6f2b2468af95af84170bd01c0fddb7f3781
+  branch: master
+  specs:
+    close_old_pull_requests (0.1.0)
+      octokit (~> 4.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -45,6 +53,8 @@ GEM
     domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
     facebook_username_extractor (0.2.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     flog (4.4.0)
       path_expander (~> 1.0)
       ruby_parser (~> 3.1, > 3.1.0)
@@ -63,10 +73,13 @@ GEM
     minitest (5.9.0)
     minitest-around (0.3.2)
       minitest (~> 5.0)
+    multipart-post (2.0.0)
     netrc (0.11.0)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
+    octokit (4.3.0)
+      sawyer (~> 0.7.0, >= 0.5.3)
     parser (2.3.1.2)
       ast (~> 2.2)
     path_expander (1.0.0)
@@ -95,6 +108,9 @@ GEM
       sexp_processor (~> 4.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
+    sawyer (0.7.0)
+      addressable (>= 2.3.5, < 2.5)
+      faraday (~> 0.8, < 0.10)
     sexp_processor (4.7.0)
     slop (3.6.0)
     unf (0.1.4)
@@ -113,6 +129,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  close_old_pull_requests!
   colorize
   csv_to_popolo (~> 0.26.1)!
   everypolitician!

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -108,3 +108,11 @@ Rake::TestTask.new do |t|
 end
 
 task default: :test
+
+desc "Go through the list of open pull requests and close any outdated ones"
+task :close_old_pull_requests do
+  require 'close_old_pull_requests'
+  CloseOldPullRequests.clean.each do |pull_request|
+    puts "Pull request #{pull_request.number} is outdated. (Newest pull request is #{pull_request.superseded_by.number})"
+  end
+end


### PR DESCRIPTION
This adds a new Rake task that gets run on Travis which goes through the open pull requests and closes any that are outdated. It uses [close_old_pull_requests](https://github.com/everypolitician/close_old_pull_requests) to do the actual work, and it replaces [pull_request_cleaner](https://github.com/everypolitician/pull_request_cleaner).