### PR TITLE
Ignore short lines from Google Analytics

### DIFF
--- a/bin/dashboard.rb
+++ b/bin/dashboard.rb
@@ -10,7 +10,9 @@ require 'csv'
 
 (analytics_file = ARGV.first) || abort("Usage: #{$PROGRAM_NAME} <analytics.csv>")
 drilldown = CSV.table(analytics_file)
-ordering = Hash[drilldown.select { |r| (r[0].to_s.length > 1) && (r[0][0] == r[0][-1]) }.each_with_index.map { |r, i| [r[0].delete('/'), i] }]
+ordering = drilldown.reject { |r| r.count < 5 }.
+  select { |r| (r[0].to_s.length > 1) && (r[0][0] == r[0][-1])
+}.each_with_index.map { |r, i| [r[0].delete('/'), i] }.to_h
 
 EveryPolitician.countries_json = 'countries.json'
 


### PR DESCRIPTION
When reading the export file from Google Analytics, ignore any lines
that don't have enough fields.

Various parts of this file (particularly at the start and end) have an
entirely different format from the 'meat' that we care about, and
something that recently changed in the layout of this started breaking
the dashboard generation script. The easiest way to prevent this is to
simply ignore lines that don't look like they're in the correct format.