### PR TITLE
use Everypolitician not EveryPolitician

### DIFF
--- a/lib/country_data.rb
+++ b/lib/country_data.rb
@@ -1,5 +1,5 @@
 
-module EveryPolitician
+module Everypolitician
   class Country
     # The metadata for a country, included in countries.json
     class Metadata


### PR DESCRIPTION
We alias EveryPolitician to Everypolitician separately, so explicitly
using EveryPolitician in the module definition causes:

```
warning: already initialized constant EveryPolitician
```