### PR TITLE
Use rake task from Everypolitician::PullRequest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-script: bundle exec rake test close_old_pull_requests pull_request_summary
+script: bundle exec rake test close_old_pull_requests pull_request_summary:travis
 cache: bundler
 rvm:
   - 2.3.1

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'slop', '~> 3.6.0' # tied to pry version
 gem 'rcsv'
 gem 'require_all'
 gem 'close_old_pull_requests', git: 'https://github.com/everypolitician/close_old_pull_requests', branch: 'master'
-gem 'everypolitician-pull_request'
+gem 'everypolitician-pull_request', git: 'https://github.com/everypolitician/everypolitician-pull_request', branch: 'master'
 
 group :test do
   gem 'minitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GIT
 
 GIT
   remote: https://github.com/everypolitician/everypolitician-pull_request
-  revision: c51041571d1d709a14eb68101ca96fe66856ecba
+  revision: 89d50f6903f8e6b7bb9f43c822067c49b2e17815
   branch: master
   specs:
     everypolitician-pull_request (0.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,16 @@ GIT
     close_old_pull_requests (0.1.0)
       octokit (~> 4.3)
 
+GIT
+  remote: https://github.com/everypolitician/everypolitician-pull_request
+  revision: c51041571d1d709a14eb68101ca96fe66856ecba
+  branch: master
+  specs:
+    everypolitician-pull_request (0.4.0)
+      everypolitician-popolo
+      octokit
+      require_all
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -52,10 +62,6 @@ GEM
       safe_yaml (~> 1.0.0)
     domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
-    everypolitician-pull_request (0.1.0)
-      everypolitician-popolo
-      octokit
-      require_all
     facebook_username_extractor (0.2.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -138,7 +144,7 @@ DEPENDENCIES
   csv_to_popolo (~> 0.26.1)!
   everypolitician!
   everypolitician-popolo (~> 0.6.0)!
-  everypolitician-pull_request
+  everypolitician-pull_request!
   facebook_username_extractor (~> 0.2.0)
   flog
   fuzzy_match

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -68,23 +68,5 @@ task :close_old_pull_requests do
   end
 end
 
-desc "Post a summary of the pull request that's currently being built"
-task :pull_request_summary do
-  if ENV['TRAVIS_PULL_REQUEST'] == 'false'
-    warn 'Not building a pull request, skipping pull_request_summary'
-    next
-  end
-  require 'everypolitician/pull_request'
-  repo_slug = ENV.fetch('TRAVIS_REPO_SLUG', 'everypolitician/everypolitician-data')
-  pull_request_number = ENV['TRAVIS_PULL_REQUEST'] || ENV['PULL_REQUEST']
-  abort 'error: Please supply a pull request number: ' \
-    'bundle exec rake pull_request_summary PULL_REQUEST=12345' if pull_request_number.nil?
-  body = Everypolitician::PullRequest::Summary.new(pull_request_number).as_markdown
-  github = Octokit::Client.new(access_token: ENV['GITHUB_ACCESS_TOKEN'])
-  begin
-    github.add_comment(repo_slug, pull_request_number, body)
-  rescue Octokit::Unauthorized
-    abort 'unauthorized: Please set GITHUB_ACCESS_TOKEN in the environment ' \
-      'and try again. https://github.com/settings/tokens'
-  end
-end
+require 'everypolitician/pull_request/rake_task'
+Everypolitician::PullRequest::RakeTask.new

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -69,4 +69,4 @@ task :close_old_pull_requests do
 end
 
 require 'everypolitician/pull_request/rake_task'
-Everypolitician::PullRequest::RakeTask.new
+Everypolitician::PullRequest::RakeTask.new.install_tasks


### PR DESCRIPTION
~~This change splits up the `rake pull_request_summary` command. There are now three versions:~~

~~1. `pull_request_summary:print` will print a summary of the pull request
    to the terminal.
2. `pull_request_summary:comment` is for running locally and will post a
    comment to GitHub as you if there's an access token in the environment.
3. `pull_request_summary:travis` is for running on Travis and will post
    a comment to GitHub as the bot.~~


This switches to the rake task that was introduced in https://github.com/everypolitician/everypolitician-pull_request/pull/6. This means that we're not filling up the rakefiles with code that's better suited living in the same place as the library it calls.

Follows on from #16985 