### PR TITLE
Run the tests last on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-script: bundle exec rake test close_old_pull_requests pull_request_summary:travis
+script: bundle exec rake close_old_pull_requests pull_request_summary:travis test
 cache: bundler
 rvm:
   - 2.3.1


### PR DESCRIPTION
The tests are the slowest of the three rake tasks that run on Travis by quite a margin. Running them last means that the pull request summary and cleaner can get their work done before the actual testing begins.

This is all part of the wider move to doing more work as part of the Travis build.