### PR TITLE
use everpolitician-dataview-terms to generate CSVs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'rcsv'
 gem 'require_all'
 gem 'close_old_pull_requests', git: 'https://github.com/everypolitician/close_old_pull_requests', branch: 'master'
 gem 'everypolitician-pull_request', git: 'https://github.com/everypolitician/everypolitician-pull_request', branch: 'master'
+gem 'everypolitician-dataview-terms', github: 'everypolitician/everypolitician-dataview-terms'
 
 group :test do
   gem 'minitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: git://github.com/everypolitician/everypolitician-dataview-terms.git
+  revision: c492d2247b5a5693a91f45575b5d753bbe58931c
+  specs:
+    everypolitician-dataview-terms (0.0.1)
+      everypolitician-popolo
+
+GIT
   remote: git://github.com/everypolitician/everypolitician-popolo.git
   revision: 63c7a135c8436e77f0b7c5e6d3c43f91ee11e88a
   specs:
@@ -143,6 +150,7 @@ DEPENDENCIES
   colorize
   csv_to_popolo (~> 0.26.1)!
   everypolitician!
+  everypolitician-dataview-terms!
   everypolitician-popolo (~> 0.6.0)!
   everypolitician-pull_request!
   facebook_username_extractor (~> 0.2.0)


### PR DESCRIPTION
The code for generating the term CSVs has been extracted to its own gem:
  https://github.com/everypolitician/everypolitician-dataview-terms

This replaces the internal implementation with calls to that library instead.

`bundle exec bin/run_command_for_each_legislature rake clean default` shows no changes to any CSV file.

Part of https://github.com/everypolitician/everypolitician/issues/320