### PR TITLE
EP_COUNTRY_REFRESH should work by slug

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -1,4 +1,5 @@
 
+require 'everypolitician'
 require 'fileutils'
 require 'pathname'
 require 'pry'
@@ -26,9 +27,8 @@ task 'countries.json' do
   # we only build any country that contains that string. For example:
   #    EP_COUNTRY_REFRESH=Latvia be rake countries.json
   to_build = ENV['EP_COUNTRY_REFRESH'] || 'data'
-
-  countries = @HOUSES.group_by { |h| h.split('/')[1] }.select do |_, hs|
-    hs.any? { |h| h.include? to_build }
+  countries = EveryPolitician.countries.select do |c|
+    c.slug.downcase.include? to_build.downcase
   end
 
   data = json_load('countries.json') rescue {}
@@ -36,13 +36,16 @@ task 'countries.json' do
   # it's much faster to pass the single directory 'data' than a list
   # of every country directory:
   commit_metadata = file_to_commit_metadata(
-    to_build == 'data' ? ['data'] : countries.values.flatten
+    to_build == 'data' ?
+      ['data'] :
+      countries.flat_map(&:legislatures).map { |l| 'data/' + l.directory }
   )
 
-  countries.each do |c, hs|
+  countries.each do |c|
     country = Everypolitician::Country::Metadata.new(
-      country: c,
-      dirs: hs,
+      # TODO: change this to accept an EveryPolitician::Country
+      country: c.name,
+      dirs: c.legislatures.map { |l| 'data/' + l.directory },
       commit_metadata: commit_metadata,
     ).stanza
     data[data.find_index { |c| c[:name] == country[:name] }] = country

--- a/lib/country_data.rb
+++ b/lib/country_data.rb
@@ -41,7 +41,7 @@ module Everypolitician
       end
 
       def slug
-        country.tr('_', '-')
+        country.tr('_', '-').tr(' ', '-')
       end
     end
   end


### PR DESCRIPTION
## Context

Previously we assumed we were working with a country in directory-name format (e.g. South_Africa), but the Rebuilder is passing us slugs (i.e. South-Africa). That's the more correct behaviour, so switch to assuming that's what we're getting.

## Related tickets

Closes https://github.com/everypolitician/everypolitician/issues/486

## Notes to reviewer
The implementation is a little bit clumsy at the moment — we can clean things up substantially by making everything assume they'll be dealing with `EveryPolitician::Country` or `EveryPolitician::Legislature objects`, but that should happen as a separate change.

Also, there's still a slight bootstrapping problem here when we add a new country, but in that case we can just generate an entire file, rather than by country name.

