### PR TITLE
Deploy everypolitician.org from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,8 @@ rvm:
 env:
   global:
     secure: ZCQVQdKDUyPY/BM1FYriv6h+rNF+PqQETnj5FwU/jQKNz8utvaUVjXD/pIMwEmO5orzng5/MnZvErkr2+JZBs+0JghXWtjDxQHxJzfBTZJnaiAY9hWZBC9Kgbl1/mJvUvK132W5GzQ5xS9lw/pyKFGRba9A7rfoYFfkaJKmgq1U=
+deploy:
+  provider: script
+  script: scripts/deploy.sh
+  on:
+    branch: master

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,7 +21,7 @@ build_viewer_static() {
 
 deploy_viewer_static() {
   cd /tmp
-  git clone https://github.com/everypolitician/viewer-static.git
+  git clone --depth=1 https://github.com/everypolitician/viewer-static.git
   cd viewer-static
   git checkout gh-pages
   cp -R /tmp/localhost:4567/* .

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+[[ "$TRACE" ]] && set -x
+
+start_viewer_sinatra() {
+  mkdir -p /tmp/viewer-sinatra
+  cd /tmp/viewer-sinatra
+  # TODO: Make `master` configurable
+  curl -fsSL https://github.com/everypolitician/viewer-sinatra/archive/master.tar.gz | tar -x -f - --strip 1
+  bundle install
+  bundle exec ruby app.rb &
+  while ! nc -z localhost 4567; do sleep 1; done
+}
+
+build_viewer_static() {
+  cd /tmp
+  wget -nv -m localhost:4567/status/all_countries.html || (echo "wget exited with non-zero exit code: $?" >&2 && exit 1)
+}
+
+deploy_viewer_static() {
+  cd /tmp
+  git clone https://github.com/everypolitician/viewer-static.git
+  cd viewer-static
+  git checkout gh-pages
+  cp -R /tmp/localhost:4567/* .
+  git add .
+  git -c "user.name=everypoliticianbot" -c "user.email=everypoliticianbot@users.noreply.github.com" commit -m "Automated commit" || true
+  git push origin gh-pages
+}
+
+main() {
+  start_viewer_sinatra
+  build_viewer_static
+  deploy_viewer_static
+}
+
+main

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+#
+# This script is very similar to, but not exactly the same as
+# `scripts/release.sh` in viewer-sinatra. Any significant changes to this
+# script might also need to be made there as well. It may also get to a point
+# where we want to combine the scripts into a shared repository, but for now
+# they're different enough to keep separate, I think.
+#
+# @see https://git.io/viyyo
 
 set -eo pipefail
 


### PR DESCRIPTION
This adds a script to deploy http://everypolitician.org that runs each time Travis successfully builds the `master` branch.

It does this by installing [viewer-sinatra](https://github.com/everypolitician/viewer-sinatra) and using it to rebuild [viewer-static](https://github.com/everypolitician/viewer-static).

Related to https://github.com/everypolitician/everypolitician/issues/506 as part of [changing how everypolitician.org is deployed](https://github.com/everypolitician/everypolitician/projects/2).