### PR TITLE
Add missing switch to tar command in deploy script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,7 +16,7 @@ start_viewer_sinatra() {
   mkdir -p /tmp/viewer-sinatra
   cd /tmp/viewer-sinatra
   # TODO: Make `master` configurable
-  curl -fsSL https://github.com/everypolitician/viewer-sinatra/archive/master.tar.gz | tar -x -f - --strip 1
+  curl -fsSL https://github.com/everypolitician/viewer-sinatra/archive/master.tar.gz | tar -z -x -f - --strip 1
   bundle install
   bundle exec ruby app.rb &
   while ! nc -z localhost 4567; do sleep 1; done


### PR DESCRIPTION
Travis was failing to deploy because the version of tar(1) on Linux
doesn't automatically add the -z switch like the OS X version does.

https://travis-ci.org/everypolitician/everypolitician-data/builds/161313383#L312-L313