### PR TITLE
Use .netrc on Travis for GitHub access token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - echo -e "machine github.com\n  login $GITHUB_ACCESS_TOKEN" >> ~/.netrc
 script: bundle exec rake close_old_pull_requests pull_request_summary:travis test
 cache: bundler
 rvm:


### PR DESCRIPTION
Rather than embed the access token in the url we want to add it to `.netrc` so that it gets picked up by git.

This is the same as the change I made in https://github.com/everypolitician/viewer-sinatra/pull/15551, it should have been part of https://github.com/everypolitician/everypolitician-data/pull/17407 but I forgot to include it 😞 

Travis docs: https://docs.travis-ci.com/user/private-dependencies/#API-Token