### PR TITLE
Try using a newer Ruby version for deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ env:
     secure: ZCQVQdKDUyPY/BM1FYriv6h+rNF+PqQETnj5FwU/jQKNz8utvaUVjXD/pIMwEmO5orzng5/MnZvErkr2+JZBs+0JghXWtjDxQHxJzfBTZJnaiAY9hWZBC9Kgbl1/mJvUvK132W5GzQ5xS9lw/pyKFGRba9A7rfoYFfkaJKmgq1U=
 deploy:
   provider: script
-  script: scripts/deploy.sh
+  script: rvm $TRAVIS_RUBY_VERSION do scripts/deploy.sh
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ env:
     secure: ZCQVQdKDUyPY/BM1FYriv6h+rNF+PqQETnj5FwU/jQKNz8utvaUVjXD/pIMwEmO5orzng5/MnZvErkr2+JZBs+0JghXWtjDxQHxJzfBTZJnaiAY9hWZBC9Kgbl1/mJvUvK132W5GzQ5xS9lw/pyKFGRba9A7rfoYFfkaJKmgq1U=
 deploy:
   provider: script
+  # $TRAVIS_RUBY_VERSION will be set to the Ruby version the Travis build uses,
+  # which is set in the `rvm` section above.
+  # @see https://docs.travis-ci.com/user/deployment/script/#Deployment-is-executed-by-Ruby-1.9.3
   script: rvm $TRAVIS_RUBY_VERSION do scripts/deploy.sh
   on:
     branch: master


### PR DESCRIPTION
Travis [defaults to Ruby 1.9.3 for "reliability"](https://docs.travis-ci.com/user/deployment/script/#Deployment-is-executed-by-Ruby-1.9.3). This change means that the deploy script will be run in an [rvm environment](https://rvm.io/set/do) that configures the Ruby on the current `PATH` to be the same as the Ruby that we use for the rest of the build.

Fixes https://github.com/everypolitician/everypolitician/issues/511