### PR TITLE
Correct how Wikidata is added to a Term

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
-﻿# This file documents substantial changes to the format of data files
+﻿# This file documents substantial changes to the format of data files
+
+2016-09-23
+
+* Wikidata references are no longer at the top level of legislative
+period `Event`s, but now correctly included as `identifiers`
 
 2016-07-26
 

--- a/data/Estonia/Riigikogu/ep-popolo-v1.0.json
+++ b/data/Estonia/Riigikogu/ep-popolo-v1.0.json
@@ -29790,10 +29790,15 @@
       "classification": "legislative period",
       "end_date": "2015-03-23",
       "id": "term/12",
+      "identifiers": [
+        {
+          "identifier": "Q967549",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "12th Riigikogu",
       "organization_id": "1ba661a9-22ad-4d0f-8a60-fe8e28f2488c",
-      "start_date": "2011-03-27",
-      "wikidata": "Q967549"
+      "start_date": "2011-03-27"
     },
     {
       "classification": "general election",
@@ -29805,10 +29810,15 @@
     {
       "classification": "legislative period",
       "id": "term/13",
+      "identifiers": [
+        {
+          "identifier": "Q20530392",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "13th Riigikogu",
       "organization_id": "1ba661a9-22ad-4d0f-8a60-fe8e28f2488c",
-      "start_date": "2015-03-30",
-      "wikidata": "Q20530392"
+      "start_date": "2015-03-30"
     }
   ],
   "areas": [

--- a/rake_build/generate_ep_popolo.rb
+++ b/rake_build/generate_ep_popolo.rb
@@ -77,7 +77,10 @@ namespace :transform do
         name:            row['name'],
         start_date:      row['start_date'],
         end_date:        row['end_date'],
-        wikidata:        row['wikidata'],
+        identifiers:     row['wikidata'].to_s.empty? ? [] : [{
+          scheme:     'wikidata',
+          identifier: row['wikidata']
+        }],
         classification:  'legislative period',
         organization_id: @legislature[:id],
       }.reject { |_, v| v.nil? || v.empty? }


### PR DESCRIPTION
These should be included in `identifiers` per http://www.popoloproject.com/specs/event.html (and per how we do it for Persons, Organisations, etc), not directly embedded at the top level.

Fixes https://github.com/everypolitician/everypolitician/issues/513