### PR TITLE
Add an `Instructions.sources_of_type` method

### DIFF
--- a/lib/instructions.rb
+++ b/lib/instructions.rb
@@ -9,6 +9,10 @@ class Instructions
     @sources ||= raw_sources.map { |s| Source::Base.instantiate(s) }
   end
 
+  def sources_of_type(type)
+    sources.select { |src| src.type.to_s.downcase == type.to_s.downcase }
+  end
+
   def write(data)
     path.write(JSON.pretty_generate(data))
   end

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -40,10 +40,6 @@ module Source
       false
     end
 
-    def is_wikidata?
-      false
-    end
-
     def is_bios?
       false
     end
@@ -212,10 +208,6 @@ module Source
   class Wikidata < Person
     def fields
       super << :identifier__wikidata
-    end
-
-    def is_wikidata?
-      true
     end
 
     def reconciliation_file

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -36,7 +36,7 @@ module Source
       i(:merge)
     end
 
-    def is_bios?
+    def person_data?
       false
     end
 
@@ -180,7 +180,7 @@ module Source
   end
 
   class Person < CSV
-    def is_bios?
+    def person_data?
       true
     end
   end

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -36,10 +36,6 @@ module Source
       i(:merge)
     end
 
-    def is_memberships?
-      false
-    end
-
     def is_bios?
       false
     end
@@ -149,10 +145,6 @@ module Source
   end
 
   class Membership < CSV
-    def is_memberships?
-      true
-    end
-
     def id_map
       id_mapper.mapping
     end

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -44,10 +44,6 @@ module Source
       false
     end
 
-    def has_people?
-      false
-    end
-
     def recreateable?
       i(:create)
     end
@@ -157,10 +153,6 @@ module Source
       true
     end
 
-    def has_people?
-      true
-    end
-
     def id_map
       id_mapper.mapping
     end
@@ -197,10 +189,6 @@ module Source
 
   class Person < CSV
     def is_bios?
-      true
-    end
-
-    def has_people
       true
     end
   end

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -143,7 +143,7 @@ namespace :merge_sources do
     end
 
     # Gender information from Gender-Balance.org
-    if gb = @SOURCES.find { |src| src.type.downcase == 'gender' }
+    @INSTRUCTIONS.sources_of_type('gender').each do |gb|
       warn "Adding GenderBalance results from #{gb.filename}".green
       results = GenderBalancer.new(gb.as_table).results
       gb_score = gb_added = 0
@@ -166,7 +166,7 @@ namespace :merge_sources do
     end
 
     # Map Areas
-    if area = @SOURCES.find { |src| src.type.downcase == 'ocd' }
+    @INSTRUCTIONS.sources_of_type('ocd').each do |area|
       warn "Adding OCD areas from #{area.filename}".green
       ocds = area.as_table.group_by { |r| r[:id] }
 
@@ -202,7 +202,7 @@ namespace :merge_sources do
     end
 
     # Any local corrections in manual/corrections.csv
-    if corrs = @SOURCES.find { |src| src.type.downcase == 'corrections' }
+    @INSTRUCTIONS.sources_of_type('corrections').each do |corrs|
       warn "Applying local corrections from #{corrs.filename}".green
       corrs.as_table.each do |correction|
         rows = merged_rows.select { |r| r[:uuid] == correction[:uuid] }

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -65,7 +65,7 @@ namespace :merge_sources do
     merged_rows = []
 
     # First get all the `membership` rows, and either merge or concat
-    @SOURCES.select(&:is_memberships?).each do |src|
+    @INSTRUCTIONS.sources_of_type('membership').each do |src|
       warn "Add memberships from #{src.filename}".green
 
       incoming_data = src.as_table

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -93,9 +93,8 @@ namespace :merge_sources do
 
     end
 
-    # Then merge with Biographical data files
-
-    @SOURCES.select(&:is_bios?).each do |src|
+    # Then merge with sources of plain Person data (i.e Person or Wikidata)
+    @SOURCES.select(&:person_data?).each do |src|
       warn "Merging with #{src.filename}".green
 
       incoming_data = src.as_table

--- a/rake_build/generate_ep_popolo.rb
+++ b/rake_build/generate_ep_popolo.rb
@@ -170,7 +170,7 @@ namespace :transform do
   #---------------------------------------------------------------------
   task write: :election_info
   task election_info: :load do
-    @SOURCES.select { |src| src.type.to_s.downcase == 'wikidata-elections' }.each do |src|
+    @INSTRUCTIONS.sources_of_type('wikidata-elections').each do |src|
       elections = src.as_json
       elections.each do |id, data|
         name = data[:other_names].find { |h| h[:lang] == 'en' } or next warn "no English name for #{id}"
@@ -195,7 +195,7 @@ namespace :transform do
   #---------------------------------------------------------------------
   task write: :area_wikidata
   task area_wikidata: :load do
-    @SOURCES.select { |src| src.type.to_s.downcase == 'area-wikidata' }.each do |src|
+    @INSTRUCTIONS.sources_of_type('area-wikidata').each do |src|
       area_data = src.as_json
       @json[:areas].each do |area|
         next unless area[:type] == 'constituency'
@@ -210,7 +210,7 @@ namespace :transform do
   #---------------------------------------------------------------------
   task write: :group_wikidata
   task group_wikidata: :load do
-    @SOURCES.select { |src| src.type.to_s.downcase == 'group' }.each do |src|
+    @INSTRUCTIONS.sources_of_type('group').each do |src|
       group_data = src.as_json
       @json[:organizations].select { |o| o[:classification] == 'party' }.each do |org|
         # FIXME: This doesn't do a deep merge, so any nested arrays on 'org'

--- a/rake_config/wikidata.rb
+++ b/rake_config/wikidata.rb
@@ -2,7 +2,7 @@
 desc 'Handle moved Wikidata'
 namespace :wikidata do
   task :handle_move, [:from, :to] do |_, args|
-    rfile = sources.find(&:is_wikidata?).reconciliation_file
+    rfile = @INSTRUCTIONS.sources_of_type('wikidata').first.reconciliation_file
     data = rfile.to_h
     abort "No existing data for #{args[:from]}" unless data[args[:from]]
     abort "Already have data for #{args[:to]}" if data[args[:to]]


### PR DESCRIPTION
Rather than having multiple places iterate over all sources, checking their
type, hide this all behind a `sources_of_type` method on the Instructions class.

This isn’t really an ideal name, but it’ll do for now, whilst we’re heavily rewriting this whole area.