### PR TITLE
Split out separate Source class files

### DIFF
--- a/lib/source.rb
+++ b/lib/source.rb
@@ -88,9 +88,6 @@ module Source
     end
   end
 
-  class Area < JSON
-  end
-
   class Elections < JSON
   end
 

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -87,7 +87,4 @@ module Source
       File.read(filename)
     end
   end
-
-  class Corrections < PlainCSV
-  end
 end

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -88,9 +88,6 @@ module Source
     end
   end
 
-  class Elections < JSON
-  end
-
   class Positions < JSON
   end
 

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -88,22 +88,6 @@ module Source
     end
   end
 
-  class CSV < PlainCSV
-    def fields
-      headers.map { |h| remap(h.to_s.downcase) }
-    end
-
-    def raw_table
-      rows = []
-      super.each do |row|
-        # Need to make a copy in case there are multiple source columns
-        # mapping to the same term (e.g. with areas)
-        rows << Hash[row.keys.each.map { |h| [remap(h), row[h].nil? ? nil : row[h].tidy] }]
-      end
-      rows
-    end
-  end
-
   class JSON < Base
     def fields
       []

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -98,41 +98,6 @@ module Source
     end
   end
 
-  class Membership < CSV
-    def id_map
-      id_mapper.mapping
-    end
-
-    def write_id_map_file!(data)
-      id_mapper.rewrite(data)
-    end
-
-    def raw_table
-      super.each do |r|
-        # if the source has no ID, generate one
-        r[:id] = r[:name].downcase.gsub(/\s+/, '_') if r[:id].to_s.empty?
-      end
-    end
-
-    # Currently we just recognise a hash of k:v pairs to accept if matching
-    # TODO: add 'reject' and more complex expressions
-    def as_table
-      return raw_table unless i(:filter)
-      filter = ->(row) { i(:filter)[:accept].all? { |k, v| row[k] == v } }
-      @_filtered ||= raw_table.select { |row| filter.call(row) }
-    end
-
-    private
-
-    def id_mapper
-      @map ||= UuidMapFile.new(id_map_file)
-    end
-
-    def id_map_file
-      Pathname.new(filename.sub(/.csv$/, '-ids.csv'))
-    end
-  end
-
   class Person < CSV
     def person_data?
       true

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -98,19 +98,6 @@ module Source
     end
   end
 
-
-  class Wikidata < Person
-    def fields
-      super << :identifier__wikidata
-    end
-
-    def reconciliation_file
-      Reconciliation::File.new(
-        Pathname.new('sources/') + i(:merge)[:reconciliation_file]
-      )
-    end
-  end
-
   class OCD < CSV
     def fields
       %i(area area_id)

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -88,9 +88,6 @@ module Source
     end
   end
 
-  class Group < JSON
-  end
-
   class Area < JSON
   end
 

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -88,9 +88,6 @@ module Source
     end
   end
 
-  class Term < PlainCSV
-  end
-
   class Group < JSON
   end
 

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -98,11 +98,6 @@ module Source
     end
   end
 
-  class Person < CSV
-    def person_data?
-      true
-    end
-  end
 
   class Wikidata < Person
     def fields

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -88,9 +88,6 @@ module Source
     end
   end
 
-  class Positions < JSON
-  end
-
   class Corrections < PlainCSV
   end
 end

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -98,26 +98,6 @@ module Source
     end
   end
 
-  class OCD < CSV
-    def fields
-      %i(area area_id)
-    end
-
-    def fuzzy_match?
-      i(:merge)[:fuzzy]
-    end
-
-    def overrides
-      return {} unless i(:merge)
-      return {} unless i(:merge).key? :overrides
-      i(:merge)[:overrides]
-    end
-
-    def generate
-      i(:generate)
-    end
-  end
-
   class Term < PlainCSV
   end
 

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -171,16 +171,6 @@ module Source
     end
   end
 
-  class Gender < PlainCSV
-    def converter(h)
-      h == 'uuid' ? :string : :int
-    end
-
-    def fields
-      %i(gender)
-    end
-  end
-
   class Term < PlainCSV
   end
 

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -1,4 +1,3 @@
-require 'rcsv'
 require_relative 'uuid_map'
 
 module Source
@@ -86,35 +85,6 @@ module Source
 
     def file_contents
       File.read(filename)
-    end
-  end
-
-  class PlainCSV < Base
-    def raw_table
-      Rcsv.parse(file_contents, row_as_hash: true, columns: rcsv_column_options)
-    end
-
-    def as_table
-      raw_table
-    end
-
-    def rcsv_column_options
-      @header_converters ||= Hash[headers.map do |h|
-        [h, { alias: h.to_s.downcase.strip.gsub(/\s+/, '_').gsub(/\W+/, '').to_sym, type: converter(h) }]
-      end]
-    end
-
-    def headers
-      (header_line = File.open(filename, &:gets)) || abort("#{filename} is empty!".red)
-      Rcsv.parse(header_line, header: :none).first
-    end
-
-    def fields
-      []
-    end
-
-    def converter(_)
-      :string
     end
   end
 

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -88,16 +88,6 @@ module Source
     end
   end
 
-  class JSON < Base
-    def fields
-      []
-    end
-
-    def as_json
-      ::JSON.parse(file_contents, symbolize_names: true)
-    end
-  end
-
   class Term < PlainCSV
   end
 

--- a/lib/source/area.rb
+++ b/lib/source/area.rb
@@ -1,0 +1,6 @@
+require_relative 'json'
+
+module Source
+  class Area < JSON
+  end
+end

--- a/lib/source/corrections.rb
+++ b/lib/source/corrections.rb
@@ -1,0 +1,6 @@
+require_relative 'plain_csv'
+
+module Source
+  class Corrections < PlainCSV
+  end
+end

--- a/lib/source/csv.rb
+++ b/lib/source/csv.rb
@@ -1,0 +1,19 @@
+require_relative 'plain_csv'
+
+module Source
+  class CSV < PlainCSV
+    def fields
+      headers.map { |h| remap(h.to_s.downcase) }
+    end
+
+    def raw_table
+      rows = []
+      super.each do |row|
+        # Need to make a copy in case there are multiple source columns
+        # mapping to the same term (e.g. with areas)
+        rows << Hash[row.keys.each.map { |h| [remap(h), row[h].nil? ? nil : row[h].tidy] }]
+      end
+      rows
+    end
+  end
+end

--- a/lib/source/elections.rb
+++ b/lib/source/elections.rb
@@ -1,0 +1,6 @@
+require_relative 'json'
+
+module Source
+  class Elections < JSON
+  end
+end

--- a/lib/source/gender.rb
+++ b/lib/source/gender.rb
@@ -1,0 +1,13 @@
+require_relative 'plain_csv'
+
+module Source
+  class Gender < PlainCSV
+    def converter(h)
+      h == 'uuid' ? :string : :int
+    end
+
+    def fields
+      %i(gender)
+    end
+  end
+end

--- a/lib/source/group.rb
+++ b/lib/source/group.rb
@@ -1,0 +1,6 @@
+require_relative 'json'
+
+module Source
+  class Group < JSON
+  end
+end

--- a/lib/source/json.rb
+++ b/lib/source/json.rb
@@ -1,0 +1,11 @@
+module Source
+  class JSON < Base
+    def fields
+      []
+    end
+
+    def as_json
+      ::JSON.parse(file_contents, symbolize_names: true)
+    end
+  end
+end

--- a/lib/source/membership.rb
+++ b/lib/source/membership.rb
@@ -1,0 +1,38 @@
+require_relative 'csv'
+
+module Source
+  class Membership < CSV
+    def id_map
+      id_mapper.mapping
+    end
+
+    def write_id_map_file!(data)
+      id_mapper.rewrite(data)
+    end
+
+    def raw_table
+      super.each do |r|
+        # if the source has no ID, generate one
+        r[:id] = r[:name].downcase.gsub(/\s+/, '_') if r[:id].to_s.empty?
+      end
+    end
+
+    # Currently we just recognise a hash of k:v pairs to accept if matching
+    # TODO: add 'reject' and more complex expressions
+    def as_table
+      return raw_table unless i(:filter)
+      filter = ->(row) { i(:filter)[:accept].all? { |k, v| row[k] == v } }
+      @_filtered ||= raw_table.select { |row| filter.call(row) }
+    end
+
+    private
+
+    def id_mapper
+      @map ||= UuidMapFile.new(id_map_file)
+    end
+
+    def id_map_file
+      Pathname.new(filename.sub(/.csv$/, '-ids.csv'))
+    end
+  end
+end

--- a/lib/source/ocd.rb
+++ b/lib/source/ocd.rb
@@ -1,0 +1,23 @@
+require_relative 'csv'
+
+module Source
+  class OCD < CSV
+    def fields
+      %i(area area_id)
+    end
+
+    def fuzzy_match?
+      i(:merge)[:fuzzy]
+    end
+
+    def overrides
+      return {} unless i(:merge)
+      return {} unless i(:merge).key? :overrides
+      i(:merge)[:overrides]
+    end
+
+    def generate
+      i(:generate)
+    end
+  end
+end

--- a/lib/source/person.rb
+++ b/lib/source/person.rb
@@ -1,0 +1,9 @@
+require_relative 'csv'
+
+module Source
+  class Person < CSV
+    def person_data?
+      true
+    end
+  end
+end

--- a/lib/source/plain_csv.rb
+++ b/lib/source/plain_csv.rb
@@ -1,0 +1,32 @@
+require 'rcsv'
+
+module Source
+  class PlainCSV < Base
+    def raw_table
+      Rcsv.parse(file_contents, row_as_hash: true, columns: rcsv_column_options)
+    end
+
+    def as_table
+      raw_table
+    end
+
+    def rcsv_column_options
+      @header_converters ||= Hash[headers.map do |h|
+        [h, { alias: h.to_s.downcase.strip.gsub(/\s+/, '_').gsub(/\W+/, '').to_sym, type: converter(h) }]
+      end]
+    end
+
+    def headers
+      (header_line = File.open(filename, &:gets)) || abort("#{filename} is empty!".red)
+      Rcsv.parse(header_line, header: :none).first
+    end
+
+    def fields
+      []
+    end
+
+    def converter(_)
+      :string
+    end
+  end
+end

--- a/lib/source/positions.rb
+++ b/lib/source/positions.rb
@@ -1,0 +1,6 @@
+require_relative 'json'
+
+module Source
+  class Positions < JSON
+  end
+end

--- a/lib/source/term.rb
+++ b/lib/source/term.rb
@@ -1,0 +1,6 @@
+require_relative 'plain_csv'
+
+module Source
+  class Term < PlainCSV
+  end
+end

--- a/lib/source/wikidata.rb
+++ b/lib/source/wikidata.rb
@@ -1,0 +1,15 @@
+require_relative 'person'
+
+module Source
+  class Wikidata < Person
+    def fields
+      super << :identifier__wikidata
+    end
+
+    def reconciliation_file
+      Reconciliation::File.new(
+        Pathname.new('sources/') + i(:merge)[:reconciliation_file]
+      )
+    end
+  end
+end


### PR DESCRIPTION
Rather than having all the different Source classes embedded in a single file, split it up into one file per class. This is largely preparation for starting to add a lot more behaviour onto the individual classes.