### PR TITLE
Make RemoteSource work with new Instructions file

### DIFF
--- a/lib/remotesource.rb
+++ b/lib/remotesource.rb
@@ -5,7 +5,7 @@ require 'csv'
 class RemoteSource
   # Instantiate correct subclass based on instructions
   def self.instantiate(i)
-    c = i[:create]
+    c = i.i(:create)
     return RemoteSource::URL.new(i)                if c.key? :url
     return RemoteSource::Morph.new(i)              if c[:from] == 'morph'
     return RemoteSource::Parlparse.new(i)          if c[:from] == 'parlparse'
@@ -23,7 +23,7 @@ class RemoteSource
   end
 
   def i(k)
-    @instructions[k.to_sym]
+    @instructions.i(k.to_sym)
   end
 
   def c(k)


### PR DESCRIPTION
https://github.com/everypolitician/everypolitician-data/pull/17645 changed how `Instructions` work, and didn't update the `RemoteSource` class to work with it (having tested only `rake clean` builds, rather than `rake clobber` ones)

Bring this back in line.

The class now has some odd redirections, but we can tidy that up later.