### PR TITLE
Move "combine this source" logic into Source classes

### DIFF
--- a/lib/source.rb
+++ b/lib/source.rb
@@ -2,6 +2,8 @@ require_relative 'uuid_map'
 
 module Source
   class Base
+    attr_reader :warnings
+
     # Instantiate correct subclass based on instructions
     def self.instantiate(i)
       raise "Missing `type` in #{i}" unless i.key? :type
@@ -22,6 +24,7 @@ module Source
 
     def initialize(i)
       @instructions = i
+      @warnings = Set.new
     end
 
     def i(k)
@@ -86,6 +89,12 @@ module Source
 
     def file_contents
       File.read(filename)
+    end
+
+    private
+
+    def add_warning(str)
+      @warnings << str
     end
   end
 end

--- a/lib/source/corrections.rb
+++ b/lib/source/corrections.rb
@@ -2,5 +2,24 @@ require_relative 'plain_csv'
 
 module Source
   class Corrections < PlainCSV
+    def merged_with(csv)
+      as_table.each do |correction|
+        rows = csv.select { |r| r[:uuid] == correction[:uuid] }
+        if rows.empty?
+          add_warning "Can't correct #{correction[:uuid]} — no such person"
+          next
+        end
+
+        field = correction[:field].to_sym
+        rows.each do |row|
+          unless row[field] == correction[:old]
+            add_warning "Can't correct #{correction[:uuid]}: #{field} is '#{row[field]} not '#{correction[:old]}'"
+            next
+          end
+          row[field] = correction[:new]
+        end
+      end
+      csv
+    end
   end
 end

--- a/lib/source/gender.rb
+++ b/lib/source/gender.rb
@@ -9,5 +9,28 @@ module Source
     def fields
       %i(gender)
     end
+
+    def merged_with(csv)
+      gb_score = gb_added = 0
+      results = GenderBalancer.new(as_table).results
+
+      csv.each do |r|
+        next unless winner = results[r[:uuid]]
+        gb_score += 1
+
+        # if our results are different from another source
+        # warn, and keep the original
+        if r[:gender]
+          add_warning "    ☁ Mismatch for #{r[:uuid]} #{r[:name]} (Was: #{r[:gender]} | GB: #{winner})" if r[:gender] != winner
+          next
+        end
+
+        r[:gender] = winner
+        gb_added += 1
+      end
+      # TODO: have a standardised way of passing back reporting info
+      warn "  ⚥ data for #{gb_score}; #{gb_added} added\n".cyan
+      csv
+    end
   end
 end

--- a/lib/source/ocd.rb
+++ b/lib/source/ocd.rb
@@ -25,5 +25,19 @@ module Source
   end
 
   class OCD::Names < OCD
+    def merged_with(csv)
+      ocds = as_table.group_by { |r| r[:id] }
+      csv.each do |r|
+        if ocds.key?(r[:area_id])
+          r[:area] = ocds[r[:area_id]].first[:name]
+        elsif r[:area_id].to_s.empty?
+          add_warning "    No area_id given for #{r[:uuid]}"
+        else
+          # :area_id was given but didn't resolve to an OCD ID.
+          add_warning "    Could not resolve area_id #{r[:area_id]} for #{r[:uuid]}"
+        end
+      end
+      csv
+    end
   end
 end

--- a/lib/source/person.rb
+++ b/lib/source/person.rb
@@ -2,8 +2,57 @@ require_relative 'csv'
 
 module Source
   class Person < CSV
+    # TODO change logic so that headers are gathered _after_ merge, rather
+    # than before, so we don't need an extra field
+    attr_reader :additional_headers
+
     def person_data?
       true
+    end
+
+    # TODO: split this up. This version was migrated directly from the
+    # original Rakefile approach, so is still doing too many things.
+    def merged_with(csv)
+      abort "No merge instructions for #{filename}" unless merge_instructions
+      reconciler = Reconciler.new(merge_instructions, ENV['GENERATE_RECONCILIATION_INTERFACE'], csv, as_table)
+
+      if reconciler.filename
+        pr = reconciler.reconciliation_data rescue abort($!.to_s)
+        matcher = Matcher::Reconciled.new(csv, merge_instructions, pr)
+      else
+        matcher = Matcher::Exact.new(csv, merge_instructions)
+      end
+
+      unmatched = []
+      @additional_headers = Set.new
+
+      as_table.each do |incoming_row|
+        incoming_row[:identifier__wikidata] ||= incoming_row[:id] if i(:type) == 'wikidata'
+
+        to_patch = matcher.find_all(incoming_row)
+        if to_patch && !to_patch.size.zero?
+          # Be careful to take a copy and not delete from the core list
+          to_patch = to_patch.select { |r| r[:term].to_s == incoming_row[:term].to_s } if merge_instructions[:term_match]
+          uids = to_patch.map { |r| r[:uuid] }.uniq
+          if uids.count > 1
+            add_warning "Error: trying to patch multiple people: #{uids.join('; ')}".red.on_yellow
+            next
+          end
+          to_patch.each do |existing_row|
+            patcher = Patcher.new(existing_row, incoming_row, merge_instructions[:patch])
+            existing_row = patcher.patched
+            @additional_headers |= patcher.new_headers.to_a
+            patcher.warnings.each { |w| add_warning w }
+          end
+        else
+          unmatched << incoming_row
+        end
+      end
+      add_warning '* %d of %d unmatched'.magenta % [unmatched.count, as_table.count] if unmatched.any?
+      unmatched.sample(10).each do |r|
+        add_warning "\t#{r.to_hash.reject { |_, v| v.to_s.empty? }.select { |k, _| %i(id name).include? k }}"
+      end
+      csv
     end
   end
 end

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -190,23 +190,12 @@ namespace :merge_sources do
     end
 
     # Any local corrections in manual/corrections.csv
-    @INSTRUCTIONS.sources_of_type('corrections').each do |corrs|
-      warn "Applying local corrections from #{corrs.filename}".green
-      corrs.as_table.each do |correction|
-        rows = merged_rows.select { |r| r[:uuid] == correction[:uuid] }
-        if rows.empty?
-          warn "Can't correct #{correction[:uuid]} — no such person"
-          next
-        end
-
-        field = correction[:field].to_sym
-        rows.each do |row|
-          unless row[field] == correction[:old]
-            warn "Can't correct #{correction[:uuid]}: #{field} is '#{row[field]} not '#{correction[:old]}'"
-            next
-          end
-          row[field] = correction[:new]
-        end
+    @INSTRUCTIONS.sources_of_type('corrections').each do |source|
+      warn "Applying local corrections from #{source.filename}".green
+      merged_rows = source.merged_with(merged_rows)
+      if source.warnings.any?
+        warn 'Corrections Problems'
+        warn source.warnings.to_a.join("\n")
       end
     end
 

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -93,20 +93,13 @@ namespace :merge_sources do
     end
 
     # OCD IDs -> names
-    @INSTRUCTIONS.sources_of_type('ocd-names').each do |area|
-      warn "Adding OCD names from #{area.filename}".green
-      ocds = area.as_table.group_by { |r| r[:id] }
-      merged_rows.each do |r|
-        if ocds.key?(r[:area_id])
-          r[:area] = ocds[r[:area_id]].first[:name]
-        elsif r[:area_id].to_s.empty?
-          warn_once "    No area_id given for #{r[:uuid]}"
-        else
-          # :area_id was given but didn't resolve to an OCD ID.
-          warn_once "    Could not resolve area_id #{r[:area_id]} for #{r[:uuid]}"
-        end
+    @INSTRUCTIONS.sources_of_type('ocd-names').each do |source|
+      warn "Adding OCD names from #{source.filename}".green
+      merged_rows = source.merged_with(merged_rows)
+      if source.warnings.any?
+        warn 'OCD ID issues'
+        warn source.warnings.to_a.join("\n")
       end
-      output_warnings('OCD ID issues')
     end
 
     # OCD names -> IDs

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -142,26 +142,13 @@ namespace :merge_sources do
     end
 
     # Gender information from Gender-Balance.org
-    @INSTRUCTIONS.sources_of_type('gender').each do |gb|
-      warn "Adding GenderBalance results from #{gb.filename}".green
-      results = GenderBalancer.new(gb.as_table).results
-      gb_score = gb_added = 0
-
-      merged_rows.each do |r|
-        (winner = results[r[:uuid]]) || next
-        gb_score += 1
-
-        # Warn if our results are different from another source
-        if r[:gender]
-          warn_once "    ☁ Mismatch for #{r[:uuid]} #{r[:name]} (Was: #{r[:gender]} | GB: #{winner})" if r[:gender] != winner
-          next
-        end
-
-        r[:gender] = winner
-        gb_added += 1
+    @INSTRUCTIONS.sources_of_type('gender').each do |source|
+      warn "Adding GenderBalance results from #{source.filename}".green
+      merged_rows = source.merged_with(merged_rows)
+      if source.warnings.any?
+        warn 'GenderBalance Mismatches'
+        warn source.warnings.to_a.join("\n")
       end
-      output_warnings('GenderBalance Mismatches')
-      warn "  ⚥ data for #{gb_score}; #{gb_added} added\n".cyan
     end
 
     # OCD IDs -> names

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -49,16 +49,6 @@ namespace :merge_sources do
     end
   end
 
-  @warnings = Set.new
-  def warn_once(str)
-    @warnings << str
-  end
-
-  def output_warnings(header)
-    warn ['', header, @warnings.to_a, '', ''].join("\n") if @warnings.any?
-    @warnings = Set.new
-  end
-
   def combine_sources
     all_headers = (%i(id uuid) + @SOURCES.map(&:fields)).flatten.uniq
 

--- a/rake_build/combine_sources.rb
+++ b/rake_build/combine_sources.rb
@@ -103,24 +103,13 @@ namespace :merge_sources do
     end
 
     # OCD names -> IDs
-    @INSTRUCTIONS.sources_of_type('ocd-ids').each do |area|
-      warn "Adding OCD ids from #{area.filename}".green
-      ocds = area.as_table.group_by { |r| r[:id] }
-
-      # Generate IDs from names
-      overrides_with_string_keys = Hash[area.overrides.map { |k, v| [k.to_s, v] }]
-      lookup_class = area.fuzzy_match? ? OCD::Lookup::Fuzzy : OCD::Lookup::Plain
-      ocd_ids = lookup_class.new(area.as_table, overrides_with_string_keys)
-
-      merged_rows.select { |r| r[:area_id].nil? }.each do |r|
-        area = ocd_ids.from_name(r[:area])
-        if area.nil?
-          warn_once "  No area match for #{r[:area]}"
-          next
-        end
-        r[:area_id] = area
+    @INSTRUCTIONS.sources_of_type('ocd-ids').each do |source|
+      warn "Adding OCD ids from #{source.filename}".green
+      merged_rows = source.merged_with(merged_rows)
+      if source.warnings.any?
+        warn 'Unmatched areas'
+        warn source.warnings.to_a.join("\n")
       end
-      output_warnings('Unmatched areas')
     end
 
     # Any local corrections in manual/corrections.csv


### PR DESCRIPTION
`combine_sources` steps through lots of sources building up the datastructure that will become `merged.csv`.

Rather than having the logic for how to combine each source in the Rakefile, pull it out into the Source classes.

We still need to handle legacy IDs, and then work out how to reduce the duplication (each section is almost identical), and we also need to do more work on refactoring the code that has been extracted, but this a major step forward, and reduces the flog score of `combine_sources` from 408.4 to 175.2