### PR TITLE
Switch to deploying everypolitician.org in after_success hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,11 @@ language: ruby
 before_install:
   - echo -e "machine github.com\n  login $GITHUB_ACCESS_TOKEN" >> ~/.netrc
 script: bundle exec rake close_old_pull_requests pull_request_summary:travis test
+after_success:
+  - scripts/deploy.sh
 cache: bundler
 rvm:
   - 2.3.1
 env:
   global:
     secure: ZCQVQdKDUyPY/BM1FYriv6h+rNF+PqQETnj5FwU/jQKNz8utvaUVjXD/pIMwEmO5orzng5/MnZvErkr2+JZBs+0JghXWtjDxQHxJzfBTZJnaiAY9hWZBC9Kgbl1/mJvUvK132W5GzQ5xS9lw/pyKFGRba9A7rfoYFfkaJKmgq1U=
-deploy:
-  provider: script
-  # $TRAVIS_RUBY_VERSION will be set to the Ruby version the Travis build uses,
-  # which is set in the `rvm` section above.
-  # @see https://docs.travis-ci.com/user/deployment/script/#Deployment-is-executed-by-Ruby-1.9.3
-  script: rvm $TRAVIS_RUBY_VERSION do scripts/deploy.sh
-  on:
-    branch: master

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -39,9 +39,11 @@ deploy_viewer_static() {
 }
 
 main() {
-  start_viewer_sinatra
-  build_viewer_static
-  deploy_viewer_static
+  if [[ "$TRAVIS_PULL_REQUEST" == false && "$TRAVIS_BRANCH" == master ]]; then
+    start_viewer_sinatra
+    build_viewer_static
+    deploy_viewer_static
+  fi
 }
 
 main


### PR DESCRIPTION
This changes the way we're attempting to deploy everypolitician.org on Travis to use an `after_success` hook, rather than using [Travis' script deployment](https://docs.travis-ci.com/user/deployment/script/).

The script based deployment doesn't seem to work because it runs in an odd environment that has a very old version of ruby and git. This was causing errors saying [`fatal: repository 'https://github.com/everypolitician/close_old_pull_requests/' not found`](https://travis-ci.org/everypolitician/everypolitician-data/builds/163344759#L325), which is odd because that repository very much _does_ exist.

### Relevant issues

This follows on from other attempts to deploy everypolitician.org as part of this repo's Travis build - #17407 and #17487.

Fixes https://github.com/everypolitician/everypolitician/issues/511

(hopefully)

### Notes to reviewer

It's very tricky to test this because the script is designed to only run on `master`, so really we just need to merge it and see what happens. However if it does fail then we're no worse off than we were before.