### PR TITLE
Unset BUNDLE_GEMFILE before trying to install viewer-sinatra

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -17,6 +17,7 @@ start_viewer_sinatra() {
   cd /tmp/viewer-sinatra
   # TODO: Make `master` configurable
   curl -fsSL https://github.com/everypolitician/viewer-sinatra/archive/master.tar.gz | tar -z -x -f - --strip 1
+  unset BUNDLE_GEMFILE
   bundle install
   bundle exec ruby app.rb &
   while ! nc -z localhost 4567; do sleep 1; done


### PR DESCRIPTION
Travis sets a BUNDLE_GEMFILE environment variable pointing to the
`Gemfile` of the application that's being built, everypolitician-data in
this case. However we want to install viewer-sinatra so that we can
deploy everypolitician.org, so we need to unset BUNDLE_GEMFILE so that
`bundle install` picks up the correct `Gemfile` for viewer-sinatra.

This follows on from https://github.com/everypolitician/everypolitician-data/pull/17836

Fixes https://github.com/everypolitician/everypolitician/issues/511 🙏 