### PR TITLE
Make Source::Membershis#id_mapper public

### DIFF
--- a/lib/source/membership.rb
+++ b/lib/source/membership.rb
@@ -47,14 +47,14 @@ module Source
       csv
     end
 
+    def id_mapper
+      @map ||= UuidMapFile.new(id_map_file)
+    end
+
     private
 
     def write_id_map_file!(id_map)
       id_mapper.rewrite(id_map)
-    end
-
-    def id_mapper
-      @map ||= UuidMapFile.new(id_map_file)
     end
 
     def id_map_file

--- a/lib/source/membership.rb
+++ b/lib/source/membership.rb
@@ -21,7 +21,7 @@ module Source
     # TODO: split this up. This version was migrated directly from the
     # original Rakefile approach, so is still doing too many things.
     def merged_with(csv)
-      id_map = id_mapper.mapping
+      id_map = mapfile.mapping
 
       if merge_instructions
         reconciler = Reconciler.new(merge_instructions, ENV['GENERATE_RECONCILIATION_INTERFACE'], csv, as_table)
@@ -47,14 +47,14 @@ module Source
       csv
     end
 
-    def id_mapper
+    def mapfile
       @map ||= UuidMapFile.new(id_map_file)
     end
 
     private
 
     def write_id_map_file!(id_map)
-      id_mapper.rewrite(id_map)
+      mapfile.rewrite(id_map)
     end
 
     def id_map_file

--- a/lib/uuid_map.rb
+++ b/lib/uuid_map.rb
@@ -17,9 +17,8 @@ class UuidMapFile
   end
 
   def mapping
-    file = [@newfile, @oldfile].find(&:exist?)
-    raw  = file.read unless file.nil?
-    return {} if file.nil? || raw.empty?
+    raw  = source.read unless source.nil?
+    return {} if source.nil? || raw.empty?
     Hash[Rcsv.parse(raw, row_as_hash: true, columns: {}).map { |r| [r['id'], r['uuid']] }]
   end
 
@@ -30,5 +29,9 @@ class UuidMapFile
       csv << %i(id uuid)
       data.each { |id, uuid| csv << [id, uuid] }
     end
+  end
+
+  def source
+    [@newfile, @oldfile].find(&:exist?)
   end
 end


### PR DESCRIPTION
It's useful to be able to access the ID map information for a Membership
source in other contexts (e.g. from Rakefiles), so promote it from
private to public.