### PR TITLE
Add rake task to remap ids in idmap files from memberships

### DIFF
--- a/lib/uuid_map.rb
+++ b/lib/uuid_map.rb
@@ -44,5 +44,6 @@ class UuidMapFile
 
   def check_ids(data, from, to)
     abort "No existing data for #{from}" unless data[from]
+    abort "Already have data for #{to}" if data[to]
   end
 end

--- a/lib/uuid_map.rb
+++ b/lib/uuid_map.rb
@@ -38,6 +38,8 @@ class UuidMapFile
   def remap(from, to)
     @data ||= mapping
     check_ids(@data, from, to)
+    @data[to] = @data.delete(from)
+    rewrite(@data)
   end
 
   private

--- a/lib/uuid_map.rb
+++ b/lib/uuid_map.rb
@@ -34,4 +34,15 @@ class UuidMapFile
   def source
     [@newfile, @oldfile].find(&:exist?)
   end
+
+  def remap(from, to)
+    @data ||= mapping
+    check_ids(@data, from, to)
+  end
+
+  private
+
+  def check_ids(data, from, to)
+    abort "No existing data for #{from}" unless data[from]
+  end
 end

--- a/rake_config/memberships.rb
+++ b/rake_config/memberships.rb
@@ -1,0 +1,21 @@
+
+desc 'Remap memberships ids'
+namespace :memberships do
+  task :remap_ids, [:from, :to] do |_, args|
+    @INSTRUCTIONS.sources_of_type('membership').each do |source|
+      file = source.mapfile
+      data = remap(file, args)
+      file.rewrite(data)
+    end
+  end
+end
+
+private
+
+def remap(file, args)
+  data = file.mapping
+  abort "No existing data for #{args[:from]}" unless data[args[:from]]
+  abort "Already have data for #{args[:to]}" if data[args[:to]]
+  data[args[:to]] = data.delete(args[:from])
+  data
+end

--- a/rake_config/memberships.rb
+++ b/rake_config/memberships.rb
@@ -3,19 +3,7 @@ desc 'Remap memberships ids'
 namespace :memberships do
   task :remap_ids, [:from, :to] do |_, args|
     @INSTRUCTIONS.sources_of_type('membership').each do |source|
-      file = source.mapfile
-      data = remap(file, args)
-      file.rewrite(data)
+      source.mapfile.remap(args[:from], args[:to])
     end
   end
-end
-
-private
-
-def remap(file, args)
-  data = file.mapping
-  abort "No existing data for #{args[:from]}" unless data[args[:from]]
-  abort "Already have data for #{args[:to]}" if data[args[:to]]
-  data[args[:to]] = data.delete(args[:from])
-  data
 end

--- a/test/uuid_map_test.rb
+++ b/test/uuid_map_test.rb
@@ -38,42 +38,44 @@ describe 'UUID Mapper' do
     newdata['barney'].must_equal 'uuid-2'
   end
 
-  it 'remaps existing UUID to a new id' do
-    file   = new_tempfile
-    mapper = UuidMapFile.new(file)
-    data   = {}
-    data['fred'] = 'uuid-1'
-    mapper.rewrite(data)
+  describe '#remap' do
+    it 'remaps existing UUID to a new id' do
+      file   = new_tempfile
+      mapper = UuidMapFile.new(file)
+      data   = {}
+      data['fred'] = 'uuid-1'
+      mapper.rewrite(data)
 
-    mapper.remap('fred', 'freddy')
+      mapper.remap('fred', 'freddy')
 
-    newdata = mapper.mapping
-    newdata['fred'].must_be_nil
-    newdata['freddy'].must_equal 'uuid-1'
-  end
-
-  it 'does not remap if old id does not exist' do
-    file   = new_tempfile
-    mapper = UuidMapFile.new(file)
-    data   = {}
-    data['fred'] = 'uuid-1'
-    mapper.rewrite(data)
-
-    assert_raises SystemExit do
-      mapper.remap('frida', 'freddy')
+      newdata = mapper.mapping
+      newdata['fred'].must_be_nil
+      newdata['freddy'].must_equal 'uuid-1'
     end
-  end
 
-  it 'does not remap if new id exists' do
-    file   = new_tempfile
-    mapper = UuidMapFile.new(file)
-    data   = {}
-    data['fred']   = 'uuid-1'
-    data['barney'] = 'uuid-2'
-    mapper.rewrite(data)
+    it 'does not remap if old id does not exist' do
+      file   = new_tempfile
+      mapper = UuidMapFile.new(file)
+      data   = {}
+      data['fred'] = 'uuid-1'
+      mapper.rewrite(data)
 
-    assert_raises SystemExit do
-      mapper.remap('fred', 'barney')
+      assert_raises SystemExit do
+        mapper.remap('frida', 'freddy')
+      end
+    end
+
+    it 'does not remap if new id exists' do
+      file   = new_tempfile
+      mapper = UuidMapFile.new(file)
+      data   = {}
+      data['fred']   = 'uuid-1'
+      data['barney'] = 'uuid-2'
+      mapper.rewrite(data)
+
+      assert_raises SystemExit do
+        mapper.remap('fred', 'barney')
+      end
     end
   end
 end

--- a/test/uuid_map_test.rb
+++ b/test/uuid_map_test.rb
@@ -48,4 +48,17 @@ describe 'UUID Mapper' do
       mapper.remap('frida', 'freddy')
     end
   end
+
+  it 'does not remap if new id exists' do
+    file   = new_tempfile
+    mapper = UuidMapFile.new(file)
+    data   = {}
+    data['fred']   = 'uuid-1'
+    data['barney'] = 'uuid-2'
+    mapper.rewrite(data)
+
+    assert_raises SystemExit do
+      mapper.remap('fred', 'barney')
+    end
+  end
 end

--- a/test/uuid_map_test.rb
+++ b/test/uuid_map_test.rb
@@ -36,4 +36,16 @@ describe 'UUID Mapper' do
     newdata.keys.count.must_equal 2
     newdata['barney'].must_equal 'uuid-2'
   end
+
+  it 'does not remap if old id does not exist' do
+    file   = new_tempfile
+    mapper = UuidMapFile.new(file)
+    data   = {}
+    data['fred'] = 'uuid-1'
+    mapper.rewrite(data)
+
+    assert_raises SystemExit do
+      mapper.remap('frida', 'freddy')
+    end
+  end
 end

--- a/test/uuid_map_test.rb
+++ b/test/uuid_map_test.rb
@@ -39,13 +39,12 @@ describe 'UUID Mapper' do
   end
 
   describe '#remap' do
-    it 'remaps existing UUID to a new id' do
-      file   = new_tempfile
-      mapper = UuidMapFile.new(file)
-      data   = {}
-      data['fred'] = 'uuid-1'
-      mapper.rewrite(data)
+    let(:file)   { new_tempfile }
+    let(:mapper) { UuidMapFile.new(file) }
+    let(:data)   { { 'fred' => 'uuid-1' } }
 
+    it 'remaps existing UUID to a new id' do
+      mapper.rewrite(data)
       mapper.remap('fred', 'freddy')
 
       newdata = mapper.mapping
@@ -54,10 +53,6 @@ describe 'UUID Mapper' do
     end
 
     it 'does not remap if old id does not exist' do
-      file   = new_tempfile
-      mapper = UuidMapFile.new(file)
-      data   = {}
-      data['fred'] = 'uuid-1'
       mapper.rewrite(data)
 
       assert_raises SystemExit do
@@ -66,10 +61,6 @@ describe 'UUID Mapper' do
     end
 
     it 'does not remap if new id exists' do
-      file   = new_tempfile
-      mapper = UuidMapFile.new(file)
-      data   = {}
-      data['fred']   = 'uuid-1'
       data['barney'] = 'uuid-2'
       mapper.rewrite(data)
 

--- a/test/uuid_map_test.rb
+++ b/test/uuid_map_test.rb
@@ -29,12 +29,27 @@ describe 'UUID Mapper' do
     data.must_be_empty
     data['fred'] = 'uuid-1'
     data['barney'] = 'uuid-2'
+
     mapper.rewrite(data)
 
     # read it back in again
     newdata = UuidMapFile.new(file).mapping
     newdata.keys.count.must_equal 2
     newdata['barney'].must_equal 'uuid-2'
+  end
+
+  it 'remaps existing UUID to a new id' do
+    file   = new_tempfile
+    mapper = UuidMapFile.new(file)
+    data   = {}
+    data['fred'] = 'uuid-1'
+    mapper.rewrite(data)
+
+    mapper.remap('fred', 'freddy')
+
+    newdata = mapper.mapping
+    newdata['fred'].must_be_nil
+    newdata['freddy'].must_equal 'uuid-1'
   end
 
   it 'does not remap if old id does not exist' do


### PR DESCRIPTION
If the id of a politician changes, or a politician is given a UUID
because they didn't have one, we need to update our idmap files
to point the new ID at our UUID.

This adds a rake task to do that. You call it as:

```rake
be rake memberships:remap_ids[oldID,newID]
```

(some shells, e.g. zsh, may need to quote those square brackets)

P.S. Not sure if the `remap` helper method should be moved to the `UuidMapFile` class.