### PR TITLE
Use legislature UUIDs in Posts

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -5035,11 +5035,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Kenya/Assembly/sources",
         "popolo": "data/Kenya/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8fda08725ff7704a7ad844e9bb18179d55d5e2c6/data/Kenya/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e0ee2b88f3cd439518cf23cecb899cba4254a032/data/Kenya/Assembly/ep-popolo-v1.0.json",
         "names": "data/Kenya/Assembly/names.csv",
-        "lastmod": "1476023748",
+        "lastmod": "1476102832",
         "person_count": 355,
-        "sha": "8fda08725ff7704a7ad844e9bb18179d55d5e2c6",
+        "sha": "e0ee2b88f3cd439518cf23cecb899cba4254a032",
         "legislative_periods": [
           {
             "id": "term/11",
@@ -10201,11 +10201,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Uganda/Parliament/sources",
         "popolo": "data/Uganda/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d281f26fad349eede1326ba1f0c79bfcb7e4ab76/data/Uganda/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4de4067a3845f54748a6f4f39f8fad91994a195a/data/Uganda/Parliament/ep-popolo-v1.0.json",
         "names": "data/Uganda/Parliament/names.csv",
-        "lastmod": "1471256037",
+        "lastmod": "1476102856",
         "person_count": 647,
-        "sha": "d281f26fad349eede1326ba1f0c79bfcb7e4ab76",
+        "sha": "4de4067a3845f54748a6f4f39f8fad91994a195a",
         "legislative_periods": [
           {
             "id": "term/10",

--- a/data/Kenya/Assembly/ep-popolo-v1.0.json
+++ b/data/Kenya/Assembly/ep-popolo-v1.0.json
@@ -3,12 +3,12 @@
     {
       "id": "nominated_representative",
       "label": "Nominated Representative",
-      "organization_id": "legislature"
+      "organization_id": "574eff8e-8171-4f2b-8279-60ed8dec1a2a"
     },
     {
       "id": "women's_representative",
       "label": "Women's Representative",
-      "organization_id": "legislature"
+      "organization_id": "574eff8e-8171-4f2b-8279-60ed8dec1a2a"
     }
   ],
   "persons": [

--- a/data/Uganda/Parliament/ep-popolo-v1.0.json
+++ b/data/Uganda/Parliament/ep-popolo-v1.0.json
@@ -3,32 +3,32 @@
     {
       "id": "woman_representative",
       "label": "Woman Representative",
-      "organization_id": "legislature"
+      "organization_id": "c0450875-2933-4737-b774-d03e0ffa61ec"
     },
     {
       "id": "ex-officio",
       "label": "EX-OFFICIO",
-      "organization_id": "legislature"
+      "organization_id": "c0450875-2933-4737-b774-d03e0ffa61ec"
     },
     {
       "id": "youth",
       "label": "YOUTH",
-      "organization_id": "legislature"
+      "organization_id": "c0450875-2933-4737-b774-d03e0ffa61ec"
     },
     {
       "id": "updf",
       "label": "UPDF",
-      "organization_id": "legislature"
+      "organization_id": "c0450875-2933-4737-b774-d03e0ffa61ec"
     },
     {
       "id": "workers'_representative",
       "label": "Workers' Representative",
-      "organization_id": "legislature"
+      "organization_id": "c0450875-2933-4737-b774-d03e0ffa61ec"
     },
     {
       "id": "pwd",
       "label": "PWD",
-      "organization_id": "legislature"
+      "organization_id": "c0450875-2933-4737-b774-d03e0ffa61ec"
     }
   ],
   "persons": [

--- a/rake_build/generate_ep_popolo.rb
+++ b/rake_build/generate_ep_popolo.rb
@@ -54,8 +54,11 @@ namespace :transform do
       identifier: @legislature.delete(:wikidata),
     } if @legislature.key?(:wikidata)
 
-    # Switch the legislature ID
+    # Switch the legislature ID everywhere it's used
     @json[:memberships].select { |m| m[:organization_id] == @legislature[:id] }.each do |m|
+      m[:organization_id] = @legislature[:uuid]
+    end
+    @json[:posts].select { |m| m[:organization_id] == @legislature[:id] }.each do |m|
       m[:organization_id] = @legislature[:uuid]
     end
     @legislature[:id] = @legislature.delete :uuid


### PR DESCRIPTION
When we assign the legislature's UUID, we update all the Memberships to
point at the correct organization_id, but we had previously forgotten to
also do this for Posts. So also update it there as well.

Closes https://github.com/everypolitician/everypolitician-data/issues/18412