### PR TITLE
Refresh countries.json for all countries

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -2160,7 +2160,7 @@
     "name": "Congo-Kinshasa (DRC)",
     "country": "Congo-Kinshasa (DRC)",
     "code": "CD",
-    "slug": "Congo-Kinshasa-(DRC)",
+    "slug": "Congo-Kinshasa",
     "legislatures": [
       {
         "name": "National Assembly",
@@ -5671,11 +5671,11 @@
         "slug": "Dewan-Rakyat",
         "sources_directory": "data/Malaysia/Dewan_Rakyat/sources",
         "popolo": "data/Malaysia/Dewan_Rakyat/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/60936978de3f6fef120c4acb64e21520ae4d86f4/data/Malaysia/Dewan_Rakyat/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c0e2864fc2c20e8049cac42fbd96bb7d1d599cc8/data/Malaysia/Dewan_Rakyat/ep-popolo-v1.0.json",
         "names": "data/Malaysia/Dewan_Rakyat/names.csv",
         "lastmod": "1476176663",
         "person_count": 1152,
-        "sha": "60936978de3f6fef120c4acb64e21520ae4d86f4",
+        "sha": "c0e2864fc2c20e8049cac42fbd96bb7d1d599cc8",
         "legislative_periods": [
           {
             "id": "term/13",
@@ -5683,7 +5683,7 @@
             "start_date": "2013-06-24",
             "slug": "13",
             "csv": "data/Malaysia/Dewan_Rakyat/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/60936978de3f6fef120c4acb64e21520ae4d86f4/data/Malaysia/Dewan_Rakyat/term-13.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c0e2864fc2c20e8049cac42fbd96bb7d1d599cc8/data/Malaysia/Dewan_Rakyat/term-13.csv"
           },
           {
             "end_date": "2013",
@@ -5692,7 +5692,7 @@
             "start_date": "2008",
             "slug": "12",
             "csv": "data/Malaysia/Dewan_Rakyat/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/60936978de3f6fef120c4acb64e21520ae4d86f4/data/Malaysia/Dewan_Rakyat/term-12.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c0e2864fc2c20e8049cac42fbd96bb7d1d599cc8/data/Malaysia/Dewan_Rakyat/term-12.csv"
           },
           {
             "end_date": "2008",
@@ -5782,7 +5782,7 @@
             "start_date": "1964",
             "slug": "2",
             "csv": "data/Malaysia/Dewan_Rakyat/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/60936978de3f6fef120c4acb64e21520ae4d86f4/data/Malaysia/Dewan_Rakyat/term-2.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c0e2864fc2c20e8049cac42fbd96bb7d1d599cc8/data/Malaysia/Dewan_Rakyat/term-2.csv"
           },
           {
             "end_date": "1964",
@@ -5791,7 +5791,7 @@
             "start_date": "1959",
             "slug": "1",
             "csv": "data/Malaysia/Dewan_Rakyat/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/60936978de3f6fef120c4acb64e21520ae4d86f4/data/Malaysia/Dewan_Rakyat/term-1.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c0e2864fc2c20e8049cac42fbd96bb7d1d599cc8/data/Malaysia/Dewan_Rakyat/term-1.csv"
           }
         ],
         "statement_count": 47850
@@ -7855,7 +7855,7 @@
     "name": "Saint Barthélemy",
     "country": "Saint Barthélemy",
     "code": "BL",
-    "slug": "Saint-Barthélemy",
+    "slug": "Saint-Barthelemy",
     "legislatures": [
       {
         "name": "Territorial Council",
@@ -9053,11 +9053,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Suriname/Assembly/sources",
         "popolo": "data/Suriname/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/292d1180707b0a447c652272d32773056dc12ddc/data/Suriname/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c0543f36b42d8f40e5cb62ca080ae1823a9b16b5/data/Suriname/Assembly/ep-popolo-v1.0.json",
         "names": "data/Suriname/Assembly/names.csv",
-        "lastmod": "1475334200",
+        "lastmod": "1473611915",
         "person_count": 87,
-        "sha": "292d1180707b0a447c652272d32773056dc12ddc",
+        "sha": "c0543f36b42d8f40e5cb62ca080ae1823a9b16b5",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -10833,11 +10833,11 @@
         "slug": "Pontifical-Commission",
         "sources_directory": "data/Vatican_City/Pontifical_Commission/sources",
         "popolo": "data/Vatican_City/Pontifical_Commission/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f447a845d5e4ded84f982e8674d59d54d3630b0b/data/Vatican_City/Pontifical_Commission/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/828ac11968481deaee985fedbe16aac09c9eb123/data/Vatican_City/Pontifical_Commission/ep-popolo-v1.0.json",
         "names": "data/Vatican_City/Pontifical_Commission/names.csv",
         "lastmod": "1476180342",
         "person_count": 8,
-        "sha": "f447a845d5e4ded84f982e8674d59d54d3630b0b",
+        "sha": "828ac11968481deaee985fedbe16aac09c9eb123",
         "legislative_periods": [
           {
             "id": "term/2016",
@@ -10845,7 +10845,7 @@
             "start_date": "2016-06-11",
             "slug": "2016",
             "csv": "data/Vatican_City/Pontifical_Commission/term-2016.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f447a845d5e4ded84f982e8674d59d54d3630b0b/data/Vatican_City/Pontifical_Commission/term-2016.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/828ac11968481deaee985fedbe16aac09c9eb123/data/Vatican_City/Pontifical_Commission/term-2016.csv"
           },
           {
             "end_date": "2016-06-10",
@@ -10854,7 +10854,7 @@
             "start_date": "2011-10-01",
             "slug": "2011",
             "csv": "data/Vatican_City/Pontifical_Commission/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f524110eceda223af5d846d2f0900aa79a7b733e/data/Vatican_City/Pontifical_Commission/term-2011.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/76d1bac226888ce7251cd63e6d7f846d6608a669/data/Vatican_City/Pontifical_Commission/term-2011.csv"
           }
         ],
         "statement_count": 1449


### PR DESCRIPTION
This does a full refresh of `countries.json` to catch a few countries where things had slipped a bit out of sync. Specifically this fixes Malaysia, which is currently pointing to a SHA that doesn't exist on `master`.

This uses the code from https://github.com/everypolitician/everypolitician-data/pull/18449 to perform the full rebuild.