### PR TITLE
Add Task class for rebuilding countries.json

### DIFF
--- a/lib/task/rebuild_countries_json.rb
+++ b/lib/task/rebuild_countries_json.rb
@@ -1,0 +1,41 @@
+require 'everypolitician'
+require 'json'
+
+module Task
+  class RebuildCountriesJSON
+    def initialize(to_build = 'data')
+      @to_build = to_build
+    end
+
+    def execute
+      countries = EveryPolitician.countries.select do |c|
+        c.slug.downcase.include? to_build.downcase
+      end
+
+      data = json_load('countries.json') rescue {}
+      # If we know we'll need data for every country directory anyway,
+      # it's much faster to pass the single directory 'data' than a list
+      # of every country directory:
+      commit_metadata = file_to_commit_metadata(
+        to_build == 'data' ?
+          ['data'] :
+          countries.flat_map(&:legislatures).map { |l| 'data/' + l.directory }
+      )
+
+      countries.each do |c|
+        country = Everypolitician::Country::Metadata.new(
+          # TODO: change this to accept an EveryPolitician::Country
+          country: c.name,
+          dirs: c.legislatures.map { |l| 'data/' + l.directory },
+          commit_metadata: commit_metadata,
+        ).stanza
+        data[data.find_index { |c| c[:name] == country[:name] }] = country
+      end
+      File.write('countries.json', JSON.pretty_generate(data.sort_by { |c| c[:name] }.to_a))
+    end
+
+    private
+
+    attr_reader :to_build
+  end
+end

--- a/lib/task/rebuild_countries_json.rb
+++ b/lib/task/rebuild_countries_json.rb
@@ -3,39 +3,63 @@ require 'json'
 
 module Task
   class RebuildCountriesJSON
-    def initialize(to_build = 'data')
+    def initialize(to_build)
       @to_build = to_build
     end
 
     def execute
-      countries = EveryPolitician.countries.select do |c|
-        c.slug.downcase.include? to_build.downcase
-      end
-
-      data = json_load('countries.json') rescue {}
-      # If we know we'll need data for every country directory anyway,
-      # it's much faster to pass the single directory 'data' than a list
-      # of every country directory:
-      commit_metadata = file_to_commit_metadata(
-        to_build == 'data' ?
-          ['data'] :
-          countries.flat_map(&:legislatures).map { |l| 'data/' + l.directory }
+      countries_file.write(
+        JSON.pretty_generate(updated_data.sort_by { |c| c[:name] }.to_a)
       )
-
-      countries.each do |c|
-        country = Everypolitician::Country::Metadata.new(
-          # TODO: change this to accept an EveryPolitician::Country
-          country: c.name,
-          dirs: c.legislatures.map { |l| 'data/' + l.directory },
-          commit_metadata: commit_metadata,
-        ).stanza
-        data[data.find_index { |c| c[:name] == country[:name] }] = country
-      end
-      File.write('countries.json', JSON.pretty_generate(data.sort_by { |c| c[:name] }.to_a))
     end
 
     private
 
     attr_reader :to_build
+
+    def countries_file
+      Pathname.new('countries.json')
+    end
+
+    def existing_data
+      JSON.parse(countries_file.read, symbolize_names: true)
+    end
+
+    def all_countries
+      EveryPolitician.countries
+    end
+
+    def countries
+      return all_countries if to_build.to_s.empty?
+      all_countries.select { |c| c.slug.downcase.include? to_build.downcase }
+    end
+
+    def commit_metadata
+      @cmd ||= file_to_commit_metadata(commit_path)
+    end
+
+    # If we know we'll need data for every country directory anyway,
+    # it's much faster to pass the single directory 'data' than a list
+    # of every country directory
+    def commit_path
+      return ['data'] if to_build.to_s.empty?
+      countries.flat_map(&:legislatures).map { |l| 'data/' + l.directory }
+    end
+
+    def updated_data
+      data = existing_data
+
+      countries.each do |c|
+        country = Everypolitician::Country::Metadata.new(
+          # TODO: change this to accept an EveryPolitician::Country
+          country:         c.name,
+          dirs:            c.legislatures.map { |l| 'data/' + l.directory },
+          commit_metadata: commit_metadata
+        ).stanza
+        data[data.find_index { |c| c[:name] == country[:name] }] = country
+      end
+
+      data
+    end
   end
 end


### PR DESCRIPTION
Move the logic for the 'countries.json' task out of the Rakefile into a
Task class.

Then use this to fixes the bug that was preventing all countries being rebuilt when there is no EP_COUNTRY_REFRESH environment variable set. (https://github.com/everypolitician/everypolitician-data/pull/18449)