### PR TITLE
Add bundle audit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 before_install:
   - echo -e "machine github.com\n  login $GITHUB_ACCESS_TOKEN" >> ~/.netrc
-script: bundle exec rake close_old_pull_requests pull_request_summary:travis test
+script:
+  - bundle exec rake close_old_pull_requests pull_request_summary:travis test
+  - bundle exec rake bundle:audit
 after_success:
   - scripts/deploy.sh
 cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'everypolitician-pull_request', github: 'everypolitician/everypolitician-pul
 gem 'everypolitician-dataview-terms', github: 'everypolitician/everypolitician-dataview-terms'
 
 group :test do
+  gem 'bundler-audit'
   gem 'minitest'
   gem 'minitest-around'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,9 @@ GEM
   specs:
     addressable (2.4.0)
     ast (2.3.0)
+    bundler-audit (0.5.0)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     coderay (1.1.1)
     colorize (0.8.1)
     crack (0.4.3)
@@ -130,6 +133,7 @@ GEM
       faraday (~> 0.8, < 0.10)
     sexp_processor (4.7.0)
     slop (3.6.0)
+    thor (0.19.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
@@ -146,6 +150,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bundler-audit
   close_old_pull_requests!
   colorize
   csv_to_popolo (~> 0.27.1)!

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -49,3 +49,6 @@ end
 
 require 'everypolitician/pull_request/rake_task'
 Everypolitician::PullRequest::RakeTask.new.install_tasks
+
+require 'bundler/audit/task'
+Bundler::Audit::Task.new


### PR DESCRIPTION
# What does this do?

Adds the bundle audit gem to the Gemfile

# Why was this needed?

For security reasons snce we want to switch to using https to link to gems that live in GitHub, as described in http://bundler.io/git.html#security

# Relevant Issue(s)

Part of https://github.com/everypolitician/everypolitician/issues/518

# Implementation notes

* There was no rake task for bundle:audit so I added the gem

* The rake file and Travis where updated to use bundle audit 

* I made [another PR](https://github.com/everypolitician/everypolitician-data/pull/18542) to test that it works, where I change the git urls in the Gemfile. After that I ran `bundle exec rake bundle:audit` against that PR and got:
```bash
:) be rake bundle:audit
Updating ruby-advisory-db ...
De https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
Already up-to-date.
Updated ruby-advisory-db
ruby-advisory-db: 273 advisories
No vulnerabilities found
```

# Screenshots

None

# Notes to Reviewer

None

# Notes to Merger

I think it makes sense to merge https://github.com/everypolitician/everypolitician-data/pull/18542 first, so that Travis is green