### PR TITLE
Brunei: remove ISO code from legislature

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -1454,11 +1454,11 @@
         "slug": "Legislative-Council",
         "sources_directory": "data/Brunei/Legislative_Council/sources",
         "popolo": "data/Brunei/Legislative_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5f92aa824fd9e1f8724533ee1f962e6e9d96c986/data/Brunei/Legislative_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2d67233f93564cdd95e6da8c76cd2c9dab63ef01/data/Brunei/Legislative_Council/ep-popolo-v1.0.json",
         "names": "data/Brunei/Legislative_Council/names.csv",
-        "lastmod": "1469383421",
+        "lastmod": "1476310115",
         "person_count": 19,
-        "sha": "5f92aa824fd9e1f8724533ee1f962e6e9d96c986",
+        "sha": "2d67233f93564cdd95e6da8c76cd2c9dab63ef01",
         "legislative_periods": [
           {
             "end_date": "2015-03-24",
@@ -1470,7 +1470,7 @@
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a1ee914c2e9714d5f3dbcb5e8c3f9ddde471ec2d/data/Brunei/Legislative_Council/term-11.csv"
           }
         ],
-        "statement_count": 311
+        "statement_count": 310
       }
     ]
   },

--- a/data/Brunei/Legislative_Council/ep-popolo-v1.0.json
+++ b/data/Brunei/Legislative_Council/ep-popolo-v1.0.json
@@ -451,7 +451,6 @@
           "scheme": "wikidata"
         }
       ],
-      "iso_code": "BN",
       "name": "Legislative Council of Brunei",
       "seats": 36
     },

--- a/data/Brunei/Legislative_Council/meta.json
+++ b/data/Brunei/Legislative_Council/meta.json
@@ -1,5 +1,4 @@
 {
-  "iso_code": "BN",
   "name": "Legislative Council of Brunei",
   "seats": 36,
   "wikidata": "Q2396996",


### PR DESCRIPTION
The meta file for the legislature included the ISO code for the country.
This is meant to live in the meta file one directory up instead (as it
already does).

Fixes https://github.com/everypolitician/everypolitician/issues/524