### PR TITLE
Map 'transgender female' to 'female' in Popolo

### DIFF
--- a/rake_build/generate_ep_popolo.rb
+++ b/rake_build/generate_ep_popolo.rb
@@ -156,7 +156,7 @@ namespace :transform do
   task write: :remap_gender
   GENDER_MAP = {
     'male'   => %w(m male homme),
-    'female' => %w(f female femme),
+    'female' => ['f', 'female', 'femme', 'transgender female'],
     'other'  => %w(o other),
   }.freeze
 


### PR DESCRIPTION
We will probably want to expose the more detailed information later, but
for now we want to expose this in a simple and consistent way for people
using the data. https://github.com/everypolitician/everypolitician/issues/525

This should fix the New Zealand and Poland builds, which are both currently failing because `transgender female` wasn't mapped to anything.