### PR TITLE
Update everypolitician-popolo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 abort 'Ruby should be >= 2.1.0' unless RUBY_VERSION.to_f >= 2.1
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 gem 'json'
 gem 'nokogiri'
@@ -15,15 +16,15 @@ gem 'sass'
 gem 'unicode_utils'
 gem 'wikisnakker', '~> 0.7.0', github: 'everypolitician/wikisnakker'
 gem 'everypolitician', github: 'everypolitician/everypolitician-ruby'
-gem 'everypolitician-popolo', '~> 0.6.0', github: 'everypolitician/everypolitician-popolo'
+gem 'everypolitician-popolo', '~> 0.7.0', github: 'everypolitician/everypolitician-popolo'
 gem 'twitter_username_extractor', github: 'everypolitician/twitter_username_extractor'
 gem 'facebook_username_extractor', '~> 0.2.0'
 gem 'json5'
 gem 'slop', '~> 3.6.0' # tied to pry version
 gem 'rcsv'
 gem 'require_all'
-gem 'close_old_pull_requests', git: 'https://github.com/everypolitician/close_old_pull_requests', branch: 'master'
-gem 'everypolitician-pull_request', git: 'https://github.com/everypolitician/everypolitician-pull_request', branch: 'master'
+gem 'close_old_pull_requests', github: 'everypolitician/close_old_pull_requests'
+gem 'everypolitician-pull_request', github: 'everypolitician/everypolitician-pull_request'
 gem 'everypolitician-dataview-terms', github: 'everypolitician/everypolitician-dataview-terms'
 
 group :test do
@@ -34,5 +35,3 @@ group :test do
   gem 'rubocop'
   gem 'flog'
 end
-
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,37 +1,55 @@
 GIT
-  remote: git://github.com/everypolitician/everypolitician-dataview-terms.git
-  revision: c492d2247b5a5693a91f45575b5d753bbe58931c
+  remote: https://github.com/everypolitician/close_old_pull_requests.git
+  revision: ba2dc4ebe77e20fcc663d0adee30e808b1f1154c
+  specs:
+    close_old_pull_requests (0.1.0)
+      octokit (~> 4.3)
+
+GIT
+  remote: https://github.com/everypolitician/everypolitician-dataview-terms.git
+  revision: f2fc1dd7c8cc4cab65d4a8e1bca7e1790264f808
   specs:
     everypolitician-dataview-terms (0.0.1)
       everypolitician-popolo
 
 GIT
-  remote: git://github.com/everypolitician/everypolitician-popolo.git
-  revision: 63c7a135c8436e77f0b7c5e6d3c43f91ee11e88a
+  remote: https://github.com/everypolitician/everypolitician-popolo.git
+  revision: 3b3b7abc6d3ed4fc6cd4d3295e4f019219e568bf
   specs:
-    everypolitician-popolo (0.6.1)
+    everypolitician-popolo (0.7.0)
+      require_all
 
 GIT
-  remote: git://github.com/everypolitician/everypolitician-ruby.git
-  revision: 1ab5d5ba15ff42cb1af01ba7528b948becfb1544
+  remote: https://github.com/everypolitician/everypolitician-pull_request.git
+  revision: 489a65cdd5c39d7648c4c4c76286489221c0242b
   specs:
-    everypolitician (0.7.0)
+    everypolitician-pull_request (0.4.0)
       everypolitician-popolo
+      octokit
+      require_all
 
 GIT
-  remote: git://github.com/everypolitician/twitter_username_extractor.git
-  revision: 891a0f4ea587195fc952305562048f53498b2d84
+  remote: https://github.com/everypolitician/everypolitician-ruby.git
+  revision: 3ebe575c1d8a3729440096842264d9c0201e0b06
   specs:
-    twitter_username_extractor (0.1.0)
+    everypolitician (0.18.0)
+      everypolitician-popolo
+      require_all
 
 GIT
-  remote: git://github.com/everypolitician/wikisnakker.git
-  revision: 3c438db2bb6ac10660d4e03adcbeae35d5834b3a
+  remote: https://github.com/everypolitician/twitter_username_extractor.git
+  revision: cc0aebc0ac8724f2d32ffba8426489ca7b1d92dd
+  specs:
+    twitter_username_extractor (0.2.0)
+
+GIT
+  remote: https://github.com/everypolitician/wikisnakker.git
+  revision: cc55a4f45290c8ad86dc3e2a41ea678e02e3dd94
   specs:
     wikisnakker (0.7.0)
 
 GIT
-  remote: git://github.com/tmtmtmtm/csv_to_popolo.git
+  remote: https://github.com/tmtmtmtm/csv_to_popolo.git
   revision: 130f7fc9dbc1a1fbdb7082e598e0a0bedf55d197
   specs:
     csv_to_popolo (0.27.1)
@@ -39,24 +57,6 @@ GIT
       json
       rcsv
       twitter_username_extractor
-
-GIT
-  remote: https://github.com/everypolitician/close_old_pull_requests
-  revision: ea9fe6f2b2468af95af84170bd01c0fddb7f3781
-  branch: master
-  specs:
-    close_old_pull_requests (0.1.0)
-      octokit (~> 4.3)
-
-GIT
-  remote: https://github.com/everypolitician/everypolitician-pull_request
-  revision: 489a65cdd5c39d7648c4c4c76286489221c0242b
-  branch: master
-  specs:
-    everypolitician-pull_request (0.4.0)
-      everypolitician-popolo
-      octokit
-      require_all
 
 GEM
   remote: https://rubygems.org/
@@ -151,7 +151,7 @@ DEPENDENCIES
   csv_to_popolo (~> 0.27.1)!
   everypolitician!
   everypolitician-dataview-terms!
-  everypolitician-popolo (~> 0.6.0)!
+  everypolitician-popolo (~> 0.7.0)!
   everypolitician-pull_request!
   facebook_username_extractor (~> 0.2.0)
   flog


### PR DESCRIPTION
# What does this do?

Updates to the latest version of everypolitician-popolo. Whilst doing this, switch to using secure `github:` shortcuts in the `Gemfile`.

# Why was this needed?

The latest everypolitician-popolo has significant speed improvements over earlier versions (by building indexes).  The switch in protocols is for security reasons, as described in http://bundler.io/git.html#security

# Relevant Issue(s)

Part of https://github.com/everypolitician/everypolitician/issues/518

# Implementation notes

This was a revised version of https://github.com/everypolitician/everypolitician-data/pull/18542 which had awkward merge conflicts. I cherry-picked the changes from that, but isolated only to the Gemfile, squashed them together, and then rebuilt the Gemfile.lock as a separate step.