### PR TITLE
Refactor build: move logic from Rakefile to Source classes

### DIFF
--- a/lib/source/area.rb
+++ b/lib/source/area.rb
@@ -2,5 +2,8 @@ require_relative 'json'
 
 module Source
   class Area < JSON
+    def to_popolo
+      { areas: as_json.map { |k, v| v.merge(id: k.to_s) } }
+    end
   end
 end

--- a/lib/source/elections.rb
+++ b/lib/source/elections.rb
@@ -2,5 +2,25 @@ require_relative 'json'
 
 module Source
   class Elections < JSON
+    def to_popolo
+      { events: events }
+    end
+
+    private
+
+    def events
+      as_json.map do |id, data|
+        name = data[:other_names].find { |h| h[:lang] == 'en' } or next warn "no English name for #{id}"
+        dates = [data[:dates], data[:start_date], data[:end_date]].flatten.compact.sort
+        next warn "No dates for election #{id} (#{name[:name]})" if dates.empty?
+        {
+          id:             id,
+          name:           name[:name],
+          start_date:     dates.first,
+          end_date:       dates.last,
+          classification: 'general election',
+        }
+      end.compact
+    end
   end
 end

--- a/lib/source/group.rb
+++ b/lib/source/group.rb
@@ -2,5 +2,8 @@ require_relative 'json'
 
 module Source
   class Group < JSON
+    def to_popolo
+      { organizations: as_json.map { |k, v| v.merge(id: k.to_s) } }
+    end
   end
 end

--- a/rake_build/generate_ep_popolo.rb
+++ b/rake_build/generate_ep_popolo.rb
@@ -174,22 +174,7 @@ namespace :transform do
   task write: :election_info
   task election_info: :load do
     @INSTRUCTIONS.sources_of_type('wikidata-elections').each do |src|
-      elections = src.as_json
-      elections.each do |id, data|
-        name = data[:other_names].find { |h| h[:lang] == 'en' } or next warn "no English name for #{id}"
-        dates = [data[:dates], data[:start_date], data[:end_date]].flatten.compact.sort
-        next warn "No dates for election #{id} (#{name[:name]})" if dates.empty?
-
-        info = {
-          id:             id,
-          name:           name[:name],
-          start_date:     dates.first,
-          end_date:       dates.last,
-          classification: 'general election',
-        }
-
-        @json[:events] << info
-      end
+      @json[:events] += src.to_popolo[:events]
     end
   end
 


### PR DESCRIPTION
As part of the ongoing process of moving logic out of the Rakefiles into
the Source classes, teach some of those classes how to return Popolo that the
Rakefile can then merge together with that from the other sources.

The logic for combining them is quite similar, and can be teased out
further in a later change.