### PR TITLE
Revert "Add bundle audit"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: ruby
 before_install:
   - echo -e "machine github.com\n  login $GITHUB_ACCESS_TOKEN" >> ~/.netrc
-script:
-  - bundle exec rake close_old_pull_requests pull_request_summary:travis test
-  - bundle exec rake bundle:audit
+script: bundle exec rake close_old_pull_requests pull_request_summary:travis test
 after_success:
   - scripts/deploy.sh
 cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ gem 'everypolitician-pull_request', github: 'everypolitician/everypolitician-pul
 gem 'everypolitician-dataview-terms', github: 'everypolitician/everypolitician-dataview-terms'
 
 group :test do
-  gem 'bundler-audit'
   gem 'minitest'
   gem 'minitest-around'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,9 +63,6 @@ GEM
   specs:
     addressable (2.4.0)
     ast (2.3.0)
-    bundler-audit (0.5.0)
-      bundler (~> 1.2)
-      thor (~> 0.18)
     coderay (1.1.1)
     colorize (0.8.1)
     crack (0.4.3)
@@ -133,7 +130,6 @@ GEM
       faraday (~> 0.8, < 0.10)
     sexp_processor (4.7.0)
     slop (3.6.0)
-    thor (0.19.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
@@ -150,7 +146,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler-audit
   close_old_pull_requests!
   colorize
   csv_to_popolo (~> 0.27.1)!

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -49,6 +49,3 @@ end
 
 require 'everypolitician/pull_request/rake_task'
 Everypolitician::PullRequest::RakeTask.new.install_tasks
-
-require 'bundler/audit/task'
-Bundler::Audit::Task.new


### PR DESCRIPTION
Reverts everypolitician/everypolitician-data#18496

The rebuilder log is full of errors:

```
2016-10-16T07:21:38.995840+00:00 app[worker.1]: rake aborted!
2016-10-16T07:21:38.995870+00:00 app[worker.1]: LoadError: cannot load such file -- bundler/audit/task
2016-10-16T07:21:38.996016+00:00 app[worker.1]: /tmp/d20161016-3-1twjob0/Rakefile.rb:53:in `require'
2016-10-16T07:21:38.996017+00:00 app[worker.1]: /tmp/d20161016-3-1twjob0/Rakefile.rb:53:in `<top (required)>'
2016-10-16T07:21:38.996021+00:00 app[worker.1]: /tmp/d20161016-3-1twjob0/vendor/bundle/gems/rake-11.2.2/exe/rake:27:in `<top (required)>'
2016-10-16T07:21:38.996023+00:00 app[worker.1]: (See full trace by running task with --trace)
```

and the `countries.json` file isn't being added to any PR