### PR TITLE
Add rake task to remap ids in idmap files from memberships

### DIFF
--- a/lib/uuid_map.rb
+++ b/lib/uuid_map.rb
@@ -36,6 +36,13 @@ class UuidMapFile
     end
   end
 
+  def remap(from, to)
+    if uuid_for(from) && !uuid_for(to)
+      mapping[to] = mapping.delete(from)
+      rewrite(mapping)
+    end
+  end
+
   private
 
   attr_reader :pathname

--- a/rake_config/memberships.rb
+++ b/rake_config/memberships.rb
@@ -1,0 +1,13 @@
+
+desc 'Remap memberships ids'
+namespace :memberships do
+  task :remap_ids, [:from, :to] do |_, args|
+    @INSTRUCTIONS.sources_of_type('membership').each do |source|
+      data = source.mapfile
+      abort "No existing data for #{args[:from]}" unless data.uuid_for(args[:from])
+      abort "Already have data for #{args[:to]}" if data.uuid_for(args[:to])
+      data.remap(args[:from], args[:to])
+      puts "Remapped #{args[:from]} to #{args[:to]} in #{source.filename.to_s}."
+    end
+  end
+end

--- a/test/uuid_map_test.rb
+++ b/test/uuid_map_test.rb
@@ -34,4 +34,30 @@ describe 'UUID Mapper' do
     newmap.uuid_for('barney').must_equal 'uuid-2'
     newmap.id_for('uuid-1').must_equal 'fred'
   end
+
+  describe '#remap' do
+    let(:file)   { new_tempfile }
+    let(:mapper) { UuidMapFile.new(file) }
+    let(:data)   { { 'fred' => 'uuid-1' } }
+
+    it 'remaps existing UUID to a new id' do
+      mapper.rewrite(data)
+      mapper.remap('fred', 'freddy')
+      mapper.uuid_for('fred').must_be_nil
+      mapper.uuid_for('freddy').must_equal 'uuid-1'
+    end
+
+    it 'does not remap if old id does not exist' do
+      mapper.rewrite(data)
+      mapper.remap('frida', 'freddy')
+      mapper.mapping.must_equal(data)
+    end
+
+    it 'does not remap if new id exists' do
+      data['barney'] = 'uuid-2'
+      mapper.rewrite(data)
+      mapper.remap('fred', 'barney')
+      mapper.mapping.must_equal(data)
+    end
+  end
 end


### PR DESCRIPTION
If the id of a politician changes, or a politician is given a UUID
because they didn't have one, we need to update our idmap files
to point the new ID at our UUID.

This adds a rake task to do that. You call it as:

``` rake
bundle exec rake memberships:remap_ids[oldID,newID]
```

(some shells, e.g. zsh, may need to quote those square brackets)

Tested against Spain - Congress:

``` bash
:) be rake memberships:remap_ids[0,ldsfhjsdf]
No existing data for 0

:( be rake memberships:remap_ids[1,2]
Already have data for 2

:( be rake memberships:remap_ids[1,lksjfdhlaskjdf]
Remapped 1 to lksjfdhlaskjdf in sources/morph/data.csv.
Remapped 1 to lksjfdhlaskjdf in sources/manual/old-official-2015.csv.
```

Diffs:

``` diff
diff --git a/data/Spain/Congress/sources/idmap/data.csv b/data/Spain/Congress/sources/idmap/data.csv
index e0e74910..d250c54 100644
--- a/data/Spain/Congress/sources/idmap/data.csv
+++ b/data/Spain/Congress/sources/idmap/data.csv
@@ -315,7 +315,6 @@ id,uuid
286,3a2f1c00-145a-4a0d-9bfa-47b9f4021a3d
147,96f05bef-2754-4016-9741-ae3fafbdada5
133,3144e6dd-6bda-4ea8-9216-b62412908d84
-1,e7d91367-5354-42c1-afbd-255fda10b3b4
207,120e7186-a938-492b-a338-144eac6b135e
191,5652f7b8-5a2c-4b43-9af6-65eb712fd058
69,d509bc83-28fe-4cc9-9a8a-9872a9afd10f
@@ -396,3 +395,4 @@ id,uuid
134,3758465f-8950-4f8f-87f6-3a77ade17856
255,1dc74f90-60de-4605-bc5f-1d2806a28baf
128,dccb7a59-805b-4849-9a01-e2250169dd4d
+lksjfdhlaskjdf,e7d91367-5354-42c1-afbd-255fda10b3b4
```

``` diff
diff --git a/data/Spain/Congress/sources/idmap/old-official-2015.csv b/data/Spain/Congress/sources/idmap/old-official-2015.csv
index 01d218e..7cb30a6 100644
--- a/data/Spain/Congress/sources/idmap/old-official-2015.csv
+++ b/data/Spain/Congress/sources/idmap/old-official-2015.csv
@@ -88,7 +88,6 @@ id,uuid
217,adc29b53-c852-4ee8-9657-95097b3fbd11
123,b3d6f99d-7a8f-4fde-b299-39e59a6a72bd
281,b4058bd9-5c6c-433b-bf89-c0cfb90949d3
-1,b57f060a-4dae-4fb6-8897-c1e2ab1787e4
149,b8601e64-70e4-451b-9e0f-ef95673b4ad2
115,bb8b3468-016c-4b8c-9906-a7ce148f20d6
342,bc1025e8-ffac-421e-86f0-76d5c090b13c
@@ -350,3 +349,4 @@ id,uuid
87,12ad07c5-873b-48a6-87d0-4b71cfa2f0c0
58,d0321bfa-0c33-471c-a910-b3a43cebcc04
351,8a9762b0-3826-4f81-9dda-e33f28a4f674
+lksjfdhlaskjdf,b57f060a-4dae-4fb6-8897-c1e2ab1787e4
```
