### PR TITLE
Spain add term 12 to manual/terms.csv file

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -9237,13 +9237,14 @@
         "slug": "Congress",
         "sources_directory": "data/Spain/Congress/sources",
         "popolo": "data/Spain/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/19c4f423e734f35968f331229b30e1381af0ab78/data/Spain/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e26c60f91e2dc3ea5f99f3cbe6f95ca64428eb00/data/Spain/Congress/ep-popolo-v1.0.json",
         "names": "data/Spain/Congress/names.csv",
-        "lastmod": "1479728874",
+        "lastmod": "1479838020",
         "person_count": 621,
-        "sha": "19c4f423e734f35968f331229b30e1381af0ab78",
+        "sha": "e26c60f91e2dc3ea5f99f3cbe6f95ca64428eb00",
         "legislative_periods": [
           {
+            "end_date": "2016-05-03",
             "id": "term/11",
             "name": "XI Legislatura",
             "start_date": "2016-01-13",
@@ -9261,7 +9262,7 @@
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/19c4f423e734f35968f331229b30e1381af0ab78/data/Spain/Congress/term-10.csv"
           }
         ],
-        "statement_count": 33713,
+        "statement_count": 33718,
         "type": "unicameral legislature"
       }
     ]

--- a/data/Spain/Congress/ep-popolo-v1.0.json
+++ b/data/Spain/Congress/ep-popolo-v1.0.json
@@ -63465,6 +63465,7 @@
     },
     {
       "classification": "legislative period",
+      "end_date": "2016-05-03",
       "id": "term/11",
       "name": "XI Legislatura",
       "organization_id": "a0ade8ef-8127-47eb-8cb5-9403d5dbeb4c",

--- a/data/Spain/Congress/ep-popolo-v1.0.json
+++ b/data/Spain/Congress/ep-popolo-v1.0.json
@@ -63446,6 +63446,12 @@
       "classification": "legislative period",
       "end_date": "2015-10-27",
       "id": "term/10",
+      "identifiers": [
+        {
+          "identifier": "Q2498034",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "X Legislatura",
       "organization_id": "a0ade8ef-8127-47eb-8cb5-9403d5dbeb4c",
       "start_date": "2011-11-28"
@@ -63467,6 +63473,12 @@
       "classification": "legislative period",
       "end_date": "2016-05-03",
       "id": "term/11",
+      "identifiers": [
+        {
+          "identifier": "Q21857364",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "XI Legislatura",
       "organization_id": "a0ade8ef-8127-47eb-8cb5-9403d5dbeb4c",
       "start_date": "2016-01-13"

--- a/data/Spain/Congress/sources/manual/terms.csv
+++ b/data/Spain/Congress/sources/manual/terms.csv
@@ -1,3 +1,4 @@
 id,name,start_date,end_date,wikidata
 10,X Legislatura,2011-11-28,2015-10-27
-11,XI Legislatura,2016-01-13,
+11,XI Legislatura,2016-01-13,2016-05-03
+12,XII Legislatura,2016-07-19,

--- a/data/Spain/Congress/sources/manual/terms.csv
+++ b/data/Spain/Congress/sources/manual/terms.csv
@@ -1,4 +1,4 @@
 id,name,start_date,end_date,wikidata
-10,X Legislatura,2011-11-28,2015-10-27
-11,XI Legislatura,2016-01-13,2016-05-03
-12,XII Legislatura,2016-07-19,
+10,X Legislatura,2011-11-28,2015-10-27,Q2498034
+11,XI Legislatura,2016-01-13,2016-05-03,Q21857364
+12,XII Legislatura,2016-07-19,,Q24025404

--- a/data/Spain/Congress/sources/manual/terms.csv
+++ b/data/Spain/Congress/sources/manual/terms.csv
@@ -1,3 +1,3 @@
-id,name,start_date,end_date
+id,name,start_date,end_date,wikidata
 10,X Legislatura,2011-11-28,2015-10-27
 11,XI Legislatura,2016-01-13,


### PR DESCRIPTION
This PR updates the terms file to:
1) Update it to the new format described in <https://github.com/everypolitician/everypolitician/wiki/terms.csv>
2) Add the ending date of the previous term and the starting date of the new term according to [the IPU site](http://www.ipu.org/parline-e/reports/2293_E.htm).

* [x] new term added to `terms.csv`
* [x] new term start date is correct, and source credited in commit message
* [x] previous term end date is set (and, if added here, source is credited in commit message)
