### PR TITLE
Guernsey: Swap name order

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -4128,11 +4128,11 @@
         "slug": "States",
         "sources_directory": "data/Guernsey/States/sources",
         "popolo": "data/Guernsey/States/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d665a023b9ea42dc1c418a3ea910365b8b82ee29/data/Guernsey/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0533a9ac726ef0c6ca8b429168426af0c5575b69/data/Guernsey/States/ep-popolo-v1.0.json",
         "names": "data/Guernsey/States/names.csv",
-        "lastmod": "1476563201",
+        "lastmod": "1476784289",
         "person_count": 49,
-        "sha": "d665a023b9ea42dc1c418a3ea910365b8b82ee29",
+        "sha": "0533a9ac726ef0c6ca8b429168426af0c5575b69",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -4140,7 +4140,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Guernsey/States/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/145fb27181efe040e91fba081c7f7703d29b591d/data/Guernsey/States/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0533a9ac726ef0c6ca8b429168426af0c5575b69/data/Guernsey/States/term-2012.csv"
           }
         ],
         "statement_count": 1310

--- a/data/Guernsey/States/ep-popolo-v1.0.json
+++ b/data/Guernsey/States/ep-popolo-v1.0.json
@@ -18,34 +18,105 @@
           "scheme": "everypolitician_legacy"
         }
       ],
-      "name": "Adam, A. Hunter"
+      "name": "A. Hunter Adam"
     },
     {
       "contact_details": [
         {
           "type": "email",
-          "value": "elis.bebb@gmail.com"
+          "value": "al.brouard@deputies.gov.gg"
+        }
+      ],
+      "email": "al.brouard@deputies.gov.gg",
+      "id": "22e754e3-7656-4673-9dde-a3c7f1c274a9",
+      "identifiers": [
+        {
+          "identifier": "brouard,_al_h.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Al H. Brouard"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "allister.langlois@deputies.gov.gg"
+        }
+      ],
+      "email": "allister.langlois@deputies.gov.gg",
+      "id": "0834c5ff-9cc5-42b7-aeaa-818cc61cfaa5",
+      "identifiers": [
+        {
+          "identifier": "langlois,_allister_h.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Allister H. Langlois"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "lelievre@fsmail.net"
+        }
+      ],
+      "email": "lelievre@fsmail.net",
+      "gender": "male",
+      "id": "7a7232be-622f-4bb1-8c40-87419c926ca9",
+      "identifiers": [
+        {
+          "identifier": "le_lievre,_andrew_r.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Andrew R. Le Lievre"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Arrun.Wilkie@deputies.gov.gg"
         },
         {
           "type": "twitter",
-          "value": "ElisBebb"
+          "value": "ArrunWilkie"
         }
       ],
-      "email": "elis.bebb@gmail.com",
-      "id": "2a86f938-d509-4eaf-b24f-46ccb056ff79",
+      "email": "Arrun.Wilkie@deputies.gov.gg",
+      "gender": "male",
+      "id": "ff2138c8-e8f8-4456-9c16-a4ed53fbb871",
       "identifiers": [
         {
-          "identifier": "bebb,_elis_g.",
+          "identifier": "wilkie,_arrun_m.",
           "scheme": "everypolitician_legacy"
         }
       ],
       "links": [
         {
           "note": "twitter",
-          "url": "https://twitter.com/ElisBebb"
+          "url": "https://twitter.com/ArrunWilkie"
         }
       ],
-      "name": "Bebb, Elis G."
+      "name": "Arrun M. Wilkie"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Barry.Paint@deputies.gov.gg"
+        }
+      ],
+      "email": "Barry.Paint@deputies.gov.gg",
+      "gender": "male",
+      "id": "705c20b5-2149-47b4-9d3e-a58e6e0d5f9b",
+      "identifiers": [
+        {
+          "identifier": "paint,_barry_j._e.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Barry J. E. Paint"
     },
     {
       "contact_details": [
@@ -73,252 +144,18 @@
           "url": "https://twitter.com/deputybaz"
         }
       ],
-      "name": "Brehaut, Barry L."
+      "name": "Barry L. Brehaut"
     },
     {
       "contact_details": [
         {
           "type": "email",
-          "value": "al.brouard@deputies.gov.gg"
+          "value": "Charles.Parkinson@deputies.gov.gg"
         }
       ],
-      "email": "al.brouard@deputies.gov.gg",
-      "id": "22e754e3-7656-4673-9dde-a3c7f1c274a9",
-      "identifiers": [
-        {
-          "identifier": "brouard,_al_h.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Brouard, Al H."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "yvonne.burford@deputies.gov.gg"
-        },
-        {
-          "type": "twitter",
-          "value": "YvonneBurford"
-        }
-      ],
-      "email": "yvonne.burford@deputies.gov.gg",
-      "gender": "female",
-      "id": "47ebccc8-b779-49aa-a800-eb45b48e3dad",
-      "identifiers": [
-        {
-          "identifier": "burford,_yvonne",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "links": [
-        {
-          "note": "twitter",
-          "url": "https://twitter.com/YvonneBurford"
-        }
-      ],
-      "name": "Burford, Yvonne"
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Garry.Collins@deputies.gov.gg"
-        },
-        {
-          "type": "twitter",
-          "value": "GarryCollinsGue"
-        }
-      ],
-      "email": "Garry.Collins@deputies.gov.gg",
-      "id": "f4ae0bb0-5382-4105-a4e6-012974134b3b",
-      "identifiers": [
-        {
-          "identifier": "collins,_garry_m.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "links": [
-        {
-          "note": "twitter",
-          "url": "https://twitter.com/GarryCollinsGue"
-        }
-      ],
-      "name": "Collins, Garry M."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Richard.Conder@deputies.gov.gg"
-        }
-      ],
-      "email": "Richard.Conder@deputies.gov.gg",
-      "gender": "male",
-      "id": "7304e050-e141-475e-bbd4-9afbeb4be566",
-      "identifiers": [
-        {
-          "identifier": "conder,_richard",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Conder, Richard"
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "delisle.david@cwgsy.net"
-        },
-        {
-          "type": "twitter",
-          "value": "delisledavid"
-        }
-      ],
-      "email": "delisle.david@cwgsy.net",
-      "gender": "male",
-      "id": "ba64f08a-c809-4cb5-9fa1-9ab669574be1",
-      "identifiers": [
-        {
-          "identifier": "de_lisle,_david_de_g",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "links": [
-        {
-          "note": "twitter",
-          "url": "https://twitter.com/delisledavid"
-        }
-      ],
-      "name": "De Lisle, David de G"
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Roger.Domaille@deputies.gov.gg"
-        }
-      ],
-      "email": "Roger.Domaille@deputies.gov.gg",
-      "gender": "male",
-      "id": "16b52004-d66c-479d-949b-b61050d86abe",
-      "identifiers": [
-        {
-          "identifier": "domaille,_roger",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Domaille, Roger"
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Mark.Dorey@deputies.gov.gg"
-        }
-      ],
-      "email": "Mark.Dorey@deputies.gov.gg",
-      "gender": "male",
-      "id": "a1129c34-55df-45d2-8780-e2a279ba8b47",
-      "identifiers": [
-        {
-          "identifier": "dorey,_mark_h.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Dorey, Mark H."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Darren.Duquemin@deputies.gov.gg"
-        },
-        {
-          "type": "twitter",
-          "value": "darrenduquemin"
-        }
-      ],
-      "email": "Darren.Duquemin@deputies.gov.gg",
-      "gender": "male",
-      "id": "7bb1ec99-1b27-48ba-916c-9f3261adc9eb",
-      "identifiers": [
-        {
-          "identifier": "duquemin,_darren_j.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "links": [
-        {
-          "note": "twitter",
-          "url": "https://twitter.com/darrenduquemin"
-        }
-      ],
-      "name": "Duquemin, Darren J."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "mattfallaize@cwgsy.net"
-        }
-      ],
-      "email": "mattfallaize@cwgsy.net",
-      "gender": "male",
-      "id": "615a4e62-bdaa-4ced-9528-d23cbf9a23ac",
-      "identifiers": [
-        {
-          "identifier": "fallaize,_matthew_j.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Fallaize, Matthew J."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Peter.Gillson@gov.gg"
-        }
-      ],
-      "email": "Peter.Gillson@gov.gg",
-      "gender": "male",
-      "id": "0a85ff4b-c495-44f9-9b33-4141e6e2b09a",
-      "identifiers": [
-        {
-          "identifier": "gillson,_peter_l.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Gillson, Peter L."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "John.Gollop@deputies.gov.gg"
-        },
-        {
-          "type": "twitter",
-          "value": "GollopGuern"
-        }
-      ],
-      "email": "John.Gollop@deputies.gov.gg",
-      "id": "188c99cd-2336-40d5-aec0-c0028f53b364",
-      "identifiers": [
-        {
-          "identifier": "gollop,_john_a._b.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "links": [
-        {
-          "note": "twitter",
-          "url": "https://twitter.com/GollopGuern"
-        }
-      ],
-      "name": "Gollop, John A. B."
+      "email": "Charles.Parkinson@deputies.gov.gg",
+      "id": "9055f7fc-324b-40fb-93bf-5ff4d8b2ccbb",
+      "name": "Charles Parkinson"
     },
     {
       "contact_details": [
@@ -346,127 +183,35 @@
           "url": "https://twitter.com/deputycgreen"
         }
       ],
-      "name": "Green, Christopher J."
+      "name": "Christopher J. Green"
     },
     {
       "contact_details": [
         {
           "type": "email",
-          "value": "Mike.Hadley@deputies.gov.gg"
-        }
-      ],
-      "email": "Mike.Hadley@deputies.gov.gg",
-      "gender": "male",
-      "id": "c38b874b-e9ba-42eb-b023-7ae395c57582",
-      "identifiers": [
-        {
-          "identifier": "hadley,_michael_p._j.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Hadley, Michael P. J."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Neil.Harvey@deputies.gov.gg"
-        }
-      ],
-      "email": "Neil.Harvey@deputies.gov.gg",
-      "gender": "male",
-      "id": "b6d46b0f-24ef-42c6-b7ee-8f3b08ff87e1",
-      "identifiers": [
-        {
-          "identifier": "harvey,_neil",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Harvey, Neil"
-    },
-    {
-      "birth_date": "1947",
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Peter.Harwood@deputies.gov.gg"
-        }
-      ],
-      "email": "Peter.Harwood@deputies.gov.gg",
-      "gender": "male",
-      "given_name": "Peter",
-      "id": "a556d367-f9ac-452e-baae-c248b0938d1c",
-      "identifiers": [
-        {
-          "identifier": "harwood,_peter_a.",
-          "scheme": "everypolitician_legacy"
+          "value": "Darren.Duquemin@deputies.gov.gg"
         },
         {
-          "identifier": "Q7174570",
-          "scheme": "wikidata"
+          "type": "twitter",
+          "value": "darrenduquemin"
+        }
+      ],
+      "email": "Darren.Duquemin@deputies.gov.gg",
+      "gender": "male",
+      "id": "7bb1ec99-1b27-48ba-916c-9f3261adc9eb",
+      "identifiers": [
+        {
+          "identifier": "duquemin,_darren_j.",
+          "scheme": "everypolitician_legacy"
         }
       ],
       "links": [
         {
-          "note": "Wikipedia (el)",
-          "url": "https://el.wikipedia.org/wiki/Πίτερ_Χάργουντ"
-        },
-        {
-          "note": "Wikipedia (en)",
-          "url": "https://en.wikipedia.org/wiki/Peter_Harwood"
-        },
-        {
-          "note": "Wikipedia (fr)",
-          "url": "https://fr.wikipedia.org/wiki/Peter_Harwood"
+          "note": "twitter",
+          "url": "https://twitter.com/darrenduquemin"
         }
       ],
-      "name": "Harwood, Peter A.",
-      "other_names": [
-        {
-          "name": "Peter Harwood",
-          "note": "alternate"
-        },
-        {
-          "lang": "de",
-          "name": "Peter Harwood",
-          "note": "multilingual"
-        },
-        {
-          "lang": "el",
-          "name": "Πίτερ Χάργουντ",
-          "note": "multilingual"
-        },
-        {
-          "lang": "en",
-          "name": "Peter Harwood",
-          "note": "multilingual"
-        },
-        {
-          "lang": "en-ca",
-          "name": "Peter Harwood",
-          "note": "multilingual"
-        },
-        {
-          "lang": "en-gb",
-          "name": "Peter Harwood",
-          "note": "multilingual"
-        },
-        {
-          "lang": "fr",
-          "name": "Peter Harwood",
-          "note": "multilingual"
-        },
-        {
-          "lang": "hu",
-          "name": "Peter Harwood",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Peter Harwood",
-          "note": "multilingual"
-        }
-      ]
+      "name": "Darren J. Duquemin"
     },
     {
       "contact_details": [
@@ -498,51 +243,7 @@
           "url": "https://twitter.com/DavidInglisGsy"
         }
       ],
-      "name": "Inglis, David A."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Sandra.James@deputies.gov.gg"
-        },
-        {
-          "type": "twitter",
-          "value": "DepSandraJames"
-        }
-      ],
-      "email": "Sandra.James@deputies.gov.gg",
-      "id": "f157f548-0e79-46af-97fc-9886aeeabaf8",
-      "identifiers": [
-        {
-          "identifier": "james,_sandra_a.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "links": [
-        {
-          "note": "twitter",
-          "url": "https://twitter.com/DepSandraJames"
-        }
-      ],
-      "name": "James, Sandra A."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Louis.Jean@deputies.gov.gg"
-        }
-      ],
-      "email": "Louis.Jean@deputies.gov.gg",
-      "id": "bba10897-2d47-4b8d-b2e9-dcfaa16bdae5",
-      "identifiers": [
-        {
-          "identifier": "jean,_louis",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Jean, Louis"
+      "name": "David A. Inglis"
     },
     {
       "contact_details": [
@@ -570,34 +271,180 @@
           "url": "https://twitter.com/DeputyDaveJones"
         }
       ],
-      "name": "Jones, David B."
+      "name": "David B. Jones"
     },
     {
       "contact_details": [
         {
           "type": "email",
-          "value": "Robert.Jones@deputies.gov.gg"
+          "value": "delisle.david@cwgsy.net"
         },
         {
           "type": "twitter",
-          "value": "deputyrobjones"
+          "value": "delisledavid"
         }
       ],
-      "email": "Robert.Jones@deputies.gov.gg",
-      "id": "84d2583a-725e-4444-bcf8-8bda48ed3f39",
+      "email": "delisle.david@cwgsy.net",
+      "gender": "male",
+      "id": "ba64f08a-c809-4cb5-9fa1-9ab669574be1",
       "identifiers": [
         {
-          "identifier": "jones,_robert_a.",
+          "identifier": "de_lisle,_david_de_g",
           "scheme": "everypolitician_legacy"
         }
       ],
       "links": [
         {
           "note": "twitter",
-          "url": "https://twitter.com/deputyrobjones"
+          "url": "https://twitter.com/delisledavid"
         }
       ],
-      "name": "Jones, Robert A."
+      "name": "David G de Lisle"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "elis.bebb@gmail.com"
+        },
+        {
+          "type": "twitter",
+          "value": "ElisBebb"
+        }
+      ],
+      "email": "elis.bebb@gmail.com",
+      "id": "2a86f938-d509-4eaf-b24f-46ccb056ff79",
+      "identifiers": [
+        {
+          "identifier": "bebb,_elis_g.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "links": [
+        {
+          "note": "twitter",
+          "url": "https://twitter.com/ElisBebb"
+        }
+      ],
+      "name": "Elis G. Bebb"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Francis.Quin@deputies.gov.gg"
+        }
+      ],
+      "email": "Francis.Quin@deputies.gov.gg",
+      "id": "41f38b5b-60a4-4e5e-bd8f-02e0a6637a33",
+      "identifiers": [
+        {
+          "identifier": "quin,_francis_w.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Francis W. Quin"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Garry.Collins@deputies.gov.gg"
+        },
+        {
+          "type": "twitter",
+          "value": "GarryCollinsGue"
+        }
+      ],
+      "email": "Garry.Collins@deputies.gov.gg",
+      "id": "f4ae0bb0-5382-4105-a4e6-012974134b3b",
+      "identifiers": [
+        {
+          "identifier": "collins,_garry_m.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "links": [
+        {
+          "note": "twitter",
+          "url": "https://twitter.com/GarryCollinsGue"
+        }
+      ],
+      "name": "Garry M. Collins"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Gavin.StPier@deputies.gov.gg"
+        },
+        {
+          "type": "twitter",
+          "value": "gavinstpier"
+        }
+      ],
+      "email": "Gavin.StPier@deputies.gov.gg",
+      "gender": "male",
+      "id": "320594a7-8505-457f-8a84-c18561b4455e",
+      "identifiers": [
+        {
+          "identifier": "st._pier,_gavin_a",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "links": [
+        {
+          "note": "linkedin",
+          "url": "http://www.linkedin.com/pub/gavin-st-pier/46/4b8/45b?trk=pub-pbmap"
+        },
+        {
+          "note": "twitter",
+          "url": "https://twitter.com/gavinstpier"
+        }
+      ],
+      "name": "Gavin A St. Pier"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Graham.McKinley@deputies.gov.gg"
+        }
+      ],
+      "email": "Graham.McKinley@deputies.gov.gg",
+      "id": "b1863f9c-5a8c-4808-a38d-e0e57c7f0da4",
+      "name": "Graham McKinley"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Heidi.Soulsby@deputies.gov.gg"
+        },
+        {
+          "type": "twitter",
+          "value": "HeidiSoulsby"
+        }
+      ],
+      "email": "Heidi.Soulsby@deputies.gov.gg",
+      "id": "a65d0059-362b-4db9-9a05-1c762afc4011",
+      "identifiers": [
+        {
+          "identifier": "soulsby,_heidi_j._r.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "links": [
+        {
+          "note": "linkedin",
+          "url": "http://www.linkedin.com/pub/heidi-soulsby/25/835/891"
+        },
+        {
+          "note": "twitter",
+          "url": "https://twitter.com/HeidiSoulsby"
+        }
+      ],
+      "name": "Heidi J. R. Soulsby"
     },
     {
       "contact_details": [
@@ -614,87 +461,34 @@
           "scheme": "everypolitician_legacy"
         }
       ],
-      "name": "Kuttelwascher, Jan"
+      "name": "Jan Kuttelwascher"
     },
     {
       "contact_details": [
         {
           "type": "email",
-          "value": "allister.langlois@deputies.gov.gg"
-        }
-      ],
-      "email": "allister.langlois@deputies.gov.gg",
-      "id": "0834c5ff-9cc5-42b7-aeaa-818cc61cfaa5",
-      "identifiers": [
-        {
-          "identifier": "langlois,_allister_h.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Langlois, Allister H."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Michelle.LeClerc@deputies.gov.gg"
+          "value": "John.Gollop@deputies.gov.gg"
         },
         {
           "type": "twitter",
-          "value": "mkleclerc"
+          "value": "GollopGuern"
         }
       ],
-      "email": "Michelle.LeClerc@deputies.gov.gg",
-      "gender": "female",
-      "id": "fec5dc7a-6eae-4e5b-8fb4-062fca557f53",
+      "email": "John.Gollop@deputies.gov.gg",
+      "id": "188c99cd-2336-40d5-aec0-c0028f53b364",
       "identifiers": [
         {
-          "identifier": "le_clerc,_michelle_k.",
+          "identifier": "gollop,_john_a._b.",
           "scheme": "everypolitician_legacy"
         }
       ],
       "links": [
         {
           "note": "twitter",
-          "url": "https://twitter.com/mkleclerc"
+          "url": "https://twitter.com/GollopGuern"
         }
       ],
-      "name": "Le Clerc, Michelle K."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "lelievre@fsmail.net"
-        }
-      ],
-      "email": "lelievre@fsmail.net",
-      "gender": "male",
-      "id": "7a7232be-622f-4bb1-8c40-87419c926ca9",
-      "identifiers": [
-        {
-          "identifier": "le_lievre,_andrew_r.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Le Lievre, Andrew R."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Paul.LePelley@deputies.gov.gg"
-        }
-      ],
-      "email": "Paul.LePelley@deputies.gov.gg",
-      "id": "2b11b882-cb89-47a4-b930-847796867f1a",
-      "identifiers": [
-        {
-          "identifier": "le_pelley,_paul_r.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Le Pelley, Paul R."
+      "name": "John A. B. Gollop"
     },
     {
       "birth_date": "1964-03-04",
@@ -744,7 +538,7 @@
           "url": "https://twitter.com/letocq"
         }
       ],
-      "name": "Le Tocq, Jonathan P.",
+      "name": "Jonathan P. Le Tocq",
       "other_names": [
         {
           "name": "Jonathan Le Tocq",
@@ -796,360 +590,6 @@
       "contact_details": [
         {
           "type": "email",
-          "value": "marylowe@cwgsy.net"
-        },
-        {
-          "type": "twitter",
-          "value": "DeputyMaryLowe"
-        }
-      ],
-      "email": "marylowe@cwgsy.net",
-      "gender": "female",
-      "id": "2c4d1331-c726-4591-b50c-6e68bd526abc",
-      "identifiers": [
-        {
-          "identifier": "lowe,_mary_m.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "links": [
-        {
-          "note": "twitter",
-          "url": "https://twitter.com/DeputyMaryLowe"
-        }
-      ],
-      "name": "Lowe, Mary M."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Paul.Luxon@deputies.gov.gg"
-        },
-        {
-          "type": "twitter",
-          "value": "paul_luxon"
-        }
-      ],
-      "email": "Paul.Luxon@deputies.gov.gg",
-      "gender": "male",
-      "id": "8d947ab2-464a-4ddc-bcfd-149f6137e211",
-      "identifiers": [
-        {
-          "identifier": "luxon,_paul_a.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "links": [
-        {
-          "note": "linkedin",
-          "url": "http://uk.linkedin.com/pub/paul-luxon/36/14a/663?trk=pub-pbmap"
-        },
-        {
-          "note": "twitter",
-          "url": "https://twitter.com/paul_luxon"
-        }
-      ],
-      "name": "Luxon, Paul A."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Graham.McKinley@deputies.gov.gg"
-        }
-      ],
-      "email": "Graham.McKinley@deputies.gov.gg",
-      "id": "b1863f9c-5a8c-4808-a38d-e0e57c7f0da4",
-      "name": "McKinley, Graham"
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "mike.ohara@cwgsy.net"
-        }
-      ],
-      "email": "mike.ohara@cwgsy.net",
-      "gender": "male",
-      "id": "e5e619cf-d153-45b8-920e-924e4cdb5cfb",
-      "identifiers": [
-        {
-          "identifier": "o'hara,_michael_g.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "O'Hara, Michael G."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Scott.Ogier@deputies.gov.gg"
-        },
-        {
-          "type": "twitter",
-          "value": "DeputyOgier"
-        }
-      ],
-      "email": "Scott.Ogier@deputies.gov.gg",
-      "gender": "male",
-      "id": "e116bd8c-1d90-4e23-9811-611ba321cdee",
-      "identifiers": [
-        {
-          "identifier": "ogier,_scott_j.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "links": [
-        {
-          "note": "linkedin",
-          "url": "http://uk.linkedin.com/pub/scott-ogier/34/431/4?trk=pub-pbmap"
-        },
-        {
-          "note": "twitter",
-          "url": "https://twitter.com/DeputyOgier"
-        }
-      ],
-      "name": "Ogier, Scott J."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Barry.Paint@deputies.gov.gg"
-        }
-      ],
-      "email": "Barry.Paint@deputies.gov.gg",
-      "gender": "male",
-      "id": "705c20b5-2149-47b4-9d3e-a58e6e0d5f9b",
-      "identifiers": [
-        {
-          "identifier": "paint,_barry_j._e.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Paint, Barry J. E."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Charles.Parkinson@deputies.gov.gg"
-        }
-      ],
-      "email": "Charles.Parkinson@deputies.gov.gg",
-      "id": "9055f7fc-324b-40fb-93bf-5ff4d8b2ccbb",
-      "name": "Parkinson, Charles"
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Roger.Perrot@deputies.gov.gg"
-        }
-      ],
-      "email": "Roger.Perrot@deputies.gov.gg",
-      "gender": "male",
-      "id": "2b2f38bf-b57f-43ab-89a2-6afd924adea3",
-      "identifiers": [
-        {
-          "identifier": "perrot,_roger_a.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Perrot, Roger A."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "laurie.queripel@gmail.com"
-        }
-      ],
-      "email": "laurie.queripel@gmail.com",
-      "id": "073c98dc-cd6d-42ce-a082-3a90eccab640",
-      "identifiers": [
-        {
-          "identifier": "queripel,_laurie_b.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Queripel, Laurie B."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "lesterqueripel@cwgsy.net"
-        }
-      ],
-      "email": "lesterqueripel@cwgsy.net",
-      "id": "b1c159f0-8ddc-48b1-9dca-0f8990c8d947",
-      "identifiers": [
-        {
-          "identifier": "queripel,_lester_c.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Queripel, Lester C."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Francis.Quin@deputies.gov.gg"
-        }
-      ],
-      "email": "Francis.Quin@deputies.gov.gg",
-      "id": "41f38b5b-60a4-4e5e-bd8f-02e0a6637a33",
-      "identifiers": [
-        {
-          "identifier": "quin,_francis_w.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Quin, Francis W."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Peter.Sherbourne@deputies.gov.gg"
-        },
-        {
-          "type": "twitter",
-          "value": "Sherbs1"
-        }
-      ],
-      "email": "Peter.Sherbourne@deputies.gov.gg",
-      "id": "9bcf918f-e618-450d-9c13-59fbb8a7a557",
-      "identifiers": [
-        {
-          "identifier": "sherbourne,_peter_a.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "links": [
-        {
-          "note": "twitter",
-          "url": "https://twitter.com/Sherbs1"
-        }
-      ],
-      "name": "Sherbourne, Peter A."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Robert.Sillars@deputies.gov.gg"
-        },
-        {
-          "type": "twitter",
-          "value": "RobertWSillars"
-        }
-      ],
-      "email": "Robert.Sillars@deputies.gov.gg",
-      "id": "511db5d0-9ad7-4ea0-8d77-563da49e5734",
-      "identifiers": [
-        {
-          "identifier": "sillars,_robert_w.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "links": [
-        {
-          "note": "twitter",
-          "url": "https://twitter.com/RobertWSillars"
-        }
-      ],
-      "name": "Sillars, Robert W."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Heidi.Soulsby@deputies.gov.gg"
-        },
-        {
-          "type": "twitter",
-          "value": "HeidiSoulsby"
-        }
-      ],
-      "email": "Heidi.Soulsby@deputies.gov.gg",
-      "id": "a65d0059-362b-4db9-9a05-1c762afc4011",
-      "identifiers": [
-        {
-          "identifier": "soulsby,_heidi_j._r.",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "links": [
-        {
-          "note": "linkedin",
-          "url": "http://www.linkedin.com/pub/heidi-soulsby/25/835/891"
-        },
-        {
-          "note": "twitter",
-          "url": "https://twitter.com/HeidiSoulsby"
-        }
-      ],
-      "name": "Soulsby, Heidi J. R."
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "tonyspruce@cwgsy.net"
-        }
-      ],
-      "email": "tonyspruce@cwgsy.net",
-      "gender": "male",
-      "id": "56154f65-50cd-47e1-b9c3-0e9f5b9c8cf9",
-      "identifiers": [
-        {
-          "identifier": "spruce,_tony",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "name": "Spruce, Tony"
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
-          "value": "Gavin.StPier@deputies.gov.gg"
-        },
-        {
-          "type": "twitter",
-          "value": "gavinstpier"
-        }
-      ],
-      "email": "Gavin.StPier@deputies.gov.gg",
-      "gender": "male",
-      "id": "320594a7-8505-457f-8a84-c18561b4455e",
-      "identifiers": [
-        {
-          "identifier": "st._pier,_gavin_a",
-          "scheme": "everypolitician_legacy"
-        }
-      ],
-      "links": [
-        {
-          "note": "linkedin",
-          "url": "http://www.linkedin.com/pub/gavin-st-pier/46/4b8/45b?trk=pub-pbmap"
-        },
-        {
-          "note": "twitter",
-          "url": "https://twitter.com/gavinstpier"
-        }
-      ],
-      "name": "St. Pier, Gavin A"
-    },
-    {
-      "contact_details": [
-        {
-          "type": "email",
           "value": "Kevin.Stewart@deputies.gov.gg"
         },
         {
@@ -1176,58 +616,58 @@
           "url": "https://twitter.com/kevinstewartgsy"
         }
       ],
-      "name": "Stewart, Kevin A."
+      "name": "Kevin A. Stewart"
     },
     {
       "contact_details": [
         {
           "type": "email",
-          "value": "Martin.Storey@deputies.gov.gg"
+          "value": "laurie.queripel@gmail.com"
         }
       ],
-      "death_date": "2015-07-22",
-      "email": "Martin.Storey@deputies.gov.gg",
-      "gender": "male",
-      "given_name": "Martin",
-      "id": "e88fa42f-8ee3-4a7e-ad85-338e9557fe60",
+      "email": "laurie.queripel@gmail.com",
+      "id": "073c98dc-cd6d-42ce-a082-3a90eccab640",
       "identifiers": [
         {
-          "identifier": "storey,_martin_j.",
+          "identifier": "queripel,_laurie_b.",
           "scheme": "everypolitician_legacy"
-        },
-        {
-          "identifier": "Q20872869",
-          "scheme": "wikidata"
         }
       ],
-      "links": [
+      "name": "Laurie B. Queripel"
+    },
+    {
+      "contact_details": [
         {
-          "note": "Wikipedia (en)",
-          "url": "https://en.wikipedia.org/wiki/Martin_Storey_(politician)"
+          "type": "email",
+          "value": "lesterqueripel@cwgsy.net"
         }
       ],
-      "name": "Storey, Martin J.",
-      "other_names": [
+      "email": "lesterqueripel@cwgsy.net",
+      "id": "b1c159f0-8ddc-48b1-9dca-0f8990c8d947",
+      "identifiers": [
         {
-          "name": "Martin Storey",
-          "note": "alternate"
-        },
-        {
-          "lang": "cy",
-          "name": "Martin Storey",
-          "note": "multilingual"
-        },
-        {
-          "lang": "en",
-          "name": "Martin Storey",
-          "note": "multilingual"
-        },
-        {
-          "lang": "fr",
-          "name": "Martin Storey",
-          "note": "multilingual"
+          "identifier": "queripel,_lester_c.",
+          "scheme": "everypolitician_legacy"
         }
-      ]
+      ],
+      "name": "Lester C. Queripel"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Louis.Jean@deputies.gov.gg"
+        }
+      ],
+      "email": "Louis.Jean@deputies.gov.gg",
+      "id": "bba10897-2d47-4b8d-b2e9-dcfaa16bdae5",
+      "identifiers": [
+        {
+          "identifier": "jean,_louis",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Louis Jean"
     },
     {
       "birth_date": "1964-07-17",
@@ -1271,7 +711,7 @@
           "url": "https://pl.wikipedia.org/wiki/Lyndon_Trott"
         }
       ],
-      "name": "Trott, Lyndon S.",
+      "name": "Lyndon S. Trott",
       "other_names": [
         {
           "name": "Lyndon Trott",
@@ -1313,29 +753,589 @@
       "contact_details": [
         {
           "type": "email",
-          "value": "Arrun.Wilkie@deputies.gov.gg"
+          "value": "Mark.Dorey@deputies.gov.gg"
+        }
+      ],
+      "email": "Mark.Dorey@deputies.gov.gg",
+      "gender": "male",
+      "id": "a1129c34-55df-45d2-8780-e2a279ba8b47",
+      "identifiers": [
+        {
+          "identifier": "dorey,_mark_h.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Mark H. Dorey"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Martin.Storey@deputies.gov.gg"
+        }
+      ],
+      "death_date": "2015-07-22",
+      "email": "Martin.Storey@deputies.gov.gg",
+      "gender": "male",
+      "given_name": "Martin",
+      "id": "e88fa42f-8ee3-4a7e-ad85-338e9557fe60",
+      "identifiers": [
+        {
+          "identifier": "storey,_martin_j.",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "Q20872869",
+          "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Martin_Storey_(politician)"
+        }
+      ],
+      "name": "Martin J. Storey",
+      "other_names": [
+        {
+          "name": "Martin Storey",
+          "note": "alternate"
+        },
+        {
+          "lang": "cy",
+          "name": "Martin Storey",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Martin Storey",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Martin Storey",
+          "note": "multilingual"
+        }
+      ]
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "marylowe@cwgsy.net"
         },
         {
           "type": "twitter",
-          "value": "ArrunWilkie"
+          "value": "DeputyMaryLowe"
         }
       ],
-      "email": "Arrun.Wilkie@deputies.gov.gg",
-      "gender": "male",
-      "id": "ff2138c8-e8f8-4456-9c16-a4ed53fbb871",
+      "email": "marylowe@cwgsy.net",
+      "gender": "female",
+      "id": "2c4d1331-c726-4591-b50c-6e68bd526abc",
       "identifiers": [
         {
-          "identifier": "wilkie,_arrun_m.",
+          "identifier": "lowe,_mary_m.",
           "scheme": "everypolitician_legacy"
         }
       ],
       "links": [
         {
           "note": "twitter",
-          "url": "https://twitter.com/ArrunWilkie"
+          "url": "https://twitter.com/DeputyMaryLowe"
         }
       ],
-      "name": "Wilkie, Arrun M."
+      "name": "Mary M. Lowe"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "mattfallaize@cwgsy.net"
+        }
+      ],
+      "email": "mattfallaize@cwgsy.net",
+      "gender": "male",
+      "id": "615a4e62-bdaa-4ced-9528-d23cbf9a23ac",
+      "identifiers": [
+        {
+          "identifier": "fallaize,_matthew_j.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Matthew J. Fallaize"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "mike.ohara@cwgsy.net"
+        }
+      ],
+      "email": "mike.ohara@cwgsy.net",
+      "gender": "male",
+      "id": "e5e619cf-d153-45b8-920e-924e4cdb5cfb",
+      "identifiers": [
+        {
+          "identifier": "o'hara,_michael_g.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Michael G. O'Hara"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Mike.Hadley@deputies.gov.gg"
+        }
+      ],
+      "email": "Mike.Hadley@deputies.gov.gg",
+      "gender": "male",
+      "id": "c38b874b-e9ba-42eb-b023-7ae395c57582",
+      "identifiers": [
+        {
+          "identifier": "hadley,_michael_p._j.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Michael P. J. Hadley"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Michelle.LeClerc@deputies.gov.gg"
+        },
+        {
+          "type": "twitter",
+          "value": "mkleclerc"
+        }
+      ],
+      "email": "Michelle.LeClerc@deputies.gov.gg",
+      "gender": "female",
+      "id": "fec5dc7a-6eae-4e5b-8fb4-062fca557f53",
+      "identifiers": [
+        {
+          "identifier": "le_clerc,_michelle_k.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "links": [
+        {
+          "note": "twitter",
+          "url": "https://twitter.com/mkleclerc"
+        }
+      ],
+      "name": "Michelle K. Le Clerc"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Neil.Harvey@deputies.gov.gg"
+        }
+      ],
+      "email": "Neil.Harvey@deputies.gov.gg",
+      "gender": "male",
+      "id": "b6d46b0f-24ef-42c6-b7ee-8f3b08ff87e1",
+      "identifiers": [
+        {
+          "identifier": "harvey,_neil",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Neil Harvey"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Paul.Luxon@deputies.gov.gg"
+        },
+        {
+          "type": "twitter",
+          "value": "paul_luxon"
+        }
+      ],
+      "email": "Paul.Luxon@deputies.gov.gg",
+      "gender": "male",
+      "id": "8d947ab2-464a-4ddc-bcfd-149f6137e211",
+      "identifiers": [
+        {
+          "identifier": "luxon,_paul_a.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "links": [
+        {
+          "note": "linkedin",
+          "url": "http://uk.linkedin.com/pub/paul-luxon/36/14a/663?trk=pub-pbmap"
+        },
+        {
+          "note": "twitter",
+          "url": "https://twitter.com/paul_luxon"
+        }
+      ],
+      "name": "Paul A. Luxon"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Paul.LePelley@deputies.gov.gg"
+        }
+      ],
+      "email": "Paul.LePelley@deputies.gov.gg",
+      "id": "2b11b882-cb89-47a4-b930-847796867f1a",
+      "identifiers": [
+        {
+          "identifier": "le_pelley,_paul_r.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Paul R. Le Pelley"
+    },
+    {
+      "birth_date": "1947",
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Peter.Harwood@deputies.gov.gg"
+        }
+      ],
+      "email": "Peter.Harwood@deputies.gov.gg",
+      "gender": "male",
+      "given_name": "Peter",
+      "id": "a556d367-f9ac-452e-baae-c248b0938d1c",
+      "identifiers": [
+        {
+          "identifier": "harwood,_peter_a.",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "Q7174570",
+          "scheme": "wikidata"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (el)",
+          "url": "https://el.wikipedia.org/wiki/Πίτερ_Χάργουντ"
+        },
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Peter_Harwood"
+        },
+        {
+          "note": "Wikipedia (fr)",
+          "url": "https://fr.wikipedia.org/wiki/Peter_Harwood"
+        }
+      ],
+      "name": "Peter A. Harwood",
+      "other_names": [
+        {
+          "name": "Peter Harwood",
+          "note": "alternate"
+        },
+        {
+          "lang": "de",
+          "name": "Peter Harwood",
+          "note": "multilingual"
+        },
+        {
+          "lang": "el",
+          "name": "Πίτερ Χάργουντ",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Peter Harwood",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en-ca",
+          "name": "Peter Harwood",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en-gb",
+          "name": "Peter Harwood",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Peter Harwood",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hu",
+          "name": "Peter Harwood",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Peter Harwood",
+          "note": "multilingual"
+        }
+      ]
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Peter.Sherbourne@deputies.gov.gg"
+        },
+        {
+          "type": "twitter",
+          "value": "Sherbs1"
+        }
+      ],
+      "email": "Peter.Sherbourne@deputies.gov.gg",
+      "id": "9bcf918f-e618-450d-9c13-59fbb8a7a557",
+      "identifiers": [
+        {
+          "identifier": "sherbourne,_peter_a.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "links": [
+        {
+          "note": "twitter",
+          "url": "https://twitter.com/Sherbs1"
+        }
+      ],
+      "name": "Peter A. Sherbourne"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Peter.Gillson@gov.gg"
+        }
+      ],
+      "email": "Peter.Gillson@gov.gg",
+      "gender": "male",
+      "id": "0a85ff4b-c495-44f9-9b33-4141e6e2b09a",
+      "identifiers": [
+        {
+          "identifier": "gillson,_peter_l.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Peter L. Gillson"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Richard.Conder@deputies.gov.gg"
+        }
+      ],
+      "email": "Richard.Conder@deputies.gov.gg",
+      "gender": "male",
+      "id": "7304e050-e141-475e-bbd4-9afbeb4be566",
+      "identifiers": [
+        {
+          "identifier": "conder,_richard",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Richard Conder"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Robert.Jones@deputies.gov.gg"
+        },
+        {
+          "type": "twitter",
+          "value": "deputyrobjones"
+        }
+      ],
+      "email": "Robert.Jones@deputies.gov.gg",
+      "id": "84d2583a-725e-4444-bcf8-8bda48ed3f39",
+      "identifiers": [
+        {
+          "identifier": "jones,_robert_a.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "links": [
+        {
+          "note": "twitter",
+          "url": "https://twitter.com/deputyrobjones"
+        }
+      ],
+      "name": "Robert A. Jones"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Robert.Sillars@deputies.gov.gg"
+        },
+        {
+          "type": "twitter",
+          "value": "RobertWSillars"
+        }
+      ],
+      "email": "Robert.Sillars@deputies.gov.gg",
+      "id": "511db5d0-9ad7-4ea0-8d77-563da49e5734",
+      "identifiers": [
+        {
+          "identifier": "sillars,_robert_w.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "links": [
+        {
+          "note": "twitter",
+          "url": "https://twitter.com/RobertWSillars"
+        }
+      ],
+      "name": "Robert W. Sillars"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Roger.Perrot@deputies.gov.gg"
+        }
+      ],
+      "email": "Roger.Perrot@deputies.gov.gg",
+      "gender": "male",
+      "id": "2b2f38bf-b57f-43ab-89a2-6afd924adea3",
+      "identifiers": [
+        {
+          "identifier": "perrot,_roger_a.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Roger A. Perrot"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Roger.Domaille@deputies.gov.gg"
+        }
+      ],
+      "email": "Roger.Domaille@deputies.gov.gg",
+      "gender": "male",
+      "id": "16b52004-d66c-479d-949b-b61050d86abe",
+      "identifiers": [
+        {
+          "identifier": "domaille,_roger",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Roger Domaille"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Sandra.James@deputies.gov.gg"
+        },
+        {
+          "type": "twitter",
+          "value": "DepSandraJames"
+        }
+      ],
+      "email": "Sandra.James@deputies.gov.gg",
+      "id": "f157f548-0e79-46af-97fc-9886aeeabaf8",
+      "identifiers": [
+        {
+          "identifier": "james,_sandra_a.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "links": [
+        {
+          "note": "twitter",
+          "url": "https://twitter.com/DepSandraJames"
+        }
+      ],
+      "name": "Sandra A. James"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "Scott.Ogier@deputies.gov.gg"
+        },
+        {
+          "type": "twitter",
+          "value": "DeputyOgier"
+        }
+      ],
+      "email": "Scott.Ogier@deputies.gov.gg",
+      "gender": "male",
+      "id": "e116bd8c-1d90-4e23-9811-611ba321cdee",
+      "identifiers": [
+        {
+          "identifier": "ogier,_scott_j.",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "links": [
+        {
+          "note": "linkedin",
+          "url": "http://uk.linkedin.com/pub/scott-ogier/34/431/4?trk=pub-pbmap"
+        },
+        {
+          "note": "twitter",
+          "url": "https://twitter.com/DeputyOgier"
+        }
+      ],
+      "name": "Scott J. Ogier"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "tonyspruce@cwgsy.net"
+        }
+      ],
+      "email": "tonyspruce@cwgsy.net",
+      "gender": "male",
+      "id": "56154f65-50cd-47e1-b9c3-0e9f5b9c8cf9",
+      "identifiers": [
+        {
+          "identifier": "spruce,_tony",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "name": "Tony Spruce"
+    },
+    {
+      "contact_details": [
+        {
+          "type": "email",
+          "value": "yvonne.burford@deputies.gov.gg"
+        },
+        {
+          "type": "twitter",
+          "value": "YvonneBurford"
+        }
+      ],
+      "email": "yvonne.burford@deputies.gov.gg",
+      "gender": "female",
+      "id": "47ebccc8-b779-49aa-a800-eb45b48e3dad",
+      "identifiers": [
+        {
+          "identifier": "burford,_yvonne",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "links": [
+        {
+          "note": "twitter",
+          "url": "https://twitter.com/YvonneBurford"
+        }
+      ],
+      "name": "Yvonne Burford"
     }
   ],
   "organizations": [

--- a/data/Guernsey/States/names.csv
+++ b/data/Guernsey/States/names.csv
@@ -1,55 +1,55 @@
 name,id
-"Adam, A. Hunter",cf186769-790b-4538-8eb2-b9154e86bf71
-"Bebb, Elis G.",2a86f938-d509-4eaf-b24f-46ccb056ff79
-"Brehaut, Barry L.",fb8a0921-0a45-4209-bb3c-c42e6f073c3b
-"Brouard, Al H.",22e754e3-7656-4673-9dde-a3c7f1c274a9
-"Burford, Yvonne",47ebccc8-b779-49aa-a800-eb45b48e3dad
-"Collins, Garry M.",f4ae0bb0-5382-4105-a4e6-012974134b3b
-"Conder, Richard",7304e050-e141-475e-bbd4-9afbeb4be566
-"De Lisle, David de G",ba64f08a-c809-4cb5-9fa1-9ab669574be1
-"Domaille, Roger",16b52004-d66c-479d-949b-b61050d86abe
-"Dorey, Mark H.",a1129c34-55df-45d2-8780-e2a279ba8b47
-"Duquemin, Darren J.",7bb1ec99-1b27-48ba-916c-9f3261adc9eb
-"Fallaize, Matthew J.",615a4e62-bdaa-4ced-9528-d23cbf9a23ac
-"Gillson, Peter L.",0a85ff4b-c495-44f9-9b33-4141e6e2b09a
-"Gollop, John A. B.",188c99cd-2336-40d5-aec0-c0028f53b364
-"Green, Christopher J.",7f503d0b-59db-4708-9f94-45684cd88c3a
-"Hadley, Michael P. J.",c38b874b-e9ba-42eb-b023-7ae395c57582
-"Harvey, Neil",b6d46b0f-24ef-42c6-b7ee-8f3b08ff87e1
-"Harwood, Peter A.",a556d367-f9ac-452e-baae-c248b0938d1c
-"Inglis, David A.",0a9eba4a-124c-46ee-9a5c-301943824d40
-"James, Sandra A.",f157f548-0e79-46af-97fc-9886aeeabaf8
-"Jean, Louis",bba10897-2d47-4b8d-b2e9-dcfaa16bdae5
+A. Hunter Adam,cf186769-790b-4538-8eb2-b9154e86bf71
+Al H. Brouard,22e754e3-7656-4673-9dde-a3c7f1c274a9
+Allister H. Langlois,0834c5ff-9cc5-42b7-aeaa-818cc61cfaa5
+Andrew R. Le Lievre,7a7232be-622f-4bb1-8c40-87419c926ca9
+Arrun M. Wilkie,ff2138c8-e8f8-4456-9c16-a4ed53fbb871
+Barry J. E. Paint,705c20b5-2149-47b4-9d3e-a58e6e0d5f9b
+Barry L. Brehaut,fb8a0921-0a45-4209-bb3c-c42e6f073c3b
+Charles Parkinson,9055f7fc-324b-40fb-93bf-5ff4d8b2ccbb
+Christopher J. Green,7f503d0b-59db-4708-9f94-45684cd88c3a
+Darren J. Duquemin,7bb1ec99-1b27-48ba-916c-9f3261adc9eb
+David A. Inglis,0a9eba4a-124c-46ee-9a5c-301943824d40
+David B. Jones,db266608-e1b3-4a1f-bb43-833f7b3b757c
+David G de Lisle,ba64f08a-c809-4cb5-9fa1-9ab669574be1
+Elis G. Bebb,2a86f938-d509-4eaf-b24f-46ccb056ff79
+Francis W. Quin,41f38b5b-60a4-4e5e-bd8f-02e0a6637a33
+Garry M. Collins,f4ae0bb0-5382-4105-a4e6-012974134b3b
+Gavin A St. Pier,320594a7-8505-457f-8a84-c18561b4455e
+Graham McKinley,b1863f9c-5a8c-4808-a38d-e0e57c7f0da4
+Heidi J. R. Soulsby,a65d0059-362b-4db9-9a05-1c762afc4011
+Jan Kuttelwascher,71ec9a6c-c567-490e-baae-69dd38f57352
+John A. B. Gollop,188c99cd-2336-40d5-aec0-c0028f53b364
 Jonathan Le Tocq,e06e1b58-295c-4837-be1c-6ffbcbfb9a86
-"Jones, David B.",db266608-e1b3-4a1f-bb43-833f7b3b757c
-"Jones, Robert A.",84d2583a-725e-4444-bcf8-8bda48ed3f39
-"Kuttelwascher, Jan",71ec9a6c-c567-490e-baae-69dd38f57352
-"Langlois, Allister H.",0834c5ff-9cc5-42b7-aeaa-818cc61cfaa5
-"Le Clerc, Michelle K.",fec5dc7a-6eae-4e5b-8fb4-062fca557f53
-"Le Lievre, Andrew R.",7a7232be-622f-4bb1-8c40-87419c926ca9
-"Le Pelley, Paul R.",2b11b882-cb89-47a4-b930-847796867f1a
-"Le Tocq, Jonathan P.",e06e1b58-295c-4837-be1c-6ffbcbfb9a86
-"Lowe, Mary M.",2c4d1331-c726-4591-b50c-6e68bd526abc
-"Luxon, Paul A.",8d947ab2-464a-4ddc-bcfd-149f6137e211
+Jonathan P. Le Tocq,e06e1b58-295c-4837-be1c-6ffbcbfb9a86
+Kevin A. Stewart,1d770029-1592-434e-9434-f00b6ac82965
+Laurie B. Queripel,073c98dc-cd6d-42ce-a082-3a90eccab640
+Lester C. Queripel,b1c159f0-8ddc-48b1-9dca-0f8990c8d947
+Louis Jean,bba10897-2d47-4b8d-b2e9-dcfaa16bdae5
+Lyndon S. Trott,957adc63-eaf0-4147-a1dc-2402c576d1d1
 Lyndon Trott,957adc63-eaf0-4147-a1dc-2402c576d1d1
+Mark H. Dorey,a1129c34-55df-45d2-8780-e2a279ba8b47
+Martin J. Storey,e88fa42f-8ee3-4a7e-ad85-338e9557fe60
 Martin Storey,e88fa42f-8ee3-4a7e-ad85-338e9557fe60
-"McKinley, Graham",b1863f9c-5a8c-4808-a38d-e0e57c7f0da4
-"O'Hara, Michael G.",e5e619cf-d153-45b8-920e-924e4cdb5cfb
-"Ogier, Scott J.",e116bd8c-1d90-4e23-9811-611ba321cdee
-"Paint, Barry J. E.",705c20b5-2149-47b4-9d3e-a58e6e0d5f9b
-"Parkinson, Charles",9055f7fc-324b-40fb-93bf-5ff4d8b2ccbb
-"Perrot, Roger A.",2b2f38bf-b57f-43ab-89a2-6afd924adea3
+Mary M. Lowe,2c4d1331-c726-4591-b50c-6e68bd526abc
+Matthew J. Fallaize,615a4e62-bdaa-4ced-9528-d23cbf9a23ac
+Michael G. O'Hara,e5e619cf-d153-45b8-920e-924e4cdb5cfb
+Michael P. J. Hadley,c38b874b-e9ba-42eb-b023-7ae395c57582
+Michelle K. Le Clerc,fec5dc7a-6eae-4e5b-8fb4-062fca557f53
+Neil Harvey,b6d46b0f-24ef-42c6-b7ee-8f3b08ff87e1
+Paul A. Luxon,8d947ab2-464a-4ddc-bcfd-149f6137e211
+Paul R. Le Pelley,2b11b882-cb89-47a4-b930-847796867f1a
+Peter A. Harwood,a556d367-f9ac-452e-baae-c248b0938d1c
+Peter A. Sherbourne,9bcf918f-e618-450d-9c13-59fbb8a7a557
 Peter Harwood,a556d367-f9ac-452e-baae-c248b0938d1c
-"Queripel, Laurie B.",073c98dc-cd6d-42ce-a082-3a90eccab640
-"Queripel, Lester C.",b1c159f0-8ddc-48b1-9dca-0f8990c8d947
-"Quin, Francis W.",41f38b5b-60a4-4e5e-bd8f-02e0a6637a33
-"Sherbourne, Peter A.",9bcf918f-e618-450d-9c13-59fbb8a7a557
-"Sillars, Robert W.",511db5d0-9ad7-4ea0-8d77-563da49e5734
-"Soulsby, Heidi J. R.",a65d0059-362b-4db9-9a05-1c762afc4011
-"Spruce, Tony",56154f65-50cd-47e1-b9c3-0e9f5b9c8cf9
-"St. Pier, Gavin A",320594a7-8505-457f-8a84-c18561b4455e
-"Stewart, Kevin A.",1d770029-1592-434e-9434-f00b6ac82965
-"Storey, Martin J.",e88fa42f-8ee3-4a7e-ad85-338e9557fe60
-"Trott, Lyndon S.",957adc63-eaf0-4147-a1dc-2402c576d1d1
-"Wilkie, Arrun M.",ff2138c8-e8f8-4456-9c16-a4ed53fbb871
+Peter L. Gillson,0a85ff4b-c495-44f9-9b33-4141e6e2b09a
+Richard Conder,7304e050-e141-475e-bbd4-9afbeb4be566
+Robert A. Jones,84d2583a-725e-4444-bcf8-8bda48ed3f39
+Robert W. Sillars,511db5d0-9ad7-4ea0-8d77-563da49e5734
+Roger A. Perrot,2b2f38bf-b57f-43ab-89a2-6afd924adea3
+Roger Domaille,16b52004-d66c-479d-949b-b61050d86abe
+Sandra A. James,f157f548-0e79-46af-97fc-9886aeeabaf8
+Scott J. Ogier,e116bd8c-1d90-4e23-9811-611ba321cdee
+Tony Spruce,56154f65-50cd-47e1-b9c3-0e9f5b9c8cf9
+Yvonne Burford,47ebccc8-b779-49aa-a800-eb45b48e3dad
 Πίτερ Χάργουντ,a556d367-f9ac-452e-baae-c248b0938d1c

--- a/data/Guernsey/States/sources/manual/data-2012.csv
+++ b/data/Guernsey/States/sources/manual/data-2012.csv
@@ -1,50 +1,50 @@
-name,area,party,email,twitter,linkedin,term,source
-"Harvey, Neil",Alderney Representative,Independent,Neil.Harvey@deputies.gov.gg,"","",2012,
-"Storey, Martin J.",St. Peter Port North,Independent,Martin.Storey@deputies.gov.gg,"","",2012,
-"Adam, A. Hunter",Castel,Independent,Hunter.Adam@deputies.gov.gg,"","",2012,
-"Bebb, Elis G.",St. Peter Port North,Independent,elis.bebb@gmail.com,https://twitter.com/ElisBebb,"",2012,
-"Brehaut, Barry L.",St. Peter Port South,Independent,barry.brehaut@deputies.gov.gg,https://twitter.com/deputybaz,"",2012,
-"Brouard, Al H.",West,Independent,al.brouard@deputies.gov.gg,"","",2012,
-"Burford, Yvonne",West,Independent,yvonne.burford@deputies.gov.gg,https://twitter.com/YvonneBurford,"",2012,
-"Collins, Garry M.",Vale,Independent,Garry.Collins@deputies.gov.gg,https://twitter.com/GarryCollinsGue,"",2012,
-"Conder, Richard",St. Peter Port North,Independent,Richard.Conder@deputies.gov.gg,"","",2012,
-"De Lisle, David de G",West,Independent,delisle.david@cwgsy.net,https://twitter.com/delisledavid,"",2012,
-"Domaille, Roger",St. Peter Port South,Independent,Roger.Domaille@deputies.gov.gg,"","",2012,
-"Dorey, Mark H.",Castel,Independent,Mark.Dorey@deputies.gov.gg,"","",2012,
-"Duquemin, Darren J.",Castel,Independent,Darren.Duquemin@deputies.gov.gg,https://twitter.com/darrenduquemin,"",2012,
-"Fallaize, Matthew J.",Vale,Independent,mattfallaize@cwgsy.net,"","",2012,
-"Gillson, Peter L.",St. Sampson,Independent,Peter.Gillson@gov.gg,"","",2012,
-"Gollop, John A. B.",St. Peter Port North,Independent,John.Gollop@deputies.gov.gg,https://twitter.com/GollopGuern,"",2012,
-"Green, Christopher J.",Castel,Independent,Christopher.Green@deputies.gov.gg,https://twitter.com/deputycgreen,"",2012,
-"Hadley, Michael P. J.",South-East,Independent,Mike.Hadley@deputies.gov.gg,"","",2012,
-"Harwood, Peter A.",St. Peter Port South,Independent,Peter.Harwood@deputies.gov.gg,"","",2012,
-"Inglis, David A.",West,Independent,dai@cwgsy.net,https://twitter.com/DavidInglisGsy,http://www.linkedin.com/in/davidinglisgsy,2012,
-"James, Sandra A.",Castel,Independent,Sandra.James@deputies.gov.gg,https://twitter.com/DepSandraJames,"",2012,
-"Jean, Louis",Alderney Representative,Independent,Louis.Jean@deputies.gov.gg,"","",2012,
-"Jones, David B.",Vale,Independent,David.Jones@deputies.gov.gg,https://twitter.com/DeputyDaveJones,"",2012,
-"Jones, Robert A.",St. Peter Port South,Independent,Robert.Jones@deputies.gov.gg,https://twitter.com/deputyrobjones,"",2012,
-"Kuttelwascher, Jan",St. Peter Port South,Independent,Jan.Kuttelwascher@deputies.gov.gg,"","",2012,
-"Langlois, Allister H.",St. Peter Port South,Independent,allister.langlois@deputies.gov.gg,"","",2012,
-"Le Clerc, Michelle K.",St. Peter Port North,Independent,Michelle.LeClerc@deputies.gov.gg,https://twitter.com/mkleclerc,"",2012,
-"Le Lievre, Andrew R.",Vale,Independent,lelievre@fsmail.net,"","",2012,
-"Le Pelley, Paul R.",St. Sampson,Independent,Paul.LePelley@deputies.gov.gg,"","",2012,
-"Le Tocq, Jonathan P.",Castel,Independent,Jonathan.LeTocq@deputies.gov.gg,https://twitter.com/letocq,http://www.linkedin.com/pub/jonathan-le-tocq/23/5a/b98?trk=pub-pbmap,2012,
-"Lowe, Mary M.",Vale,Independent,marylowe@cwgsy.net,https://twitter.com/DeputyMaryLowe,"",2012,
-"Luxon, Paul A.",South-East,Independent,Paul.Luxon@deputies.gov.gg,https://twitter.com/paul_luxon,http://uk.linkedin.com/pub/paul-luxon/36/14a/663?trk=pub-pbmap,2012,
-"McKinley, Graham",Alderney Representative,Independent,Graham.McKinley@deputies.gov.gg,"","",2012,
-"Ogier, Scott J.",St. Sampson,Independent,Scott.Ogier@deputies.gov.gg,https://twitter.com/DeputyOgier,http://uk.linkedin.com/pub/scott-ogier/34/431/4?trk=pub-pbmap,2012,
-"O'Hara, Michael G.",South-East,Independent,mike.ohara@cwgsy.net,"","",2012,
-"Paint, Barry J. E.",Castel,Independent,Barry.Paint@deputies.gov.gg,"","",2012,
-"Parkinson, Charles",St. Peter Port North,Independent,Charles.Parkinson@deputies.gov.gg,"","",2012,
-"Perrot, Roger A.",West,Independent,Roger.Perrot@deputies.gov.gg,"","",2012,
-"Queripel, Laurie B.",Vale,Independent,laurie.queripel@gmail.com,"","",2012,
-"Queripel, Lester C.",St. Peter Port North,Independent,lesterqueripel@cwgsy.net,"","",2012,
-"Quin, Francis W.",South-East,Independent,Francis.Quin@deputies.gov.gg,"","",2012,
-"Sherbourne, Peter A.",St. Peter Port North,Independent,Peter.Sherbourne@deputies.gov.gg,https://twitter.com/Sherbs1,"",2012,
-"Sillars, Robert W.",South-East,Independent,Robert.Sillars@deputies.gov.gg,https://twitter.com/RobertWSillars,"",2012,
-"Soulsby, Heidi J. R.",South-East,Independent,Heidi.Soulsby@deputies.gov.gg,https://twitter.com/HeidiSoulsby,http://www.linkedin.com/pub/heidi-soulsby/25/835/891,2012,
-"Spruce, Tony",Vale,Independent,tonyspruce@cwgsy.net,"","",2012,
-"St. Pier, Gavin A",St. Sampson,Independent,Gavin.StPier@deputies.gov.gg,https://twitter.com/gavinstpier,http://www.linkedin.com/pub/gavin-st-pier/46/4b8/45b?trk=pub-pbmap,2012,
-"Stewart, Kevin A.",St. Sampson,Independent,Kevin.Stewart@deputies.gov.gg,https://twitter.com/kevinstewartgsy,http://www.linkedin.com/in/kevinstewart2008,2012,
-"Trott, Lyndon S.",St. Sampson,Independent,Lyndon.Trott@deputies.gov.gg,"","",2012,
-"Wilkie, Arrun M.",West,Independent,Arrun.Wilkie@deputies.gov.gg,https://twitter.com/ArrunWilkie,"",2012,
+id,area,party,email,twitter,linkedin,term,source,name
+"harvey,_neil",Alderney Representative,Independent,Neil.Harvey@deputies.gov.gg,"","",2012,,Neil Harvey
+"storey,_martin_j.",St. Peter Port North,Independent,Martin.Storey@deputies.gov.gg,"","",2012,,Martin J. Storey
+"adam,_a._hunter",Castel,Independent,Hunter.Adam@deputies.gov.gg,"","",2012,,A. Hunter Adam
+"bebb,_elis_g.",St. Peter Port North,Independent,elis.bebb@gmail.com,https://twitter.com/ElisBebb,"",2012,,Elis G. Bebb
+"brehaut,_barry_l.",St. Peter Port South,Independent,barry.brehaut@deputies.gov.gg,https://twitter.com/deputybaz,"",2012,,Barry L. Brehaut
+"brouard,_al_h.",West,Independent,al.brouard@deputies.gov.gg,"","",2012,,Al H. Brouard
+"burford,_yvonne",West,Independent,yvonne.burford@deputies.gov.gg,https://twitter.com/YvonneBurford,"",2012,,Yvonne Burford
+"collins,_garry_m.",Vale,Independent,Garry.Collins@deputies.gov.gg,https://twitter.com/GarryCollinsGue,"",2012,,Garry M. Collins
+"conder,_richard",St. Peter Port North,Independent,Richard.Conder@deputies.gov.gg,"","",2012,,Richard Conder
+"de_lisle,_david_de_g",West,Independent,delisle.david@cwgsy.net,https://twitter.com/delisledavid,"",2012,,David de G De Lisle
+"domaille,_roger",St. Peter Port South,Independent,Roger.Domaille@deputies.gov.gg,"","",2012,,Roger Domaille
+"dorey,_mark_h.",Castel,Independent,Mark.Dorey@deputies.gov.gg,"","",2012,,Mark H. Dorey
+"duquemin,_darren_j.",Castel,Independent,Darren.Duquemin@deputies.gov.gg,https://twitter.com/darrenduquemin,"",2012,,Darren J. Duquemin
+"fallaize,_matthew_j.",Vale,Independent,mattfallaize@cwgsy.net,"","",2012,,Matthew J. Fallaize
+"gillson,_peter_l.",St. Sampson,Independent,Peter.Gillson@gov.gg,"","",2012,,Peter L. Gillson
+"gollop,_john_a._b.",St. Peter Port North,Independent,John.Gollop@deputies.gov.gg,https://twitter.com/GollopGuern,"",2012,,John A. B. Gollop
+"green,_christopher_j.",Castel,Independent,Christopher.Green@deputies.gov.gg,https://twitter.com/deputycgreen,"",2012,,Christopher J. Green
+"hadley,_michael_p._j.",South-East,Independent,Mike.Hadley@deputies.gov.gg,"","",2012,,Michael P. J. Hadley
+"harwood,_peter_a.",St. Peter Port South,Independent,Peter.Harwood@deputies.gov.gg,"","",2012,,Peter A. Harwood
+"inglis,_david_a.",West,Independent,dai@cwgsy.net,https://twitter.com/DavidInglisGsy,http://www.linkedin.com/in/davidinglisgsy,2012,,David A. Inglis
+"james,_sandra_a.",Castel,Independent,Sandra.James@deputies.gov.gg,https://twitter.com/DepSandraJames,"",2012,,Sandra A. James
+"jean,_louis",Alderney Representative,Independent,Louis.Jean@deputies.gov.gg,"","",2012,,Louis Jean
+"jones,_david_b.",Vale,Independent,David.Jones@deputies.gov.gg,https://twitter.com/DeputyDaveJones,"",2012,,David B. Jones
+"jones,_robert_a.",St. Peter Port South,Independent,Robert.Jones@deputies.gov.gg,https://twitter.com/deputyrobjones,"",2012,,Robert A. Jones
+"kuttelwascher,_jan",St. Peter Port South,Independent,Jan.Kuttelwascher@deputies.gov.gg,"","",2012,,Jan Kuttelwascher
+"langlois,_allister_h.",St. Peter Port South,Independent,allister.langlois@deputies.gov.gg,"","",2012,,Allister H. Langlois
+"le_clerc,_michelle_k.",St. Peter Port North,Independent,Michelle.LeClerc@deputies.gov.gg,https://twitter.com/mkleclerc,"",2012,,Michelle K. Le Clerc
+"le_lievre,_andrew_r.",Vale,Independent,lelievre@fsmail.net,"","",2012,,Andrew R. Le Lievre
+"le_pelley,_paul_r.",St. Sampson,Independent,Paul.LePelley@deputies.gov.gg,"","",2012,,Paul R. Le Pelley
+"le_tocq,_jonathan_p.",Castel,Independent,Jonathan.LeTocq@deputies.gov.gg,https://twitter.com/letocq,http://www.linkedin.com/pub/jonathan-le-tocq/23/5a/b98?trk=pub-pbmap,2012,,Jonathan P. Le Tocq
+"lowe,_mary_m.",Vale,Independent,marylowe@cwgsy.net,https://twitter.com/DeputyMaryLowe,"",2012,,Mary M. Lowe
+"luxon,_paul_a.",South-East,Independent,Paul.Luxon@deputies.gov.gg,https://twitter.com/paul_luxon,http://uk.linkedin.com/pub/paul-luxon/36/14a/663?trk=pub-pbmap,2012,,Paul A. Luxon
+"mckinley,_graham",Alderney Representative,Independent,Graham.McKinley@deputies.gov.gg,"","",2012,,Graham McKinley
+"ogier,_scott_j.",St. Sampson,Independent,Scott.Ogier@deputies.gov.gg,https://twitter.com/DeputyOgier,http://uk.linkedin.com/pub/scott-ogier/34/431/4?trk=pub-pbmap,2012,,Scott J. Ogier
+"o'hara,_michael_g.",South-East,Independent,mike.ohara@cwgsy.net,"","",2012,,Michael G. O'Hara
+"paint,_barry_j._e.",Castel,Independent,Barry.Paint@deputies.gov.gg,"","",2012,,Barry J. E. Paint
+"parkinson,_charles",St. Peter Port North,Independent,Charles.Parkinson@deputies.gov.gg,"","",2012,,Charles Parkinson
+"perrot,_roger_a.",West,Independent,Roger.Perrot@deputies.gov.gg,"","",2012,,Roger A. Perrot
+"queripel,_laurie_b.",Vale,Independent,laurie.queripel@gmail.com,"","",2012,,Laurie B. Queripel
+"queripel,_lester_c.",St. Peter Port North,Independent,lesterqueripel@cwgsy.net,"","",2012,,Lester C. Queripel
+"quin,_francis_w.",South-East,Independent,Francis.Quin@deputies.gov.gg,"","",2012,,Francis W. Quin
+"sherbourne,_peter_a.",St. Peter Port North,Independent,Peter.Sherbourne@deputies.gov.gg,https://twitter.com/Sherbs1,"",2012,,Peter A. Sherbourne
+"sillars,_robert_w.",South-East,Independent,Robert.Sillars@deputies.gov.gg,https://twitter.com/RobertWSillars,"",2012,,Robert W. Sillars
+"soulsby,_heidi_j._r.",South-East,Independent,Heidi.Soulsby@deputies.gov.gg,https://twitter.com/HeidiSoulsby,http://www.linkedin.com/pub/heidi-soulsby/25/835/891,2012,,Heidi J. R. Soulsby
+"spruce,_tony",Vale,Independent,tonyspruce@cwgsy.net,"","",2012,,Tony Spruce
+"st._pier,_gavin_a",St. Sampson,Independent,Gavin.StPier@deputies.gov.gg,https://twitter.com/gavinstpier,http://www.linkedin.com/pub/gavin-st-pier/46/4b8/45b?trk=pub-pbmap,2012,,Gavin A St. Pier
+"stewart,_kevin_a.",St. Sampson,Independent,Kevin.Stewart@deputies.gov.gg,https://twitter.com/kevinstewartgsy,http://www.linkedin.com/in/kevinstewart2008,2012,,Kevin A. Stewart
+"trott,_lyndon_s.",St. Sampson,Independent,Lyndon.Trott@deputies.gov.gg,"","",2012,,Lyndon S. Trott
+"wilkie,_arrun_m.",West,Independent,Arrun.Wilkie@deputies.gov.gg,https://twitter.com/ArrunWilkie,"",2012,,Arrun M. Wilkie

--- a/data/Guernsey/States/sources/manual/data-2012.csv
+++ b/data/Guernsey/States/sources/manual/data-2012.csv
@@ -8,7 +8,7 @@ id,area,party,email,twitter,linkedin,term,source,name
 "burford,_yvonne",West,Independent,yvonne.burford@deputies.gov.gg,https://twitter.com/YvonneBurford,"",2012,,Yvonne Burford
 "collins,_garry_m.",Vale,Independent,Garry.Collins@deputies.gov.gg,https://twitter.com/GarryCollinsGue,"",2012,,Garry M. Collins
 "conder,_richard",St. Peter Port North,Independent,Richard.Conder@deputies.gov.gg,"","",2012,,Richard Conder
-"de_lisle,_david_de_g",West,Independent,delisle.david@cwgsy.net,https://twitter.com/delisledavid,"",2012,,David de G De Lisle
+"de_lisle,_david_de_g",West,Independent,delisle.david@cwgsy.net,https://twitter.com/delisledavid,"",2012,,David G de Lisle
 "domaille,_roger",St. Peter Port South,Independent,Roger.Domaille@deputies.gov.gg,"","",2012,,Roger Domaille
 "dorey,_mark_h.",Castel,Independent,Mark.Dorey@deputies.gov.gg,"","",2012,,Mark H. Dorey
 "duquemin,_darren_j.",Castel,Independent,Darren.Duquemin@deputies.gov.gg,https://twitter.com/darrenduquemin,"",2012,,Darren J. Duquemin

--- a/data/Guernsey/States/term-2012.csv
+++ b/data/Guernsey/States/term-2012.csv
@@ -1,50 +1,50 @@
 id,name,sort_name,email,twitter,facebook,group,group_id,area_id,area,chamber,term,start_date,end_date,image,gender
-cf186769-790b-4538-8eb2-b9154e86bf71,"Adam, A. Hunter","Adam, A. Hunter",Hunter.Adam@deputies.gov.gg,,,Independent,independent,area/castel,Castel,States,2012,,,,
-2a86f938-d509-4eaf-b24f-46ccb056ff79,"Bebb, Elis G.","Bebb, Elis G.",elis.bebb@gmail.com,ElisBebb,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,
-fb8a0921-0a45-4209-bb3c-c42e6f073c3b,"Brehaut, Barry L.","Brehaut, Barry L.",barry.brehaut@deputies.gov.gg,deputybaz,,Independent,independent,area/st._peter_port_south,St. Peter Port South,States,2012,,,,male
-22e754e3-7656-4673-9dde-a3c7f1c274a9,"Brouard, Al H.","Brouard, Al H.",al.brouard@deputies.gov.gg,,,Independent,independent,area/west,West,States,2012,,,,
-47ebccc8-b779-49aa-a800-eb45b48e3dad,"Burford, Yvonne","Burford, Yvonne",yvonne.burford@deputies.gov.gg,YvonneBurford,,Independent,independent,area/west,West,States,2012,,,,female
-f4ae0bb0-5382-4105-a4e6-012974134b3b,"Collins, Garry M.","Collins, Garry M.",Garry.Collins@deputies.gov.gg,GarryCollinsGue,,Independent,independent,area/vale,Vale,States,2012,,,,
-7304e050-e141-475e-bbd4-9afbeb4be566,"Conder, Richard","Conder, Richard",Richard.Conder@deputies.gov.gg,,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,male
-ba64f08a-c809-4cb5-9fa1-9ab669574be1,"De Lisle, David de G","De Lisle, David de G",delisle.david@cwgsy.net,delisledavid,,Independent,independent,area/west,West,States,2012,,,,male
-16b52004-d66c-479d-949b-b61050d86abe,"Domaille, Roger","Domaille, Roger",Roger.Domaille@deputies.gov.gg,,,Independent,independent,area/st._peter_port_south,St. Peter Port South,States,2012,,,,male
-a1129c34-55df-45d2-8780-e2a279ba8b47,"Dorey, Mark H.","Dorey, Mark H.",Mark.Dorey@deputies.gov.gg,,,Independent,independent,area/castel,Castel,States,2012,,,,male
-7bb1ec99-1b27-48ba-916c-9f3261adc9eb,"Duquemin, Darren J.","Duquemin, Darren J.",Darren.Duquemin@deputies.gov.gg,darrenduquemin,,Independent,independent,area/castel,Castel,States,2012,,,,male
-615a4e62-bdaa-4ced-9528-d23cbf9a23ac,"Fallaize, Matthew J.","Fallaize, Matthew J.",mattfallaize@cwgsy.net,,,Independent,independent,area/vale,Vale,States,2012,,,,male
-0a85ff4b-c495-44f9-9b33-4141e6e2b09a,"Gillson, Peter L.","Gillson, Peter L.",Peter.Gillson@gov.gg,,,Independent,independent,area/st._sampson,St. Sampson,States,2012,,,,male
-188c99cd-2336-40d5-aec0-c0028f53b364,"Gollop, John A. B.","Gollop, John A. B.",John.Gollop@deputies.gov.gg,GollopGuern,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,
-7f503d0b-59db-4708-9f94-45684cd88c3a,"Green, Christopher J.","Green, Christopher J.",Christopher.Green@deputies.gov.gg,deputycgreen,,Independent,independent,area/castel,Castel,States,2012,,,,male
-c38b874b-e9ba-42eb-b023-7ae395c57582,"Hadley, Michael P. J.","Hadley, Michael P. J.",Mike.Hadley@deputies.gov.gg,,,Independent,independent,area/south-east,South-East,States,2012,,,,male
-b6d46b0f-24ef-42c6-b7ee-8f3b08ff87e1,"Harvey, Neil","Harvey, Neil",Neil.Harvey@deputies.gov.gg,,,Independent,independent,area/alderney_representative,Alderney Representative,States,2012,,,,male
-a556d367-f9ac-452e-baae-c248b0938d1c,"Harwood, Peter A.","Harwood, Peter A.",Peter.Harwood@deputies.gov.gg,,,Independent,independent,area/st._peter_port_south,St. Peter Port South,States,2012,,,,male
-0a9eba4a-124c-46ee-9a5c-301943824d40,"Inglis, David A.","Inglis, David A.",dai@cwgsy.net,DavidInglisGsy,,Independent,independent,area/west,West,States,2012,,,,male
-f157f548-0e79-46af-97fc-9886aeeabaf8,"James, Sandra A.","James, Sandra A.",Sandra.James@deputies.gov.gg,DepSandraJames,,Independent,independent,area/castel,Castel,States,2012,,,,
-bba10897-2d47-4b8d-b2e9-dcfaa16bdae5,"Jean, Louis","Jean, Louis",Louis.Jean@deputies.gov.gg,,,Independent,independent,area/alderney_representative,Alderney Representative,States,2012,,,,
-db266608-e1b3-4a1f-bb43-833f7b3b757c,"Jones, David B.","Jones, David B.",David.Jones@deputies.gov.gg,DeputyDaveJones,,Independent,independent,area/vale,Vale,States,2012,,,,male
-84d2583a-725e-4444-bcf8-8bda48ed3f39,"Jones, Robert A.","Jones, Robert A.",Robert.Jones@deputies.gov.gg,deputyrobjones,,Independent,independent,area/st._peter_port_south,St. Peter Port South,States,2012,,,,
-71ec9a6c-c567-490e-baae-69dd38f57352,"Kuttelwascher, Jan","Kuttelwascher, Jan",Jan.Kuttelwascher@deputies.gov.gg,,,Independent,independent,area/st._peter_port_south,St. Peter Port South,States,2012,,,,
-0834c5ff-9cc5-42b7-aeaa-818cc61cfaa5,"Langlois, Allister H.","Langlois, Allister H.",allister.langlois@deputies.gov.gg,,,Independent,independent,area/st._peter_port_south,St. Peter Port South,States,2012,,,,
-fec5dc7a-6eae-4e5b-8fb4-062fca557f53,"Le Clerc, Michelle K.","Le Clerc, Michelle K.",Michelle.LeClerc@deputies.gov.gg,mkleclerc,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,female
-7a7232be-622f-4bb1-8c40-87419c926ca9,"Le Lievre, Andrew R.","Le Lievre, Andrew R.",lelievre@fsmail.net,,,Independent,independent,area/vale,Vale,States,2012,,,,male
-2b11b882-cb89-47a4-b930-847796867f1a,"Le Pelley, Paul R.","Le Pelley, Paul R.",Paul.LePelley@deputies.gov.gg,,,Independent,independent,area/st._sampson,St. Sampson,States,2012,,,,
-e06e1b58-295c-4837-be1c-6ffbcbfb9a86,"Le Tocq, Jonathan P.","Le Tocq, Jonathan P.",Jonathan.LeTocq@deputies.gov.gg,letocq,,Independent,independent,area/castel,Castel,States,2012,,,,male
-2c4d1331-c726-4591-b50c-6e68bd526abc,"Lowe, Mary M.","Lowe, Mary M.",marylowe@cwgsy.net,DeputyMaryLowe,,Independent,independent,area/vale,Vale,States,2012,,,,female
-8d947ab2-464a-4ddc-bcfd-149f6137e211,"Luxon, Paul A.","Luxon, Paul A.",Paul.Luxon@deputies.gov.gg,paul_luxon,,Independent,independent,area/south-east,South-East,States,2012,,,,male
-b1863f9c-5a8c-4808-a38d-e0e57c7f0da4,"McKinley, Graham","McKinley, Graham",Graham.McKinley@deputies.gov.gg,,,Independent,independent,area/alderney_representative,Alderney Representative,States,2012,,,,
-e5e619cf-d153-45b8-920e-924e4cdb5cfb,"O'Hara, Michael G.","O'Hara, Michael G.",mike.ohara@cwgsy.net,,,Independent,independent,area/south-east,South-East,States,2012,,,,male
-e116bd8c-1d90-4e23-9811-611ba321cdee,"Ogier, Scott J.","Ogier, Scott J.",Scott.Ogier@deputies.gov.gg,DeputyOgier,,Independent,independent,area/st._sampson,St. Sampson,States,2012,,,,male
-705c20b5-2149-47b4-9d3e-a58e6e0d5f9b,"Paint, Barry J. E.","Paint, Barry J. E.",Barry.Paint@deputies.gov.gg,,,Independent,independent,area/castel,Castel,States,2012,,,,male
-9055f7fc-324b-40fb-93bf-5ff4d8b2ccbb,"Parkinson, Charles","Parkinson, Charles",Charles.Parkinson@deputies.gov.gg,,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,
-2b2f38bf-b57f-43ab-89a2-6afd924adea3,"Perrot, Roger A.","Perrot, Roger A.",Roger.Perrot@deputies.gov.gg,,,Independent,independent,area/west,West,States,2012,,,,male
-073c98dc-cd6d-42ce-a082-3a90eccab640,"Queripel, Laurie B.","Queripel, Laurie B.",laurie.queripel@gmail.com,,,Independent,independent,area/vale,Vale,States,2012,,,,
-b1c159f0-8ddc-48b1-9dca-0f8990c8d947,"Queripel, Lester C.","Queripel, Lester C.",lesterqueripel@cwgsy.net,,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,
-41f38b5b-60a4-4e5e-bd8f-02e0a6637a33,"Quin, Francis W.","Quin, Francis W.",Francis.Quin@deputies.gov.gg,,,Independent,independent,area/south-east,South-East,States,2012,,,,
-9bcf918f-e618-450d-9c13-59fbb8a7a557,"Sherbourne, Peter A.","Sherbourne, Peter A.",Peter.Sherbourne@deputies.gov.gg,Sherbs1,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,
-511db5d0-9ad7-4ea0-8d77-563da49e5734,"Sillars, Robert W.","Sillars, Robert W.",Robert.Sillars@deputies.gov.gg,RobertWSillars,,Independent,independent,area/south-east,South-East,States,2012,,,,
-a65d0059-362b-4db9-9a05-1c762afc4011,"Soulsby, Heidi J. R.","Soulsby, Heidi J. R.",Heidi.Soulsby@deputies.gov.gg,HeidiSoulsby,,Independent,independent,area/south-east,South-East,States,2012,,,,
-56154f65-50cd-47e1-b9c3-0e9f5b9c8cf9,"Spruce, Tony","Spruce, Tony",tonyspruce@cwgsy.net,,,Independent,independent,area/vale,Vale,States,2012,,,,male
-320594a7-8505-457f-8a84-c18561b4455e,"St. Pier, Gavin A","St. Pier, Gavin A",Gavin.StPier@deputies.gov.gg,gavinstpier,,Independent,independent,area/st._sampson,St. Sampson,States,2012,,,,male
-1d770029-1592-434e-9434-f00b6ac82965,"Stewart, Kevin A.","Stewart, Kevin A.",Kevin.Stewart@deputies.gov.gg,kevinstewartgsy,,Independent,independent,area/st._sampson,St. Sampson,States,2012,,,,male
-e88fa42f-8ee3-4a7e-ad85-338e9557fe60,"Storey, Martin J.","Storey, Martin J.",Martin.Storey@deputies.gov.gg,,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,male
-957adc63-eaf0-4147-a1dc-2402c576d1d1,"Trott, Lyndon S.","Trott, Lyndon S.",Lyndon.Trott@deputies.gov.gg,,,Independent,independent,area/st._sampson,St. Sampson,States,2012,,,https://upload.wikimedia.org/wikipedia/commons/9/94/Guernseys_finansminister_Lyndon_Trott_vid_Nordiska_radets_session_i_Helsingfors_2008-10-28.jpg,male
-ff2138c8-e8f8-4456-9c16-a4ed53fbb871,"Wilkie, Arrun M.","Wilkie, Arrun M.",Arrun.Wilkie@deputies.gov.gg,ArrunWilkie,,Independent,independent,area/west,West,States,2012,,,,male
+cf186769-790b-4538-8eb2-b9154e86bf71,A. Hunter Adam,A. Hunter Adam,Hunter.Adam@deputies.gov.gg,,,Independent,independent,area/castel,Castel,States,2012,,,,
+22e754e3-7656-4673-9dde-a3c7f1c274a9,Al H. Brouard,Al H. Brouard,al.brouard@deputies.gov.gg,,,Independent,independent,area/west,West,States,2012,,,,
+0834c5ff-9cc5-42b7-aeaa-818cc61cfaa5,Allister H. Langlois,Allister H. Langlois,allister.langlois@deputies.gov.gg,,,Independent,independent,area/st._peter_port_south,St. Peter Port South,States,2012,,,,
+7a7232be-622f-4bb1-8c40-87419c926ca9,Andrew R. Le Lievre,Andrew R. Le Lievre,lelievre@fsmail.net,,,Independent,independent,area/vale,Vale,States,2012,,,,male
+ff2138c8-e8f8-4456-9c16-a4ed53fbb871,Arrun M. Wilkie,Arrun M. Wilkie,Arrun.Wilkie@deputies.gov.gg,ArrunWilkie,,Independent,independent,area/west,West,States,2012,,,,male
+705c20b5-2149-47b4-9d3e-a58e6e0d5f9b,Barry J. E. Paint,Barry J. E. Paint,Barry.Paint@deputies.gov.gg,,,Independent,independent,area/castel,Castel,States,2012,,,,male
+fb8a0921-0a45-4209-bb3c-c42e6f073c3b,Barry L. Brehaut,Barry L. Brehaut,barry.brehaut@deputies.gov.gg,deputybaz,,Independent,independent,area/st._peter_port_south,St. Peter Port South,States,2012,,,,male
+9055f7fc-324b-40fb-93bf-5ff4d8b2ccbb,Charles Parkinson,Charles Parkinson,Charles.Parkinson@deputies.gov.gg,,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,
+7f503d0b-59db-4708-9f94-45684cd88c3a,Christopher J. Green,Christopher J. Green,Christopher.Green@deputies.gov.gg,deputycgreen,,Independent,independent,area/castel,Castel,States,2012,,,,male
+7bb1ec99-1b27-48ba-916c-9f3261adc9eb,Darren J. Duquemin,Darren J. Duquemin,Darren.Duquemin@deputies.gov.gg,darrenduquemin,,Independent,independent,area/castel,Castel,States,2012,,,,male
+0a9eba4a-124c-46ee-9a5c-301943824d40,David A. Inglis,David A. Inglis,dai@cwgsy.net,DavidInglisGsy,,Independent,independent,area/west,West,States,2012,,,,male
+db266608-e1b3-4a1f-bb43-833f7b3b757c,David B. Jones,David B. Jones,David.Jones@deputies.gov.gg,DeputyDaveJones,,Independent,independent,area/vale,Vale,States,2012,,,,male
+ba64f08a-c809-4cb5-9fa1-9ab669574be1,David G de Lisle,David G de Lisle,delisle.david@cwgsy.net,delisledavid,,Independent,independent,area/west,West,States,2012,,,,male
+2a86f938-d509-4eaf-b24f-46ccb056ff79,Elis G. Bebb,Elis G. Bebb,elis.bebb@gmail.com,ElisBebb,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,
+41f38b5b-60a4-4e5e-bd8f-02e0a6637a33,Francis W. Quin,Francis W. Quin,Francis.Quin@deputies.gov.gg,,,Independent,independent,area/south-east,South-East,States,2012,,,,
+f4ae0bb0-5382-4105-a4e6-012974134b3b,Garry M. Collins,Garry M. Collins,Garry.Collins@deputies.gov.gg,GarryCollinsGue,,Independent,independent,area/vale,Vale,States,2012,,,,
+320594a7-8505-457f-8a84-c18561b4455e,Gavin A St. Pier,Gavin A St. Pier,Gavin.StPier@deputies.gov.gg,gavinstpier,,Independent,independent,area/st._sampson,St. Sampson,States,2012,,,,male
+b1863f9c-5a8c-4808-a38d-e0e57c7f0da4,Graham McKinley,Graham McKinley,Graham.McKinley@deputies.gov.gg,,,Independent,independent,area/alderney_representative,Alderney Representative,States,2012,,,,
+a65d0059-362b-4db9-9a05-1c762afc4011,Heidi J. R. Soulsby,Heidi J. R. Soulsby,Heidi.Soulsby@deputies.gov.gg,HeidiSoulsby,,Independent,independent,area/south-east,South-East,States,2012,,,,
+71ec9a6c-c567-490e-baae-69dd38f57352,Jan Kuttelwascher,Jan Kuttelwascher,Jan.Kuttelwascher@deputies.gov.gg,,,Independent,independent,area/st._peter_port_south,St. Peter Port South,States,2012,,,,
+188c99cd-2336-40d5-aec0-c0028f53b364,John A. B. Gollop,John A. B. Gollop,John.Gollop@deputies.gov.gg,GollopGuern,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,
+e06e1b58-295c-4837-be1c-6ffbcbfb9a86,Jonathan P. Le Tocq,Jonathan P. Le Tocq,Jonathan.LeTocq@deputies.gov.gg,letocq,,Independent,independent,area/castel,Castel,States,2012,,,,male
+1d770029-1592-434e-9434-f00b6ac82965,Kevin A. Stewart,Kevin A. Stewart,Kevin.Stewart@deputies.gov.gg,kevinstewartgsy,,Independent,independent,area/st._sampson,St. Sampson,States,2012,,,,male
+073c98dc-cd6d-42ce-a082-3a90eccab640,Laurie B. Queripel,Laurie B. Queripel,laurie.queripel@gmail.com,,,Independent,independent,area/vale,Vale,States,2012,,,,
+b1c159f0-8ddc-48b1-9dca-0f8990c8d947,Lester C. Queripel,Lester C. Queripel,lesterqueripel@cwgsy.net,,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,
+bba10897-2d47-4b8d-b2e9-dcfaa16bdae5,Louis Jean,Louis Jean,Louis.Jean@deputies.gov.gg,,,Independent,independent,area/alderney_representative,Alderney Representative,States,2012,,,,
+957adc63-eaf0-4147-a1dc-2402c576d1d1,Lyndon S. Trott,Lyndon S. Trott,Lyndon.Trott@deputies.gov.gg,,,Independent,independent,area/st._sampson,St. Sampson,States,2012,,,https://upload.wikimedia.org/wikipedia/commons/9/94/Guernseys_finansminister_Lyndon_Trott_vid_Nordiska_radets_session_i_Helsingfors_2008-10-28.jpg,male
+a1129c34-55df-45d2-8780-e2a279ba8b47,Mark H. Dorey,Mark H. Dorey,Mark.Dorey@deputies.gov.gg,,,Independent,independent,area/castel,Castel,States,2012,,,,male
+e88fa42f-8ee3-4a7e-ad85-338e9557fe60,Martin J. Storey,Martin J. Storey,Martin.Storey@deputies.gov.gg,,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,male
+2c4d1331-c726-4591-b50c-6e68bd526abc,Mary M. Lowe,Mary M. Lowe,marylowe@cwgsy.net,DeputyMaryLowe,,Independent,independent,area/vale,Vale,States,2012,,,,female
+615a4e62-bdaa-4ced-9528-d23cbf9a23ac,Matthew J. Fallaize,Matthew J. Fallaize,mattfallaize@cwgsy.net,,,Independent,independent,area/vale,Vale,States,2012,,,,male
+e5e619cf-d153-45b8-920e-924e4cdb5cfb,Michael G. O'Hara,Michael G. O'Hara,mike.ohara@cwgsy.net,,,Independent,independent,area/south-east,South-East,States,2012,,,,male
+c38b874b-e9ba-42eb-b023-7ae395c57582,Michael P. J. Hadley,Michael P. J. Hadley,Mike.Hadley@deputies.gov.gg,,,Independent,independent,area/south-east,South-East,States,2012,,,,male
+fec5dc7a-6eae-4e5b-8fb4-062fca557f53,Michelle K. Le Clerc,Michelle K. Le Clerc,Michelle.LeClerc@deputies.gov.gg,mkleclerc,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,female
+b6d46b0f-24ef-42c6-b7ee-8f3b08ff87e1,Neil Harvey,Neil Harvey,Neil.Harvey@deputies.gov.gg,,,Independent,independent,area/alderney_representative,Alderney Representative,States,2012,,,,male
+8d947ab2-464a-4ddc-bcfd-149f6137e211,Paul A. Luxon,Paul A. Luxon,Paul.Luxon@deputies.gov.gg,paul_luxon,,Independent,independent,area/south-east,South-East,States,2012,,,,male
+2b11b882-cb89-47a4-b930-847796867f1a,Paul R. Le Pelley,Paul R. Le Pelley,Paul.LePelley@deputies.gov.gg,,,Independent,independent,area/st._sampson,St. Sampson,States,2012,,,,
+a556d367-f9ac-452e-baae-c248b0938d1c,Peter A. Harwood,Peter A. Harwood,Peter.Harwood@deputies.gov.gg,,,Independent,independent,area/st._peter_port_south,St. Peter Port South,States,2012,,,,male
+9bcf918f-e618-450d-9c13-59fbb8a7a557,Peter A. Sherbourne,Peter A. Sherbourne,Peter.Sherbourne@deputies.gov.gg,Sherbs1,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,
+0a85ff4b-c495-44f9-9b33-4141e6e2b09a,Peter L. Gillson,Peter L. Gillson,Peter.Gillson@gov.gg,,,Independent,independent,area/st._sampson,St. Sampson,States,2012,,,,male
+7304e050-e141-475e-bbd4-9afbeb4be566,Richard Conder,Richard Conder,Richard.Conder@deputies.gov.gg,,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,male
+84d2583a-725e-4444-bcf8-8bda48ed3f39,Robert A. Jones,Robert A. Jones,Robert.Jones@deputies.gov.gg,deputyrobjones,,Independent,independent,area/st._peter_port_south,St. Peter Port South,States,2012,,,,
+511db5d0-9ad7-4ea0-8d77-563da49e5734,Robert W. Sillars,Robert W. Sillars,Robert.Sillars@deputies.gov.gg,RobertWSillars,,Independent,independent,area/south-east,South-East,States,2012,,,,
+2b2f38bf-b57f-43ab-89a2-6afd924adea3,Roger A. Perrot,Roger A. Perrot,Roger.Perrot@deputies.gov.gg,,,Independent,independent,area/west,West,States,2012,,,,male
+16b52004-d66c-479d-949b-b61050d86abe,Roger Domaille,Roger Domaille,Roger.Domaille@deputies.gov.gg,,,Independent,independent,area/st._peter_port_south,St. Peter Port South,States,2012,,,,male
+f157f548-0e79-46af-97fc-9886aeeabaf8,Sandra A. James,Sandra A. James,Sandra.James@deputies.gov.gg,DepSandraJames,,Independent,independent,area/castel,Castel,States,2012,,,,
+e116bd8c-1d90-4e23-9811-611ba321cdee,Scott J. Ogier,Scott J. Ogier,Scott.Ogier@deputies.gov.gg,DeputyOgier,,Independent,independent,area/st._sampson,St. Sampson,States,2012,,,,male
+56154f65-50cd-47e1-b9c3-0e9f5b9c8cf9,Tony Spruce,Tony Spruce,tonyspruce@cwgsy.net,,,Independent,independent,area/vale,Vale,States,2012,,,,male
+47ebccc8-b779-49aa-a800-eb45b48e3dad,Yvonne Burford,Yvonne Burford,yvonne.burford@deputies.gov.gg,YvonneBurford,,Independent,independent,area/west,West,States,2012,,,,female

--- a/data/Guernsey/States/unstable/positions.csv
+++ b/data/Guernsey/States/unstable/positions.csv
@@ -1,4 +1,4 @@
 id,name,position,start_date,end_date,type
-a556d367-f9ac-452e-baae-c248b0938d1c,"Harwood, Peter A.",Chief Minister of Guernsey,2012-05-01,2014-03-12,executive
-e06e1b58-295c-4837-be1c-6ffbcbfb9a86,"Le Tocq, Jonathan P.",Chief Minister of Guernsey,2014-03-12,,executive
-957adc63-eaf0-4147-a1dc-2402c576d1d1,"Trott, Lyndon S.",Chief Minister of Guernsey,2008-05-01,2012-05-01,executive
+e06e1b58-295c-4837-be1c-6ffbcbfb9a86,Jonathan P. Le Tocq,Chief Minister of Guernsey,2014-03-12,,executive
+957adc63-eaf0-4147-a1dc-2402c576d1d1,Lyndon S. Trott,Chief Minister of Guernsey,2008-05-01,2012-05-01,executive
+a556d367-f9ac-452e-baae-c248b0938d1c,Peter A. Harwood,Chief Minister of Guernsey,2012-05-01,2014-03-12,executive


### PR DESCRIPTION
In preparation of adding term 2016 data -- where the names are formatted:
'first_name last_name' order -- this PR swaps the ordering of the 2012
term names.

This is a step towards fixing: https://github.com/everypolitician/everypolitician-data/issues/18489