### PR TITLE
Memoize the Position File JSON

### DIFF
--- a/lib/position/position_file.rb
+++ b/lib/position/position_file.rb
@@ -9,11 +9,11 @@ class WikidataPositionFile
     end
   end
 
-  def json
-    JSON.parse(pathname.read, symbolize_names: true)
-  end
-
   private
 
   attr_reader :pathname
+
+  def json
+    @json ||= JSON.parse(pathname.read, symbolize_names: true)
+  end
 end


### PR DESCRIPTION
When working with the Position file, don't keep reloading the JSON every time we're asking for the Positions for a given Person. The build calls this potentially thousands of time in sequence, for each person with Wikidata.

Removing this speeds up this section of the build for Sweden (for example) from over 15 seconds to 0.037s, or for Turkey from 139 seconds to 0.16s.