### PR TITLE
Fix REBUILD_SOURCE option

### DIFF
--- a/rake_build/fetch_sources.rb
+++ b/rake_build/fetch_sources.rb
@@ -22,6 +22,6 @@ namespace :fetch_sources do
   def _should_refetch(file)
     return true unless file.exist?
     return false unless ENV['REBUILD_SOURCE']
-    file.include? ENV['REBUILD_SOURCE']
+    file.to_s.include? ENV['REBUILD_SOURCE']
   end
 end


### PR DESCRIPTION
This was broken when we switched to using a `Pathname` as we need to
call `#to_s` first, otherwise we get an error because there is no
`Pathname#include?` method.

Fixes https://github.com/everypolitician/everypolitician/issues/527