### PR TITLE
Rubocop: Ignore long blocks in tests

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -43,3 +43,10 @@ Style/SymbolArray:
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: consistent_comma
 
+# Minitest::Spec uses long blocks to contains the specs, so disable this check
+# for the tests.
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - 't/**/*'
+    - 'test/**/*'


### PR DESCRIPTION
Most of our tests are written "spec-style" and therefore have lots of long do...end blocks, this causes the block-length cop to complain, so disable that block for the tests.

Note that this includes `spec`, `t` and `test` because this base config is shared between all the EveryPolitician repos.

This will prevent failures like [this one](https://travis-ci.org/everypolitician/close_old_pull_requests/builds/169286902).