### PR TITLE
Lithuania (Seimas): refresh data

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -5510,11 +5510,11 @@
         "slug": "Seimas",
         "sources_directory": "data/Lithuania/Seimas/sources",
         "popolo": "data/Lithuania/Seimas/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/de2be4d75b9c60f55132e6495c189cdf84148c8d/data/Lithuania/Seimas/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e7fd55d7450df53ac5ad41bf68b5ce3e8009d175/data/Lithuania/Seimas/ep-popolo-v1.0.json",
         "names": "data/Lithuania/Seimas/names.csv",
-        "lastmod": "1476488121",
+        "lastmod": "1477162492",
         "person_count": 150,
-        "sha": "de2be4d75b9c60f55132e6495c189cdf84148c8d",
+        "sha": "e7fd55d7450df53ac5ad41bf68b5ce3e8009d175",
         "legislative_periods": [
           {
             "id": "term/11",
@@ -5525,7 +5525,8 @@
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6a52d7d9a1f033baa3ca349e37cd23292a69721d/data/Lithuania/Seimas/term-11.csv"
           }
         ],
-        "statement_count": 15556
+        "statement_count": 15560,
+        "type": "unicameral legislature"
       }
     ]
   },

--- a/data/Lithuania/Seimas/ep-popolo-v1.0.json
+++ b/data/Lithuania/Seimas/ep-popolo-v1.0.json
@@ -24997,6 +24997,11 @@
           "note": "multilingual"
         },
         {
+          "lang": "ko",
+          "name": "질서와 정의",
+          "note": "multilingual"
+        },
+        {
           "lang": "eo",
           "name": "Liberalų demokratų partija",
           "note": "multilingual"
@@ -25900,7 +25905,8 @@
         }
       ],
       "name": "Seimas",
-      "seats": 141
+      "seats": 141,
+      "type": "unicameral legislature"
     },
     {
       "classification": "party",

--- a/data/Lithuania/Seimas/sources/manual/position-filter.json
+++ b/data/Lithuania/Seimas/sources/manual/position-filter.json
@@ -57,7 +57,12 @@
   },
   "unknown": {
     "unknown": [
-
+      {
+        "id": "Q3273722",
+        "name": "health minister",
+        "description": "minister in charge of health matters",
+        "count": 1
+      }
     ]
   }
 }

--- a/data/Lithuania/Seimas/sources/wikidata/elections.json
+++ b/data/Lithuania/Seimas/sources/wikidata/elections.json
@@ -663,6 +663,16 @@
         "lang": "zh",
         "name": "2016年立陶宛議會選舉",
         "note": "multilingual"
+      },
+      {
+        "lang": "es",
+        "name": "Elecciones parlamentarias de Lituania de 2016",
+        "note": "multilingual"
+      },
+      {
+        "lang": "uk",
+        "name": "Парламентські вибори в Литві 2016",
+        "note": "multilingual"
       }
     ],
     "dates": [

--- a/data/Lithuania/Seimas/sources/wikidata/groups.json
+++ b/data/Lithuania/Seimas/sources/wikidata/groups.json
@@ -1026,6 +1026,11 @@
         "note": "multilingual"
       },
       {
+        "lang": "ko",
+        "name": "질서와 정의",
+        "note": "multilingual"
+      },
+      {
         "lang": "eo",
         "name": "Liberalų demokratų partija",
         "note": "multilingual"

--- a/data/Lithuania/Seimas/sources/wikidata/positions.json
+++ b/data/Lithuania/Seimas/sources/wikidata/positions.json
@@ -267,6 +267,19 @@
       "title": "Member of the Seimas"
     }
   ],
+  "Q3660989": [
+    {
+      "id": "Q3273722",
+      "label": "health minister",
+      "title": "health minister",
+      "description": "minister in charge of health matters",
+      "qualifiers": {
+        "P580": "2016-03-15",
+        "P582": "2016-10-16",
+        "P1365": "Rimantė Šalaševičiūtė"
+      }
+    }
+  ],
   "Q270360": [
     {
       "id": "Q12663218",


### PR DESCRIPTION
```
⤈ No ORDER BY for sources/morph/data.csv
Add memberships from sources/morph/data.csv
Merging with sources/morph/wikidata.csv
Data Mismatches
* 1 of 151 unmatched
	{:id=>"Q12672459", :name=>"Saulius Jakimavičius"}
Adding GenderBalance results from sources/gender-balance/results.csv
  ⚥ data for 0; 0 added


Top identifiers:
  150 x wikidata
  31 x viaf
  29 x freebase
  17 x lcauth
  9 x gnd

Creating names.csv
Creating unstable/positions.csv
  Unknown position (x1): Q3273722 health minister — e.g. Q3660989
Persons matched to Wikidata: 150 ✓ 
Parties matched to Wikidata: 7 ✓ | 1 ✘
  No wikidata: Mišri Seimo narių grupė (party/mišri_seimo_narių_grupė)
```