### PR TITLE
Error if the EP_COUNTRY_REFRESH value doesn't match a country

### DIFF
--- a/lib/task/rebuild_countries_json.rb
+++ b/lib/task/rebuild_countries_json.rb
@@ -29,15 +29,14 @@ module Task
       EveryPolitician.countries
     end
 
+    def matching
+      all_countries.select { |c| c.slug.downcase.include? to_build.downcase }
+    end
+
     def countries
       return all_countries if to_build.to_s.empty?
-      countries_to_rebuild = all_countries.select do |c|
-        c.slug.downcase.include? to_build.downcase
-      end
-      if countries_to_rebuild.empty?
-        raise "Couldn't find the country '#{to_build}'"
-      end
-      countries_to_rebuild
+      raise "Couldn't find the country '#{to_build}'" if matching.empty?
+      matching
     end
 
     def commit_metadata

--- a/lib/task/rebuild_countries_json.rb
+++ b/lib/task/rebuild_countries_json.rb
@@ -31,7 +31,13 @@ module Task
 
     def countries
       return all_countries if to_build.to_s.empty?
-      all_countries.select { |c| c.slug.downcase.include? to_build.downcase }
+      countries_to_rebuild = all_countries.select do |c|
+        c.slug.downcase.include? to_build.downcase
+      end
+      if countries_to_rebuild.empty?
+        raise "Couldn't find the country '#{to_build}'"
+      end
+      countries_to_rebuild
     end
 
     def commit_metadata

--- a/test/selective_countries_json_refresh_test.rb
+++ b/test/selective_countries_json_refresh_test.rb
@@ -33,6 +33,14 @@ describe 'RebuildCountriesJSON' do
     countries_to_rebuild[0].name.must_equal 'United States of America'
   end
 
+  it 'finds all matching countries' do
+    rebuilder = Task::RebuildCountriesJSON.new('America')
+    countries_to_rebuild = rebuilder.send(:countries)
+    countries_to_rebuild.length.must_equal 2
+    countries_to_rebuild.map(&:name).must_include 'American Samoa'
+    countries_to_rebuild.map(&:name).must_include 'United States of America'
+  end
+
   it 'returns lots of countries when none is specified' do
     rebuilder = Task::RebuildCountriesJSON.new nil
     countries_to_rebuild = rebuilder.send(:countries)

--- a/test/selective_countries_json_refresh_test.rb
+++ b/test/selective_countries_json_refresh_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+require_relative '../lib/task/rebuild_countries_json'
+
+describe 'RebuildCountriesJSON' do
+
+  def tmp_countries_json_filename
+    @local_countries_json ||= File.join(File.dirname(__FILE__), '..', 'countries.json')
+  end
+
+  # By default Everypolitician.countries_json uses the remote URL, but
+  # we have countries.json locally in this repo, so make sure that's
+  # used in these tests.
+
+  before do
+    @old_countries_json = Everypolitician.countries_json
+    Everypolitician.countries_json = tmp_countries_json_filename
+  end
+
+  after do
+    Everypolitician.countries_json = @old_countries_json
+  end
+
+  it 'errors if the requested country does not exist' do
+    rebuilder = Task::RebuildCountriesJSON.new('freedonia')
+    err = -> { rebuilder.send(:countries) }.must_raise RuntimeError
+    err.message.must_match(/Couldn't find the country 'freedonia'/)
+  end
+
+  it 'finds a country if it does exists' do
+    rebuilder = Task::RebuildCountriesJSON.new('united-states-of-america')
+    countries_to_rebuild = rebuilder.send(:countries)
+    countries_to_rebuild.length.must_equal 1
+    countries_to_rebuild[0].name.must_equal 'United States of America'
+  end
+
+  it 'returns lots of countries when none is specified' do
+    rebuilder = Task::RebuildCountriesJSON.new nil
+    countries_to_rebuild = rebuilder.send(:countries)
+    countries_to_rebuild.length.must_be :>, 30
+  end
+
+end


### PR DESCRIPTION
Previously you'd get no error if you mispell a country in
EP_COUNTRY_REFRESH; that makes it easy to assume that countries.json
rebuilt with no changes, when in fact nothing has been rebuilt at all.

This commit makes sure that an error is thrown f EP_COUNTRY_REFRESH
is specified, but doesn't correspond to any country.