### PR TITLE
Allow Merging of Membership sources with same IDs

### DIFF
--- a/lib/source/membership.rb
+++ b/lib/source/membership.rb
@@ -29,6 +29,9 @@ module Source
 
         pr = reconciler.reconciliation_data rescue abort($!.to_s)
         pr.each { |r| id_map[r[:id]] = r[:uuid] }
+      else
+        # reuse any IDs we already have from other sources
+        csv.each { |r| id_map[r[:id]] &&= r[:uuid] }
       end
 
       # Generate UUIDs for any people we don't already know


### PR DESCRIPTION
Previously we haven't needed to merge Membership sources with the same ID, as those will almost always be coming from the same upstream source, and will therefore be in the same Morph database, and can be fetched together as a single 'source'.

Sometimes, however, we will have archived off a previous term to a manual source file, and will want to merge this with a new source file for the latest term from the same upstream source, with shared IDs.

In such a case — i.e. where we have an `instructions.json` stanza for a second Membership source, and no `merge` details, we can simply re-use any ID → UUID mapping we already know of for any of the people in this source.

## Notes to Reviewer

There are no direct tests for this functionality, but it's easy to test the behaviour exhaustively by running a build of all the existing data. With this change, every existing legislature still builds without material change (we still don't have a 100% deterministic process).

NB: This was added for https://github.com/everypolitician/everypolitician-data/pull/19176, but it turns out that that source only _appears_ to share IDs: ferrer-j in the 16th term was Jeffrey P. Ferrer, but is Juliet Marie D. Ferrer in the 17th!
