### PR TITLE
Hong Kong: fix the missing end_date for term 5

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -4379,13 +4379,14 @@
         "slug": "Legislative-Council",
         "sources_directory": "data/Hong_Kong/Legislative_Council/sources",
         "popolo": "data/Hong_Kong/Legislative_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/79674e0f6dbfeb0c8dcec32360dd208da562f375/data/Hong_Kong/Legislative_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/28e1eac120abab0a4b71a7c77d03028147c7b904/data/Hong_Kong/Legislative_Council/ep-popolo-v1.0.json",
         "names": "data/Hong_Kong/Legislative_Council/names.csv",
-        "lastmod": "1477398147",
+        "lastmod": "1477565555",
         "person_count": 71,
-        "sha": "79674e0f6dbfeb0c8dcec32360dd208da562f375",
+        "sha": "28e1eac120abab0a4b71a7c77d03028147c7b904",
         "legislative_periods": [
           {
+            "end_date": "2016-09-30",
             "id": "term/5",
             "name": "Fifth Legislative Council",
             "start_date": "2012-10-01",
@@ -4394,7 +4395,7 @@
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0fc6473d50310b8facdc01fc380fb1dbd5dfae9a/data/Hong_Kong/Legislative_Council/term-5.csv"
           }
         ],
-        "statement_count": 5942,
+        "statement_count": 5943,
         "type": "unicameral legislature"
       }
     ]

--- a/data/Hong_Kong/Legislative_Council/ep-popolo-v1.0.json
+++ b/data/Hong_Kong/Legislative_Council/ep-popolo-v1.0.json
@@ -11028,6 +11028,7 @@
     },
     {
       "classification": "legislative period",
+      "end_date": "2016-09-30",
       "id": "term/5",
       "name": "Fifth Legislative Council",
       "organization_id": "c974194b-cbc8-44ce-975b-16517fae33bf",

--- a/data/Hong_Kong/Legislative_Council/sources/manual/terms.csv
+++ b/data/Hong_Kong/Legislative_Council/sources/manual/terms.csv
@@ -1,3 +1,3 @@
-id,name,start_date,source
+id,name,start_date,end_date,source
 5,Fifth Legislative Council,2012-10-01,2016-09-30,https://en.wikipedia.org/wiki/5th_Legislative_Council_of_Hong_Kong
 6,Sixth Legislative Council,2016-10-01,,https://en.wikipedia.org/wiki/6th_Legislative_Council_of_Hong_Kong


### PR DESCRIPTION
@tmtmtmtm pointed out that the header row in the manual terms.csv source
was missing `end_date`, and so the end_date of the term wasn't being picked
up. This pull request should fix that.