### PR TITLE
Laos Assembly -- change 2011 term import instruction

### DIFF
--- a/data/Laos/Assembly/sources/instructions.json
+++ b/data/Laos/Assembly/sources/instructions.json
@@ -5,7 +5,7 @@
       "create": {
         "from": "morph",
         "scraper": "tmtmtmtm/laos-national-assembly",
-        "query": "SELECT * FROM data"
+        "query": "SELECT * FROM data WHERE term = 2011 ORDER BY name"
       },
       "source": "http://na.gov.la/",
       "type": "membership"

--- a/data/Laos/Assembly/sources/morph/data.csv
+++ b/data/Laos/Assembly/sources/morph/data.csv
@@ -1,133 +1,133 @@
 name,honorific_prefix,area_id,area,term
-Khampheuy Panmalaythong,Dr,1,Vientiane Capital,2011
-Kikeo Khaykhamphithoune,Prof. Dr,1,Vientiane Capital,2011
-Duangsavat Souphanouvong,Dr,1,Vientiane Capital,2011
-Souvanpheng Bouphanouvong,Dr,1,Vientiane Capital,2011
-Bua-Ngeun Xaphouvong,Mr,1,Vientiane Capital,2011
-Vanpheng Keonakhone,Ms,1,Vientiane Capital,2011
-Koukeo Akkhamonti,Dr,1,Vientiane Capital,2011
-Bounyong Boupha,Prof. Dr,1,Vientiane Capital,2011
-Somvang Thammasith,Colonel Dr,1,Vientiane Capital,2011
-Buakham Thipphavong,Dr,1,Vientiane Capital,2011
-Khamfong Phoumvongxay,Ms,1,Vientiane Capital,2011
-Lasanivong Amarathithada,Mr,1,Vientiane Capital,2011
-Bounpheng Sitthisak,Lieutenant Colonel,1,Vientiane Capital,2011
-Sisaliew Savengsuksa,Dr,1,Vientiane Capital,2011
-Ketkeo Sihalath,Dr,1,Vientiane Capital,2011
-Khamchan Khamvongchay,Mr,2,Phongsaly Province,2011
-Khamping Saengtannalath,Mr,2,Phongsaly Province,2011
-Chansy Saengsomphou,Dr,2,Phongsaly Province,2011
-Sikeo Sipachack,Mr,2,Phongsaly Province,2011
-Chanmany Namvong,Ms,2,Phongsaly Province,2011
-Vonkham Phetthavong,Mr,3,Luangnamtha Province,2011
-Bandit Pathoumvanh,Ms,3,Luangnamtha Province,2011
-Khamlek Saydara,Assoc. Prof. Dr,3,Luangnamtha Province,2011
-Latsamy Mingboupha,Ms,3,Luangnamtha Province,2011
-Kongphet Keobouapha,Mr,3,Luangnamtha Province,2011
-Bounlort Onphachanh,Mr,4,Oudomxay Province,2011
-Khamxao Kayxong,Mr,4,Oudomxay Province,2011
-Houmphaeng Sitthivong,Mr,4,Oudomxay Province,2011
-Somchanh Chitvongdeuan,Ms,4,Oudomxay Province,2011
-Khamphone Phimmachanh,Mrs,4,Oudomxay Province,2011
-Bounnhong Norkeo,Lieutenant Colonel,4,Oudomxay Province,2011
-Vixaykone Vannachomchanh,Mr,5,Bokeo Province,2011
-Ounkeo Vouthirath,Dr,5,Bokeo Province,2011
-Oulavanh Bounthachak,Mr,5,Bokeo Province,2011
-Khamchomphou Silitham,Dr,5,Bokeo Province,2011
-Channuan Ouankhanachak,Police Lt. Col.,5,Bokeo Province,2011
-Bouathong Phaengsavanh,Mr,6,Luangprabang Province,2011
-Bounthavy Sisouphanthong,Dr,6,Luangprabang Province,2011
-Singtan Xayleuxong,Mr,6,Luangprabang Province,2011
-Brigadier General Vilay Duangmany,Police,6,Luangprabang Province,2011
-Houmphanh Thammoungkhoun,Mr,6,Luangprabang Province,2011
-Bounthone Sitsouvong,Lt. Col.,6,Luangprabang Province,2011
-amphone Sivilaysak,Mrs,6,Luangprabang Province,2011
-Bountham Senphansiri,Mr,6,Luangprabang Province,2011
-Khamphoui Vannachit,Lt. Col.,6,Luangprabang Province,2011
-Pany Yathortou,Ms,7,Xayabouly province,2011
-Khamsouk Thor,Mr,7,Xayabouly province,2011
-Vongchanh Phomsavath,Mr,7,Xayabouly province,2011
-Thongdy Phabboua-on,Mr,7,Xayabouly province,2011
-Khamsouk Vi-inthavong,Colonel,7,Xayabouly province,2011
-Idmany Chanthakhoun,Ms,7,Xayabouly province,2011
-Chanthanom Vongsomchith,Mr,7,Xayabouly province,2011
-Somphanh Phaengkhammy,Mr,8,Houaphanh Province,2011
-Khamvone Bounthavong,Mr,8,Houaphanh Province,2011
-Phonsouk Thongsombath,Mr,8,Houaphanh Province,2011
 Amphaivone Lombounphaeng,Ms,8,Houaphanh Province,2011
-Vongsack Xaoxuayang,Major,8,Houaphanh Province,2011
-Misone Thongxaysy,Ms,8,Houaphanh Province,2011
-Bounpheng Mounphoxay,Ms,9,Xiengkhouang Province,2011
-Bounton Chanthaphone,Mr,9,Xiengkhouang Province,2011
-Bouasy Nathavong,Ms,9,Xiengkhouang Province,2011
-Somvandy Sisouphanh,Mr,9,Xiengkhouang Province,2011
-Khamla Chandala,Lieutenant Colonel,9,Xiengkhouang Province,2011
-Vilaysouk Phimmasone,Mr,9,Xiengkhouang Province,2011
-Duangdy Outthachak,Mr,10,Vientiane Province,2011
-Bounpheng Sainorlady,Mr,10,Vientiane Province,2011
-SomOck Kingsada,Assoc. Prof. Dr,10,Vientiane Province,2011
-Somdy Keodalavin,Mr,10,Vientiane Province,2011
-Onsy Saensouk,Colonel,10,Vientiane Province,2011
-Chanthaboun Phosalath,Ms,10,Vientiane Province,2011
-Khamdaeng Silavong,Mr,10,Vientiane Province,2011
-Bouavanh Thammavong,Ms,10,Vientiane Province,2011
-Khamkhen Oudtama,Lt. Col.,10,Vientiane Province,2011
-Bounma Bouchaleun,Mr,11,Bolikhamxay Province,2011
+Bandit Pathoumvanh,Ms,3,Luangnamtha Province,2011
 Bouaphanh Leekaiya,Ms,11,Bolikhamxay Province,2011
-Bounseng Pathammavong,Mr,11,Bolikhamxay Province,2011
-Chouangchanh Latsavong,Col.,11,Bolikhamxay Province,2011
-Malisa Aphaylath,Ms,11,Bolikhamxay Province,2011
-Sikhay Sipaseuth,Ms,11,Bolikhamxay Province,2011
-Bounnhong Khinsamone,Dr,12,Khammouane Province,2011
-Saengthong Phakhounthong,Mr,12,Khammouane Province,2011
-Inthava Moundala,Mr,12,Khammouane Province,2011
-Viengmany Chanthanasin,Ms,12,Khammouane Province,2011
-Bounpan Douanglaty,Mr,12,Khammouane Province,2011
-Ketsana Latxachack,Dr,12,Khammouane Province,2011
-Thipphachanh Phoxay,Police Lt. Colonel,12,Khammouane Province,2011
-Xaysomphone Phomvihane,Dr,13,Savannakhet Province,2011
-Vankham Inthichack,Mr,13,Savannakhet Province,2011
-Somphou Douangsavanh,Dr,13,Savannakhet Province,2011
-Simoun Ounlasy,Mr,13,Savannakhet Province,2011
-Somphet Inthathilath,Mr,13,Savannakhet Province,2011
+Bouasy Nathavong,Ms,9,Xiengkhouang Province,2011
+Bouathong Phaengsavanh,Mr,6,Luangprabang Province,2011
+Bouavanh Thammavong,Ms,10,Vientiane Province,2011
 Bounchanh Sinthavong,Mr,13,Savannakhet Province,2011
-Bounnheuane Thidphoutthavong,Ms,13,Savannakhet Province,2011
-Sonthanou Thammavong,Dr,13,Savannakhet Province,2011
-Bountem Xouangsayavong,Mr,13,Savannakhet Province,2011
-Khamphan Khounsacksy,Mr,13,Savannakhet Province,2011
-Bounpone Sisoulath,Mr,13,Savannakhet Province,2011
-Bounnhong Xaypanya,Mr,13,Savannakhet Province,2011
-Khammany Inthirath,Mr,13,Savannakhet Province,2011
-Thatsadaphone Saengsouliya,Ms,13,Savannakhet Province,2011
-Somphone Soutthisombath,Lt. Col.,13,Savannakhet Province,2011
-Bounpong Keorodom,Assoc. Prof. Dr,13,Savannakhet Province,2011
-Somchit Kittiyalath,Lt. Col.,13,Savannakhet Province,2011
-Davone Vangvichit,Prof.,14,Saravan Province,2011
-Bounthiem Phommasathith,Mr,14,Saravan Province,2011
-Suanesavanh Vignaket,Ms,14,Saravan Province,2011
-Manixong Leusisamouth,Ms,14,Saravan Province,2011
-Vaenphet Latdavong,Mr,14,Saravan Province,2011
-Somchay Ounchit,Mr,14,Saravan Province,2011
-Khanxay Latthahao,Mr,14,Saravan Province,2011
-Phanduangchit Vongsa,Dr,15,Champasak Province,2011
-Meksavanh Phomphithak,Mr,15,Champasak Province,2011
-Phonethep Pholsena,Prof. Dr,15,Champasak Province,2011
-Bualin Vongphachanh,Mr,15,Champasak Province,2011
-Kisinh Sinphanngam,Mr,15,Champasak Province,2011
-Bounthien Thongkeo,Mr,15,Champasak Province,2011
-Singphet Bounsavatthiphanh,Mr,15,Champasak Province,2011
-Pingkham Lasasimma,Ms,15,Champasak Province,2011
-Vannala Soutthichak,Mr,15,Champasak Province,2011
-Sivanh Outthachak,Lt. Col.,15,Champasak Province,2011
-Vatsana Silima,Ms,15,Champasak Province,2011
-Oudone Singsouvong,Mr,15,Champasak Province,2011
-Khamdaeng Kommadam,Mr,16,Xekong Province,2011
 Bounkham Ngaophasiri,Ms,16,Xekong Province,2011
-Somsanouk Keonimith,Mr,16,Xekong Province,2011
-Phetsamone Khonpasith,Mr,16,Xekong Province,2011
-Haymany Vongnorkeo,Ms,16,Xekong Province,2011
-Onkeo Phommakone,Dr,17,Attapue Province,2011
+Bounlort Onphachanh,Mr,4,Oudomxay Province,2011
+Bounma Bouchaleun,Mr,11,Bolikhamxay Province,2011
+Bounnheuane Thidphoutthavong,Ms,13,Savannakhet Province,2011
+Bounnhong Khinsamone,Dr,12,Khammouane Province,2011
+Bounnhong Norkeo,Lieutenant Colonel,4,Oudomxay Province,2011
+Bounnhong Xaypanya,Mr,13,Savannakhet Province,2011
+Bounpan Douanglaty,Mr,12,Khammouane Province,2011
+Bounpheng Mounphoxay,Ms,9,Xiengkhouang Province,2011
+Bounpheng Sainorlady,Mr,10,Vientiane Province,2011
+Bounpheng Sitthisak,Lieutenant Colonel,1,Vientiane Capital,2011
+Bounpone Sisoulath,Mr,13,Savannakhet Province,2011
+Bounpong Keorodom,Assoc. Prof. Dr,13,Savannakhet Province,2011
+Bounseng Pathammavong,Mr,11,Bolikhamxay Province,2011
+Bountem Xouangsayavong,Mr,13,Savannakhet Province,2011
+Bountham Senphansiri,Mr,6,Luangprabang Province,2011
+Bounthavy Sisouphanthong,Dr,6,Luangprabang Province,2011
+Bounthiem Phommasathith,Mr,14,Saravan Province,2011
+Bounthien Thongkeo,Mr,15,Champasak Province,2011
+Bounthone Sitsouvong,Lt. Col.,6,Luangprabang Province,2011
+Bounton Chanthaphone,Mr,9,Xiengkhouang Province,2011
 Bounxay Khammanivong,Mr,17,Attapue Province,2011
+Bounyong Boupha,Prof. Dr,1,Vientiane Capital,2011
+Brigadier General Vilay Duangmany,Police,6,Luangprabang Province,2011
+Bua-Ngeun Xaphouvong,Mr,1,Vientiane Capital,2011
+Buakham Thipphavong,Dr,1,Vientiane Capital,2011
+Bualin Vongphachanh,Mr,15,Champasak Province,2011
+Chanmany Namvong,Ms,2,Phongsaly Province,2011
+Channuan Ouankhanachak,Police Lt. Col.,5,Bokeo Province,2011
+Chansy Saengsomphou,Dr,2,Phongsaly Province,2011
+Chanthaboun Phosalath,Ms,10,Vientiane Province,2011
+Chanthanom Vongsomchith,Mr,7,Xayabouly province,2011
+Chouangchanh Latsavong,Col.,11,Bolikhamxay Province,2011
+Davone Vangvichit,Prof.,14,Saravan Province,2011
+Duangdy Outthachak,Mr,10,Vientiane Province,2011
+Duangsavat Souphanouvong,Dr,1,Vientiane Capital,2011
+Haymany Vongnorkeo,Ms,16,Xekong Province,2011
+Houmphaeng Sitthivong,Mr,4,Oudomxay Province,2011
+Houmphanh Thammoungkhoun,Mr,6,Luangprabang Province,2011
+Idmany Chanthakhoun,Ms,7,Xayabouly province,2011
+Inthava Moundala,Mr,12,Khammouane Province,2011
+Ketkeo Sihalath,Dr,1,Vientiane Capital,2011
+Ketsana Latxachack,Dr,12,Khammouane Province,2011
+Khamchan Khamvongchay,Mr,2,Phongsaly Province,2011
+Khamchomphou Silitham,Dr,5,Bokeo Province,2011
+Khamdaeng Kommadam,Mr,16,Xekong Province,2011
+Khamdaeng Silavong,Mr,10,Vientiane Province,2011
+Khamfong Phoumvongxay,Ms,1,Vientiane Capital,2011
+Khamkhen Oudtama,Lt. Col.,10,Vientiane Province,2011
+Khamla Chandala,Lieutenant Colonel,9,Xiengkhouang Province,2011
+Khamlek Saydara,Assoc. Prof. Dr,3,Luangnamtha Province,2011
+Khammany Inthirath,Mr,13,Savannakhet Province,2011
+Khamphan Khounsacksy,Mr,13,Savannakhet Province,2011
+Khampheuy Panmalaythong,Dr,1,Vientiane Capital,2011
+Khamphone Phimmachanh,Mrs,4,Oudomxay Province,2011
+Khamphoui Vannachit,Lt. Col.,6,Luangprabang Province,2011
+Khamping Saengtannalath,Mr,2,Phongsaly Province,2011
+Khamsouk Thor,Mr,7,Xayabouly province,2011
+Khamsouk Vi-inthavong,Colonel,7,Xayabouly province,2011
+Khamvone Bounthavong,Mr,8,Houaphanh Province,2011
+Khamxao Kayxong,Mr,4,Oudomxay Province,2011
+Khanxay Latthahao,Mr,14,Saravan Province,2011
+Kikeo Khaykhamphithoune,Prof. Dr,1,Vientiane Capital,2011
+Kisinh Sinphanngam,Mr,15,Champasak Province,2011
+Kongphet Keobouapha,Mr,3,Luangnamtha Province,2011
+Koukeo Akkhamonti,Dr,1,Vientiane Capital,2011
+Lasanivong Amarathithada,Mr,1,Vientiane Capital,2011
+Latsamy Mingboupha,Ms,3,Luangnamtha Province,2011
+Malisa Aphaylath,Ms,11,Bolikhamxay Province,2011
+Manixong Leusisamouth,Ms,14,Saravan Province,2011
+Meksavanh Phomphithak,Mr,15,Champasak Province,2011
+Misone Thongxaysy,Ms,8,Houaphanh Province,2011
+Onkeo Phommakone,Dr,17,Attapue Province,2011
+Onsy Saensouk,Colonel,10,Vientiane Province,2011
+Oudone Singsouvong,Mr,15,Champasak Province,2011
+Oulavanh Bounthachak,Mr,5,Bokeo Province,2011
+Ounkeo Vouthirath,Dr,5,Bokeo Province,2011
+Pany Yathortou,Ms,7,Xayabouly province,2011
+Phanduangchit Vongsa,Dr,15,Champasak Province,2011
 Phetkeo Heuangpannha,Mr,17,Attapue Province,2011
-Xokxay Phimmala,Lt. Col,17,Attapue Province,2011
+Phetsamone Khonpasith,Mr,16,Xekong Province,2011
+Phonethep Pholsena,Prof. Dr,15,Champasak Province,2011
 Phonmany Khienxayavong,Ms,17,Attapue Province,2011
+Phonsouk Thongsombath,Mr,8,Houaphanh Province,2011
+Pingkham Lasasimma,Ms,15,Champasak Province,2011
+Saengthong Phakhounthong,Mr,12,Khammouane Province,2011
+Sikeo Sipachack,Mr,2,Phongsaly Province,2011
+Sikhay Sipaseuth,Ms,11,Bolikhamxay Province,2011
+Simoun Ounlasy,Mr,13,Savannakhet Province,2011
+Singphet Bounsavatthiphanh,Mr,15,Champasak Province,2011
+Singtan Xayleuxong,Mr,6,Luangprabang Province,2011
+Sisaliew Savengsuksa,Dr,1,Vientiane Capital,2011
+Sivanh Outthachak,Lt. Col.,15,Champasak Province,2011
+SomOck Kingsada,Assoc. Prof. Dr,10,Vientiane Province,2011
+Somchanh Chitvongdeuan,Ms,4,Oudomxay Province,2011
+Somchay Ounchit,Mr,14,Saravan Province,2011
+Somchit Kittiyalath,Lt. Col.,13,Savannakhet Province,2011
+Somdy Keodalavin,Mr,10,Vientiane Province,2011
+Somphanh Phaengkhammy,Mr,8,Houaphanh Province,2011
+Somphet Inthathilath,Mr,13,Savannakhet Province,2011
+Somphone Soutthisombath,Lt. Col.,13,Savannakhet Province,2011
+Somphou Douangsavanh,Dr,13,Savannakhet Province,2011
+Somsanouk Keonimith,Mr,16,Xekong Province,2011
+Somvandy Sisouphanh,Mr,9,Xiengkhouang Province,2011
+Somvang Thammasith,Colonel Dr,1,Vientiane Capital,2011
+Sonthanou Thammavong,Dr,13,Savannakhet Province,2011
+Souvanpheng Bouphanouvong,Dr,1,Vientiane Capital,2011
+Suanesavanh Vignaket,Ms,14,Saravan Province,2011
+Thatsadaphone Saengsouliya,Ms,13,Savannakhet Province,2011
+Thipphachanh Phoxay,Police Lt. Colonel,12,Khammouane Province,2011
+Thongdy Phabboua-on,Mr,7,Xayabouly province,2011
+Vaenphet Latdavong,Mr,14,Saravan Province,2011
+Vankham Inthichack,Mr,13,Savannakhet Province,2011
+Vannala Soutthichak,Mr,15,Champasak Province,2011
+Vanpheng Keonakhone,Ms,1,Vientiane Capital,2011
+Vatsana Silima,Ms,15,Champasak Province,2011
+Viengmany Chanthanasin,Ms,12,Khammouane Province,2011
+Vilaysouk Phimmasone,Mr,9,Xiengkhouang Province,2011
+Vixaykone Vannachomchanh,Mr,5,Bokeo Province,2011
+Vongchanh Phomsavath,Mr,7,Xayabouly province,2011
+Vongsack Xaoxuayang,Major,8,Houaphanh Province,2011
+Vonkham Phetthavong,Mr,3,Luangnamtha Province,2011
+Xaysomphone Phomvihane,Dr,13,Savannakhet Province,2011
+Xokxay Phimmala,Lt. Col,17,Attapue Province,2011
+amphone Sivilaysak,Mrs,6,Luangprabang Province,2011


### PR DESCRIPTION
This PR prepares for the addition of the 2016 term.

Memberships do not have upstream IDs and matching by name is precarious as spellings differ between terms.

The plan is to import terms to separate files and reconcile new members with existing members using the reconciliation interface.

This PR makes the first step of changing the existing membership import instruction to import term 2011 (the existing term) specifically.
