### PR TITLE
Check source CSVs for well-formedness

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-abort 'Ruby should be >= 2.1.0' unless RUBY_VERSION.to_f >= 2.1
+abort 'Ruby should be >= 2.3' unless RUBY_VERSION.to_f >= 2.3
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 gem 'json'
@@ -34,4 +34,5 @@ group :test do
   gem 'webmock'
   gem 'rubocop'
   gem 'flog'
+  gem 'csvlint'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,17 +61,37 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.4.0)
     ast (2.3.0)
     coderay (1.1.1)
     colorize (0.8.1)
+    concurrent-ruby (1.0.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    csvlint (0.3.2)
+      activesupport
+      addressable
+      colorize
+      escape_utils
+      mime-types
+      open_uri_redirections
+      thor
+      typhoeus
+      uri_template
     domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
+    escape_utils (1.2.1)
+    ethon (0.9.1)
+      ffi (>= 1.3.0)
     facebook_username_extractor (0.2.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    ffi (1.9.14)
     flog (4.4.0)
       path_expander (~> 1.0)
       ruby_parser (~> 3.1, > 3.1.0)
@@ -80,6 +100,7 @@ GEM
     hashdiff (0.3.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
+    i18n (0.7.0)
     json (2.0.1)
     json5 (0.0.1)
     method_source (0.8.2)
@@ -97,6 +118,7 @@ GEM
       pkg-config (~> 1.1.7)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
+    open_uri_redirections (0.2.1)
     parser (2.3.1.2)
       ast (~> 2.2)
     path_expander (1.0.0)
@@ -130,11 +152,18 @@ GEM
       faraday (~> 0.8, < 0.10)
     sexp_processor (4.7.0)
     slop (3.6.0)
+    thor (0.19.1)
+    thread_safe (0.3.5)
+    typhoeus (1.1.0)
+      ethon (>= 0.9.0)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
     unicode-display_width (1.1.0)
     unicode_utils (1.4.0)
+    uri_template (0.7.0)
     vcr (3.0.3)
     webmock (2.1.0)
       addressable (>= 2.3.6)
@@ -149,6 +178,7 @@ DEPENDENCIES
   close_old_pull_requests!
   colorize
   csv_to_popolo (~> 0.27.1)!
+  csvlint
   everypolitician!
   everypolitician-dataview-terms!
   everypolitician-popolo (~> 0.7.0)!
@@ -177,4 +207,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.12.5
+   1.13.4

--- a/rake_build/validate_raw_sources.rb
+++ b/rake_build/validate_raw_sources.rb
@@ -1,0 +1,19 @@
+
+# Ensure that all the source CSV files are well-formed
+
+require 'csvlint'
+
+desc 'validate raw CSV sources'
+namespace :csvlint do
+  task :validate do
+    FileList['sources/**/*.csv'].each do |file|
+      validator = Csvlint::Validator.new(File.new(file))
+      next if validator.valid?
+
+      abort "Problem linting %s:\n%s" % [
+        file,
+        validator.errors.map { |e| "\t#{e.type} at line #{e.row}" }.join("\n"),
+      ]
+    end
+  end
+end

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -123,6 +123,6 @@ raise("Can't read #{@INSTRUCTIONS_FILE}") unless @INSTRUCTIONS_FILE.exist?
 
 desc 'Rebuild from source data'
 task rebuild: [:clobber, 'ep-popolo-v1.0.json']
-task default: [:csvs, 'stats:regenerate']
+task default: ['csvlint:validate', :csvs, 'stats:regenerate']
 
 Dir[File.dirname(__FILE__) + '/rake_*/*.rb'].each { |file| require file }


### PR DESCRIPTION
Use the ODI csv linter to make sure that our source CSVs (particularly the ones  we generate ourselves, such as terms files, reconciliation files etc, are well  formed before attempting a build.

This can be run manually from within a legislature sub-directory with `rake csvlint:validate`, but it is also set to be a default rake task, and thus will happen automatically in-between the `clean` or `clobber` and the start of the generation process in our normal approach.

Closes https://github.com/everypolitician/everypolitician/issues/534

## Notes to reviewer

1. This gem unfortunately requires us to up our minimally-supported ruby version. If there's a way to conditionally run these checks only if a suitable ruby version is installed, I'd be quite tempted to do that instead, but it seems to be a non-trivial amount of effort for code that is very rarely run by anyone outside the team (and even then by people who are unlikely to have a problem with using 2.3). This approach also lets us evolve towards a much more complex set of tests using JSON schemas.
1. This can be seen failing against the current `master` version of The Philippines. Many other problems were fixed separately in https://github.com/everypolitician/everypolitician-data/pull/19488
1. This currently fails if a CSV flle contains linebreaks within a field (e.g. with Kenya). I'm currently undecided whether we want to override that or not. In theory it should be perfectly acceptable to have these, but in practice we're almost never going to want them, and should be cleaning them up, either in the upstream scraper, or at input. So I'm currently leaning towards using this to force us to resolve them. (e.g. the Kenya issue is from https://github.com/mysociety/pombola/issues/2160 which we really should fix)