### PR TITLE
Move csvlint from test to production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'require_all'
 gem 'close_old_pull_requests', github: 'everypolitician/close_old_pull_requests'
 gem 'everypolitician-pull_request', github: 'everypolitician/everypolitician-pull_request'
 gem 'everypolitician-dataview-terms', github: 'everypolitician/everypolitician-dataview-terms'
+gem 'csvlint'
 
 group :test do
   gem 'minitest'
@@ -34,5 +35,4 @@ group :test do
   gem 'webmock'
   gem 'rubocop'
   gem 'flog'
-  gem 'csvlint'
 end


### PR DESCRIPTION
The rebuilder skips all gems that are in the `:test` group (https://github.com/everypolitician/rebuilder/blob/4a3562aa106404c00b2e7bfb707bb4e4d79b364d/app.rb#L54), so attempting to run the csv linting task fails.

In theory we shouldn't _need_ to run that task at the point of the actual build, but the extra check is useful, so move this to production setting rather than test.