### PR TITLE
Add wikidata identifiers to elections

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -4172,11 +4172,11 @@
         "slug": "Congress",
         "sources_directory": "data/Guatemala/Congress/sources",
         "popolo": "data/Guatemala/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d665c07ef94f40f99ddb7f7f3e15872656f8fa9c/data/Guatemala/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a96f48992ad2d9983b212dcb1a49a2b559003cec/data/Guatemala/Congress/ep-popolo-v1.0.json",
         "names": "data/Guatemala/Congress/names.csv",
-        "lastmod": "1477384602",
+        "lastmod": "1478000147",
         "person_count": 245,
-        "sha": "d665c07ef94f40f99ddb7f7f3e15872656f8fa9c",
+        "sha": "a96f48992ad2d9983b212dcb1a49a2b559003cec",
         "legislative_periods": [
           {
             "end_date": "2020-01-14",
@@ -4197,7 +4197,7 @@
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4de11443c2af322df823fae491a867bc197a981c/data/Guatemala/Congress/term-7.csv"
           }
         ],
-        "statement_count": 5608,
+        "statement_count": 5680,
         "type": "unicameral legislature"
       }
     ]

--- a/data/Guatemala/Congress/ep-popolo-v1.0.json
+++ b/data/Guatemala/Congress/ep-popolo-v1.0.json
@@ -10739,6 +10739,12 @@
       "classification": "general election",
       "end_date": "1923",
       "id": "Q5614292",
+      "identifiers": [
+        {
+          "identifier": "Q5614292",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan parliamentary election, 1923",
       "start_date": "1923"
     },
@@ -10746,6 +10752,12 @@
       "classification": "general election",
       "end_date": "1925",
       "id": "Q5614296",
+      "identifiers": [
+        {
+          "identifier": "Q5614296",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan parliamentary election, 1925",
       "start_date": "1925"
     },
@@ -10753,6 +10765,12 @@
       "classification": "general election",
       "end_date": "1926",
       "id": "Q3586582",
+      "identifiers": [
+        {
+          "identifier": "Q3586582",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 1926",
       "start_date": "1926"
     },
@@ -10760,6 +10778,12 @@
       "classification": "general election",
       "end_date": "1927",
       "id": "Q5614259",
+      "identifiers": [
+        {
+          "identifier": "Q5614259",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan Constitutional Convention election, 1927",
       "start_date": "1927"
     },
@@ -10767,6 +10791,12 @@
       "classification": "general election",
       "end_date": "1929",
       "id": "Q5614297",
+      "identifiers": [
+        {
+          "identifier": "Q5614297",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan parliamentary election, 1929",
       "start_date": "1929"
     },
@@ -10774,6 +10804,12 @@
       "classification": "general election",
       "end_date": "1931",
       "id": "Q3586583",
+      "identifiers": [
+        {
+          "identifier": "Q3586583",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 1931",
       "start_date": "1931"
     },
@@ -10781,6 +10817,12 @@
       "classification": "general election",
       "end_date": "1935",
       "id": "Q5614252",
+      "identifiers": [
+        {
+          "identifier": "Q5614252",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan Constituent Assembly election, 1935",
       "start_date": "1935"
     },
@@ -10788,6 +10830,12 @@
       "classification": "general election",
       "end_date": "1944",
       "id": "Q5614253",
+      "identifiers": [
+        {
+          "identifier": "Q5614253",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan Constitutional Assembly election, 1944",
       "start_date": "1944"
     },
@@ -10795,6 +10843,12 @@
       "classification": "general election",
       "end_date": "1944",
       "id": "Q5614306",
+      "identifiers": [
+        {
+          "identifier": "Q5614306",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan parliamentary election, November 1944",
       "start_date": "1944"
     },
@@ -10802,6 +10856,12 @@
       "classification": "general election",
       "end_date": "1944",
       "id": "Q5614308",
+      "identifiers": [
+        {
+          "identifier": "Q5614308",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan parliamentary election, October 1944",
       "start_date": "1944"
     },
@@ -10809,6 +10869,12 @@
       "classification": "general election",
       "end_date": "1947",
       "id": "Q5614299",
+      "identifiers": [
+        {
+          "identifier": "Q5614299",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan parliamentary election, 1947",
       "start_date": "1947"
     },
@@ -10816,6 +10882,12 @@
       "classification": "general election",
       "end_date": "1948",
       "id": "Q5614301",
+      "identifiers": [
+        {
+          "identifier": "Q5614301",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan parliamentary election, 1948",
       "start_date": "1948"
     },
@@ -10823,6 +10895,12 @@
       "classification": "general election",
       "end_date": "1950",
       "id": "Q5614302",
+      "identifiers": [
+        {
+          "identifier": "Q5614302",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan parliamentary election, 1950",
       "start_date": "1950"
     },
@@ -10830,6 +10908,12 @@
       "classification": "general election",
       "end_date": "1953",
       "id": "Q5614303",
+      "identifiers": [
+        {
+          "identifier": "Q5614303",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan parliamentary election, 1953",
       "start_date": "1953"
     },
@@ -10837,6 +10921,12 @@
       "classification": "general election",
       "end_date": "1954",
       "id": "Q5614274",
+      "identifiers": [
+        {
+          "identifier": "Q5614274",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 1954",
       "start_date": "1954"
     },
@@ -10844,6 +10934,12 @@
       "classification": "general election",
       "end_date": "1955",
       "id": "Q4163571",
+      "identifiers": [
+        {
+          "identifier": "Q4163571",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan parliamentary election, 1955",
       "start_date": "1955"
     },
@@ -10851,6 +10947,12 @@
       "classification": "general election",
       "end_date": "1957",
       "id": "Q3699220",
+      "identifiers": [
+        {
+          "identifier": "Q3699220",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 1957",
       "start_date": "1957"
     },
@@ -10858,6 +10960,12 @@
       "classification": "general election",
       "end_date": "1958",
       "id": "Q3699223",
+      "identifiers": [
+        {
+          "identifier": "Q3699223",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 1958",
       "start_date": "1958"
     },
@@ -10865,6 +10973,12 @@
       "classification": "general election",
       "end_date": "1959-12-16",
       "id": "Q5614305",
+      "identifiers": [
+        {
+          "identifier": "Q5614305",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan parliamentary election, 1959",
       "start_date": "1959-12-16"
     },
@@ -10872,6 +10986,12 @@
       "classification": "general election",
       "end_date": "1961-12-03",
       "id": "Q5614304",
+      "identifiers": [
+        {
+          "identifier": "Q5614304",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan parliamentary election, 1961",
       "start_date": "1961-12-03"
     },
@@ -10879,6 +10999,12 @@
       "classification": "general election",
       "end_date": "1964",
       "id": "Q5481753",
+      "identifiers": [
+        {
+          "identifier": "Q5481753",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan Constitutional Assembly election, 1964",
       "start_date": "1964"
     },
@@ -10886,6 +11012,12 @@
       "classification": "general election",
       "end_date": "1966",
       "id": "Q5614275",
+      "identifiers": [
+        {
+          "identifier": "Q5614275",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 1966",
       "start_date": "1966"
     },
@@ -10893,6 +11025,12 @@
       "classification": "general election",
       "end_date": "1970",
       "id": "Q5614276",
+      "identifiers": [
+        {
+          "identifier": "Q5614276",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 1970",
       "start_date": "1970"
     },
@@ -10900,6 +11038,12 @@
       "classification": "general election",
       "end_date": "1974",
       "id": "Q5614277",
+      "identifiers": [
+        {
+          "identifier": "Q5614277",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 1974",
       "start_date": "1974"
     },
@@ -10907,6 +11051,12 @@
       "classification": "general election",
       "end_date": "1978",
       "id": "Q5614278",
+      "identifiers": [
+        {
+          "identifier": "Q5614278",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 1978",
       "start_date": "1978"
     },
@@ -10914,6 +11064,12 @@
       "classification": "general election",
       "end_date": "1982",
       "id": "Q5614282",
+      "identifiers": [
+        {
+          "identifier": "Q5614282",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 1982",
       "start_date": "1982"
     },
@@ -10921,6 +11077,12 @@
       "classification": "general election",
       "end_date": "1984",
       "id": "Q5390600",
+      "identifiers": [
+        {
+          "identifier": "Q5390600",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan Constitutional Assembly election, 1984",
       "start_date": "1984"
     },
@@ -10928,6 +11090,12 @@
       "classification": "general election",
       "end_date": "1985",
       "id": "Q5614283",
+      "identifiers": [
+        {
+          "identifier": "Q5614283",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 1985",
       "start_date": "1985"
     },
@@ -10935,6 +11103,12 @@
       "classification": "general election",
       "end_date": "1990",
       "id": "Q5614285",
+      "identifiers": [
+        {
+          "identifier": "Q5614285",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 1990",
       "start_date": "1990"
     },
@@ -10942,6 +11116,12 @@
       "classification": "general election",
       "end_date": "1994",
       "id": "Q2892661",
+      "identifiers": [
+        {
+          "identifier": "Q2892661",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan parliamentary election, 1994",
       "start_date": "1994"
     },
@@ -10949,6 +11129,12 @@
       "classification": "general election",
       "end_date": "1995",
       "id": "Q5614286",
+      "identifiers": [
+        {
+          "identifier": "Q5614286",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 1995",
       "start_date": "1995"
     },
@@ -10956,6 +11142,12 @@
       "classification": "general election",
       "end_date": "1999-11-07",
       "id": "Q5614290",
+      "identifiers": [
+        {
+          "identifier": "Q5614290",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 1999",
       "start_date": "1999-11-07"
     },
@@ -10963,6 +11155,12 @@
       "classification": "general election",
       "end_date": "2003-11-09",
       "id": "Q3586584",
+      "identifiers": [
+        {
+          "identifier": "Q3586584",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 2003",
       "start_date": "2003-11-09"
     },
@@ -10970,6 +11168,12 @@
       "classification": "general election",
       "end_date": "2007-11-04",
       "id": "Q1508186",
+      "identifiers": [
+        {
+          "identifier": "Q1508186",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election",
       "start_date": "2007-09-09"
     },
@@ -10977,6 +11181,12 @@
       "classification": "general election",
       "end_date": "2011-09-11",
       "id": "Q2599631",
+      "identifiers": [
+        {
+          "identifier": "Q2599631",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 2011",
       "start_date": "2011-09-11"
     },
@@ -10998,6 +11208,12 @@
       "classification": "general election",
       "end_date": "2015-09-06",
       "id": "Q12164601",
+      "identifiers": [
+        {
+          "identifier": "Q12164601",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Guatemalan general election, 2015",
       "start_date": "2015-09-06"
     },

--- a/data/Guatemala/Congress/unstable/stats.json
+++ b/data/Guatemala/Congress/unstable/stats.json
@@ -9,7 +9,7 @@
   },
   "terms": {
     "count": 2,
-    "latest": "2016-01-14"
+    "latest": ""
   },
   "elections": {
     "count": 36,

--- a/lib/source/elections.rb
+++ b/lib/source/elections.rb
@@ -18,6 +18,7 @@ module Source
           name:           name[:name],
           start_date:     dates.first,
           end_date:       dates.last,
+          identifiers:    [{ identifier: id, scheme: 'wikidata' }],
           classification: 'general election',
         }
       end.compact


### PR DESCRIPTION
We currently use Wikidata IDs as our own primary IDs, but for consistency
(and so that users of the everypolitician-popolo gem can access it with the
.wikidata method) we should really expose them as identifiers too.