### PR TITLE
Slovakia: Move terms file to manual

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -8893,11 +8893,11 @@
         "slug": "National-Council",
         "sources_directory": "data/Slovakia/National_Council/sources",
         "popolo": "data/Slovakia/National_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/386d0337333308ecdb8b92e5c80e529ff2ade491/data/Slovakia/National_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65be697690b649c25e0d8d8835ed80da08c81bad/data/Slovakia/National_Council/ep-popolo-v1.0.json",
         "names": "data/Slovakia/National_Council/names.csv",
-        "lastmod": "1477980503",
+        "lastmod": "1478083865",
         "person_count": 526,
-        "sha": "386d0337333308ecdb8b92e5c80e529ff2ade491",
+        "sha": "65be697690b649c25e0d8d8835ed80da08c81bad",
         "legislative_periods": [
           {
             "id": "term/6",
@@ -8944,7 +8944,7 @@
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3f1e80bcb72ab7454267295b2d771774fb7770b4/data/Slovakia/National_Council/term-2.csv"
           }
         ],
-        "statement_count": 35699,
+        "statement_count": 35735,
         "type": "unicameral legislature"
       }
     ]

--- a/data/Slovakia/National_Council/ep-popolo-v1.0.json
+++ b/data/Slovakia/National_Council/ep-popolo-v1.0.json
@@ -63418,6 +63418,12 @@
       "classification": "general election",
       "end_date": "1938",
       "id": "Q11931912",
+      "identifiers": [
+        {
+          "identifier": "Q11931912",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election, 1938",
       "start_date": "1938"
     },
@@ -63425,6 +63431,12 @@
       "classification": "general election",
       "end_date": "1948",
       "id": "Q11931708",
+      "identifiers": [
+        {
+          "identifier": "Q11931708",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election",
       "start_date": "1948"
     },
@@ -63432,6 +63444,12 @@
       "classification": "general election",
       "end_date": "1954",
       "id": "Q11931732",
+      "identifiers": [
+        {
+          "identifier": "Q11931732",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election",
       "start_date": "1954"
     },
@@ -63439,6 +63457,12 @@
       "classification": "general election",
       "end_date": "1960",
       "id": "Q11931752",
+      "identifiers": [
+        {
+          "identifier": "Q11931752",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election, 1960",
       "start_date": "1960"
     },
@@ -63446,6 +63470,12 @@
       "classification": "general election",
       "end_date": "1964",
       "id": "Q11931767",
+      "identifiers": [
+        {
+          "identifier": "Q11931767",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election, 1964",
       "start_date": "1964"
     },
@@ -63453,6 +63483,12 @@
       "classification": "general election",
       "end_date": "1971",
       "id": "Q11931811",
+      "identifiers": [
+        {
+          "identifier": "Q11931811",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election, 1971",
       "start_date": "1971"
     },
@@ -63460,6 +63496,12 @@
       "classification": "general election",
       "end_date": "1976",
       "id": "Q11931831",
+      "identifiers": [
+        {
+          "identifier": "Q11931831",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election, 1976",
       "start_date": "1976"
     },
@@ -63467,6 +63509,12 @@
       "classification": "general election",
       "end_date": "1981",
       "id": "Q11931846",
+      "identifiers": [
+        {
+          "identifier": "Q11931846",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election, 1981",
       "start_date": "1981"
     },
@@ -63474,6 +63522,12 @@
       "classification": "general election",
       "end_date": "1986",
       "id": "Q11931864",
+      "identifiers": [
+        {
+          "identifier": "Q11931864",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election, 1986",
       "start_date": "1986"
     },
@@ -63481,6 +63535,12 @@
       "classification": "general election",
       "end_date": "1990",
       "id": "Q2053294",
+      "identifiers": [
+        {
+          "identifier": "Q2053294",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election, 1990",
       "start_date": "1990"
     },
@@ -63488,6 +63548,12 @@
       "classification": "general election",
       "end_date": "1992",
       "id": "Q2053313",
+      "identifiers": [
+        {
+          "identifier": "Q2053313",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election, 1992",
       "start_date": "1992"
     },
@@ -63495,6 +63561,12 @@
       "classification": "general election",
       "end_date": "1994",
       "id": "Q1308966",
+      "identifiers": [
+        {
+          "identifier": "Q1308966",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election, 1994",
       "start_date": "1994"
     },
@@ -63502,6 +63574,12 @@
       "classification": "general election",
       "end_date": "1998",
       "id": "Q1634782",
+      "identifiers": [
+        {
+          "identifier": "Q1634782",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election, 1998",
       "start_date": "1998"
     },
@@ -63517,6 +63595,12 @@
       "classification": "general election",
       "end_date": "2002-09-21",
       "id": "Q1512455",
+      "identifiers": [
+        {
+          "identifier": "Q1512455",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election, 2002",
       "start_date": "2002-09-21"
     },
@@ -63532,6 +63616,12 @@
       "classification": "general election",
       "end_date": "2006-06-17",
       "id": "Q937308",
+      "identifiers": [
+        {
+          "identifier": "Q937308",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election, 2006",
       "start_date": "2006-06-17"
     },
@@ -63547,6 +63637,12 @@
       "classification": "general election",
       "end_date": "2010-06-12",
       "id": "Q856417",
+      "identifiers": [
+        {
+          "identifier": "Q856417",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election, 2010",
       "start_date": "2010-06-12"
     },
@@ -63562,6 +63658,12 @@
       "classification": "general election",
       "end_date": "2012-03-10",
       "id": "Q1078236",
+      "identifiers": [
+        {
+          "identifier": "Q1078236",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election, 2012",
       "start_date": "2012-03-10"
     },
@@ -63576,6 +63678,12 @@
       "classification": "general election",
       "end_date": "2016-03-05",
       "id": "Q17325619",
+      "identifiers": [
+        {
+          "identifier": "Q17325619",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Slovak parliamentary election, 2016",
       "start_date": "2016-03-05"
     }

--- a/data/Slovakia/National_Council/sources/instructions.json
+++ b/data/Slovakia/National_Council/sources/instructions.json
@@ -26,14 +26,8 @@
       }
     },
     {
-      "file": "morph/terms.csv",
-      "type": "term",
-      "create": {
-        "file": "morph/terms.csv",
-        "from": "morph",
-        "scraper": "tmtmtmtm/slovakia-national-council",
-        "query": "SELECT * FROM terms"
-      }
+      "file": "manual/terms.csv",
+      "type": "term"
     },
     {
       "file": "gender-balance/results.csv",

--- a/data/Slovakia/National_Council/sources/manual/terms.csv
+++ b/data/Slovakia/National_Council/sources/manual/terms.csv
@@ -4,4 +4,4 @@ id,identifier__parldata,name,start_date,end_date
 3,54d2a560273a394ad5dba024,3. Národná rada 2002-2006,2002-09-22,2006-06-16
 4,54d2a637273a394ad5dbac90,4. Národná rada 2006-2010,2006-06-17,2010-06-12
 5,54d2a70d273a394ad5dbb870,5. Národná rada 2010-2012,2010-06-13,2012-03-10
-6,54d2a7e8273a394ad5dbc386,6. Národná rada 2012-,2012-03-11,""
+6,54d2a7e8273a394ad5dbc386,6. Národná rada 2012-,2012-03-11,


### PR DESCRIPTION
Term information was being sourced from http://api.parldata.eu
We're moving the terms to a manual file, since this source
is no longer being maintained.

This is a step towards adding a new term.