### PR TITLE
Nigeria (Assembly): rebuild data

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -6956,11 +6956,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Nigeria/Assembly/sources",
         "popolo": "data/Nigeria/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/851ebefc1d6dfe4345a8567dca410681c898fb11/data/Nigeria/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/edeb20e8ad059d5a2ab8010584010ae2316bbf3c/data/Nigeria/Assembly/ep-popolo-v1.0.json",
         "names": "data/Nigeria/Assembly/names.csv",
-        "lastmod": "1477150738",
+        "lastmod": "1479125437",
         "person_count": 362,
-        "sha": "851ebefc1d6dfe4345a8567dca410681c898fb11",
+        "sha": "edeb20e8ad059d5a2ab8010584010ae2316bbf3c",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -6971,7 +6971,7 @@
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6ac43705911a04512e9f890f49e793c1465ab8a9/data/Nigeria/Assembly/term-2015.csv"
           }
         ],
-        "statement_count": 6006,
+        "statement_count": 6042,
         "type": "unicameral legislature"
       }
     ]

--- a/data/Nigeria/Assembly/ep-popolo-v1.0.json
+++ b/data/Nigeria/Assembly/ep-popolo-v1.0.json
@@ -10767,6 +10767,12 @@
       "classification": "general election",
       "end_date": "1923",
       "id": "Q22283794",
+      "identifiers": [
+        {
+          "identifier": "Q22283794",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian general election, 1923",
       "start_date": "1923"
     },
@@ -10774,6 +10780,12 @@
       "classification": "general election",
       "end_date": "1928",
       "id": "Q22283791",
+      "identifiers": [
+        {
+          "identifier": "Q22283791",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian general election, 1928",
       "start_date": "1928"
     },
@@ -10781,6 +10793,12 @@
       "classification": "general election",
       "end_date": "1933",
       "id": "Q22283790",
+      "identifiers": [
+        {
+          "identifier": "Q22283790",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian general election, 1933",
       "start_date": "1933"
     },
@@ -10788,6 +10806,12 @@
       "classification": "general election",
       "end_date": "1938",
       "id": "Q22283787",
+      "identifiers": [
+        {
+          "identifier": "Q22283787",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian general election, 1938",
       "start_date": "1938"
     },
@@ -10795,6 +10819,12 @@
       "classification": "general election",
       "end_date": "1943",
       "id": "Q22283785",
+      "identifiers": [
+        {
+          "identifier": "Q22283785",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian general election, 1943",
       "start_date": "1943"
     },
@@ -10802,6 +10832,12 @@
       "classification": "general election",
       "end_date": "1947",
       "id": "Q22283781",
+      "identifiers": [
+        {
+          "identifier": "Q22283781",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian general election, 1947",
       "start_date": "1947"
     },
@@ -10809,6 +10845,12 @@
       "classification": "general election",
       "end_date": "1954",
       "id": "Q22283777",
+      "identifiers": [
+        {
+          "identifier": "Q22283777",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian general election, 1954",
       "start_date": "1954"
     },
@@ -10816,6 +10858,12 @@
       "classification": "general election",
       "end_date": "1959",
       "id": "Q1479981",
+      "identifiers": [
+        {
+          "identifier": "Q1479981",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian parliamentary election, 1959",
       "start_date": "1959"
     },
@@ -10823,6 +10871,12 @@
       "classification": "general election",
       "end_date": "1964",
       "id": "Q17091809",
+      "identifiers": [
+        {
+          "identifier": "Q17091809",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian parliamentary election, 1964",
       "start_date": "1964"
     },
@@ -10830,6 +10884,12 @@
       "classification": "general election",
       "end_date": "1979",
       "id": "Q17091814",
+      "identifiers": [
+        {
+          "identifier": "Q17091814",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian parliamentary election, 1979",
       "start_date": "1979"
     },
@@ -10837,6 +10897,12 @@
       "classification": "general election",
       "end_date": "1983",
       "id": "Q17091819",
+      "identifiers": [
+        {
+          "identifier": "Q17091819",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian parliamentary election, 1983",
       "start_date": "1983"
     },
@@ -10844,6 +10910,12 @@
       "classification": "general election",
       "end_date": "1992",
       "id": "Q7033040",
+      "identifiers": [
+        {
+          "identifier": "Q7033040",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian parliamentary election, 1992",
       "start_date": "1992"
     },
@@ -10851,6 +10923,12 @@
       "classification": "general election",
       "end_date": "1998",
       "id": "Q7033041",
+      "identifiers": [
+        {
+          "identifier": "Q7033041",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian parliamentary election, 1998",
       "start_date": "1998"
     },
@@ -10858,6 +10936,12 @@
       "classification": "general election",
       "end_date": "1999",
       "id": "Q7033042",
+      "identifiers": [
+        {
+          "identifier": "Q7033042",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian parliamentary election, 1999",
       "start_date": "1999"
     },
@@ -10865,6 +10949,12 @@
       "classification": "general election",
       "end_date": "2003",
       "id": "Q7033046",
+      "identifiers": [
+        {
+          "identifier": "Q7033046",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian parliamentary election, 2003",
       "start_date": "2003"
     },
@@ -10872,6 +10962,12 @@
       "classification": "general election",
       "end_date": "2007-04-21",
       "id": "Q177483",
+      "identifiers": [
+        {
+          "identifier": "Q177483",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian general election, 2007",
       "start_date": "2007-04-21"
     },
@@ -10879,6 +10975,12 @@
       "classification": "general election",
       "end_date": "2011",
       "id": "Q7033044",
+      "identifiers": [
+        {
+          "identifier": "Q7033044",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian parliamentary election, 2011",
       "start_date": "2011"
     },
@@ -10886,6 +10988,12 @@
       "classification": "general election",
       "end_date": "2015-03-28",
       "id": "Q18205072",
+      "identifiers": [
+        {
+          "identifier": "Q18205072",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Nigerian general election, 2015",
       "start_date": "2015-03-28"
     },

--- a/data/Nigeria/Assembly/sources/wikidata/elections.json
+++ b/data/Nigeria/Assembly/sources/wikidata/elections.json
@@ -19,7 +19,7 @@
       },
       {
         "lang": "fr",
-        "name": "Élection présidentielle nigériane de 2007",
+        "name": "élection présidentielle nigériane de 2007",
         "note": "multilingual"
       },
       {
@@ -245,7 +245,7 @@
       },
       {
         "lang": "fr",
-        "name": "Élection présidentielle nigériane de 2015",
+        "name": "élection présidentielle nigériane de 2015",
         "note": "multilingual"
       },
       {


### PR DESCRIPTION
Rebuild all sources other than nigeria-national-assembly (which is a difficult import)

```
Add memberships from sources/morph/data.csv
Adding GenderBalance results from sources/gender-balance/results.csv
  ⚥ data for 0; 0 added

Creating names.csv
Persons matched to Wikidata: 0 ✓ | 362 ✘
Parties matched to Wikidata: 2 ✓ | 4 ✘
  No wikidata: All Progressives Grand Alliance (APGA)
  No wikidata: Labour Party (LP)
  No wikidata: ACCORD (A)
  No wikidata: Social Democratic Party (SDP)
```