### PR TITLE
Guernsey States: Rename area from 'Alderney Representative' to 'Alderney'

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -4213,11 +4213,11 @@
         "slug": "States",
         "sources_directory": "data/Guernsey/States/sources",
         "popolo": "data/Guernsey/States/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/024c0829bdd6e20fae653f74c66df10ee4140863/data/Guernsey/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90397c4bc9626d5a223c4f8ed6d52ecf05e381d1/data/Guernsey/States/ep-popolo-v1.0.json",
         "names": "data/Guernsey/States/names.csv",
-        "lastmod": "1478896047",
+        "lastmod": "1479127721",
         "person_count": 68,
-        "sha": "024c0829bdd6e20fae653f74c66df10ee4140863",
+        "sha": "90397c4bc9626d5a223c4f8ed6d52ecf05e381d1",
         "legislative_periods": [
           {
             "id": "term/2016",
@@ -4234,7 +4234,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Guernsey/States/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3fb7bbafa93327f8f0bd267729de93cdddc76e4f/data/Guernsey/States/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/90397c4bc9626d5a223c4f8ed6d52ecf05e381d1/data/Guernsey/States/term-2012.csv"
           }
         ],
         "statement_count": 1927,

--- a/data/Guernsey/States/ep-popolo-v1.0.json
+++ b/data/Guernsey/States/ep-popolo-v1.0.json
@@ -3297,7 +3297,7 @@
       "role": "member"
     },
     {
-      "area_id": "area/alderney_representative",
+      "area_id": "area/alderney",
       "legislative_period_id": "term/2012",
       "on_behalf_of_id": "party/independent",
       "organization_id": "b6f68cdb-75cb-44dd-8241-f388f630efde",
@@ -3336,7 +3336,7 @@
       "role": "member"
     },
     {
-      "area_id": "area/alderney_representative",
+      "area_id": "area/alderney",
       "legislative_period_id": "term/2012",
       "on_behalf_of_id": "party/independent",
       "organization_id": "b6f68cdb-75cb-44dd-8241-f388f630efde",
@@ -3360,7 +3360,7 @@
       "role": "member"
     },
     {
-      "area_id": "area/alderney_representative",
+      "area_id": "area/alderney",
       "legislative_period_id": "term/2012",
       "on_behalf_of_id": "party/independent",
       "organization_id": "b6f68cdb-75cb-44dd-8241-f388f630efde",
@@ -3623,8 +3623,8 @@
   ],
   "areas": [
     {
-      "id": "area/alderney_representative",
-      "name": "Alderney Representative",
+      "id": "area/alderney",
+      "name": "Alderney",
       "type": "constituency"
     },
     {

--- a/data/Guernsey/States/sources/manual/data-2012.csv
+++ b/data/Guernsey/States/sources/manual/data-2012.csv
@@ -1,5 +1,5 @@
 id,area,party,email,twitter,linkedin,term,source,name
-"harvey,_neil",Alderney Representative,Independent,Neil.Harvey@deputies.gov.gg,"","",2012,,Neil Harvey
+"harvey,_neil",Alderney,Independent,Neil.Harvey@deputies.gov.gg,"","",2012,,Neil Harvey
 "storey,_martin_j.",St. Peter Port North,Independent,Martin.Storey@deputies.gov.gg,"","",2012,,Martin J. Storey
 "adam,_a._hunter",Castel,Independent,Hunter.Adam@deputies.gov.gg,"","",2012,,A. Hunter Adam
 "bebb,_elis_g.",St. Peter Port North,Independent,elis.bebb@gmail.com,https://twitter.com/ElisBebb,"",2012,,Elis G. Bebb
@@ -20,7 +20,7 @@ id,area,party,email,twitter,linkedin,term,source,name
 "harwood,_peter_a.",St. Peter Port South,Independent,Peter.Harwood@deputies.gov.gg,"","",2012,,Peter A. Harwood
 "inglis,_david_a.",West,Independent,dai@cwgsy.net,https://twitter.com/DavidInglisGsy,http://www.linkedin.com/in/davidinglisgsy,2012,,David A. Inglis
 "james,_sandra_a.",Castel,Independent,Sandra.James@deputies.gov.gg,https://twitter.com/DepSandraJames,"",2012,,Sandra A. James
-"jean,_louis",Alderney Representative,Independent,Louis.Jean@deputies.gov.gg,"","",2012,,Louis Jean
+"jean,_louis",Alderney,Independent,Louis.Jean@deputies.gov.gg,"","",2012,,Louis Jean
 "jones,_david_b.",Vale,Independent,David.Jones@deputies.gov.gg,https://twitter.com/DeputyDaveJones,"",2012,,David B. Jones
 "jones,_robert_a.",St. Peter Port South,Independent,Robert.Jones@deputies.gov.gg,https://twitter.com/deputyrobjones,"",2012,,Robert A. Jones
 "kuttelwascher,_jan",St. Peter Port South,Independent,Jan.Kuttelwascher@deputies.gov.gg,"","",2012,,Jan Kuttelwascher
@@ -31,7 +31,7 @@ id,area,party,email,twitter,linkedin,term,source,name
 "le_tocq,_jonathan_p.",Castel,Independent,Jonathan.LeTocq@deputies.gov.gg,https://twitter.com/letocq,http://www.linkedin.com/pub/jonathan-le-tocq/23/5a/b98?trk=pub-pbmap,2012,,Jonathan P. Le Tocq
 "lowe,_mary_m.",Vale,Independent,marylowe@cwgsy.net,https://twitter.com/DeputyMaryLowe,"",2012,,Mary M. Lowe
 "luxon,_paul_a.",South-East,Independent,Paul.Luxon@deputies.gov.gg,https://twitter.com/paul_luxon,http://uk.linkedin.com/pub/paul-luxon/36/14a/663?trk=pub-pbmap,2012,,Paul A. Luxon
-"mckinley,_graham",Alderney Representative,Independent,Graham.McKinley@deputies.gov.gg,"","",2012,,Graham McKinley
+"mckinley,_graham",Alderney,Independent,Graham.McKinley@deputies.gov.gg,"","",2012,,Graham McKinley
 "ogier,_scott_j.",St. Sampson,Independent,Scott.Ogier@deputies.gov.gg,https://twitter.com/DeputyOgier,http://uk.linkedin.com/pub/scott-ogier/34/431/4?trk=pub-pbmap,2012,,Scott J. Ogier
 "o'hara,_michael_g.",South-East,Independent,mike.ohara@cwgsy.net,"","",2012,,Michael G. O'Hara
 "paint,_barry_j._e.",Castel,Independent,Barry.Paint@deputies.gov.gg,"","",2012,,Barry J. E. Paint

--- a/data/Guernsey/States/term-2012.csv
+++ b/data/Guernsey/States/term-2012.csv
@@ -16,7 +16,7 @@ ba64f08a-c809-4cb5-9fa1-9ab669574be1,David G de Lisle,David G de Lisle,delisle.d
 41f38b5b-60a4-4e5e-bd8f-02e0a6637a33,Francis W. Quin,Francis W. Quin,Francis.Quin@deputies.gov.gg,,,Independent,independent,area/south-east,South-East,States,2012,,,,
 f4ae0bb0-5382-4105-a4e6-012974134b3b,Garry M. Collins,Garry M. Collins,Garry.Collins@deputies.gov.gg,GarryCollinsGue,,Independent,independent,area/vale,Vale,States,2012,,,,
 320594a7-8505-457f-8a84-c18561b4455e,Gavin A St. Pier,Gavin A St. Pier,Gavin.StPier@deputies.gov.gg,gavinstpier,gavin.stpier,Independent,independent,area/st._sampson,St. Sampson,States,2012,,,,male
-b1863f9c-5a8c-4808-a38d-e0e57c7f0da4,Graham McKinley,Graham McKinley,Graham.McKinley@deputies.gov.gg,,,Independent,independent,area/alderney_representative,Alderney Representative,States,2012,,,,
+b1863f9c-5a8c-4808-a38d-e0e57c7f0da4,Graham McKinley,Graham McKinley,Graham.McKinley@deputies.gov.gg,,,Independent,independent,area/alderney,Alderney,States,2012,,,,
 a65d0059-362b-4db9-9a05-1c762afc4011,Heidi J. R. Soulsby,Heidi J. R. Soulsby,Heidi.Soulsby@deputies.gov.gg,HeidiSoulsby,Deputy-Heidi-Soulsby-389977751018516,Independent,independent,area/south-east,South-East,States,2012,,,,
 71ec9a6c-c567-490e-baae-69dd38f57352,Jan Kuttelwascher,Jan Kuttelwascher,Jan.Kuttelwascher@deputies.gov.gg,,,Independent,independent,area/st._peter_port_south,St. Peter Port South,States,2012,,,,
 188c99cd-2336-40d5-aec0-c0028f53b364,John A. B. Gollop,John A. B. Gollop,John.Gollop@deputies.gov.gg,GollopGuern,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,
@@ -24,7 +24,7 @@ e06e1b58-295c-4837-be1c-6ffbcbfb9a86,Jonathan P. Le Tocq,Jonathan P. Le Tocq,Jon
 1d770029-1592-434e-9434-f00b6ac82965,Kevin A. Stewart,Kevin A. Stewart,Kevin.Stewart@deputies.gov.gg,kevinstewartgsy,,Independent,independent,area/st._sampson,St. Sampson,States,2012,,,,male
 073c98dc-cd6d-42ce-a082-3a90eccab640,Laurie B. Queripel,Laurie B. Queripel,laurie.queripel@gmail.com,,,Independent,independent,area/vale,Vale,States,2012,,,,
 b1c159f0-8ddc-48b1-9dca-0f8990c8d947,Lester C. Queripel,Lester C. Queripel,lesterqueripel@cwgsy.net,,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,
-bba10897-2d47-4b8d-b2e9-dcfaa16bdae5,Louis Jean,Louis Jean,Louis.Jean@deputies.gov.gg,,,Independent,independent,area/alderney_representative,Alderney Representative,States,2012,,,,
+bba10897-2d47-4b8d-b2e9-dcfaa16bdae5,Louis Jean,Louis Jean,Louis.Jean@deputies.gov.gg,,,Independent,independent,area/alderney,Alderney,States,2012,,,,
 957adc63-eaf0-4147-a1dc-2402c576d1d1,Lyndon S. Trott,Lyndon S. Trott,Lyndon.Trott@deputies.gov.gg,,,Independent,independent,area/st._sampson,St. Sampson,States,2012,,,https://upload.wikimedia.org/wikipedia/commons/9/94/Guernseys_finansminister_Lyndon_Trott_vid_Nordiska_radets_session_i_Helsingfors_2008-10-28.jpg,male
 a1129c34-55df-45d2-8780-e2a279ba8b47,Mark H. Dorey,Mark H. Dorey,Mark.Dorey@deputies.gov.gg,,,Independent,independent,area/castel,Castel,States,2012,,,,male
 e88fa42f-8ee3-4a7e-ad85-338e9557fe60,Martin J. Storey,Martin J. Storey,Martin.Storey@deputies.gov.gg,,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,male
@@ -33,7 +33,7 @@ e88fa42f-8ee3-4a7e-ad85-338e9557fe60,Martin J. Storey,Martin J. Storey,Martin.St
 e5e619cf-d153-45b8-920e-924e4cdb5cfb,Michael G. O'Hara,Michael G. O'Hara,mike.ohara@cwgsy.net,,,Independent,independent,area/south-east,South-East,States,2012,,,,male
 c38b874b-e9ba-42eb-b023-7ae395c57582,Michael P. J. Hadley,Michael P. J. Hadley,Mike.Hadley@deputies.gov.gg,,,Independent,independent,area/south-east,South-East,States,2012,,,,male
 fec5dc7a-6eae-4e5b-8fb4-062fca557f53,Michelle K. Le Clerc,Michelle K. Le Clerc,Michelle.LeClerc@deputies.gov.gg,mkleclerc,,Independent,independent,area/st._peter_port_north,St. Peter Port North,States,2012,,,,female
-b6d46b0f-24ef-42c6-b7ee-8f3b08ff87e1,Neil Harvey,Neil Harvey,Neil.Harvey@deputies.gov.gg,,,Independent,independent,area/alderney_representative,Alderney Representative,States,2012,,,,male
+b6d46b0f-24ef-42c6-b7ee-8f3b08ff87e1,Neil Harvey,Neil Harvey,Neil.Harvey@deputies.gov.gg,,,Independent,independent,area/alderney,Alderney,States,2012,,,,male
 8d947ab2-464a-4ddc-bcfd-149f6137e211,Paul A. Luxon,Paul A. Luxon,Paul.Luxon@deputies.gov.gg,paul_luxon,,Independent,independent,area/south-east,South-East,States,2012,,,,male
 2b11b882-cb89-47a4-b930-847796867f1a,Paul R. Le Pelley,Paul R. Le Pelley,Paul.LePelley@deputies.gov.gg,,,Independent,independent,area/st._sampson,St. Sampson,States,2012,,,,
 a556d367-f9ac-452e-baae-c248b0938d1c,Peter A. Harwood,Peter A. Harwood,Peter.Harwood@deputies.gov.gg,,,Independent,independent,area/st._peter_port_south,St. Peter Port South,States,2012,,,,male


### PR DESCRIPTION
In the 2012 term, Alderney representatives currently have their area listed as 'Alderney Representative'.

![screen shot 2016-11-14 at 12 43 03](https://cloud.githubusercontent.com/assets/4107953/20265349/7c8351d6-aa68-11e6-9276-460e997c1a6a.png)

The area should be 'Alderney'. Term 2016 is scraping this area as 'Alderney'.

Closes: https://github.com/everypolitician/everypolitician-data/issues/20460