### PR TITLE
Prefer election start/end dates if provided

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -1883,11 +1883,11 @@
         "slug": "Commons",
         "sources_directory": "data/Canada/Commons/sources",
         "popolo": "data/Canada/Commons/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/448dc35a9d50d0507faacf86e76636306a58680b/data/Canada/Commons/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a48dab90f2cada46d2fb5168f312b70ab4636b0/data/Canada/Commons/ep-popolo-v1.0.json",
         "names": "data/Canada/Commons/names.csv",
-        "lastmod": "1479064840",
+        "lastmod": "1479146056",
         "person_count": 537,
-        "sha": "448dc35a9d50d0507faacf86e76636306a58680b",
+        "sha": "4a48dab90f2cada46d2fb5168f312b70ab4636b0",
         "legislative_periods": [
           {
             "id": "term/42",

--- a/data/Canada/Commons/ep-popolo-v1.0.json
+++ b/data/Canada/Commons/ep-popolo-v1.0.json
@@ -68733,7 +68733,7 @@
         }
       ],
       "name": "Canadian federal election, 1867",
-      "start_date": "1867"
+      "start_date": "1867-07-20"
     },
     {
       "classification": "general election",

--- a/lib/source/elections.rb
+++ b/lib/source/elections.rb
@@ -11,7 +11,10 @@ module Source
     def events
       as_json.map do |id, data|
         name = data[:other_names].find { |h| h[:lang] == 'en' } or next warn "no English name for #{id}"
-        dates = [data[:dates], data[:start_date], data[:end_date]].flatten.compact.sort
+        dates = (data.key?(:start_date) && data.key?(:end_date) ?
+                  [data[:start_date], data[:end_date]] :
+                  [data[:dates]]
+                ).flatten.compact.sort
         next warn "No dates for election #{id} (#{name[:name]})" if dates.empty?
         {
           id:             id,


### PR DESCRIPTION
Some elections have a start_date and end_date defined (which are usually
precise dates), plus a "point in time" date, which is sometimes only a
year.

See, for example,
https://www.wikidata.org/w/index.php?title=Q2075093&oldid=402960350

In those cases, prefer the start/end-dates, otherwise fallback on the 'point in time' dates.