### PR TITLE
Don’t always assume same IDs

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -5058,11 +5058,11 @@
         "slug": "States",
         "sources_directory": "data/Jersey/States/sources",
         "popolo": "data/Jersey/States/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1775c42ceeced64e60ca65c8cdcb4ea9a3bffeee/data/Jersey/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/21e422e336ec5decc2666c9207215a8cba543901/data/Jersey/States/ep-popolo-v1.0.json",
         "names": "data/Jersey/States/names.csv",
-        "lastmod": "1477080310",
+        "lastmod": "1479149524",
         "person_count": 62,
-        "sha": "1775c42ceeced64e60ca65c8cdcb4ea9a3bffeee",
+        "sha": "21e422e336ec5decc2666c9207215a8cba543901",
         "legislative_periods": [
           {
             "id": "term/2011",
@@ -5073,7 +5073,7 @@
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1b5e1735a6ef6dc92af7856a531461782e811129/data/Jersey/States/term-2011.csv"
           }
         ],
-        "statement_count": 1665,
+        "statement_count": 1681,
         "type": "unicameral legislature"
       }
     ]

--- a/data/Jersey/States/ep-popolo-v1.0.json
+++ b/data/Jersey/States/ep-popolo-v1.0.json
@@ -3070,6 +3070,12 @@
       "classification": "general election",
       "end_date": "1993",
       "id": "Q6184998",
+      "identifiers": [
+        {
+          "identifier": "Q6184998",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Jersey general election, 1993",
       "start_date": "1993"
     },
@@ -3077,6 +3083,12 @@
       "classification": "general election",
       "end_date": "1996",
       "id": "Q6185000",
+      "identifiers": [
+        {
+          "identifier": "Q6185000",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Jersey general election, 1996",
       "start_date": "1996"
     },
@@ -3084,6 +3096,12 @@
       "classification": "general election",
       "end_date": "1999",
       "id": "Q6185002",
+      "identifiers": [
+        {
+          "identifier": "Q6185002",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Jersey general election, 1999",
       "start_date": "1999"
     },
@@ -3091,6 +3109,12 @@
       "classification": "general election",
       "end_date": "2002",
       "id": "Q16851241",
+      "identifiers": [
+        {
+          "identifier": "Q16851241",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Jersey general election, 2002",
       "start_date": "2002"
     },
@@ -3098,6 +3122,12 @@
       "classification": "general election",
       "end_date": "2005",
       "id": "Q6185006",
+      "identifiers": [
+        {
+          "identifier": "Q6185006",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Jersey general election, 2005",
       "start_date": "2005"
     },
@@ -3105,6 +3135,12 @@
       "classification": "general election",
       "end_date": "2008",
       "id": "Q6185007",
+      "identifiers": [
+        {
+          "identifier": "Q6185007",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Jersey general election, 2008",
       "start_date": "2008"
     },
@@ -3112,6 +3148,12 @@
       "classification": "general election",
       "end_date": "2011",
       "id": "Q6185010",
+      "identifiers": [
+        {
+          "identifier": "Q6185010",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Jersey general election, 2011",
       "start_date": "2011"
     },
@@ -3119,6 +3161,12 @@
       "classification": "general election",
       "end_date": "2014-10-15",
       "id": "Q18207499",
+      "identifiers": [
+        {
+          "identifier": "Q18207499",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Jersey general election, 2014",
       "start_date": "2014-10-15"
     },

--- a/data/Jersey/States/sources/instructions.json
+++ b/data/Jersey/States/sources/instructions.json
@@ -13,7 +13,8 @@
     {
       "file": "manual/members.csv",
       "source": "http://www.statesassembly.gov.je",
-      "type": "membership"
+      "type": "membership",
+      "reuse_ids": false
     },
     {
       "file": "manual/terms.csv",

--- a/lib/source/membership.rb
+++ b/lib/source/membership.rb
@@ -30,8 +30,8 @@ module Source
         pr = reconciler.reconciliation_data rescue abort($!.to_s)
         pr.each { |r| id_map[r[:id]] = r[:uuid] }
       else
-        # reuse any IDs we already have from other sources
-        csv.each { |r| id_map[r[:id]] &&= r[:uuid] }
+        # potentially reuse any IDs we already have from other sources
+        csv.each { |r| id_map[r[:id]] &&= r[:uuid] } unless i(:reuse_ids) == false
       end
 
       # Generate UUIDs for any people we don't already know


### PR DESCRIPTION
In https://github.com/everypolitician/everypolitician-data/pull/19223 we introduced the ability to treat the incoming IDs from multiple sources as being for the same person.

However, this isn’t always going to be true, and we don’t always want to have to add a `merge` section when it’s not (especially for a manual file with a single member, where the reconciliation file would be empty)

So, allow a 'reuse_ids' instruction that if set to 'false', will fall back on the old behaviour of assuming that the IDs are to map to different UUIDs.

Show this in action with Jersey (Tunisia and New Caledonia both also require it, but can be done in separate PRs)