### PR TITLE
Add Slack notifications for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ rvm:
 env:
   global:
     secure: ZCQVQdKDUyPY/BM1FYriv6h+rNF+PqQETnj5FwU/jQKNz8utvaUVjXD/pIMwEmO5orzng5/MnZvErkr2+JZBs+0JghXWtjDxQHxJzfBTZJnaiAY9hWZBC9Kgbl1/mJvUvK132W5GzQ5xS9lw/pyKFGRba9A7rfoYFfkaJKmgq1U=
+notifications:
+  slack:
+    secure: KGGTh4XFNqQ4TrQB90B++X4q4jOohQxsZatRk54cYqZOSsrLm8CEJU4eBFVfhQ0p/iiYIBwfZlECyjMgKR+3OUYAAcHGuPSuE5q9M9KUi+c5O11Lx02lQAwhMzUXR0/BmKiUYWssOdV7RsfG3VXOu7vUKmapcT+oQUHmbRd+b8U=


### PR DESCRIPTION
This will post a message to our Slack's #travis channel whenever a build on Travis completes. This should help us spot any errors that occur on the `master` branch when deploying everypolitician.org.