### PR TITLE
Slovakia (National Assembly): Fix source url

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -8895,11 +8895,11 @@
         "slug": "National-Council",
         "sources_directory": "data/Slovakia/National_Council/sources",
         "popolo": "data/Slovakia/National_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9aa9bcccddfbf43b7f7c39159271a0c60929a4c8/data/Slovakia/National_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2e8cfb84392b327ba69df33187ab72771a08a323/data/Slovakia/National_Council/ep-popolo-v1.0.json",
         "names": "data/Slovakia/National_Council/names.csv",
-        "lastmod": "1479288263",
+        "lastmod": "1479473557",
         "person_count": 600,
-        "sha": "9aa9bcccddfbf43b7f7c39159271a0c60929a4c8",
+        "sha": "2e8cfb84392b327ba69df33187ab72771a08a323",
         "legislative_periods": [
           {
             "id": "term/7",

--- a/data/Slovakia/National_Council/ep-popolo-v1.0.json
+++ b/data/Slovakia/National_Council/ep-popolo-v1.0.json
@@ -56430,7 +56430,7 @@
   "meta": {
     "sources": [
       "http://api.parldata.eu/sk/nrsr/",
-      "'http://www.nrsr.sk/web/",
+      "http://www.nrsr.sk/web/",
       "http://wikidata.org/"
     ]
   },

--- a/data/Slovakia/National_Council/sources/instructions.json
+++ b/data/Slovakia/National_Council/sources/instructions.json
@@ -17,7 +17,7 @@
         "scraper": "everypolitician-scrapers/slovakia-national-assembly-2016",
         "query": "SELECT * FROM data"
       },
-      "source": "'http://www.nrsr.sk/web/",
+      "source": "http://www.nrsr.sk/web/",
       "type": "membership",
       "merge": {
       "incoming_field": "name",


### PR DESCRIPTION
There was an unwanted `'` character at the beginning of the source url in the Slovakia `instructions.json` which was causing an invalid link in the viewer-sinatra HTML, which in turn prevented http://everypolitician.org/ from being deployed correctly. This invalid url was originally introduced in https://github.com/everypolitician/everypolitician-data/pull/19629.

This change just fixes the source url, I'll open a separate pull request to make some changes to ensure we catch this in the future.