### PR TITLE
Ensure all source urls are valid

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -850,11 +850,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Azerbaijan/National_Assembly/sources",
         "popolo": "data/Azerbaijan/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/61db64bd5808366cf9e7d5a1fbac5e63d8b3b9e2/data/Azerbaijan/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e5263d573bf3852a9a9496601de6555f7bafe63/data/Azerbaijan/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Azerbaijan/National_Assembly/names.csv",
-        "lastmod": "1479272050",
+        "lastmod": "1479485266",
         "person_count": 152,
-        "sha": "61db64bd5808366cf9e7d5a1fbac5e63d8b3b9e2",
+        "sha": "6e5263d573bf3852a9a9496601de6555f7bafe63",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -890,11 +890,11 @@
         "slug": "House-of-Assembly",
         "sources_directory": "data/Bahamas/House_of_Assembly/sources",
         "popolo": "data/Bahamas/House_of_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2f71b03692960e308006534557089eef78b37e3e/data/Bahamas/House_of_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e5263d573bf3852a9a9496601de6555f7bafe63/data/Bahamas/House_of_Assembly/ep-popolo-v1.0.json",
         "names": "data/Bahamas/House_of_Assembly/names.csv",
-        "lastmod": "1478476610",
+        "lastmod": "1479485266",
         "person_count": 38,
-        "sha": "2f71b03692960e308006534557089eef78b37e3e",
+        "sha": "6e5263d573bf3852a9a9496601de6555f7bafe63",
         "legislative_periods": [
           {
             "id": "term/2012",
@@ -2071,11 +2071,11 @@
         "slug": "Congress",
         "sources_directory": "data/China/Congress/sources",
         "popolo": "data/China/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4e7bb1238e5ed01cee50b5710529d4ea7bbce6f6/data/China/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e5263d573bf3852a9a9496601de6555f7bafe63/data/China/Congress/ep-popolo-v1.0.json",
         "names": "data/China/Congress/names.csv",
-        "lastmod": "1476562682",
+        "lastmod": "1479485266",
         "person_count": 2957,
-        "sha": "4e7bb1238e5ed01cee50b5710529d4ea7bbce6f6",
+        "sha": "6e5263d573bf3852a9a9496601de6555f7bafe63",
         "legislative_periods": [
           {
             "id": "term/12",
@@ -3118,11 +3118,11 @@
         "slug": "Eduskunta",
         "sources_directory": "data/Finland/Eduskunta/sources",
         "popolo": "data/Finland/Eduskunta/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a8c51ff0add3dddddddc97abf63a02ba63ad050d/data/Finland/Eduskunta/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e5263d573bf3852a9a9496601de6555f7bafe63/data/Finland/Eduskunta/ep-popolo-v1.0.json",
         "names": "data/Finland/Eduskunta/names.csv",
-        "lastmod": "1479061165",
+        "lastmod": "1479485266",
         "person_count": 494,
-        "sha": "a8c51ff0add3dddddddc97abf63a02ba63ad050d",
+        "sha": "6e5263d573bf3852a9a9496601de6555f7bafe63",
         "legislative_periods": [
           {
             "end_date": "2019",
@@ -8071,11 +8071,11 @@
         "slug": "Council",
         "sources_directory": "data/Saint_Barthelemy/Council/sources",
         "popolo": "data/Saint_Barthelemy/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/04bfd7efbb506ae2364c72a45cf82e6129b08565/data/Saint_Barthelemy/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6e5263d573bf3852a9a9496601de6555f7bafe63/data/Saint_Barthelemy/Council/ep-popolo-v1.0.json",
         "names": "data/Saint_Barthelemy/Council/names.csv",
-        "lastmod": "1478155001",
+        "lastmod": "1479485266",
         "person_count": 19,
-        "sha": "04bfd7efbb506ae2364c72a45cf82e6129b08565",
+        "sha": "6e5263d573bf3852a9a9496601de6555f7bafe63",
         "legislative_periods": [
           {
             "id": "term/2012",

--- a/data/Azerbaijan/National_Assembly/ep-popolo-v1.0.json
+++ b/data/Azerbaijan/National_Assembly/ep-popolo-v1.0.json
@@ -7166,7 +7166,7 @@
   ],
   "meta": {
     "sources": [
-      "https://az.wikipedia.org/wiki/Azərbaycan_Respublikası_Milli_Məclisinin_deputatlarının_siyahısı_(IV_çağırış)",
+      "https://az.wikipedia.org/wiki/Az%C9%99rbaycan_Respublikas%C4%B1_Milli_M%C9%99clisinin_deputatlar%C4%B1n%C4%B1n_siyah%C4%B1s%C4%B1_(IV_%C3%A7a%C4%9F%C4%B1r%C4%B1%C5%9F)",
       "http://wikidata.org/"
     ]
   },

--- a/data/Bahamas/House_of_Assembly/ep-popolo-v1.0.json
+++ b/data/Bahamas/House_of_Assembly/ep-popolo-v1.0.json
@@ -2026,7 +2026,7 @@
   "meta": {
     "sources": [
       "https://en.wikipedia.org/wiki/Bahamian_general_election,_2012",
-      "http://www.bahamas.gov.bs/wps/portal/public/?urile=wcm%3apath%3a/MOF_Content/internet/The+Government/Government/The+Government/Legislative/Members+of+Parliament/"
+      "http://www.bahamas.gov.bs/wps/portal/public/?urile=wcm:path:/MOF_Content/internet/The+Government/Government/The+Government/Legislative/Members+of+Parliament/"
     ]
   },
   "memberships": [

--- a/data/China/Congress/ep-popolo-v1.0.json
+++ b/data/China/Congress/ep-popolo-v1.0.json
@@ -29590,7 +29590,7 @@
   ],
   "meta": {
     "sources": [
-      "https://zh.wikipedia.org/wiki/第十二届全国人民代表大会代表名单"
+      "https://zh.wikipedia.org/wiki/%E7%AC%AC%E5%8D%81%E4%BA%8C%E5%B1%8A%E5%85%A8%E5%9B%BD%E4%BA%BA%E6%B0%91%E4%BB%A3%E8%A1%A8%E5%A4%A7%E4%BC%9A%E4%BB%A3%E8%A1%A8%E5%90%8D%E5%8D%95"
     ]
   },
   "memberships": [

--- a/data/Finland/Eduskunta/ep-popolo-v1.0.json
+++ b/data/Finland/Eduskunta/ep-popolo-v1.0.json
@@ -59290,7 +59290,7 @@
   "meta": {
     "sources": [
       "http://kansanmuisti.fi/",
-      "https://fi.wikipedia.org/wiki/Luettelo_vaalikauden_2015–2019_kansanedustajista",
+      "https://fi.wikipedia.org/wiki/Luettelo_vaalikauden_2015%E2%80%932019_kansanedustajista",
       "http://wikidata.org/",
       "https://twitter.com/SuomenEduskunta/lists/kansanedustajat"
     ]

--- a/data/Saint_Barthelemy/Council/ep-popolo-v1.0.json
+++ b/data/Saint_Barthelemy/Council/ep-popolo-v1.0.json
@@ -552,7 +552,7 @@
   ],
   "meta": {
     "sources": [
-      "https://fr.wikipedia.org/wiki/Conseil_territorial_de_Saint-Barthélemy"
+      "https://fr.wikipedia.org/wiki/Conseil_territorial_de_Saint-Barth%C3%A9lemy"
     ]
   },
   "memberships": [

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -94,6 +94,18 @@ module Source
       File.read(filename)
     end
 
+    def urls
+      Array(i(:source)).map do |url|
+        begin
+          URI.parse(
+            URI.encode(URI.decode(url)).gsub('[', '%5B').gsub(']', '%5D')
+          ).to_s
+        rescue URI::InvalidURIError
+          abort "#{url} is not a valid URL"
+        end
+      end
+    end
+
     private
 
     def add_warning(str)

--- a/rake_build/turn_csv_to_popolo.rb
+++ b/rake_build/turn_csv_to_popolo.rb
@@ -11,7 +11,7 @@ namespace :whittle do
 
   task meta_info: :load do
     @json[:meta] ||= {}
-    @json[:meta][:sources] = @SOURCES.flat_map { |s| s.i(:source) }.compact.uniq
+    @json[:meta][:sources] = @SOURCES.flat_map(&:urls).compact.uniq
   end
 
   # Remove any 'warnings' left behind from (e.g.) csv-to-popolo


### PR DESCRIPTION
Following on from https://github.com/everypolitician/everypolitician-data/pull/20671 this adds some extra logic to ensure the source urls in `instructions.json` are actually valid. Because we're running the urls though `URI.encode(URI.decode(url))` we're now getting the "correct" but ugly version of the url appearing in the Popolo JSON, which doesn't seem ideal but I can't immediately think of a way to avoid.