### PR TITLE
Hopefully fix intermittent UUID map error

### DIFF
--- a/lib/uuid_map.rb
+++ b/lib/uuid_map.rb
@@ -4,10 +4,6 @@ require 'rcsv'
 # Encapsulates the 'data-ids' files that tie
 # incoming source IDs to our UUIDs
 #
-# We're in the process of moving the location of those files, so for
-# this currently checks _both_ locations for reading, but always writes
-# back out to the new location
-#
 # TODO: Add the 'give me a new UUID' logic here
 
 class UuidMapFile

--- a/test/uuid_map_test.rb
+++ b/test/uuid_map_test.rb
@@ -1,16 +1,11 @@
 require 'test_helper'
 require_relative '../lib/uuid_map'
 
-# As we need to sometimes move the file to a sibling directory, we need
-# to make sure we create a tempfile one level deep in a subdir. There's
-# possibly some option to Tempfile that does this in one shot, but I
-# couldn't find it, so we instead create a dummy tempfile, then make a
-# subdir at the same level as that, and put our "real" test file in it.
-def new_tempfile
-  Pathname.new(Tempfile.new(['data-ids', '.csv']).path)
-end
-
 describe 'UUID Mapper' do
+  let(:new_tempfile) do
+    Pathname.new(Tempfile.new(['data-ids', '.csv']).path)
+  end
+
   it "has nothing if the file doesn't exist" do
     UuidMapFile.new(Pathname.new('not/a/file')).mapping.must_be_empty
   end


### PR DESCRIPTION
Occasionally the test for rewriting a UUID map would fail, saying there
are zero entries in the file rather than two.

This is very hard to replicate, so difficult to investigate, but we
suspect that it might be because nothing is holding a reference to the
Tempfile itself, and so sometimes the garbage collection kicks in and
deletes it before we get around to reading from it again.

Setting this up in a `let` block instead should keep it around long
enough to not disappear (if this _is_ the problem), and with no
ill-effects even if it's not.