### PR TITLE
Hopefully fix intermittent UUID test error

### DIFF
--- a/test/uuid_map_test.rb
+++ b/test/uuid_map_test.rb
@@ -2,8 +2,12 @@ require 'test_helper'
 require_relative '../lib/uuid_map'
 
 describe 'UUID Mapper' do
-  let(:new_tempfile) do
-    Pathname.new(Tempfile.new(['data-ids', '.csv']).path)
+  let(:tempfile) do
+    Tempfile.new(['data-ids', '.csv'])
+  end
+
+  let(:tempfile_path) do
+    Pathname.new(tempfile.path)
   end
 
   it "has nothing if the file doesn't exist" do
@@ -11,12 +15,11 @@ describe 'UUID Mapper' do
   end
 
   it 'has nothing in an empty tempfile' do
-    UuidMapFile.new(new_tempfile).mapping.must_be_empty
+    UuidMapFile.new(tempfile_path).mapping.must_be_empty
   end
 
   it 'has new data after writing' do
-    file = new_tempfile
-    mapper = UuidMapFile.new(file)
+    mapper = UuidMapFile.new(tempfile_path)
     data = mapper.mapping
     data.must_be_empty
     data['fred'] = 'uuid-1'
@@ -24,7 +27,7 @@ describe 'UUID Mapper' do
     mapper.rewrite(data)
 
     # read it back in again
-    newmap = UuidMapFile.new(file)
+    newmap = UuidMapFile.new(tempfile_path)
     newmap.mapping.keys.count.must_equal 2
     newmap.uuid_for('barney').must_equal 'uuid-2'
     newmap.id_for('uuid-1').must_equal 'fred'


### PR DESCRIPTION
This is a hard to debug failure, but I think this test is occasionally
failing because we're not holding onto the reference to the tempfile
that we're using, so it's getting garbage collected before we can read
from it.

This should fix errors like https://travis-ci.org/everypolitician/everypolitician-data/builds/177861445.

This follows on from https://github.com/everypolitician/everypolitician-data/pull/20899