### PR TITLE
Silence a few test warnings

### DIFF
--- a/lib/reconciliation/fuzzer.rb
+++ b/lib/reconciliation/fuzzer.rb
@@ -8,7 +8,6 @@ require 'unicode_utils'
 
 module Reconciliation
   class Fuzzer
-    attr_reader :fuzzer
     attr_reader :existing_rows
     attr_reader :incoming_rows
     attr_reader :instructions

--- a/lib/task/rebuild_countries_json.rb
+++ b/lib/task/rebuild_countries_json.rb
@@ -25,6 +25,10 @@ module Task
       JSON.parse(countries_file.read, symbolize_names: true)
     end
 
+    def existing_data_as_hash
+      existing_data.map { |e| [ e[:name], e ] }.to_h
+    end
+
     def all_countries
       EveryPolitician.countries
     end
@@ -52,7 +56,7 @@ module Task
     end
 
     def updated_data
-      data = existing_data.map { |e| [ e[:name], e ] }.to_h
+      data = existing_data_as_hash
 
       countries.each do |c|
         country = Everypolitician::Country::Metadata.new(

--- a/lib/task/rebuild_countries_json.rb
+++ b/lib/task/rebuild_countries_json.rb
@@ -52,7 +52,7 @@ module Task
     end
 
     def updated_data
-      data = existing_data
+      data = existing_data.map { |e| [ e[:name], e ] }.to_h
 
       countries.each do |c|
         country = Everypolitician::Country::Metadata.new(
@@ -61,10 +61,10 @@ module Task
           dirs:            c.legislatures.map { |l| 'data/' + l.directory },
           commit_metadata: commit_metadata
         ).stanza
-        data[data.find_index { |c| c[:name] == country[:name] }] = country
+        data[c[:name]] = country
       end
 
-      data
+      data.values
     end
   end
 end


### PR DESCRIPTION
Kill off these warnings:
```
/home/travis/build/everypolitician/everypolitician-data/lib/reconciliation/fuzzer.rb:29: warning: method redefined; discarding old fuzzer
/home/travis/build/everypolitician/everypolitician-data/lib/task/rebuild_countries_json.rb:64: warning: shadowing outer local variable - c
```