### PR TITLE
Mongolia (Assembly): rebuild data

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -6318,11 +6318,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Mongolia/Assembly/sources",
         "popolo": "data/Mongolia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/62a8aa4982d9f1b9e086eaa89583f4d9090c606b/data/Mongolia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/95f1342f9d5d6bfa5ed98ff45cb24fc3d323acff/data/Mongolia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Mongolia/Assembly/names.csv",
-        "lastmod": "1478551123",
+        "lastmod": "1481546990",
         "person_count": 117,
-        "sha": "62a8aa4982d9f1b9e086eaa89583f4d9090c606b",
+        "sha": "95f1342f9d5d6bfa5ed98ff45cb24fc3d323acff",
         "legislative_periods": [
           {
             "end_date": "2016-06-28",
@@ -6343,7 +6343,7 @@
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8043a092cb5985d613ededcd3c1a9dbb6528c7d4/data/Mongolia/Assembly/term-2008.csv"
           }
         ],
-        "statement_count": 5051,
+        "statement_count": 5087,
         "type": "unicameral legislature"
       }
     ]

--- a/data/Mongolia/Assembly/ep-popolo-v1.0.json
+++ b/data/Mongolia/Assembly/ep-popolo-v1.0.json
@@ -56,12 +56,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Agipar BAKEI",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Agipar BAKEI"
     },
     {
       "contact_details": [
@@ -104,12 +99,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Almalik TLEIKHAN",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Almalik TLEIKHAN"
     },
     {
       "birth_date": "1964-07-06",
@@ -210,12 +200,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Badmaanyambuu BAT-ERDENE",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Badmaanyambuu BAT-ERDENE"
     },
     {
       "birth_date": "1953-12-03",
@@ -267,11 +252,6 @@
           "name": "Batjargalyn Batbayar",
           "note": "multilingual"
         }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-        }
       ]
     },
     {
@@ -288,11 +268,6 @@
           "lang": "mn",
           "name": "Батхүүгийн Гарамгайбаатар",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
         }
       ]
     },
@@ -349,12 +324,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Batsukh NARANKHUU",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Batsukh NARANKHUU"
     },
     {
       "contact_details": [
@@ -397,12 +367,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Battogtokh CHOIJILSUREN",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Battogtokh CHOIJILSUREN"
     },
     {
       "contact_details": [
@@ -445,12 +410,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Bayarbaatar BOLOR",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Bayarbaatar BOLOR"
     },
     {
       "contact_details": [
@@ -493,12 +453,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Chimed KHURELBAATAR",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Chimed KHURELBAATAR"
     },
     {
       "birth_date": "1969",
@@ -707,12 +662,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Chimed SAIKHANBILEG",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Chimed SAIKHANBILEG"
     },
     {
       "contact_details": [
@@ -755,12 +705,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Chultem ULAAN",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Chultem ULAAN"
     },
     {
       "id": "6eadb1a4-b915-4a2e-b124-ca1a29ba7ca9",
@@ -776,11 +721,6 @@
           "lang": "mn",
           "name": "Дагвадоржийн Очирбат",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -825,12 +765,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Damdin DEMBEREL",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Damdin DEMBEREL"
     },
     {
       "contact_details": [
@@ -873,12 +808,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Damdin KHAYANKHYARVAA",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Damdin KHAYANKHYARVAA"
     },
     {
       "birth_date": "1941-04-15",
@@ -978,11 +908,6 @@
           "name": "达木丁·登贝尔勒",
           "note": "multilingual"
         }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-        }
       ]
     },
     {
@@ -1000,11 +925,6 @@
           "name": "Дамдины Хаянхярваа",
           "note": "multilingual"
         }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-        }
       ]
     },
     {
@@ -1021,11 +941,6 @@
           "lang": "mn",
           "name": "Дангаасүрэнгийн Энхбат",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -1070,12 +985,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Danzan LUNDEEJANTSAN",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Danzan LUNDEEJANTSAN"
     },
     {
       "contact_details": [
@@ -1142,12 +1052,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Dashdemberel BAT-ERDENE",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Dashdemberel BAT-ERDENE"
     },
     {
       "contact_details": [
@@ -1190,12 +1095,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Dashdondog GANBAT",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Dashdondog GANBAT"
     },
     {
       "id": "276fb3cf-b0e1-4e3b-8609-90803f022237",
@@ -1211,11 +1111,6 @@
           "lang": "mn",
           "name": "Дашдоржийн Зоригт",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -1260,12 +1155,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Dashjamts ARVIN",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Dashjamts ARVIN"
     },
     {
       "id": "270bfd69-81e8-4789-903c-75d9627fddf5",
@@ -1281,11 +1171,6 @@
           "lang": "mn",
           "name": "Дашзэвэгийн Зоригт",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
         }
       ]
     },
@@ -1348,11 +1233,6 @@
           "name": "Kyokushūzan Noboru",
           "note": "multilingual"
         }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-        }
       ]
     },
     {
@@ -1411,12 +1291,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Davaajav GANKHUAYG",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Davaajav GANKHUAYG"
     },
     {
       "id": "b243db6f-407e-4d0e-9ad7-c2678235588f",
@@ -1432,11 +1307,6 @@
           "lang": "mn",
           "name": "Дэлэгийн Загджав",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -1481,12 +1351,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Dendev TERBISHDAVGA",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Dendev TERBISHDAVGA"
     },
     {
       "id": "ea38b990-a4fd-4611-b0c5-1dda2e5e4634",
@@ -1502,11 +1367,6 @@
           "lang": "mn",
           "name": "Догсомжавын Балдан-Очир",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -1551,12 +1411,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Dogsom BATTSOGT",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Dogsom BATTSOGT"
     },
     {
       "birth_date": "1974",
@@ -1636,11 +1491,6 @@
           "name": "Dolgorsürengijn Sumjaabadzar",
           "note": "multilingual"
         }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
       ]
     },
     {
@@ -1657,11 +1507,6 @@
           "lang": "mn",
           "name": "Долцонгийн Дондог",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -1706,12 +1551,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Dondogdorj ERDENEBAT",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Dondogdorj ERDENEBAT"
     },
     {
       "id": "575ebc42-b190-4b62-be08-7548cefee957",
@@ -1727,11 +1567,6 @@
           "lang": "mn",
           "name": "Дорждамбын Дамба-Очир",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -1749,11 +1584,6 @@
           "lang": "mn",
           "name": "Доржийн Одбаяр",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -1798,12 +1628,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Dulamsuren OYUNKHOROL",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Dulamsuren OYUNKHOROL"
     },
     {
       "id": "76936b71-363e-4ce5-bbe9-e633a9e5a13e",
@@ -1819,11 +1644,6 @@
           "lang": "mn",
           "name": "Дүрзээгийн Одхүү",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -1841,11 +1661,6 @@
           "lang": "mn",
           "name": "Энэбишийн Мөнх-Очир",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -1922,11 +1737,6 @@
           "name": "额尔登·巴特乌勒",
           "note": "multilingual"
         }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-        }
       ]
     },
     {
@@ -1982,12 +1792,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Gantumur UYANGA",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Gantumur UYANGA"
     },
     {
       "contact_details": [
@@ -2030,12 +1835,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Garidkhuu BAYARSAIKHAN",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Garidkhuu BAYARSAIKHAN"
     },
     {
       "contact_details": [
@@ -2095,12 +1895,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Gavaa BATKHUU",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Gavaa BATKHUU"
     },
     {
       "birth_date": "1970-03-08",
@@ -2204,11 +1999,6 @@
           "name": "贡布扎布·赞达沙塔尔",
           "note": "multilingual"
         }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-        }
       ]
     },
     {
@@ -2252,12 +2042,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Jadamba ENKHBAYAR",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Jadamba ENKHBAYAR"
     },
     {
       "contact_details": [
@@ -2300,12 +2085,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Jalbasuren BATZANDAN",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Jalbasuren BATZANDAN"
     },
     {
       "id": "9dad4b4a-4c46-4e3d-bab7-b56493321fc0",
@@ -2321,11 +2101,6 @@
           "lang": "mn",
           "name": "Жамъянхорлоогийн Сүхбаатар",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -2370,12 +2145,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Jamiyansuren BATSUURI",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Jamiyansuren BATSUURI"
     },
     {
       "contact_details": [
@@ -2418,12 +2188,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Jargaltulga ERDENEBAT",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Jargaltulga ERDENEBAT"
     },
     {
       "id": "dd90c651-3ba0-4b88-b4e7-dcaf4bed9249",
@@ -2439,11 +2204,6 @@
           "lang": "mn",
           "name": "Халидолдайн Жекей",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -2519,12 +2279,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Khaltmaa BATTULGA",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Khaltmaa BATTULGA"
     },
     {
       "id": "ce99f478-4450-4062-a41f-b89ab3e86533",
@@ -2540,11 +2295,6 @@
           "lang": "mn",
           "name": "Халзхүүгийн Наранхүү",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -2563,11 +2313,6 @@
           "name": "Хавдисламын Баделхан",
           "note": "multilingual"
         }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-        }
       ]
     },
     {
@@ -2584,11 +2329,6 @@
           "lang": "mn",
           "name": "Хаянгаагийн Болорчулуун",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
         }
       ]
     },
@@ -2653,12 +2393,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Khishigdemberel TEMUUJIN",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Khishigdemberel TEMUUJIN"
     },
     {
       "id": "45735411-3d83-4cfa-a43c-d9c419f48287",
@@ -2674,11 +2409,6 @@
           "lang": "mn",
           "name": "Хоохорын Бадамсүрэн",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -2771,11 +2501,6 @@
           "name": "拉木扎布·貢達賴",
           "note": "multilingual"
         }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-        }
       ]
     },
     {
@@ -2819,12 +2544,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Log TSOG",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Log TSOG"
     },
     {
       "contact_details": [
@@ -2879,12 +2599,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Luvsan ERDENECHIMEG",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Luvsan ERDENECHIMEG"
     },
     {
       "contact_details": [
@@ -2939,12 +2654,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Luvsannyam GANTUMUR",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Luvsannyam GANTUMUR"
     },
     {
       "contact_details": [
@@ -2987,12 +2697,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Luvsantseren ENKH-AMGALAN",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Luvsantseren ENKH-AMGALAN"
     },
     {
       "contact_details": [
@@ -3047,12 +2752,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Luvsanvandan BOLD",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Luvsanvandan BOLD"
     },
     {
       "id": "a638ad90-3a81-4213-87ed-7a4bbb2f2171",
@@ -3068,11 +2768,6 @@
           "lang": "mn",
           "name": "Лүймэдийн Гансүх",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -3117,12 +2812,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Migeddorj BATCHIMEG",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Migeddorj BATCHIMEG"
     },
     {
       "contact_details": [
@@ -3165,12 +2855,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Mishig SONOMPIL",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Mishig SONOMPIL"
     },
     {
       "id": "d19e82bf-0260-4e32-ad44-0b60a853e74c",
@@ -3186,11 +2871,6 @@
           "lang": "mn",
           "name": "Миеэгомбо Энхболд",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
         }
       ]
     },
@@ -3415,12 +3095,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Myegombo ENKHBOLD",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-        }
-      ]
+      "sort_name": "Myegombo ENKHBOLD"
     },
     {
       "birth_date": "1964-09-15",
@@ -3499,12 +3174,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Munkhchuluun ZORIGT",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Munkhchuluun ZORIGT"
     },
     {
       "contact_details": [
@@ -3547,12 +3217,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Namdag BATTSEREG",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Namdag BATTSEREG"
     },
     {
       "id": "eb23d6b1-8455-440f-9011-6cefa9f2ed20",
@@ -3568,11 +3233,6 @@
           "lang": "mn",
           "name": "Наваансамдангийн Ганбямба",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -3825,12 +3485,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Norov ALTANKHUYAG",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Norov ALTANKHUYAG"
     },
     {
       "contact_details": [
@@ -3873,12 +3528,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Nyamaa ENKHBOLD",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Nyamaa ENKHBOLD"
     },
     {
       "contact_details": [
@@ -3933,12 +3583,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Nyamjav BATBAYAR",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Nyamjav BATBAYAR"
     },
     {
       "contact_details": [
@@ -3993,12 +3638,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Nyamtaishir NOMTOIBAYAR",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Nyamtaishir NOMTOIBAYAR"
     },
     {
       "id": "5dde5a4c-8723-4236-ad69-f8fe8633f479",
@@ -4014,11 +3654,6 @@
           "lang": "mn",
           "name": "Очирбатын Чулуунбат",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -4075,12 +3710,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Octyaber BAASANKHUU",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Octyaber BAASANKHUU"
     },
     {
       "contact_details": [
@@ -4123,12 +3753,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Otgonbileg SODBILEG",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Otgonbileg SODBILEG"
     },
     {
       "id": "993e645f-d077-4e5d-af9b-473d6b1ed386",
@@ -4144,11 +3769,6 @@
           "lang": "mn",
           "name": "Пүрэвийн Алтангэрэл",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -4166,11 +3786,6 @@
           "lang": "mn",
           "name": "Раднаабазарын Раш",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -4215,12 +3830,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Radnaa BURMAA",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Radnaa BURMAA"
     },
     {
       "contact_details": [
@@ -4263,12 +3873,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Radnasumberel GONCHIGDORJ",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Radnasumberel GONCHIGDORJ"
     },
     {
       "id": "636292f3-7f3b-4f41-b4ba-6e3d8c17a2ae",
@@ -4284,11 +3889,6 @@
           "lang": "mn",
           "name": "Рэнцэнгийн Буд",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -4443,12 +4043,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Rinchinnyam AMARJARGAL",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Rinchinnyam AMARJARGAL"
     },
     {
       "contact_details": [
@@ -4503,12 +4098,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Sainkhuu GANBAATAR",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Sainkhuu GANBAATAR"
     },
     {
       "contact_details": [
@@ -4551,12 +4141,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Saldan ODONTUYA",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Saldan ODONTUYA"
     },
     {
       "contact_details": [
@@ -4599,12 +4184,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Sambuu DEMBEREL",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Sambuu DEMBEREL"
     },
     {
       "id": "f8ac29cd-5bec-4c07-bff7-9564b3544982",
@@ -4620,11 +4200,6 @@
           "lang": "mn",
           "name": "Самбуугийн Ламбаа",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -4669,12 +4244,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Sandag BYAMBATSOGT",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Sandag BYAMBATSOGT"
     },
     {
       "contact_details": [
@@ -4717,12 +4287,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Sangajav BAYARTSOGT",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-        }
-      ]
+      "sort_name": "Sangajav BAYARTSOGT"
     },
     {
       "id": "d64d96f9-480b-414c-a81c-826f54de2a80",
@@ -4738,11 +4303,6 @@
           "lang": "mn",
           "name": "Сангажавын Баярцогт",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
         }
       ]
     },
@@ -4970,11 +4530,6 @@
           "name": "桑吉·巴亞爾",
           "note": "multilingual"
         }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-        }
       ]
     },
     {
@@ -5018,12 +4573,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Sanjaasuren OYUN",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Sanjaasuren OYUN"
     },
     {
       "contact_details": [
@@ -5066,12 +4616,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Sharavdorj TUVDENDORJ",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Sharavdorj TUVDENDORJ"
     },
     {
       "id": "fcedf776-8306-4e2e-be00-40383fca81aa",
@@ -5087,11 +4632,6 @@
           "lang": "mn",
           "name": "Шинэнсамбуугийн Сайхансамбуу",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -5148,12 +4688,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Sodnomzundui ERDENE",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Sodnomzundui ERDENE"
     },
     {
       "contact_details": [
@@ -5196,12 +4731,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Sundui BATBOLD",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Sundui BATBOLD"
     },
     {
       "birth_date": "1963-06-24",
@@ -5475,12 +5005,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Sukhbaatar BATBOLD",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Sukhbaatar BATBOLD"
     },
     {
       "birth_date": "1963-03-30",
@@ -5949,11 +5474,6 @@
           "name": "查希亚·额勒贝格道尔吉",
           "note": "multilingual"
         }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-        }
       ]
     },
     {
@@ -5997,12 +5517,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Tsedevdamba OYUNGEREL",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Tsedevdamba OYUNGEREL"
     },
     {
       "contact_details": [
@@ -6045,12 +5560,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Tsedev DASHDORJ",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Tsedev DASHDORJ"
     },
     {
       "id": "6ef73ada-0607-42a1-a8ee-14257b748aba",
@@ -6066,11 +5576,6 @@
           "lang": "mn",
           "name": "Цэгмидийн Цэнгэл",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -6088,11 +5593,6 @@
           "lang": "mn",
           "name": "Цэндийн Мөнх-Оргил",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -6194,12 +5694,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Tsend NYAMDORJ",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Tsend NYAMDORJ"
     },
     {
       "id": "16e68f51-ede7-44cc-8f79-5f7ed6bda312",
@@ -6215,11 +5710,6 @@
           "lang": "mn",
           "name": "Цэндийн Шинэбаяр",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -6237,11 +5727,6 @@
           "lang": "mn",
           "name": "Цэрэнбатын Сэдванчиг",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -6286,12 +5771,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Tserendash OYUNBAATAR",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Tserendash OYUNBAATAR"
     },
     {
       "contact_details": [
@@ -6334,12 +5814,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Tserendash TSOLMON",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Tserendash TSOLMON"
     },
     {
       "contact_details": [
@@ -6382,12 +5857,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Tserenpil DAVAASUREN",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Tserenpil DAVAASUREN"
     },
     {
       "contact_details": [
@@ -6430,12 +5900,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Tsevelmaa BAYARSAIKHAN",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Tsevelmaa BAYARSAIKHAN"
     },
     {
       "id": "279bd36d-e972-4231-aa93-d4001ffd11d4",
@@ -6451,11 +5916,6 @@
           "lang": "mn",
           "name": "Цогтын Батбаяр",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -6473,11 +5933,6 @@
           "lang": "mn",
           "name": "Ухнаагийн Хүрэлсүх",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
         }
       ]
     },
@@ -6522,12 +5977,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Yadamsuren SANJMYATAV",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Yadamsuren SANJMYATAV"
     },
     {
       "id": "99f1f6bc-8ab4-4de6-a94b-76d5bd5e9c2d",
@@ -6543,11 +5993,6 @@
           "lang": "mn",
           "name": "Яйчилийн Батсуурь",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -6592,12 +6037,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Yangug SODBAATAR",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Yangug SODBAATAR"
     },
     {
       "contact_details": [
@@ -6640,12 +6080,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Yondon OTGONBAYAR",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Yondon OTGONBAYAR"
     },
     {
       "birth_date": "1966-05-23",
@@ -6768,12 +6203,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Zandaakhuu ENKHBOLD",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Zandaakhuu ENKHBOLD"
     },
     {
       "contact_details": [
@@ -6816,12 +6246,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Zangad BAYANSELENGE",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Zangad BAYANSELENGE"
     },
     {
       "id": "cce1bf46-0d28-482b-b7f4-46d6285db391",
@@ -6837,11 +6262,6 @@
           "lang": "mn",
           "name": "Зоригийн Алтай",
           "note": "multilingual"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
         }
       ]
     },
@@ -6928,12 +6348,7 @@
           "note": "multilingual"
         }
       ],
-      "sort_name": "Ulziisaikhan ENKHTUVSHIN",
-      "sources": [
-        {
-          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-        }
-      ]
+      "sort_name": "Ulziisaikhan ENKHTUVSHIN"
     }
   ],
   "organizations": [
@@ -8189,7 +7604,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "002e9611-c423-4964-b780-aaa5c1377392",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/dundgovi",
@@ -8197,7 +7617,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "01934652-d956-43f9-9fed-596d86d6edd9",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/bayankhongor",
@@ -8205,7 +7630,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "01fb02cf-2cd1-418b-9746-18bd7ed1efa1",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/Ömnögovi",
@@ -8213,7 +7643,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "033995bf-e413-445b-ae6c-bfd601a1a0fa",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/govisümber•dornogovi",
@@ -8221,7 +7656,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "08f5f1a8-e3e7-4cd6-b437-f574d81fef03",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/govisümber•dornogovi",
@@ -8229,7 +7669,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "08f5f1a8-e3e7-4cd6-b437-f574d81fef03",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/bayan-Ölgii",
@@ -8237,7 +7682,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "0de0e663-1792-4ea8-8320-43d78fff631f",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/arkhangai",
@@ -8245,7 +7695,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "10d213c2-f622-42a5-bb57-6ecd60649e4c",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/arkhangai",
@@ -8253,7 +7708,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "10d213c2-f622-42a5-bb57-6ecd60649e4c",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/govi-altai",
@@ -8261,7 +7721,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "11454c5e-ebf6-4a0d-826f-37e4a0f6e01e",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8269,7 +7734,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "11454c5e-ebf6-4a0d-826f-37e4a0f6e01e",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/dornod",
@@ -8277,7 +7747,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "16e68f51-ede7-44cc-8f79-5f7ed6bda312",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8285,7 +7760,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "19444af9-ff6c-46c3-95cc-cc90be718fbf",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/Ömnögovi",
@@ -8293,7 +7773,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "1d8956ab-a0c8-4e6f-a959-299d676c2f5a",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8301,7 +7786,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "1d8956ab-a0c8-4e6f-a959-299d676c2f5a",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/khövsgöl",
@@ -8309,7 +7799,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "1f2733f3-fd76-4472-84cf-02c5dd68cce6",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8317,7 +7812,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "1f2733f3-fd76-4472-84cf-02c5dd68cce6",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/Övörkhangai",
@@ -8325,7 +7825,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "270bfd69-81e8-4789-903c-75d9627fddf5",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/Övörkhangai",
@@ -8333,7 +7838,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "270bfd69-81e8-4789-903c-75d9627fddf5",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_chingeltei",
@@ -8341,7 +7851,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "276fb3cf-b0e1-4e3b-8609-90803f022237",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_bayanzürkh•nalaikh",
@@ -8349,7 +7864,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "279bd36d-e972-4231-aa93-d4001ffd11d4",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/Övörkhangai",
@@ -8357,7 +7877,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "29cc6cec-74ca-4fb8-9dbc-ae53ede1924c",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8365,7 +7890,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "29cc6cec-74ca-4fb8-9dbc-ae53ede1924c",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/bayan-Ölgii",
@@ -8373,7 +7903,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "2b08df74-7880-43c9-a2be-91681ebea545",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/bayan-Ölgii",
@@ -8381,7 +7916,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "2b08df74-7880-43c9-a2be-91681ebea545",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/khovd",
@@ -8389,7 +7929,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "321601d6-b2aa-45fc-8909-51a915b9ae0c",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulaanbaatar_—_sükhbaatar",
@@ -8397,7 +7942,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "321601d6-b2aa-45fc-8909-51a915b9ae0c",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_bayangol",
@@ -8405,7 +7955,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "3329774a-83b0-4d41-89eb-c285a069201e",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulaanbaatar_—_bayangol",
@@ -8413,7 +7968,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "3329774a-83b0-4d41-89eb-c285a069201e",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/selenge",
@@ -8421,7 +7981,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "33bb2298-1eb6-47dd-ba9d-825065800029",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_sükhbaatar",
@@ -8429,7 +7994,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "34548447-e8d7-4808-8e24-1f0ef9bdb45e",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulaanbaatar_—_sükhbaatar",
@@ -8437,7 +8007,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "34548447-e8d7-4808-8e24-1f0ef9bdb45e",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_bayangol",
@@ -8445,7 +8020,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "36077b4f-cecb-47ef-839f-7e0f09d42110",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/arkhangai",
@@ -8453,7 +8033,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "393615b1-c5d9-46bb-90bb-ad9b1547cf54",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8461,7 +8046,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "393615b1-c5d9-46bb-90bb-ad9b1547cf54",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/darkhan-uul",
@@ -8469,7 +8059,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "3cc6fb9d-7afd-4ac7-8d88-2093e09b419e",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_bayanzürkh•nalaikh",
@@ -8477,7 +8072,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "41065287-b891-4c42-892e-fb5d8a825b69",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulaanbaatar_—_bayanzürkh•nalaikh",
@@ -8485,7 +8085,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "41065287-b891-4c42-892e-fb5d8a825b69",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8493,7 +8098,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "45406a4d-857a-4252-9ec9-146573a09636",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/Ömnögovi",
@@ -8501,7 +8111,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "45735411-3d83-4cfa-a43c-d9c419f48287",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_baganuur•bagakhangai•khan-uul",
@@ -8509,7 +8124,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "45a20ead-0d7d-440f-8a0e-dc322844803f",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulaanbaatar_—_baganuur•bagakhangai•khan-uul",
@@ -8517,7 +8137,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "45a20ead-0d7d-440f-8a0e-dc322844803f",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8525,7 +8150,12 @@
       "on_behalf_of_id": "party/civil_will-green_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "465b4294-7e6c-42f0-bfec-949cb25c1414",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/sükhbaatar",
@@ -8533,7 +8163,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "46bef770-e45f-47dc-9f37-bc23acb83b29",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_bayangol",
@@ -8541,7 +8176,12 @@
       "on_behalf_of_id": "party/civil_will-green_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "489dd0d1-0882-4e7a-89a3-d94c4fbc3689",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulaanbaatar_—_bayanzürkh•nalaikh",
@@ -8549,7 +8189,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "48e5bda2-c6ed-4376-a4da-0081a59e546a",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/bayan-Ölgii",
@@ -8557,7 +8202,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "4bf70f7d-d11e-4326-8522-8a2013feae9e",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_bayangol",
@@ -8565,7 +8215,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "4d7f7d25-3984-4977-ac99-bd5b3e8baa12",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8573,7 +8228,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "4d7f7d25-3984-4977-ac99-bd5b3e8baa12",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/Övörkhangai",
@@ -8581,7 +8241,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "50218128-a922-4256-addf-b6c82e312a73",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8589,7 +8254,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "50218128-a922-4256-addf-b6c82e312a73",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/darkhan-uul",
@@ -8597,7 +8267,12 @@
       "on_behalf_of_id": "party/independent",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "51470d6a-556e-4af8-b79d-5c8d4f62c013",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/ulaanbaatar_—_bayangol",
@@ -8605,7 +8280,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "52f7528b-97cf-446a-a656-0db19916d06c",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/orkhon",
@@ -8613,7 +8293,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "575ebc42-b190-4b62-be08-7548cefee957",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_songino_khairkhan",
@@ -8621,7 +8306,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "5b13b215-dd13-4335-8fc9-c411dcb46254",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/selenge",
@@ -8629,7 +8319,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "5dde5a4c-8723-4236-ad69-f8fe8633f479",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8637,7 +8332,12 @@
       "on_behalf_of_id": "party/justice_coalition",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "5fcb6a5f-3134-4be2-a8dd-4cbe95501e42",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/orkhon",
@@ -8645,7 +8345,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "6099d378-bcdb-4caf-8be9-100f469c946e",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/dornod",
@@ -8653,7 +8358,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "620c1228-1035-4ea7-988e-692cf9cb33f4",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_chingeltei",
@@ -8661,7 +8371,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "621f0e59-e228-455b-b7c8-539a3103645b",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulaanbaatar_—_chingeltei",
@@ -8669,7 +8384,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "621f0e59-e228-455b-b7c8-539a3103645b",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/bulgan",
@@ -8677,7 +8397,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "627f3663-3b34-4771-a9aa-8fba9e136fa5",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/sükhbaatar",
@@ -8685,7 +8410,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "636292f3-7f3b-4f41-b4ba-6e3d8c17a2ae",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/uvs",
@@ -8693,7 +8423,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "63d33048-8f25-4674-b96d-6df3c6d3ef6b",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/uvs",
@@ -8701,7 +8436,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "63d33048-8f25-4674-b96d-6df3c6d3ef6b",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/dundgovi",
@@ -8709,7 +8449,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "6512664b-8106-4dc8-a822-76d6d9810515",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/khövsgöl",
@@ -8717,7 +8462,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "65fdbb42-20e3-47cc-b7b5-450c496c9ac3",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/khövsgöl",
@@ -8725,7 +8475,12 @@
       "on_behalf_of_id": "party/independent",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "65fdbb42-20e3-47cc-b7b5-450c496c9ac3",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/darkhan-uul",
@@ -8733,7 +8488,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "6aeb9550-7d70-4ce2-a67c-ccadc9516ed1",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/bayankhongor",
@@ -8741,7 +8501,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "6dd1ba94-0ef1-4fbc-9656-c0596d343117",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_chingeltei",
@@ -8749,7 +8514,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "6eadb1a4-b915-4a2e-b124-ca1a29ba7ca9",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/bulgan",
@@ -8757,7 +8527,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "6ef73ada-0607-42a1-a8ee-14257b748aba",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/orkhon",
@@ -8765,7 +8540,12 @@
       "on_behalf_of_id": "party/justice_coalition",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "7063f26d-b1af-4049-a98b-582bbe340e05",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/dornod",
@@ -8773,7 +8553,12 @@
       "on_behalf_of_id": "party/independent",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "70e525ac-89aa-4951-a711-630fab059ca6",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/ulaanbaatar_—_baganuur•bagakhangai•khan-uul",
@@ -8781,7 +8566,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "755cf1dd-26ee-498d-a03a-542fc38a50fa",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/orkhon",
@@ -8789,7 +8579,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "76936b71-363e-4ce5-bbe9-e633a9e5a13e",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/töv",
@@ -8797,7 +8592,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "8567ab98-c0e6-4fd2-adfa-753d2e78c7f7",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8805,7 +8605,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "8567ab98-c0e6-4fd2-adfa-753d2e78c7f7",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/zavkhan",
@@ -8813,7 +8618,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "86ca7119-76eb-40e9-8b26-72de2184b70b",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/zavkhan",
@@ -8821,7 +8631,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "86ca7119-76eb-40e9-8b26-72de2184b70b",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/töv",
@@ -8829,7 +8644,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "886e085f-af5d-4af6-9952-e57add0dab65",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/töv",
@@ -8837,7 +8657,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "896f737a-dbd6-401e-abb0-7895f93463a7",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/uvs",
@@ -8845,7 +8670,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "8a197aba-85e0-45e4-842d-e250f8a82f66",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8853,7 +8683,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "8a197aba-85e0-45e4-842d-e250f8a82f66",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/khentii",
@@ -8861,7 +8696,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "8a23a6c6-216c-4b87-a08a-3a526ca4dcbe",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/khentii",
@@ -8869,7 +8709,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "8a23a6c6-216c-4b87-a08a-3a526ca4dcbe",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/khovd",
@@ -8877,7 +8722,12 @@
       "on_behalf_of_id": "party/justice_coalition",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "8ae12efe-54ea-43a5-b91d-718807da3202",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8885,7 +8735,12 @@
       "on_behalf_of_id": "party/justice_coalition",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "8b975c75-0c33-4f69-bde4-90becca61dcf",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/ulaanbaatar_—_songino_khairkhan",
@@ -8893,7 +8748,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "90b77768-c1e7-465d-ae9e-2d6e125be1e9",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8901,7 +8761,12 @@
       "on_behalf_of_id": "party/justice_coalition",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "92232516-78e9-45ef-b04c-8c19a758bcb4",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_songino_khairkhan",
@@ -8909,7 +8774,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "9398cdb6-d8de-45f4-9e84-ff1c65616c44",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8917,7 +8787,12 @@
       "on_behalf_of_id": "party/justice_coalition",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "9398cdb6-d8de-45f4-9e84-ff1c65616c44",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/khentii",
@@ -8925,7 +8800,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "966ee42e-ac5e-42c2-93c0-0c74b9b3270e",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/dornod",
@@ -8933,7 +8813,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "993e645f-d077-4e5d-af9b-473d6b1ed386",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/govisümber•dornogovi",
@@ -8941,7 +8826,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "99f1f6bc-8ab4-4de6-a94b-76d5bd5e9c2d",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_songino_khairkhan",
@@ -8949,7 +8839,12 @@
       "on_behalf_of_id": "party/civil_will-green_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "9be31e26-dc52-465f-9d00-2aa4fd3b187e",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8957,7 +8852,12 @@
       "on_behalf_of_id": "party/civil_will-green_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "9be31e26-dc52-465f-9d00-2aa4fd3b187e",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/ulaanbaatar_—_chingeltei",
@@ -8965,7 +8865,12 @@
       "on_behalf_of_id": "party/justice_coalition",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "9d93666a-7b22-4170-b990-53c91537731f",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/darkhan-uul",
@@ -8973,7 +8878,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "9dad4b4a-4c46-4e3d-bab7-b56493321fc0",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/sükhbaatar",
@@ -8981,7 +8891,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "a38867dc-73e6-4990-90df-cf89f0b25be5",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -8989,7 +8904,12 @@
       "on_behalf_of_id": "party/justice_coalition",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "a38867dc-73e6-4990-90df-cf89f0b25be5",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/khovd",
@@ -8997,7 +8917,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "a439cef5-2afe-47cb-ae83-34048790aa51",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/khovd",
@@ -9005,7 +8930,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "a439cef5-2afe-47cb-ae83-34048790aa51",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -9013,7 +8943,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "a44e20f9-6dbb-4df1-bafd-9369bdf66b74",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/darkhan-uul",
@@ -9021,7 +8956,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "a638ad90-3a81-4213-87ed-7a4bbb2f2171",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/khövsgöl",
@@ -9029,7 +8969,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "a8ab3cbf-b818-44ec-8323-e3da09ba9c7d",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -9037,7 +8982,12 @@
       "on_behalf_of_id": "party/justice_coalition",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "a8f70505-03c1-4ebe-b6ef-2b459f3fe714",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/ulaanbaatar_—_songino_khairkhan",
@@ -9045,7 +8995,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "aa14c88c-838d-4c56-bf89-716b2c647b00",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -9053,7 +9008,12 @@
       "on_behalf_of_id": "party/justice_coalition",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "af638d58-f0bb-42be-a7a9-00a8356ca4d3",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/bayankhongor",
@@ -9061,7 +9021,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "affa1ab2-d95a-4132-9204-2fddde0fae93",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/bayankhongor",
@@ -9069,7 +9034,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "affa1ab2-d95a-4132-9204-2fddde0fae93",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/khovd",
@@ -9077,7 +9047,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "b0361342-c120-442d-91f7-14a4b49bb7ac",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_baganuur•bagakhangai•khan-uul",
@@ -9085,7 +9060,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "b243db6f-407e-4d0e-9ad7-c2678235588f",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/khövsgöl",
@@ -9093,7 +9073,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "b7b67e3b-ec80-4b2f-bfc5-cfe3492b1eae",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_bayanzürkh•nalaikh",
@@ -9101,7 +9086,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "b7e35947-42fe-4949-973b-25b2a2129514",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -9109,7 +9099,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "b7e35947-42fe-4949-973b-25b2a2129514",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -9117,7 +9112,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "b823623f-91a6-427a-95da-ea3d771e589c",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/govi-altai",
@@ -9125,7 +9125,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "b95eab1d-6326-4ea8-8014-980c6f74583b",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/govi-altai",
@@ -9133,7 +9138,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "b95eab1d-6326-4ea8-8014-980c6f74583b",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/Övörkhangai",
@@ -9141,7 +9151,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "bc60b97c-6c66-4034-b79d-77ddbd1f86d1",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/Övörkhangai",
@@ -9149,7 +9164,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "bc60b97c-6c66-4034-b79d-77ddbd1f86d1",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/zavkhan",
@@ -9157,7 +9177,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "bc99d8b9-8610-4164-a979-1a40cb91fbd2",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/khentii",
@@ -9165,7 +9190,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "ca30348a-a09b-4d17-8dc7-1a3d76946265",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulaanbaatar_—_bayanzürkh•nalaikh",
@@ -9173,7 +9203,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "ca30348a-a09b-4d17-8dc7-1a3d76946265",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -9181,7 +9216,12 @@
       "on_behalf_of_id": "party/justice_coalition",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "cbfe0c1a-aa0c-472d-bf35-5dbfa4a39af7",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_bayanzürkh•nalaikh",
@@ -9189,7 +9229,12 @@
       "on_behalf_of_id": "party/independent",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "cce1bf46-0d28-482b-b7f4-46d6285db391",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/dundgovi",
@@ -9197,7 +9242,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "ce99f478-4450-4062-a41f-b89ab3e86533",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/töv",
@@ -9205,7 +9255,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "d19e82bf-0260-4e32-ad44-0b60a853e74c",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -9213,7 +9268,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "d2c9fdee-6212-42fa-a9c7-304602400562",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/khövsgöl",
@@ -9221,7 +9281,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "d4a68d04-24ff-4456-9824-28bdeb686ef0",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/selenge",
@@ -9229,7 +9294,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "d64d96f9-480b-414c-a81c-826f54de2a80",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/töv",
@@ -9237,7 +9307,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "d86ac537-e736-468c-8209-e04947449aaf",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -9245,7 +9320,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "d86ac537-e736-468c-8209-e04947449aaf",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -9253,7 +9333,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "dcd67e5c-1d3f-43ec-81ac-4ac155dde61d",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/bayan-Ölgii",
@@ -9261,7 +9346,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "dd90c651-3ba0-4b88-b4e7-dcaf4bed9249",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_songino_khairkhan",
@@ -9269,7 +9359,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "de3fb53d-dc5d-438d-9335-32612345cbc4",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -9277,7 +9372,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "de3fb53d-dc5d-438d-9335-32612345cbc4",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_sükhbaatar",
@@ -9285,7 +9385,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "e2ed0caf-877d-4ed1-ae89-0fbf4cea4421",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/selenge",
@@ -9293,7 +9398,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "e36fa0ac-2c4c-4ece-bc1a-7434ec558f24",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/bulgan",
@@ -9301,7 +9411,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "e62d790c-29a7-4482-abe7-d78ddb7af5e1",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/n/a",
@@ -9309,7 +9424,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "e891f20f-c3b0-4813-bbd3-98dca0e603e5",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/ulan_bator_—_sükhbaatar",
@@ -9317,7 +9437,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "e9db8a15-a158-458d-a772-e954888e6eb4",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/töv",
@@ -9325,7 +9450,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "e9db8a15-a158-458d-a772-e954888e6eb4",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/zavkhan",
@@ -9333,7 +9463,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "ea38b990-a4fd-4611-b0c5-1dda2e5e4634",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/khentii",
@@ -9341,7 +9476,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "eb23d6b1-8455-440f-9011-6cefa9f2ed20",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/uvs",
@@ -9349,7 +9489,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "f85e7e30-eb6a-4a7f-88f9-ec7b22470886",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/uvs",
@@ -9357,7 +9502,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "f85e7e30-eb6a-4a7f-88f9-ec7b22470886",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/arkhangai",
@@ -9365,7 +9515,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "f8ac29cd-5bec-4c07-bff7-9564b3544982",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/selenge",
@@ -9373,7 +9528,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "fc0dd3ab-b36f-4bb8-ada2-a390e7b037fd",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/dornod",
@@ -9381,7 +9541,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "fca41e77-1bd5-4ce5-b337-dfb88d5b031f",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/zavkhan",
@@ -9389,7 +9554,12 @@
       "on_behalf_of_id": "party/mongolian_people's_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "fcedf776-8306-4e2e-be00-40383fca81aa",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     },
     {
       "area_id": "area/arkhangai",
@@ -9397,7 +9567,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "fdb19fce-977e-4aba-8c42-148cbceae5c1",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
+        }
+      ]
     },
     {
       "area_id": "area/bayankhongor",
@@ -9405,7 +9580,12 @@
       "on_behalf_of_id": "party/democratic_party",
       "organization_id": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
       "person_id": "fef2ae4a-5a33-434b-94f0-29a93d0f741f",
-      "role": "member"
+      "role": "member",
+      "sources": [
+        {
+          "url": "https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+        }
+      ]
     }
   ],
   "events": [


### PR DESCRIPTION
Rebuild with new 'source' credits

```
Add memberships from sources/morph/data.csv
Merging with sources/morph/official.csv
Data Mismatches
* 1 of 72 unmatched
	{:id=>"212", :name=>"SARANGEREL Davaajantsan"}
Merging with sources/morph/wikidata.csv
Data Mismatches
* 14 of 47 unmatched
	{:id=>"Q24174848", :name=>"Догсомын Батцогт"}
	{:id=>"Q24174856", :name=>"Раднаасүмбэрэлийн Гончигдорж"}
	{:id=>"Q24174855", :name=>"Агипарын Бакей"}
	{:id=>"Q23771599", :name=>"Nyamaagiin Enkhbold"}
	{:id=>"Q276238", :name=>"Санжаасүрэнгийн Оюун"}
	{:id=>"Q24174854", :name=>"Данзангийн Лүндээжанцан"}
	{:id=>"Q24174857", :name=>"Мигэддоржийн Батчимэг"}
	{:id=>"Q25848773", :name=>"Жаргалтулгын Эрдэнэбат"}
	{:id=>"Q24174849", :name=>"Лувсанцэрэнгийн Энх-Амгалан"}
	{:id=>"Q7849825", :name=>"Tsogtyn Batbayar"}
Adding GenderBalance results from sources/gender-balance/results.csv
  ⚥ data for 0; 0 added


Top identifiers:
  33 x wikidata
  8 x freebase
  6 x viaf
  1 x lcauth

Creating names.csv
Creating unstable/positions.csv
Persons matched to Wikidata: 33 ✓ | 84 ✘
  No wikidata: Khalidoldain Jekei (dd90c651-3ba0-4b88-b4e7-dcaf4bed9249)
  No wikidata: Sanjaasürengiin Oyuun (9be31e26-dc52-465f-9d00-2aa4fd3b187e)
  No wikidata: Oktyabriin Baasankhüü (8b975c75-0c33-4f69-bde4-90becca61dcf)
  No wikidata: Tsedeviin Dashdorj (b95eab1d-6326-4ea8-8014-980c6f74583b)
  No wikidata: Jamyansürengiin Batsuuri (08f5f1a8-e3e7-4cd6-b437-f574d81fef03)
  No wikidata: Sunduin Batbold (8567ab98-c0e6-4fd2-adfa-753d2e78c7f7)
  No wikidata: Logiin Tsog (7063f26d-b1af-4049-a98b-582bbe340e05)
  No wikidata: Namdagiin Battsereg (af638d58-f0bb-42be-a7a9-00a8356ca4d3)
  No wikidata: Sandagiin Byambatsogt (a439cef5-2afe-47cb-ae83-34048790aa51)
  No wikidata: Radnaasümbereliin Gonchigdorj (393615b1-c5d9-46bb-90bb-ad9b1547cf54)
Parties matched to Wikidata: 5 ✓ 
```