### PR TITLE
Fix Yajl double quote encoding error

### DIFF
--- a/lib/wikidata_lookup.rb
+++ b/lib/wikidata_lookup.rb
@@ -70,9 +70,9 @@ class GroupLookup < WikidataLookup
   def other_fields_for(result)
     {
       links: links(result),
-      image: logo(result),
+      image: logo(result).to_s,
       srgb:  colour(result),
-    }.reject { |_, v| v.nil? }
+    }.reject { |_, v| v.to_s.empty? }
   end
 
   def logo(result)


### PR DESCRIPTION
This is a workaround for Yajl not correctly encoding objects that
contain strings that contain double quotes. I'm not entirely sure what
it is in Yajl that is causing this, I _think_ it's because they redefine
the `to_json` method in the `json_gem` file, but I haven't dug into it
any deeper than that.

You can find a simple script for reproducing this problem here - https://gist.github.com/chrismytton/3d4166069556a4e44e76306e7904f4f1.

This fixes the Ukraine error, which means that can now be built again without errors.