### PR TITLE
Ensure every legislature has a 'terms' instruction

### DIFF
--- a/data/Estonia/Riigikogu/sources/instructions.json
+++ b/data/Estonia/Riigikogu/sources/instructions.json
@@ -50,6 +50,10 @@
       }
     },
     {
+      "file": "manual/terms.csv",
+      "type": "term"
+    },
+    {
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {

--- a/data/Gambia/National_Assembly/sources/instructions.json
+++ b/data/Gambia/National_Assembly/sources/instructions.json
@@ -11,6 +11,10 @@
       "type": "membership"
     },
     {
+      "file": "manual/terms.csv",
+      "type": "term"
+    },
+    {
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {

--- a/data/Honduras/Congreso_Nacional/sources/instructions.json
+++ b/data/Honduras/Congreso_Nacional/sources/instructions.json
@@ -26,6 +26,10 @@
       }
     },
     {
+      "file": "manual/terms.csv",
+      "type": "term"
+    },
+    {
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {

--- a/data/Jordan/House_of_Representatives/sources/instructions.json
+++ b/data/Jordan/House_of_Representatives/sources/instructions.json
@@ -26,6 +26,10 @@
       }
     },
     {
+      "file": "manual/terms.csv",
+      "type": "term"
+    },
+    {
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {

--- a/data/Kuwait/National_Assembly/sources/instructions.json
+++ b/data/Kuwait/National_Assembly/sources/instructions.json
@@ -26,6 +26,10 @@
       }
     },
     {
+      "file": "manual/terms.csv",
+      "type": "term"
+    },
+    {
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {

--- a/data/Lebanon/Parliament/sources/instructions.json
+++ b/data/Lebanon/Parliament/sources/instructions.json
@@ -31,6 +31,10 @@
       }
     },
     {
+      "file": "manual/terms.csv",
+      "type": "term"
+    },
+    {
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {

--- a/data/Malaysia/Dewan_Rakyat/sources/instructions.json
+++ b/data/Malaysia/Dewan_Rakyat/sources/instructions.json
@@ -26,6 +26,10 @@
       }
     },
     {
+      "file": "manual/terms.csv",
+      "type": "term"
+    },
+    {
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {

--- a/data/Saint_Helena/Legislative_Council/sources/instructions.json
+++ b/data/Saint_Helena/Legislative_Council/sources/instructions.json
@@ -26,6 +26,10 @@
       }
     },
     {
+      "file": "manual/terms.csv",
+      "type": "term"
+    },
+    {
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {

--- a/data/Saint_Kitts_and_Nevis/Assembly/sources/instructions.json
+++ b/data/Saint_Kitts_and_Nevis/Assembly/sources/instructions.json
@@ -146,6 +146,10 @@
       }
     },
     {
+      "file": "manual/terms.csv",
+      "type": "term"
+    },
+    {
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {

--- a/data/Samoa/Parliament/sources/instructions.json
+++ b/data/Samoa/Parliament/sources/instructions.json
@@ -41,6 +41,10 @@
       }
     },
     {
+      "file": "manual/terms.csv",
+      "type": "term"
+    },
+    {
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {

--- a/data/Suriname/Assembly/sources/instructions.json
+++ b/data/Suriname/Assembly/sources/instructions.json
@@ -37,6 +37,10 @@
       }
     },
     {
+      "file": "manual/terms.csv",
+      "type": "term"
+    },
+    {
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {

--- a/data/Thailand/National_Legislative_Assembly/sources/instructions.json
+++ b/data/Thailand/National_Legislative_Assembly/sources/instructions.json
@@ -26,6 +26,10 @@
       }
     },
     {
+      "file": "manual/terms.csv",
+      "type": "term"
+    },
+    {
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {

--- a/data/Turks_and_Caicos_Islands/Assembly/sources/instructions.json
+++ b/data/Turks_and_Caicos_Islands/Assembly/sources/instructions.json
@@ -41,6 +41,10 @@
       }
     },
     {
+      "file": "manual/terms.csv",
+      "type": "term"
+    },
+    {
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {

--- a/data/UK/Commons/sources/instructions.json
+++ b/data/UK/Commons/sources/instructions.json
@@ -79,6 +79,10 @@
       }
     },
     {
+      "file": "manual/terms.csv",
+      "type": "term"
+    },
+    {
       "file": "wikidata/groups.json",
       "type": "group",
       "create": {

--- a/data/US_Virgin_Islands/Legislature/sources/instructions.json
+++ b/data/US_Virgin_Islands/Legislature/sources/instructions.json
@@ -25,6 +25,10 @@
       }
     },
     {
+      "file": "manual/terms.csv",
+      "type": "term"
+    },
+    {
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {

--- a/data/Wallis_and_Futuna/Territorial_Assembly/sources/instructions.json
+++ b/data/Wallis_and_Futuna/Territorial_Assembly/sources/instructions.json
@@ -41,6 +41,10 @@
       }
     },
     {
+      "file": "manual/terms.csv",
+      "type": "term"
+    },
+    {
       "file": "gender-balance/results.csv",
       "type": "gender",
       "create": {


### PR DESCRIPTION
The code currently infers one if it's not provided, but we want to get rid of that, and require an explicit block everywhere.

Closes https://github.com/everypolitician/everypolitician/issues/541