### PR TITLE
Increase our default allowable LineLength to 120

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -7,6 +7,8 @@ Lint/AssignmentInCondition:
 Lint/Debugger:
   Enabled: false
 
+Metrics/LineLength:
+  Max: 120
 
 Performance/Casecmp:
   Enabled: false


### PR DESCRIPTION
In the rubocop configuration we inhert from in pretty much every other
repo, set the default max LineLength to 120 characters. Individual repos
can still increase, or decrease, this at will, but this will give them a
little more latitude to start with.