### PR TITLE
Slovenia (National Assembly): switch Morph source to EP-scrapers

### DIFF
--- a/data/Slovenia/National_Assembly/sources/instructions.json
+++ b/data/Slovenia/National_Assembly/sources/instructions.json
@@ -14,7 +14,7 @@
       "file": "morph/wikidata.csv",
       "create": {
         "from": "morph",
-        "scraper": "chrismytton/slovenia-national-assembly-wikidata",
+        "scraper": "everypolitician-scrapers/slovenia-national-assembly-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://wikidata.org/",


### PR DESCRIPTION
This was still pointing at the version in @chrismytton's own account

(Chris: you should also now delete https://morph.io/chrismytton/slovenia-national-assembly-wikidata)