### PR TITLE
Update stats files for 2017 elections

### DIFF
--- a/data/Falkland_Islands/Assembly/unstable/stats.json
+++ b/data/Falkland_Islands/Assembly/unstable/stats.json
@@ -22,7 +22,7 @@
   },
   "elections": {
     "count": 19,
-    "latest": "2013-11-07"
+    "latest": "2017"
   },
   "positions": {
     "cabinet": 0

--- a/data/Germany/Bundestag/unstable/stats.json
+++ b/data/Germany/Bundestag/unstable/stats.json
@@ -22,7 +22,7 @@
   },
   "elections": {
     "count": 19,
-    "latest": "2013-09-22"
+    "latest": "2017"
   },
   "positions": {
     "cabinet": 8

--- a/data/Lebanon/Parliament/unstable/stats.json
+++ b/data/Lebanon/Parliament/unstable/stats.json
@@ -22,7 +22,7 @@
   },
   "elections": {
     "count": 16,
-    "latest": "2009-06-07"
+    "latest": "2017"
   },
   "positions": {
     "cabinet": 0

--- a/data/Netherlands/House_of_Representatives/unstable/stats.json
+++ b/data/Netherlands/House_of_Representatives/unstable/stats.json
@@ -22,7 +22,7 @@
   },
   "elections": {
     "count": 33,
-    "latest": "2012-09-12"
+    "latest": "2017"
   },
   "positions": {
     "cabinet": 0

--- a/data/Somaliland/Representatives/unstable/stats.json
+++ b/data/Somaliland/Representatives/unstable/stats.json
@@ -22,7 +22,7 @@
   },
   "elections": {
     "count": 2,
-    "latest": "2005-09-29"
+    "latest": "2017"
   },
   "positions": {
     "cabinet": 0

--- a/data/South_Sudan/Assembly/unstable/stats.json
+++ b/data/South_Sudan/Assembly/unstable/stats.json
@@ -22,7 +22,7 @@
   },
   "elections": {
     "count": 2,
-    "latest": "2010-04-11"
+    "latest": "2017"
   },
   "positions": {
     "cabinet": 0

--- a/data/Timor_Leste/Parlamento/unstable/stats.json
+++ b/data/Timor_Leste/Parlamento/unstable/stats.json
@@ -22,7 +22,7 @@
   },
   "elections": {
     "count": 4,
-    "latest": "2012-07-07"
+    "latest": "2017"
   },
   "positions": {
     "cabinet": 0

--- a/data/Yemen/Majlis/unstable/stats.json
+++ b/data/Yemen/Majlis/unstable/stats.json
@@ -22,7 +22,7 @@
   },
   "elections": {
     "count": 4,
-    "latest": "2003-04-27"
+    "latest": "2017"
   },
   "positions": {
     "cabinet": 0


### PR DESCRIPTION
The stats file skips elections that are in a year greater than the
current one. As we've now rolled over into 2017, elections that are
scheduled for this year are no longer ignored.