### PR TITLE
Simplify the terms.csv merge process

### DIFF
--- a/data/American_Samoa/House/sources/manual/terms.csv
+++ b/data/American_Samoa/House/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-2014,2015–,2015-01-03,,https://en.wikipedia.org/wiki/American_Samoan_general_election,_2014
+id,name,start_date,end_date
+2014,2015–,2015-01-03,

--- a/data/Bahamas/House_of_Assembly/sources/manual/terms.csv
+++ b/data/Bahamas/House_of_Assembly/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-2012,2012–,2012-05-08,,https://en.wikipedia.org/wiki/Bahamian_general_election,_2012
+id,name,start_date,end_date
+2012,2012–,2012-05-08,

--- a/data/Bahrain/Council_of_Representatives/sources/manual/terms.csv
+++ b/data/Bahrain/Council_of_Representatives/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-2014,2014–,2014-12-14,,https://en.wikipedia.org/wiki/Bahraini_general_election,_2014
+id,name,start_date,end_date
+2014,2014–,2014-12-14,

--- a/data/Belgium/Representatives/sources/instructions.json
+++ b/data/Belgium/Representatives/sources/instructions.json
@@ -40,7 +40,7 @@
       }
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Belgium/Representatives/sources/manual/terms.csv
+++ b/data/Belgium/Representatives/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,source
-54,Législature 54,2014-06-19,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvlist54.cfm?legis=54
+id,name,start_date
+54,Législature 54,2014-06-19

--- a/data/Bosnia_and_Herzegovina/House_of_Representatives/sources/instructions.json
+++ b/data/Bosnia_and_Herzegovina/House_of_Representatives/sources/instructions.json
@@ -11,7 +11,7 @@
       "type": "membership"
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Bosnia_and_Herzegovina/House_of_Representatives/sources/manual/terms.csv
+++ b/data/Bosnia_and_Herzegovina/House_of_Representatives/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-7,2014–,2014-12-09,,https://www.parlament.ba/sadrzaj/plenarne_sjednice/Archive.aspx
+id,name,start_date,end_date
+7,2014–,2014-12-09,

--- a/data/Cabo_Verde/Assembly/sources/instructions.json
+++ b/data/Cabo_Verde/Assembly/sources/instructions.json
@@ -31,7 +31,7 @@
       "type": "membership"
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Cambodia/National_Assembly/sources/instructions.json
+++ b/data/Cambodia/National_Assembly/sources/instructions.json
@@ -26,7 +26,7 @@
       }
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Cambodia/National_Assembly/sources/manual/terms.csv
+++ b/data/Cambodia/National_Assembly/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-5,5th Mandate,2013-09-23,,https://en.wikipedia.org/wiki/Cambodian_general_election,_2013
+id,name,start_date,end_date
+5,5th Mandate,2013-09-23,

--- a/data/Chad/Assembly/sources/instructions.json
+++ b/data/Chad/Assembly/sources/instructions.json
@@ -11,7 +11,7 @@
       "type": "membership"
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Colombia/Representatives/sources/manual/terms.csv
+++ b/data/Colombia/Representatives/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-2014,2014–,2014-07-20,,https://en.wikipedia.org/wiki/Colombian_parliamentary_election,_2014
+id,name,start_date,end_date
+2014,2014–,2014-07-20,

--- a/data/Colombia/Senate/sources/manual/terms.csv
+++ b/data/Colombia/Senate/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-2014,2014–,2014-07-20,,https://en.wikipedia.org/wiki/Colombian_parliamentary_election,_2014
+id,name,start_date,end_date
+2014,2014–,2014-07-20,

--- a/data/Comoros/Assembly/sources/manual/terms.csv
+++ b/data/Comoros/Assembly/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-2015,2015–,2015-04-03,,https://en.wikipedia.org/wiki/Comorian_legislative_election,_2015
+id,name,start_date,end_date
+2015,2015–,2015-04-03,

--- a/data/Djibouti/Assembly/sources/instructions.json
+++ b/data/Djibouti/Assembly/sources/instructions.json
@@ -11,7 +11,7 @@
       "type": "membership"
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Djibouti/Assembly/sources/manual/terms.csv
+++ b/data/Djibouti/Assembly/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,source
-6,6th National Assembly,2013-03-05,https://en.wikipedia.org/wiki/National_Assembly_(Djibouti)
+id,name,start_date
+6,6th National Assembly,2013-03-05

--- a/data/Dominican_Republic/Diputados/sources/instructions.json
+++ b/data/Dominican_Republic/Diputados/sources/instructions.json
@@ -21,7 +21,7 @@
       }
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Gabon/Assembly/sources/instructions.json
+++ b/data/Gabon/Assembly/sources/instructions.json
@@ -26,7 +26,7 @@
       }
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Guernsey/States/sources/manual/terms.csv
+++ b/data/Guernsey/States/sources/manual/terms.csv
@@ -1,3 +1,3 @@
-id,name,start_date,end_date,source
-2012,2012–2016,2012,2016-04-26,https://en.wikipedia.org/wiki/Guernsey_general_election,_2012
-2016,2016–,2016-04-27,,https://en.wikipedia.org/wiki/Guernsey_general_election,_2016
+id,name,start_date,end_date
+2012,2012–2016,2012,2016-04-26
+2016,2016–,2016-04-27,

--- a/data/Guinea-Bissau/Assembly/sources/manual/terms.csv
+++ b/data/Guinea-Bissau/Assembly/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-2014,2014-,2014-06-16,,https://en.wikipedia.org/wiki/Guinea-Bissau_general_election,_2014
+id,name,start_date,end_date
+2014,2014-,2014-06-16,

--- a/data/Jordan/House_of_Representatives/sources/manual/terms.csv
+++ b/data/Jordan/House_of_Representatives/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-2013,2013–,2013-02-10,,https://en.wikipedia.org/wiki/Jordanian_general_election,_2013
+id,name,start_date,end_date
+2013,2013–,2013-02-10,

--- a/data/Liberia/House/sources/instructions.json
+++ b/data/Liberia/House/sources/instructions.json
@@ -11,7 +11,7 @@
       "type": "membership"
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Liechtenstein/Landtag/sources/instructions.json
+++ b/data/Liechtenstein/Landtag/sources/instructions.json
@@ -26,7 +26,7 @@
       }
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Liechtenstein/Landtag/sources/manual/terms.csv
+++ b/data/Liechtenstein/Landtag/sources/manual/terms.csv
@@ -1,4 +1,4 @@
-id,name,start_date,end_date,source
-2013,2013-2017,2013-03-27,2017,http://www.landtag.li/personen.aspx?nid=4158&auswahl=4158&lang=de
-2009,2009-2013,2009-03-18,2013-02-02,http://www.landtag.li/personen.aspx?nid=4158&auswahl=4158&lang=de&jahr=2009&sitzordnung=0
-2005,2005-2009,2005-04-14,2009-02-07,http://www.landtag.li/personen.aspx?nid=4158&auswahl=4158&lang=de&jahr=2005&sitzordnung=0
+id,name,start_date,end_date
+2013,2013-2017,2013-03-27,2017
+2009,2009-2013,2009-03-18,2013-02-02
+2005,2005-2009,2005-04-14,2009-02-07

--- a/data/Malta/Assembly/sources/manual/terms.csv
+++ b/data/Malta/Assembly/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-12,12th Parliament,2013-04-06,,https://en.wikipedia.org/wiki/List_of_members_of_the_parliament_of_Malta,_2013–
+id,name,start_date,end_date
+12,12th Parliament,2013-04-06,

--- a/data/Moldova/Parlamentul/sources/instructions.json
+++ b/data/Moldova/Parlamentul/sources/instructions.json
@@ -31,7 +31,7 @@
       }
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Namibia/Assembly/sources/instructions.json
+++ b/data/Namibia/Assembly/sources/instructions.json
@@ -26,7 +26,7 @@
       }
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Namibia/Council/sources/instructions.json
+++ b/data/Namibia/Council/sources/instructions.json
@@ -11,7 +11,7 @@
       "type": "membership"
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/North_Korea/National_Assembly/sources/manual/terms.csv
+++ b/data/North_Korea/National_Assembly/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-13,13th Assembly,2014-03-09,,https://en.wikipedia.org/wiki/North_Korean_parliamentary_election,_2014
+id,name,start_date,end_date
+13,13th Assembly,2014-03-09,

--- a/data/Northern_Mariana_Islands/House/sources/manual/terms.csv
+++ b/data/Northern_Mariana_Islands/House/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-19,19th Commonwealth Legislature,2014,,https://en.wikipedia.org/wiki/Northern_Mariana_Islands_general_election,_2014
+id,name,start_date,end_date
+19,19th Commonwealth Legislature,2014,

--- a/data/Oman/Majlis/sources/instructions.json
+++ b/data/Oman/Majlis/sources/instructions.json
@@ -11,7 +11,7 @@
       "type": "membership"
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Panama/Assembly/sources/manual/terms.csv
+++ b/data/Panama/Assembly/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-2014,2014–,2014-07-01,,https://en.wikipedia.org/wiki/Panamanian_general_election,_2014
+id,name,start_date,end_date
+2014,2014–,2014-07-01,

--- a/data/Papua_New_Guinea/Parliament/sources/instructions.json
+++ b/data/Papua_New_Guinea/Parliament/sources/instructions.json
@@ -26,7 +26,7 @@
       }
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Pitcairn/Island_Council/sources/manual/terms.csv
+++ b/data/Pitcairn/Island_Council/sources/manual/terms.csv
@@ -1,4 +1,4 @@
-id,name,start_date,end_date,source
-2013,2013–,2013-11-12,,https://en.wikipedia.org/wiki/Pitcairn_Islands_general_election,_2013
-2011,2011–2013,2011-12-12,2013-11-11,https://en.wikipedia.org/wiki/Pitcairn_Islands_general_election,_2011
-2009,2009–2011,2009-12-11,2011-12-11,https://en.wikipedia.org/wiki/Pitcairn_Islands_general_election,_2009
+id,name,start_date,end_date
+2013,2013–,2013-11-12,
+2011,2011–2013,2011-12-12,2013-11-11
+2009,2009–2011,2009-12-11,2011-12-11

--- a/data/Saint_Helena/Legislative_Council/sources/manual/terms.csv
+++ b/data/Saint_Helena/Legislative_Council/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-2013,2013–,2013-07-17,,https://en.wikipedia.org/wiki/Saint_Helena_general_election,_2013
+id,name,start_date,end_date
+2013,2013–,2013-07-17,

--- a/data/Saint_Vincent_and_the_Grenadines/Assembly/sources/instructions.json
+++ b/data/Saint_Vincent_and_the_Grenadines/Assembly/sources/instructions.json
@@ -11,7 +11,7 @@
       "type": "membership"
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Seychelles/Assembly/sources/instructions.json
+++ b/data/Seychelles/Assembly/sources/instructions.json
@@ -11,7 +11,7 @@
       "type": "membership"
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Sierra_Leone/Parliament/sources/instructions.json
+++ b/data/Sierra_Leone/Parliament/sources/instructions.json
@@ -11,7 +11,7 @@
       "type": "membership"
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Sierra_Leone/Parliament/sources/manual/terms.csv
+++ b/data/Sierra_Leone/Parliament/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,source
-2-4,Fourth Parliament of the Second Republic,2012-12-07,http://www.parliament.gov.sl/AboutUs/History.aspx
+id,name,start_date
+2-4,Fourth Parliament of the Second Republic,2012-12-07

--- a/data/Solomon_Islands/Parliament/sources/instructions.json
+++ b/data/Solomon_Islands/Parliament/sources/instructions.json
@@ -41,7 +41,7 @@
       }
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Solomon_Islands/Parliament/sources/manual/terms.csv
+++ b/data/Solomon_Islands/Parliament/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,source
-10,10th Parliament,2014-12-09,http://www.parliament.gov.sb/index.php?q=node/833
+id,name,start_date
+10,10th Parliament,2014-12-09

--- a/data/Somaliland/Representatives/sources/manual/terms.csv
+++ b/data/Somaliland/Representatives/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-2005,First Parliament,2005-09-29,,https://en.wikipedia.org/wiki/Somaliland_parliamentary_election,_2005
+id,name,start_date,end_date
+2005,First Parliament,2005-09-29,

--- a/data/South_Africa/Assembly/sources/instructions.json
+++ b/data/South_Africa/Assembly/sources/instructions.json
@@ -34,7 +34,7 @@
       }
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/South_Korea/National_Assembly/sources/manual/terms.csv
+++ b/data/South_Korea/National_Assembly/sources/manual/terms.csv
@@ -1,3 +1,3 @@
-id,name,start_date,end_date,source
-19,19th National Assembly,2012-05-30,2016-05-29,https://en.wikipedia.org/wiki/List_of_members_of_the_National_Assembly_(South_Korea),_2012%E2%80%9316
-20,20th National Assembly,2016-05-30,2020-05-29,https://en.wikipedia.org/wiki/List_of_members_of_the_National_Assembly_(South_Korea),_2016%E2%80%93present
+id,name,start_date,end_date
+19,19th National Assembly,2012-05-30,2016-05-29
+20,20th National Assembly,2016-05-30,2020-05-29

--- a/data/South_Ossetia/Parliament/sources/manual/terms.csv
+++ b/data/South_Ossetia/Parliament/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-2014,6th Convocation,2014-06-09,,https://en.wikipedia.org/wiki/South_Ossetian_parliamentary_election,_2014
+id,name,start_date,end_date
+2014,6th Convocation,2014-06-09,

--- a/data/Tajikistan/Representatives/sources/manual/terms.csv
+++ b/data/Tajikistan/Representatives/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-2015,2015–,2015-03-17,,https://en.wikipedia.org/wiki/Tajikistani_parliamentary_election,_2015
+id,name,start_date,end_date
+2015,2015–,2015-03-17,

--- a/data/Togo/Assembly/sources/instructions.json
+++ b/data/Togo/Assembly/sources/instructions.json
@@ -26,7 +26,7 @@
       }
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Tonga/Assembly/sources/instructions.json
+++ b/data/Tonga/Assembly/sources/instructions.json
@@ -11,7 +11,7 @@
       "type": "membership"
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Turkmenistan/Mejlis/sources/instructions.json
+++ b/data/Turkmenistan/Mejlis/sources/instructions.json
@@ -11,7 +11,7 @@
       "type": "membership"
     },
     {
-      "file": "morph/terms.csv",
+      "file": "manual/terms.csv",
       "type": "term"
     },
     {

--- a/data/Turkmenistan/Mejlis/sources/manual/terms.csv
+++ b/data/Turkmenistan/Mejlis/sources/manual/terms.csv
@@ -1,3 +1,3 @@
-id,name,start_date,source,end_date
-5,5th Convocation,2014-01-07,http://mejlis2.bushluk.com/tm/parliamentaries/search/?convocation=14118,
-4,4th Convocation,2009,http://mejlis2.bushluk.com/tm/parliamentaries/search/?convocation=2159,2013
+id,name,start_date,end_date
+5,5th Convocation,2014-01-07,
+4,4th Convocation,2009,2013

--- a/data/Uzbekistan/Legislative_Chamber/sources/manual/terms.csv
+++ b/data/Uzbekistan/Legislative_Chamber/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-5,5th Convocation,2015-01-12,,https://en.wikipedia.org/wiki/Uzbekistani_parliamentary_election,_2014%E2%80%932015
+id,name,start_date,end_date
+5,5th Convocation,2015-01-12,

--- a/data/Wallis_and_Futuna/Territorial_Assembly/sources/manual/terms.csv
+++ b/data/Wallis_and_Futuna/Territorial_Assembly/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-2012,2012–,2012,,https://en.wikipedia.org/wiki/Wallis_and_Futuna_Territorial_Assembly_election,_2012
+id,name,start_date,end_date
+2012,2012–,2012,

--- a/lib/source/term.rb
+++ b/lib/source/term.rb
@@ -2,5 +2,26 @@ require_relative 'plain_csv'
 
 module Source
   class Term < PlainCSV
+    def to_popolo
+      { events: events }
+    end
+
+    private
+
+    def events
+      as_table.map do |row|
+        {
+          id:              row[:id][/\//] ? row[:id] : "term/#{row[:id]}",
+          name:            row[:name],
+          start_date:      row[:start_date],
+          end_date:        row[:end_date],
+          identifiers:     row[:wikidata].to_s.empty? ? nil : [{
+            scheme:     'wikidata',
+            identifier: row[:wikidata]
+          }],
+          classification:  'legislative period',
+        }.reject { |_, v| v.to_s.empty? }
+      end
+    end
   end
 end

--- a/rake_build/generate_ep_popolo.rb
+++ b/rake_build/generate_ep_popolo.rb
@@ -67,9 +67,9 @@ namespace :transform do
   #---------------------------------------------------------------------
   # Merge with terms.csv
   #---------------------------------------------------------------------
-  task write: :ensure_term
+  task write: :merge_termfile
 
-  task ensure_term: :ensure_legislature do
+  task merge_termfile: :ensure_legislature do
     terms = @INSTRUCTIONS.sources_of_type('term')
             .flat_map { |src| src.to_popolo[:events] }
             .each { |t| t[:organization_id] = @legislature[:id] }
@@ -86,7 +86,7 @@ namespace :transform do
   #   and ensure they're within the term
   #---------------------------------------------------------------------
   task write: :tidy_memberships
-  task tidy_memberships: :ensure_term do
+  task tidy_memberships: :merge_termfile do
     @json[:memberships].each do |m|
       (e = @json[:events].find { |e| e[:id] == m[:legislative_period_id] }) || abort("#{m[:legislative_period_id]} is not a term")
 


### PR DESCRIPTION
Now that every legislature has an explicit entry for the terms.csv file in
instructions.csv, and we have a Term source with a `to_popolo` method, we
can simplify this, in line with how we process other source files.

(Quite a few legislatures were incorrectly configured, and needed fixed for the build to pass everywhere.)

Closes https://github.com/everypolitician/everypolitician/issues/548

This should also speed the build slightly in countries with lots of terms, as the old process was re-reading the `terms.csv` file for each term.