### PR TITLE
rename 'Source::Positions' to '::Old'

### DIFF
--- a/lib/source.rb
+++ b/lib/source.rb
@@ -13,7 +13,7 @@ module Source
       'ocd-names'          => Source::OCD::Names,
       'area-wikidata'      => Source::Area,
       'gender'             => Source::Gender,
-      'wikidata-positions' => Source::Positions,
+      'wikidata-positions' => Source::Positions::Old,
       'wikidata-elections' => Source::Elections,
       'term'               => Source::Term,
       'corrections'        => Source::Corrections,

--- a/lib/source/positions.rb
+++ b/lib/source/positions.rb
@@ -1,6 +1,10 @@
 require_relative 'json'
 
 module Source
-  class Positions < JSON
+  class Positions
+    # Deprecated approach where we build this ourselves. This should all
+    # be done on morph and simply imported as a CSV.
+    class Old < JSON
+    end
   end
 end


### PR DESCRIPTION
This is the old, deprecated, way where we build all the P39 information
using Wikisnakker at build time. This is very slow, and is being
migrated to being build in morph scrapers.

Renaming this file makes it more obvious that this is the old way, and
frees up the namespace for the new approach.