### PR TITLE
Migrate the JSON position filter to CSV

### DIFF
--- a/data/Estonia/Riigikogu/sources/manual/position-filter.csv
+++ b/data/Estonia/Riigikogu/sources/manual/position-filter.csv
@@ -1,0 +1,30 @@
+id,label,type
+Q16405106,Minister of Agriculture,cabinet
+Q16402952,Minister of Culture,cabinet
+Q23725838,Minister of Culture and Education,cabinet
+Q3741249,Minister of Defence,cabinet
+Q21121665,Minister of Economic Affairs and Communications,cabinet
+Q16403845,Minister of Economic Affairs and Infrastructure,cabinet
+Q6866110,Minister of Education and Research,cabinet
+Q20933474,Minister of Entrepreneurship,cabinet
+Q21103025,Minister of Finance,cabinet
+Q1760777,Minister of Foreign Affairs,cabinet
+Q24058803,Minister of Foreign Trade and Entrepreneurship,cabinet
+Q24060082,Minister of Health and Labour,cabinet
+Q20528230,Minister of Justice,cabinet
+Q24061775,Minister of Population and Ethnic Affairs,cabinet
+Q20528404,Minister of Public Administration,cabinet
+Q23268238,Minister of Regional Affairs,cabinet
+Q24060239,Minister of Rural Affairs,cabinet
+Q16402881,Minister of Social Affairs,cabinet
+Q24060088,Minister of Social Protection,cabinet
+Q12361541,Minister of the Environment,cabinet
+Q6866431,Minister of the Interior,cabinet
+Q24067751,minister without portfolio,cabinet
+Q737115,Prime Minister of Estonia,cabinet
+Q948558,European Commissioner for Digital Agenda,other
+Q3740505,Mayor of Tallinn,other
+Q6627739,Mayor of Tartu,other
+Q27169,member of the European Parliament,other_legislatures
+Q21100241,member of the Estonian Riigikogu,self
+Q140686,chairperson,unknown

--- a/lib/position/map.rb
+++ b/lib/position/map.rb
@@ -1,6 +1,7 @@
-# TODO: move this to its own file
 class PositionMap
-  # Which Wikidata Positions we're interested in, and how to group them
+  # old JSON version of file listing the Wikidata Positions we're interested in
+  # This has been superseded by a CSV version. To convert to that use:
+  #    bundle exec rake convert_position_filter
 
   def initialize(pathname:)
     @pathname = pathname

--- a/lib/source/cabinet.rb
+++ b/lib/source/cabinet.rb
@@ -3,7 +3,8 @@ require_relative 'plain_csv'
 module Source
   class Cabinet < PlainCSV
     def filtered(position_map:)
-      wanted = position_map.cabinet_ids
+      map = ::CSV.table(position_map)
+      wanted = map.select { |r| r[:type] == 'cabinet' }.map { |r| r[:id] }
       as_table.select { |r| wanted.include? r[:position] }
     end
   end

--- a/rake_build/generate_final_csvs.rb
+++ b/rake_build/generate_final_csvs.rb
@@ -80,22 +80,25 @@ namespace :term_csvs do
   end
 end
 
+desc 'Convert the old JSON position filter to a CSV'
+task :convert_position_filter do
+  # for now, simply convert the old JSON file to a new CSV one
+  src = @INSTRUCTIONS.sources_of_type('wikidata-cabinet').first or next
+  map = PositionMap.new(pathname: POSITION_FILTER)
+
+  csv_headers = %w(id label type).to_csv
+  csv_data = src.as_table.group_by { |r| r[:position] }.map do |id, ps|
+    [id, ps.first[:label], map.type(id) || 'unknown']
+  end.sort_by { |d| [d[2], d[1].downcase] }.map(&:to_csv)
+
+  POSITION_FILTER_CSV.dirname.mkpath
+  POSITION_FILTER_CSV.write(csv_headers + csv_data.join)
+end
+
 desc 'Generate the position filter interface'
 task :generate_position_interface do
-  raise "Not implemented yet"
-  # Rebuild the position filter, with counts on unknowns
-  # new_map = position_map.to_json
-  # unknown = grouped_posns.sort_by { |_, us| us.first.label.to_s }.map do |id, us|
-    # {
-      # id:          id,
-      # name:        us.first.label,
-      # description: us.first.description,
-      # count:       us.count,
-    # }
-  # end
-  # (new_map[:unknown] ||= {})[:unknown] = unknown
-  # POSITION_FILTER.write(JSON.pretty_generate(new_map))
-
+  abort "not implemented yet"
+  # TODO make the HTML interface to this again.
   # new_map = PositionMap.new(pathname: POSITION_FILTER).to_json
   # html = Position::Filter::HTML.new(new_map).html
   # POSITION_HTML.write(html)

--- a/rake_build/generate_final_csvs.rb
+++ b/rake_build/generate_final_csvs.rb
@@ -61,7 +61,7 @@ namespace :term_csvs do
   task positions: ['ep-popolo-v1.0.json'] do
     src = @INSTRUCTIONS.sources_of_type('wikidata-cabinet').first or next
 
-    data = src.filtered(position_map: PositionMap.new(pathname: POSITION_FILTER))
+    data = src.filtered(position_map: POSITION_FILTER_CSV)
     members = @popolo.persons.select(&:wikidata).group_by(&:wikidata)
 
     csv_headers = %w(id name position start_date end_date type).to_csv

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -48,6 +48,7 @@ require_rel 'lib'
 MERGED_JSON = Pathname.new('sources/merged.json')
 MERGED_CSV  = Pathname.new('sources/merged.csv')
 POSITION_FILTER = Pathname.new('sources/manual/position-filter.json')
+POSITION_FILTER_CSV = Pathname.new('sources/manual/position-filter.csv')
 POSITION_HTML = Pathname.new('sources/manual/.position-filter.html')
 POSITION_RAW = Pathname.new('sources/wikidata/positions.json')
 POSITION_CSV = Pathname.new('unstable/positions.csv')


### PR DESCRIPTION
Simplify the position filter file from the old JSON-based version to a
simpler CSV-based one, and add a rake task to migrate from one to the
other.