### PR TITLE
Report on Cabinet memberships not posts

### DIFF
--- a/data/Canada/Commons/unstable/stats.json
+++ b/data/Canada/Commons/unstable/stats.json
@@ -25,6 +25,6 @@
     "latest": "2015-10-19"
   },
   "positions": {
-    "cabinet": 0
+    "cabinet": 82
   }
 }

--- a/data/Estonia/Riigikogu/unstable/stats.json
+++ b/data/Estonia/Riigikogu/unstable/stats.json
@@ -25,6 +25,6 @@
     "latest": "2015-03-01"
   },
   "positions": {
-    "cabinet": 23
+    "cabinet": 95
   }
 }

--- a/data/Ireland/Dail/unstable/stats.json
+++ b/data/Ireland/Dail/unstable/stats.json
@@ -25,6 +25,6 @@
     "latest": "2016-02-26"
   },
   "positions": {
-    "cabinet": 0
+    "cabinet": 51
   }
 }

--- a/lib/legislature_stats.rb
+++ b/lib/legislature_stats.rb
@@ -6,10 +6,10 @@ class StatsFile
   # as JSON and writing out to the `stats.json` for that house.
 
   # @param popolo [EveryPolitician::Popolo]
-  # @param position_filter [Pathname]
-  def initialize(popolo:, position_filter:)
+  # @param position_file [Pathname]
+  def initialize(popolo:, position_file:)
     @popolo = popolo
-    @position_filter = position_filter
+    @position_file = position_file
   end
 
   # Re-generated statistics for this legislature
@@ -27,7 +27,7 @@ class StatsFile
 
   private
 
-  attr_reader :popolo, :position_filter
+  attr_reader :popolo, :position_file
 
   def people_stats
     current = popolo.latest_term.memberships.map(&:person).uniq(&:id)
@@ -99,8 +99,8 @@ class StatsFile
   end
 
   def cabinet_positions
-    return 0 unless position_filter.file?
-    posns = JSON.parse(position_filter.read, symbolize_names: true)
-    posns[:include][:cabinet].count rescue 0
+    return 0 unless position_file.file?
+    posns = CSV.table(position_file)
+    posns.select { |r| r[:type] == 'cabinet' }.count rescue 0
   end
 end

--- a/rake_build/generate_stats.rb
+++ b/rake_build/generate_stats.rb
@@ -7,7 +7,7 @@ STATSFILE = Pathname.new('unstable/stats.json')
 namespace :stats do
   task regenerate: 'ep-popolo-v1.0.json' do
     popolo = Everypolitician::Popolo.read('ep-popolo-v1.0.json')
-    stats = StatsFile.new(popolo: popolo, position_filter: POSITION_FILTER).stats
+    stats = StatsFile.new(popolo: popolo, position_file: POSITION_CSV).stats
 
     STATSFILE.dirname.mkpath
     STATSFILE.write(JSON.pretty_generate(stats))


### PR DESCRIPTION
Change the stats reporting to list the number of known Cabinet memberships
not just roles — i.e. so that it goes up when we know a new person becoming
Minister of Defence, not just when we add a new position.