### PR TITLE
Syria Majlis -- add term dates

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -9713,22 +9713,23 @@
         "slug": "Majlis",
         "sources_directory": "data/Syria/Majlis/sources",
         "popolo": "data/Syria/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c04327186f285631eb38d728ed6689fea236c820/data/Syria/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/141f2eae05764800fc5a85e44c3500dead743512/data/Syria/Majlis/ep-popolo-v1.0.json",
         "names": "data/Syria/Majlis/names.csv",
-        "lastmod": "1481564294",
+        "lastmod": "1484740087",
         "person_count": 274,
-        "sha": "c04327186f285631eb38d728ed6689fea236c820",
+        "sha": "141f2eae05764800fc5a85e44c3500dead743512",
         "legislative_periods": [
           {
+            "end_date": "2016-04-12",
             "id": "term/2012",
-            "name": "2012–",
+            "name": "2012–2016",
             "start_date": "2012-05-24",
             "slug": "2012",
             "csv": "data/Syria/Majlis/term-2012.csv",
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d5b0308b90f8e4282664646e4c535d7d5c58a318/data/Syria/Majlis/term-2012.csv"
           }
         ],
-        "statement_count": 4183,
+        "statement_count": 4186,
         "type": "unicameral legislature"
       }
     ]

--- a/data/Syria/Majlis/ep-popolo-v1.0.json
+++ b/data/Syria/Majlis/ep-popolo-v1.0.json
@@ -8825,8 +8825,15 @@
     },
     {
       "classification": "legislative period",
+      "end_date": "2016-04-12",
       "id": "term/2012",
-      "name": "2012–",
+      "identifiers": [
+        {
+          "identifier": "Q28379948",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "2012–2016",
       "organization_id": "38d3ebeb-ed76-41c6-8b30-5ad9900f8f21",
       "start_date": "2012-05-24"
     },

--- a/data/Syria/Majlis/sources/manual/terms.csv
+++ b/data/Syria/Majlis/sources/manual/terms.csv
@@ -1,2 +1,3 @@
-id,name,start_date,end_date,source
-2012,2012–,2012-05-24,,
+id,name,start_date,end_date,wikidata
+2012,2012–2016,2012-05-24,2016-04-12,Q28379948
+2016,2016-,2016-06-06,,Q28379971

--- a/data/Syria/Majlis/unstable/stats.json
+++ b/data/Syria/Majlis/unstable/stats.json
@@ -18,7 +18,7 @@
   "terms": {
     "count": 1,
     "latest": "2012-05-24",
-    "wikidata": 0
+    "wikidata": 1
   },
   "elections": {
     "count": 16,


### PR DESCRIPTION
This is a step towards adding the 2016 term.

The end date of the 2012 term has been recorded as the day before the 2016 election.
The start date of the 2016 term has been recorded as the date of the first session of parliament.

Source: http://www.ipu.org/parline-e/reports/2307_E.htm