### PR TITLE
Belarus House of Representatives -- add term dates

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -1023,13 +1023,14 @@
         "slug": "Chamber",
         "sources_directory": "data/Belarus/Chamber/sources",
         "popolo": "data/Belarus/Chamber/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b354d16bcc33b588dcf3ef5f2108c23defa16500/data/Belarus/Chamber/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/88c33d52c332797a42d9b4a836a24c6db6d90532/data/Belarus/Chamber/ep-popolo-v1.0.json",
         "names": "data/Belarus/Chamber/names.csv",
-        "lastmod": "1483433137",
+        "lastmod": "1484759182",
         "person_count": 109,
-        "sha": "b354d16bcc33b588dcf3ef5f2108c23defa16500",
+        "sha": "88c33d52c332797a42d9b4a836a24c6db6d90532",
         "legislative_periods": [
           {
+            "end_date": "2016-09-10",
             "id": "term/5",
             "name": "5th Convocation",
             "start_date": "2012-09-23",
@@ -1038,7 +1039,7 @@
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20f29b1769f4d04235d8be330169e7f9bd0d06a8/data/Belarus/Chamber/term-5.csv"
           }
         ],
-        "statement_count": 3479,
+        "statement_count": 3482,
         "type": "unicameral legislature"
       }
     ]

--- a/data/Belarus/Chamber/ep-popolo-v1.0.json
+++ b/data/Belarus/Chamber/ep-popolo-v1.0.json
@@ -6382,7 +6382,14 @@
     },
     {
       "classification": "legislative period",
+      "end_date": "2016-09-10",
       "id": "term/5",
+      "identifiers": [
+        {
+          "identifier": "Q28381376",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "5th Convocation",
       "organization_id": "2be7ca8f-4489-4098-9493-e5c8a62e91fc",
       "start_date": "2012-09-23"

--- a/data/Belarus/Chamber/sources/manual/terms.csv
+++ b/data/Belarus/Chamber/sources/manual/terms.csv
@@ -1,2 +1,3 @@
-id,name,start_date,end_date
-5,5th Convocation,2012-09-23,
+id,name,start_date,end_date,wikidata
+5,5th Convocation,2012-09-23,2016-09-10,Q28381376
+6,6th Convocation,2016-09-11,,Q28381393

--- a/data/Belarus/Chamber/unstable/stats.json
+++ b/data/Belarus/Chamber/unstable/stats.json
@@ -18,7 +18,7 @@
   "terms": {
     "count": 1,
     "latest": "2012-09-23",
-    "wikidata": 0
+    "wikidata": 1
   },
   "elections": {
     "count": 7,


### PR DESCRIPTION
This is a step towards importing data for the new term.

Records end of 2012 term as the day before 2016 election.
Start of 2016 term recorded as the day of the 2016 election.

Source: http://www.ipu.org/parline-e/reports/2027_E.htm