### PR TITLE
Error if no ID column in 'vanishing_data' source

### DIFF
--- a/rake_config/vanishing_data.rb
+++ b/rake_config/vanishing_data.rb
@@ -20,6 +20,8 @@ class SourceCSV
   end
 
   def grouped
+    # TODO: have an option to group by some other column
+    raise "No ID column in data" unless as_csv.headers.include? :id
     @grouped ||= as_csv.group_by { |r| r[:id] }
   end
 end


### PR DESCRIPTION
If a column has no ID column, we want to blow up, rather than silently
claiming there are no changes.

It would be nice if we could specify an alternative column to group by,
but that can be a later addition.