### PR TITLE
Set default Max BlockLength to 10

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -51,6 +51,7 @@ Style/TrailingCommaInLiteral:
 # Minitest::Spec uses long blocks to contains the specs, so disable this check
 # for the tests.
 Metrics/BlockLength:
+  Max: 10
   Exclude:
     - 'spec/**/*'
     - 't/**/*'


### PR DESCRIPTION
Rubocop recently introduced a 'Metrics/BlockLength' cop, which is
similar to the `MethodLength` one, though interestingly its default is
25 lines, rather than the default 10 for methods. This is particularly
bad for us in scrapers (which inherit from this config), where `field`
should essentially be treated as a method, but is really a block.

So set the default BlockLength to 10 as well.

The other place this will force us to get better is in `rake` tasks, but
that's also a Good Thing.