### PR TITLE
Lithuania (Seimas): add new term data

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -5645,22 +5645,23 @@
         "slug": "Seimas",
         "sources_directory": "data/Lithuania/Seimas/sources",
         "popolo": "data/Lithuania/Seimas/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0a73a27870480ec5050337890613a8a593659837/data/Lithuania/Seimas/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/73245e642cdb029431cb4418430cf49223dbe449/data/Lithuania/Seimas/ep-popolo-v1.0.json",
         "names": "data/Lithuania/Seimas/names.csv",
-        "lastmod": "1485067926",
+        "lastmod": "1485190526",
         "person_count": 150,
-        "sha": "0a73a27870480ec5050337890613a8a593659837",
+        "sha": "73245e642cdb029431cb4418430cf49223dbe449",
         "legislative_periods": [
           {
+            "end_date": "2016-11-10",
             "id": "term/11",
-            "name": "11th Seimas",
+            "name": "Eleventh Seimas",
             "start_date": "2012-11-17",
             "slug": "11",
             "csv": "data/Lithuania/Seimas/term-11.csv",
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6a52d7d9a1f033baa3ca349e37cd23292a69721d/data/Lithuania/Seimas/term-11.csv"
           }
         ],
-        "statement_count": 15769,
+        "statement_count": 15772,
         "type": "unicameral legislature"
       }
     ]

--- a/data/Lithuania/Seimas/ep-popolo-v1.0.json
+++ b/data/Lithuania/Seimas/ep-popolo-v1.0.json
@@ -28305,8 +28305,15 @@
     },
     {
       "classification": "legislative period",
+      "end_date": "2016-11-10",
       "id": "term/11",
-      "name": "11th Seimas",
+      "identifiers": [
+        {
+          "identifier": "Q64510",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "Eleventh Seimas",
       "organization_id": "6bbde962-f014-4c7d-b988-10a442342a7c",
       "start_date": "2012-11-17"
     },

--- a/data/Lithuania/Seimas/sources/manual/terms.csv
+++ b/data/Lithuania/Seimas/sources/manual/terms.csv
@@ -1,2 +1,8 @@
-id,name,start_date,end_date
-11,11th Seimas,2012-11-17,
+id,name,start_date,end_date,wikidata
+12,Twelfth Seimas,2016-11-14,,Q27749062
+11,Eleventh Seimas,2012-11-17,2016-11-10,Q64510
+10,Tenth Seimas,2008-11-17,2012-11-14,Q11165206
+9,Ninth Seimas,2004-11-15,2008-11-16,Q11825303
+8,Eighth Seimas,2000-10-19,2004-11-11,Q11825300
+7,Seventh Seimas,1996-11-25,2000-10-18,Q11825301
+6,Sixth Seimas,1992-11-25,1996-11-19,Q10978469

--- a/data/Lithuania/Seimas/unstable/stats.json
+++ b/data/Lithuania/Seimas/unstable/stats.json
@@ -18,7 +18,7 @@
   "terms": {
     "count": 1,
     "latest": "2012-11-17",
-    "wikidata": 0
+    "wikidata": 1
   },
   "elections": {
     "count": 9,


### PR DESCRIPTION
Generated from `generate_terms_from_wikidata.rb Q27749062`

```
Add memberships from sources/morph/data.csv
Merging with sources/morph/wikidata.csv
Data Mismatches
* 1 of 151 unmatched
	{:id=>"Q12672459", :name=>"Saulius Jakimavičius"}
Adding GenderBalance results from sources/gender-balance/results.csv
  ⚥ data for 0; 0 added


Top identifiers:
  150 x wikidata
  32 x viaf
  29 x freebase
  17 x lcauth
  9 x gnd

Creating names.csv
Persons matched to Wikidata: 150 ✓ 
Parties matched to Wikidata: 7 ✓ | 1 ✘
  No wikidata: Mišri Seimo narių grupė (party/mišri_seimo_narių_grupė)
```