### PR TITLE
Alderney States -- Change term dates

### DIFF
--- a/data/Alderney/States/sources/manual/terms.csv
+++ b/data/Alderney/States/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date,source
-2014,2014–2016,2014-11-22,2016-11,
+id,name,start_date,end_date
+2014,2015–2016,2015-01-01,2016-12-31


### PR DESCRIPTION
The legislature has an 'ordinary' election every two years where five
of the standing legislature stand for re-election. There are no formal
terms therefore this term represents a 'virtual' term.

Previously, the term start dates had been recorded as the date of the 2016 election. The end date had been given as the month of the next election.

Now, the start date is recorded as the start date of members elected in 2014
(http://www.alderney.gov.gg/article/4386/Steve-Roberts).

The end date is recorded as the 31st December 2016 (End date of 2014
elected members is 31st December 2008
(http://www.alderney.gov.gg/article/4389/Matthew-Birmingham) -- and
2016 elected members is 31st Decemeber 2020
(http://www.alderney.gov.gg/article/157566/Mike-Dean)).

This is a step towards importing adding the dates for the new term before importing the new term data.