### PR TITLE
Add Wikidata count for current term members

### DIFF
--- a/bin/dashboard.rb
+++ b/bin/dashboard.rb
@@ -16,6 +16,11 @@ ordering = drilldown.reject { |r| r.count < 5 }.
 
 EveryPolitician.countries_json = 'countries.json'
 
+def percentage(x, y)
+  '%0.3f' % (x.to_f / y.to_f)
+end
+
+
 data = EveryPolitician::Index.new.countries.map(&:lower_house).map do |l|
   statsfile = File.join(File.dirname(l.raw_data[:popolo]), 'unstable/stats.json')
   raise "No statsfile for #{l.country.name}/#{l.name}" unless File.exist? statsfile
@@ -32,17 +37,19 @@ data = EveryPolitician::Index.new.countries.map(&:lower_house).map do |l|
     lastmod:             last_build.to_s,
     ago:                 (now - last_build).to_i,
     people:              stats[:people][:count],
-    wikidata:            stats[:people][:wikidata],
+    wikidata_all:        stats[:people][:wikidata],
     parties:             stats[:groups][:count],
     wd_parties:          stats[:groups][:wikidata],
     terms:               l.legislative_periods.count,
     wd_terms:            stats[:terms][:wikidata],
     elections:           stats[:elections][:count],
-    latest_term:         l.legislative_periods.first.raw_data[:start_date],
     latest_election:     stats[:elections][:latest],
-    email:               latest[:contacts][:email].to_f / latest[:count].to_f,
-    twitter:             latest[:contacts][:twitter].to_f / latest[:count].to_f,
-    facebook:            latest[:contacts][:facebook].to_f / latest[:count].to_f,
+    latest_term:         l.legislative_periods.first.raw_data[:start_date],
+    latest_count:        latest[:count],
+    latest_wikidata:     latest[:wikidata],
+    email:               percentage(latest[:contacts][:email], latest[:count]),
+    twitter:             percentage(latest[:contacts][:twitter], latest[:count]),
+    facebook:            percentage(latest[:contacts][:facebook], latest[:count]),
     cabinet:             stats[:positions][:cabinet],
   }
 end.flatten

--- a/data/Abkhazia/Assembly/unstable/stats.json
+++ b/data/Abkhazia/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 3,
     "latest_term": {
       "count": 35,
+      "wikidata": 3,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Afghanistan/Wolesi_Jirga/unstable/stats.json
+++ b/data/Afghanistan/Wolesi_Jirga/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 17,
     "latest_term": {
       "count": 228,
+      "wikidata": 17,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Aland/Lagting/unstable/stats.json
+++ b/data/Aland/Lagting/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 37,
     "latest_term": {
       "count": 30,
+      "wikidata": 11,
       "contacts": {
         "email": 30,
         "facebook": 0,
@@ -25,6 +26,6 @@
     "latest": "2015-10-18"
   },
   "positions": {
-    "cabinet": 4
+    "cabinet": 8
   }
 }

--- a/data/Albania/Assembly/unstable/stats.json
+++ b/data/Albania/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 118,
     "latest_term": {
       "count": 138,
+      "wikidata": 70,
       "contacts": {
         "email": 128,
         "facebook": 0,

--- a/data/Alderney/States/unstable/stats.json
+++ b/data/Alderney/States/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 10,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Algeria/Majlis/unstable/stats.json
+++ b/data/Algeria/Majlis/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 11,
     "latest_term": {
       "count": 478,
+      "wikidata": 11,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/American_Samoa/House/unstable/stats.json
+++ b/data/American_Samoa/House/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 2,
     "latest_term": {
       "count": 17,
+      "wikidata": 2,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Andorra/General_Council/unstable/stats.json
+++ b/data/Andorra/General_Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 4,
     "latest_term": {
       "count": 31,
+      "wikidata": 4,
       "contacts": {
         "email": 31,
         "facebook": 0,

--- a/data/Angola/National_Assembly/unstable/stats.json
+++ b/data/Angola/National_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 7,
     "latest_term": {
       "count": 222,
+      "wikidata": 7,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Anguilla/Assembly/unstable/stats.json
+++ b/data/Anguilla/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 7,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Antigua_and_Barbuda/Representatives/unstable/stats.json
+++ b/data/Antigua_and_Barbuda/Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 7,
     "latest_term": {
       "count": 17,
+      "wikidata": 3,
       "contacts": {
         "email": 0,
         "facebook": 17,

--- a/data/Argentina/Diputados/unstable/stats.json
+++ b/data/Argentina/Diputados/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 251,
     "latest_term": {
       "count": 392,
+      "wikidata": 251,
       "contacts": {
         "email": 133,
         "facebook": 10,

--- a/data/Argentina/Senado/unstable/stats.json
+++ b/data/Argentina/Senado/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 36,
     "latest_term": {
       "count": 72,
+      "wikidata": 36,
       "contacts": {
         "email": 72,
         "facebook": 27,

--- a/data/Armenia/Assembly/unstable/stats.json
+++ b/data/Armenia/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 55,
     "latest_term": {
       "count": 132,
+      "wikidata": 55,
       "contacts": {
         "email": 89,
         "facebook": 0,

--- a/data/Aruba/Estates/unstable/stats.json
+++ b/data/Aruba/Estates/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 21,
+      "wikidata": 0,
       "contacts": {
         "email": 11,
         "facebook": 17,

--- a/data/Australia/Representatives/unstable/stats.json
+++ b/data/Australia/Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 512,
     "latest_term": {
       "count": 150,
+      "wikidata": 150,
       "contacts": {
         "email": 121,
         "facebook": 107,

--- a/data/Australia/Senate/unstable/stats.json
+++ b/data/Australia/Senate/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 244,
     "latest_term": {
       "count": 77,
+      "wikidata": 64,
       "contacts": {
         "email": 51,
         "facebook": 17,

--- a/data/Austria/Nationalrat/unstable/stats.json
+++ b/data/Austria/Nationalrat/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 182,
     "latest_term": {
       "count": 182,
+      "wikidata": 182,
       "contacts": {
         "email": 170,
         "facebook": 35,

--- a/data/Azerbaijan/National_Assembly/unstable/stats.json
+++ b/data/Azerbaijan/National_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 137,
     "latest_term": {
       "count": 124,
+      "wikidata": 109,
       "contacts": {
         "email": 0,
         "facebook": 1,

--- a/data/Bahamas/House_of_Assembly/unstable/stats.json
+++ b/data/Bahamas/House_of_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 12,
     "latest_term": {
       "count": 38,
+      "wikidata": 12,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Bahrain/Council_of_Representatives/unstable/stats.json
+++ b/data/Bahrain/Council_of_Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 40,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Bangladesh/House/unstable/stats.json
+++ b/data/Bangladesh/House/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 54,
     "latest_term": {
       "count": 353,
+      "wikidata": 38,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Barbados/House_of_Assembly/unstable/stats.json
+++ b/data/Barbados/House_of_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 30,
+      "wikidata": 0,
       "contacts": {
         "email": 30,
         "facebook": 0,

--- a/data/Belarus/Chamber/unstable/stats.json
+++ b/data/Belarus/Chamber/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 32,
     "latest_term": {
       "count": 109,
+      "wikidata": 32,
       "contacts": {
         "email": 79,
         "facebook": 0,

--- a/data/Belgium/Representatives/unstable/stats.json
+++ b/data/Belgium/Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 170,
     "latest_term": {
       "count": 170,
+      "wikidata": 170,
       "contacts": {
         "email": 153,
         "facebook": 3,

--- a/data/Belize/Representatives/unstable/stats.json
+++ b/data/Belize/Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 16,
     "latest_term": {
       "count": 31,
+      "wikidata": 14,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Benin/National_Assembly/unstable/stats.json
+++ b/data/Benin/National_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 83,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Bermuda/Assembly/unstable/stats.json
+++ b/data/Bermuda/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 5,
     "latest_term": {
       "count": 38,
+      "wikidata": 5,
       "contacts": {
         "email": 37,
         "facebook": 0,

--- a/data/Bhutan/Assembly/unstable/stats.json
+++ b/data/Bhutan/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 16,
     "latest_term": {
       "count": 48,
+      "wikidata": 16,
       "contacts": {
         "email": 48,
         "facebook": 1,

--- a/data/Bolivia/Deputies/unstable/stats.json
+++ b/data/Bolivia/Deputies/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 1,
     "latest_term": {
       "count": 128,
+      "wikidata": 1,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Bosnia_and_Herzegovina/House_of_Representatives/unstable/stats.json
+++ b/data/Bosnia_and_Herzegovina/House_of_Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 42,
+      "wikidata": 0,
       "contacts": {
         "email": 42,
         "facebook": 0,

--- a/data/Botswana/Assembly/unstable/stats.json
+++ b/data/Botswana/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 11,
     "latest_term": {
       "count": 63,
+      "wikidata": 11,
       "contacts": {
         "email": 10,
         "facebook": 0,

--- a/data/Brazil/Deputies/unstable/stats.json
+++ b/data/Brazil/Deputies/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 608,
     "latest_term": {
       "count": 596,
+      "wikidata": 443,
       "contacts": {
         "email": 569,
         "facebook": 37,

--- a/data/British_Virgin_Islands/Assembly/unstable/stats.json
+++ b/data/British_Virgin_Islands/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 7,
     "latest_term": {
       "count": 13,
+      "wikidata": 3,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/British_Virgin_Islands/Council/unstable/stats.json
+++ b/data/British_Virgin_Islands/Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 11,
     "latest_term": {
       "count": 13,
+      "wikidata": 5,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Brunei/Legislative_Council/unstable/stats.json
+++ b/data/Brunei/Legislative_Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 19,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Bulgaria/National_Assembly/unstable/stats.json
+++ b/data/Bulgaria/National_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 238,
     "latest_term": {
       "count": 253,
+      "wikidata": 36,
       "contacts": {
         "email": 215,
         "facebook": 1,

--- a/data/Burkina_Faso/Assembly/unstable/stats.json
+++ b/data/Burkina_Faso/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 127,
+      "wikidata": 0,
       "contacts": {
         "email": 18,
         "facebook": 0,

--- a/data/Burundi/Assembly/unstable/stats.json
+++ b/data/Burundi/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 121,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Cabo_Verde/Assembly/unstable/stats.json
+++ b/data/Cabo_Verde/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 77,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Cambodia/National_Assembly/unstable/stats.json
+++ b/data/Cambodia/National_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 45,
     "latest_term": {
       "count": 123,
+      "wikidata": 45,
       "contacts": {
         "email": 0,
         "facebook": 1,

--- a/data/Cameroon/Assembly/unstable/stats.json
+++ b/data/Cameroon/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 12,
     "latest_term": {
       "count": 111,
+      "wikidata": 1,
       "contacts": {
         "email": 111,
         "facebook": 0,

--- a/data/Cameroon/Senate/unstable/stats.json
+++ b/data/Cameroon/Senate/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 100,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Canada/Commons/unstable/stats.json
+++ b/data/Canada/Commons/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 538,
     "latest_term": {
       "count": 339,
+      "wikidata": 339,
       "contacts": {
         "email": 338,
         "facebook": 90,

--- a/data/Cayman_Islands/Legislative_Assembly/unstable/stats.json
+++ b/data/Cayman_Islands/Legislative_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 18,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Chad/Assembly/unstable/stats.json
+++ b/data/Chad/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 191,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Chile/Deputies/unstable/stats.json
+++ b/data/Chile/Deputies/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 313,
     "latest_term": {
       "count": 121,
+      "wikidata": 120,
       "contacts": {
         "email": 121,
         "facebook": 0,

--- a/data/China/Congress/unstable/stats.json
+++ b/data/China/Congress/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 2956,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Colombia/Representatives/unstable/stats.json
+++ b/data/Colombia/Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 54,
     "latest_term": {
       "count": 170,
+      "wikidata": 54,
       "contacts": {
         "email": 169,
         "facebook": 8,

--- a/data/Colombia/Senate/unstable/stats.json
+++ b/data/Colombia/Senate/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 95,
     "latest_term": {
       "count": 101,
+      "wikidata": 95,
       "contacts": {
         "email": 97,
         "facebook": 46,

--- a/data/Comoros/Assembly/unstable/stats.json
+++ b/data/Comoros/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 24,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Congo-Brazzaville/Assembly/unstable/stats.json
+++ b/data/Congo-Brazzaville/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 122,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Congo-Kinshasa/Assembly/unstable/stats.json
+++ b/data/Congo-Kinshasa/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 20,
     "latest_term": {
       "count": 498,
+      "wikidata": 20,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Cook_Islands/Parliament/unstable/stats.json
+++ b/data/Cook_Islands/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 37,
     "latest_term": {
       "count": 24,
+      "wikidata": 14,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Costa_Rica/Assembly/unstable/stats.json
+++ b/data/Costa_Rica/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 14,
     "latest_term": {
       "count": 57,
+      "wikidata": 14,
       "contacts": {
         "email": 57,
         "facebook": 0,

--- a/data/Croatia/Sabor/unstable/stats.json
+++ b/data/Croatia/Sabor/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 60,
     "latest_term": {
       "count": 172,
+      "wikidata": 35,
       "contacts": {
         "email": 0,
         "facebook": 2,

--- a/data/Curacao/Estates/unstable/stats.json
+++ b/data/Curacao/Estates/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 21,
+      "wikidata": 0,
       "contacts": {
         "email": 19,
         "facebook": 16,

--- a/data/Cyprus/House_of_Representatives/unstable/stats.json
+++ b/data/Cyprus/House_of_Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 33,
     "latest_term": {
       "count": 56,
+      "wikidata": 16,
       "contacts": {
         "email": 56,
         "facebook": 1,

--- a/data/Czech_Republic/Deputies/unstable/stats.json
+++ b/data/Czech_Republic/Deputies/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 886,
     "latest_term": {
       "count": 211,
+      "wikidata": 210,
       "contacts": {
         "email": 0,
         "facebook": 5,

--- a/data/Denmark/Folketing/unstable/stats.json
+++ b/data/Denmark/Folketing/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 549,
     "latest_term": {
       "count": 201,
+      "wikidata": 185,
       "contacts": {
         "email": 200,
         "facebook": 42,

--- a/data/Djibouti/Assembly/unstable/stats.json
+++ b/data/Djibouti/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 65,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Dominica/House_of_Assembly/unstable/stats.json
+++ b/data/Dominica/House_of_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 21,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Dominican_Republic/Diputados/unstable/stats.json
+++ b/data/Dominican_Republic/Diputados/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 6,
     "latest_term": {
       "count": 190,
+      "wikidata": 6,
       "contacts": {
         "email": 186,
         "facebook": 0,

--- a/data/Ecuador/Asamblea/unstable/stats.json
+++ b/data/Ecuador/Asamblea/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 30,
     "latest_term": {
       "count": 144,
+      "wikidata": 30,
       "contacts": {
         "email": 0,
         "facebook": 126,

--- a/data/Egypt/Parliament/unstable/stats.json
+++ b/data/Egypt/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 11,
     "latest_term": {
       "count": 600,
+      "wikidata": 11,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/El_Salvador/Legislative_Assembly/unstable/stats.json
+++ b/data/El_Salvador/Legislative_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 84,
+      "wikidata": 0,
       "contacts": {
         "email": 84,
         "facebook": 0,

--- a/data/Estonia/Riigikogu/unstable/stats.json
+++ b/data/Estonia/Riigikogu/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 205,
     "latest_term": {
       "count": 145,
+      "wikidata": 140,
       "contacts": {
         "email": 133,
         "facebook": 86,

--- a/data/Falkland_Islands/Assembly/unstable/stats.json
+++ b/data/Falkland_Islands/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 20,
     "latest_term": {
       "count": 8,
+      "wikidata": 8,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Faroe_Islands/Logting/unstable/stats.json
+++ b/data/Faroe_Islands/Logting/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 103,
     "latest_term": {
       "count": 33,
+      "wikidata": 33,
       "contacts": {
         "email": 0,
         "facebook": 2,

--- a/data/Fiji/Parliament/unstable/stats.json
+++ b/data/Fiji/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 3,
     "latest_term": {
       "count": 54,
+      "wikidata": 3,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Finland/Eduskunta/unstable/stats.json
+++ b/data/Finland/Eduskunta/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 493,
     "latest_term": {
       "count": 203,
+      "wikidata": 203,
       "contacts": {
         "email": 126,
         "facebook": 14,

--- a/data/France/National_Assembly/unstable/stats.json
+++ b/data/France/National_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 1026,
     "latest_term": {
       "count": 645,
+      "wikidata": 644,
       "contacts": {
         "email": 0,
         "facebook": 173,

--- a/data/French_Polynesia/Assembly/unstable/stats.json
+++ b/data/French_Polynesia/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 15,
     "latest_term": {
       "count": 59,
+      "wikidata": 15,
       "contacts": {
         "email": 57,
         "facebook": 1,

--- a/data/Gabon/Assembly/unstable/stats.json
+++ b/data/Gabon/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 10,
     "latest_term": {
       "count": 114,
+      "wikidata": 10,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Gambia/National_Assembly/unstable/stats.json
+++ b/data/Gambia/National_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 53,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Georgia/Parliament/unstable/stats.json
+++ b/data/Georgia/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 9,
     "latest_term": {
       "count": 148,
+      "wikidata": 9,
       "contacts": {
         "email": 137,
         "facebook": 28,

--- a/data/Germany/Bundestag/unstable/stats.json
+++ b/data/Germany/Bundestag/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 3802,
     "latest_term": {
       "count": 655,
+      "wikidata": 648,
       "contacts": {
         "email": 0,
         "facebook": 436,

--- a/data/Ghana/Parliament/unstable/stats.json
+++ b/data/Ghana/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 32,
     "latest_term": {
       "count": 277,
+      "wikidata": 32,
       "contacts": {
         "email": 26,
         "facebook": 0,

--- a/data/Gibraltar/Parliament/unstable/stats.json
+++ b/data/Gibraltar/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 22,
     "latest_term": {
       "count": 24,
+      "wikidata": 16,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Greece/Parliament/unstable/stats.json
+++ b/data/Greece/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 312,
     "latest_term": {
       "count": 302,
+      "wikidata": 67,
       "contacts": {
         "email": 234,
         "facebook": 2,

--- a/data/Greenland/Inatsisartut/unstable/stats.json
+++ b/data/Greenland/Inatsisartut/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 29,
     "latest_term": {
       "count": 47,
+      "wikidata": 17,
       "contacts": {
         "email": 47,
         "facebook": 1,

--- a/data/Grenada/House_of_Representatives/unstable/stats.json
+++ b/data/Grenada/House_of_Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 15,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Guam/Parliament/unstable/stats.json
+++ b/data/Guam/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 8,
     "latest_term": {
       "count": 15,
+      "wikidata": 5,
       "contacts": {
         "email": 15,
         "facebook": 0,

--- a/data/Guatemala/Congress/unstable/stats.json
+++ b/data/Guatemala/Congress/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 162,
+      "wikidata": 0,
       "contacts": {
         "email": 162,
         "facebook": 0,

--- a/data/Guernsey/States/unstable/stats.json
+++ b/data/Guernsey/States/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 5,
     "latest_term": {
       "count": 41,
+      "wikidata": 3,
       "contacts": {
         "email": 41,
         "facebook": 9,

--- a/data/Guinea-Bissau/Assembly/unstable/stats.json
+++ b/data/Guinea-Bissau/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 100,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Guyana/National_Assembly/unstable/stats.json
+++ b/data/Guyana/National_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 55,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Haiti/Deputies/unstable/stats.json
+++ b/data/Haiti/Deputies/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 99,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Honduras/Congreso_Nacional/unstable/stats.json
+++ b/data/Honduras/Congreso_Nacional/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 3,
     "latest_term": {
       "count": 131,
+      "wikidata": 3,
       "contacts": {
         "email": 0,
         "facebook": 1,

--- a/data/Hong_Kong/Legislative_Council/unstable/stats.json
+++ b/data/Hong_Kong/Legislative_Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 98,
     "latest_term": {
       "count": 70,
+      "wikidata": 70,
       "contacts": {
         "email": 70,
         "facebook": 2,

--- a/data/Hungary/Assembly/unstable/stats.json
+++ b/data/Hungary/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 174,
     "latest_term": {
       "count": 201,
+      "wikidata": 174,
       "contacts": {
         "email": 199,
         "facebook": 0,

--- a/data/Iceland/Assembly/unstable/stats.json
+++ b/data/Iceland/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 161,
     "latest_term": {
       "count": 64,
+      "wikidata": 63,
       "contacts": {
         "email": 0,
         "facebook": 5,

--- a/data/India/Lok_Sabha/unstable/stats.json
+++ b/data/India/Lok_Sabha/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 440,
     "latest_term": {
       "count": 541,
+      "wikidata": 440,
       "contacts": {
         "email": 511,
         "facebook": 9,

--- a/data/Indonesia/Council/unstable/stats.json
+++ b/data/Indonesia/Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 193,
     "latest_term": {
       "count": 583,
+      "wikidata": 193,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Iran/Assembly/unstable/stats.json
+++ b/data/Iran/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 21,
     "latest_term": {
       "count": 290,
+      "wikidata": 5,
       "contacts": {
         "email": 122,
         "facebook": 0,

--- a/data/Iraq/Majlis/unstable/stats.json
+++ b/data/Iraq/Majlis/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 328,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Ireland/Dail/unstable/stats.json
+++ b/data/Ireland/Dail/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 226,
     "latest_term": {
       "count": 158,
+      "wikidata": 158,
       "contacts": {
         "email": 0,
         "facebook": 1,

--- a/data/Isle_of_Man/House_of_Keys/unstable/stats.json
+++ b/data/Isle_of_Man/House_of_Keys/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 21,
     "latest_term": {
       "count": 29,
+      "wikidata": 21,
       "contacts": {
         "email": 21,
         "facebook": 0,

--- a/data/Israel/Knesset/unstable/stats.json
+++ b/data/Israel/Knesset/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 933,
     "latest_term": {
       "count": 132,
+      "wikidata": 132,
       "contacts": {
         "email": 0,
         "facebook": 50,

--- a/data/Italy/House/unstable/stats.json
+++ b/data/Italy/House/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 666,
     "latest_term": {
       "count": 666,
+      "wikidata": 666,
       "contacts": {
         "email": 623,
         "facebook": 480,

--- a/data/Italy/Senate/unstable/stats.json
+++ b/data/Italy/Senate/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 322,
     "latest_term": {
       "count": 322,
+      "wikidata": 322,
       "contacts": {
         "email": 304,
         "facebook": 221,

--- a/data/Ivory_Coast/Assembly/unstable/stats.json
+++ b/data/Ivory_Coast/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 241,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Jamaica/House_of_Representatives/unstable/stats.json
+++ b/data/Jamaica/House_of_Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 35,
     "latest_term": {
       "count": 64,
+      "wikidata": 30,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Japan/House_of_Representatives/unstable/stats.json
+++ b/data/Japan/House_of_Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 264,
     "latest_term": {
       "count": 479,
+      "wikidata": 264,
       "contacts": {
         "email": 0,
         "facebook": 70,

--- a/data/Jersey/States/unstable/stats.json
+++ b/data/Jersey/States/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 62,
+      "wikidata": 0,
       "contacts": {
         "email": 60,
         "facebook": 0,

--- a/data/Jordan/House_of_Representatives/unstable/stats.json
+++ b/data/Jordan/House_of_Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 9,
     "latest_term": {
       "count": 150,
+      "wikidata": 9,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Kazakhstan/Assembly/unstable/stats.json
+++ b/data/Kazakhstan/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 107,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Kenya/Assembly/unstable/stats.json
+++ b/data/Kenya/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 47,
     "latest_term": {
       "count": 355,
+      "wikidata": 47,
       "contacts": {
         "email": 276,
         "facebook": 86,

--- a/data/Kiribati/Parliament/unstable/stats.json
+++ b/data/Kiribati/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 11,
     "latest_term": {
       "count": 45,
+      "wikidata": 9,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Kosovo/Assembly/unstable/stats.json
+++ b/data/Kosovo/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 1,
     "latest_term": {
       "count": 116,
+      "wikidata": 1,
       "contacts": {
         "email": 0,
         "facebook": 1,

--- a/data/Kuwait/National_Assembly/unstable/stats.json
+++ b/data/Kuwait/National_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 8,
     "latest_term": {
       "count": 45,
+      "wikidata": 8,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Kyrgyzstan/Council/unstable/stats.json
+++ b/data/Kyrgyzstan/Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 10,
     "latest_term": {
       "count": 121,
+      "wikidata": 7,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Laos/Assembly/unstable/stats.json
+++ b/data/Laos/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 18,
     "latest_term": {
       "count": 149,
+      "wikidata": 5,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Latvia/Saeima/unstable/stats.json
+++ b/data/Latvia/Saeima/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 182,
     "latest_term": {
       "count": 119,
+      "wikidata": 106,
       "contacts": {
         "email": 110,
         "facebook": 0,

--- a/data/Lebanon/Parliament/unstable/stats.json
+++ b/data/Lebanon/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 74,
     "latest_term": {
       "count": 130,
+      "wikidata": 74,
       "contacts": {
         "email": 0,
         "facebook": 1,

--- a/data/Lesotho/Assembly/unstable/stats.json
+++ b/data/Lesotho/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 5,
     "latest_term": {
       "count": 120,
+      "wikidata": 5,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Liberia/House/unstable/stats.json
+++ b/data/Liberia/House/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 73,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Libya/House_of_Representatives/unstable/stats.json
+++ b/data/Libya/House_of_Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 189,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Liechtenstein/Landtag/unstable/stats.json
+++ b/data/Liechtenstein/Landtag/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 51,
     "latest_term": {
       "count": 26,
+      "wikidata": 26,
       "contacts": {
         "email": 25,
         "facebook": 0,

--- a/data/Lithuania/Seimas/unstable/stats.json
+++ b/data/Lithuania/Seimas/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 150,
     "latest_term": {
       "count": 150,
+      "wikidata": 150,
       "contacts": {
         "email": 141,
         "facebook": 1,

--- a/data/Luxembourg/Chamber/unstable/stats.json
+++ b/data/Luxembourg/Chamber/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 62,
     "latest_term": {
       "count": 62,
+      "wikidata": 62,
       "contacts": {
         "email": 62,
         "facebook": 0,

--- a/data/Macao/Assembly/unstable/stats.json
+++ b/data/Macao/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 18,
     "latest_term": {
       "count": 33,
+      "wikidata": 18,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Macedonia/Sobranie/unstable/stats.json
+++ b/data/Macedonia/Sobranie/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 6,
     "latest_term": {
       "count": 92,
+      "wikidata": 6,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Madagascar/Assembly/unstable/stats.json
+++ b/data/Madagascar/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 17,
     "latest_term": {
       "count": 155,
+      "wikidata": 17,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Malawi/Assembly/unstable/stats.json
+++ b/data/Malawi/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 193,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Malaysia/Dewan_Rakyat/unstable/stats.json
+++ b/data/Malaysia/Dewan_Rakyat/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 469,
     "latest_term": {
       "count": 228,
+      "wikidata": 173,
       "contacts": {
         "email": 0,
         "facebook": 2,

--- a/data/Maldives/Majlis/unstable/stats.json
+++ b/data/Maldives/Majlis/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 85,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Mali/Assembly/unstable/stats.json
+++ b/data/Mali/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 142,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Malta/Assembly/unstable/stats.json
+++ b/data/Malta/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 40,
     "latest_term": {
       "count": 74,
+      "wikidata": 40,
       "contacts": {
         "email": 70,
         "facebook": 0,

--- a/data/Marshall_Islands/Nitijela/unstable/stats.json
+++ b/data/Marshall_Islands/Nitijela/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 33,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Mauritania/National_Assembly/unstable/stats.json
+++ b/data/Mauritania/National_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 147,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Mauritius/National_Assembly/unstable/stats.json
+++ b/data/Mauritius/National_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 62,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Mexico/Deputies/unstable/stats.json
+++ b/data/Mexico/Deputies/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 438,
     "latest_term": {
       "count": 531,
+      "wikidata": 2,
       "contacts": {
         "email": 495,
         "facebook": 0,

--- a/data/Micronesia/Congress/unstable/stats.json
+++ b/data/Micronesia/Congress/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 3,
     "latest_term": {
       "count": 15,
+      "wikidata": 1,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Moldova/Parlamentul/unstable/stats.json
+++ b/data/Moldova/Parlamentul/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 93,
     "latest_term": {
       "count": 116,
+      "wikidata": 93,
       "contacts": {
         "email": 43,
         "facebook": 2,

--- a/data/Monaco/Council/unstable/stats.json
+++ b/data/Monaco/Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 24,
+      "wikidata": 0,
       "contacts": {
         "email": 24,
         "facebook": 0,

--- a/data/Mongolia/Assembly/unstable/stats.json
+++ b/data/Mongolia/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 45,
     "latest_term": {
       "count": 76,
+      "wikidata": 13,
       "contacts": {
         "email": 25,
         "facebook": 2,

--- a/data/Montenegro/Assembly/unstable/stats.json
+++ b/data/Montenegro/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 10,
     "latest_term": {
       "count": 82,
+      "wikidata": 10,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Montserrat/Assembly/unstable/stats.json
+++ b/data/Montserrat/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 9,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Morocco/House/unstable/stats.json
+++ b/data/Morocco/House/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 12,
     "latest_term": {
       "count": 395,
+      "wikidata": 5,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Mozambique/Assembly/unstable/stats.json
+++ b/data/Mozambique/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 250,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Myanmar/House_of_Representatives/unstable/stats.json
+++ b/data/Myanmar/House_of_Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 314,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Nagorno_Karabakh/Assembly/unstable/stats.json
+++ b/data/Nagorno_Karabakh/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 33,
+      "wikidata": 0,
       "contacts": {
         "email": 20,
         "facebook": 0,

--- a/data/Namibia/Assembly/unstable/stats.json
+++ b/data/Namibia/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 135,
     "latest_term": {
       "count": 104,
+      "wikidata": 42,
       "contacts": {
         "email": 38,
         "facebook": 0,

--- a/data/Namibia/Council/unstable/stats.json
+++ b/data/Namibia/Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 42,
+      "wikidata": 0,
       "contacts": {
         "email": 41,
         "facebook": 0,

--- a/data/Nauru/Parliament/unstable/stats.json
+++ b/data/Nauru/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 25,
     "latest_term": {
       "count": 19,
+      "wikidata": 11,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Nepal/Assembly/unstable/stats.json
+++ b/data/Nepal/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 42,
     "latest_term": {
       "count": 550,
+      "wikidata": 42,
       "contacts": {
         "email": 272,
         "facebook": 0,

--- a/data/Netherlands/House_of_Representatives/unstable/stats.json
+++ b/data/Netherlands/House_of_Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 194,
     "latest_term": {
       "count": 194,
+      "wikidata": 194,
       "contacts": {
         "email": 162,
         "facebook": 6,

--- a/data/New_Caledonia/Congress/unstable/stats.json
+++ b/data/New_Caledonia/Congress/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 22,
     "latest_term": {
       "count": 56,
+      "wikidata": 22,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/New_Zealand/House/unstable/stats.json
+++ b/data/New_Zealand/House/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 231,
     "latest_term": {
       "count": 115,
+      "wikidata": 115,
       "contacts": {
         "email": 115,
         "facebook": 109,

--- a/data/Nicaragua/Asamblea/unstable/stats.json
+++ b/data/Nicaragua/Asamblea/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 90,
+      "wikidata": 0,
       "contacts": {
         "email": 86,
         "facebook": 0,

--- a/data/Niger/Assembly/unstable/stats.json
+++ b/data/Niger/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 113,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Nigeria/Representatives/unstable/stats.json
+++ b/data/Nigeria/Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 362,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Niue/Assembly/unstable/stats.json
+++ b/data/Niue/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 9,
     "latest_term": {
       "count": 20,
+      "wikidata": 9,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Norfolk_Island/Assembly/unstable/stats.json
+++ b/data/Norfolk_Island/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 9,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/North_Korea/National_Assembly/unstable/stats.json
+++ b/data/North_Korea/National_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 49,
     "latest_term": {
       "count": 687,
+      "wikidata": 49,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Northern_Cyprus/Assembly/unstable/stats.json
+++ b/data/Northern_Cyprus/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 13,
     "latest_term": {
       "count": 50,
+      "wikidata": 13,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Northern_Ireland/Assembly/unstable/stats.json
+++ b/data/Northern_Ireland/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 272,
     "latest_term": {
       "count": 110,
+      "wikidata": 110,
       "contacts": {
         "email": 0,
         "facebook": 1,

--- a/data/Northern_Mariana_Islands/House/unstable/stats.json
+++ b/data/Northern_Mariana_Islands/House/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 1,
     "latest_term": {
       "count": 20,
+      "wikidata": 1,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Norway/Storting/unstable/stats.json
+++ b/data/Norway/Storting/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 1138,
     "latest_term": {
       "count": 169,
+      "wikidata": 169,
       "contacts": {
         "email": 0,
         "facebook": 4,

--- a/data/Oman/Majlis/unstable/stats.json
+++ b/data/Oman/Majlis/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 84,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Pakistan/Assembly/unstable/stats.json
+++ b/data/Pakistan/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 335,
     "latest_term": {
       "count": 350,
+      "wikidata": 335,
       "contacts": {
         "email": 0,
         "facebook": 1,

--- a/data/Palau/House_of_Delegates/unstable/stats.json
+++ b/data/Palau/House_of_Delegates/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 16,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Panama/Assembly/unstable/stats.json
+++ b/data/Panama/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 74,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Papua_New_Guinea/Parliament/unstable/stats.json
+++ b/data/Papua_New_Guinea/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 11,
     "latest_term": {
       "count": 111,
+      "wikidata": 11,
       "contacts": {
         "email": 61,
         "facebook": 0,

--- a/data/Paraguay/Deputies/unstable/stats.json
+++ b/data/Paraguay/Deputies/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 82,
+      "wikidata": 0,
       "contacts": {
         "email": 82,
         "facebook": 0,

--- a/data/Peru/Congreso/unstable/stats.json
+++ b/data/Peru/Congreso/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 87,
     "latest_term": {
       "count": 127,
+      "wikidata": 87,
       "contacts": {
         "email": 127,
         "facebook": 1,

--- a/data/Philippines/House/unstable/stats.json
+++ b/data/Philippines/House/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 122,
     "latest_term": {
       "count": 295,
+      "wikidata": 74,
       "contacts": {
         "email": 0,
         "facebook": 1,

--- a/data/Pitcairn/Island_Council/unstable/stats.json
+++ b/data/Pitcairn/Island_Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 2,
     "latest_term": {
       "count": 5,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Poland/Sejm/unstable/stats.json
+++ b/data/Poland/Sejm/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 2179,
     "latest_term": {
       "count": 470,
+      "wikidata": 470,
       "contacts": {
         "email": 0,
         "facebook": 6,

--- a/data/Portugal/Assembly/unstable/stats.json
+++ b/data/Portugal/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 213,
     "latest_term": {
       "count": 282,
+      "wikidata": 46,
       "contacts": {
         "email": 39,
         "facebook": 0,

--- a/data/Puerto_Rico/House_of_Representatives/unstable/stats.json
+++ b/data/Puerto_Rico/House_of_Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 56,
     "latest_term": {
       "count": 51,
+      "wikidata": 34,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Romania/Deputies/unstable/stats.json
+++ b/data/Romania/Deputies/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 416,
     "latest_term": {
       "count": 416,
+      "wikidata": 416,
       "contacts": {
         "email": 0,
         "facebook": 1,

--- a/data/Russia/Duma/unstable/stats.json
+++ b/data/Russia/Duma/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 412,
     "latest_term": {
       "count": 452,
+      "wikidata": 266,
       "contacts": {
         "email": 0,
         "facebook": 17,

--- a/data/Rwanda/Deputies/unstable/stats.json
+++ b/data/Rwanda/Deputies/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 77,
+      "wikidata": 0,
       "contacts": {
         "email": 77,
         "facebook": 0,

--- a/data/Saint_Barthelemy/Council/unstable/stats.json
+++ b/data/Saint_Barthelemy/Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 2,
     "latest_term": {
       "count": 19,
+      "wikidata": 2,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Saint_Helena/Legislative_Council/unstable/stats.json
+++ b/data/Saint_Helena/Legislative_Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 12,
+      "wikidata": 0,
       "contacts": {
         "email": 7,
         "facebook": 0,

--- a/data/Saint_Kitts_and_Nevis/Assembly/unstable/stats.json
+++ b/data/Saint_Kitts_and_Nevis/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 11,
     "latest_term": {
       "count": 11,
+      "wikidata": 9,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Saint_Lucia/Assembly/unstable/stats.json
+++ b/data/Saint_Lucia/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 23,
     "latest_term": {
       "count": 17,
+      "wikidata": 12,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Saint_Martin/Council/unstable/stats.json
+++ b/data/Saint_Martin/Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 3,
     "latest_term": {
       "count": 23,
+      "wikidata": 3,
       "contacts": {
         "email": 0,
         "facebook": 1,

--- a/data/Saint_Pierre_and_Miquelon/Territorial_Council/unstable/stats.json
+++ b/data/Saint_Pierre_and_Miquelon/Territorial_Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 3,
     "latest_term": {
       "count": 19,
+      "wikidata": 2,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Saint_Vincent_and_the_Grenadines/Assembly/unstable/stats.json
+++ b/data/Saint_Vincent_and_the_Grenadines/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 15,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Samoa/Parliament/unstable/stats.json
+++ b/data/Samoa/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 17,
     "latest_term": {
       "count": 49,
+      "wikidata": 17,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/San_Marino/Council/unstable/stats.json
+++ b/data/San_Marino/Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 34,
     "latest_term": {
       "count": 63,
+      "wikidata": 34,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Sark/Chief_Pleas/unstable/stats.json
+++ b/data/Sark/Chief_Pleas/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 29,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Saudi_Arabia/Shura/unstable/stats.json
+++ b/data/Saudi_Arabia/Shura/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 148,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Scotland/Parliament/unstable/stats.json
+++ b/data/Scotland/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 302,
     "latest_term": {
       "count": 130,
+      "wikidata": 130,
       "contacts": {
         "email": 0,
         "facebook": 3,

--- a/data/Senegal/Assembly/unstable/stats.json
+++ b/data/Senegal/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 11,
     "latest_term": {
       "count": 149,
+      "wikidata": 11,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Serbia/National_Assembly/unstable/stats.json
+++ b/data/Serbia/National_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 37,
     "latest_term": {
       "count": 267,
+      "wikidata": 28,
       "contacts": {
         "email": 0,
         "facebook": 69,

--- a/data/Seychelles/Assembly/unstable/stats.json
+++ b/data/Seychelles/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 32,
+      "wikidata": 0,
       "contacts": {
         "email": 32,
         "facebook": 0,

--- a/data/Sierra_Leone/Parliament/unstable/stats.json
+++ b/data/Sierra_Leone/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 124,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Singapore/Parliament/unstable/stats.json
+++ b/data/Singapore/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 138,
     "latest_term": {
       "count": 103,
+      "wikidata": 88,
       "contacts": {
         "email": 0,
         "facebook": 12,

--- a/data/Sint_Maarten/Estates/unstable/stats.json
+++ b/data/Sint_Maarten/Estates/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 17,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Slovakia/National_Council/unstable/stats.json
+++ b/data/Slovakia/National_Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 360,
     "latest_term": {
       "count": 152,
+      "wikidata": 67,
       "contacts": {
         "email": 150,
         "facebook": 0,

--- a/data/Slovenia/National_Assembly/unstable/stats.json
+++ b/data/Slovenia/National_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 34,
     "latest_term": {
       "count": 93,
+      "wikidata": 34,
       "contacts": {
         "email": 0,
         "facebook": 38,

--- a/data/Solomon_Islands/Parliament/unstable/stats.json
+++ b/data/Solomon_Islands/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 29,
     "latest_term": {
       "count": 50,
+      "wikidata": 29,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Somalia/Lower/unstable/stats.json
+++ b/data/Somalia/Lower/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 204,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Somaliland/Representatives/unstable/stats.json
+++ b/data/Somaliland/Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 82,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/South_Africa/Assembly/unstable/stats.json
+++ b/data/South_Africa/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 98,
     "latest_term": {
       "count": 400,
+      "wikidata": 98,
       "contacts": {
         "email": 331,
         "facebook": 0,

--- a/data/South_Korea/National_Assembly/unstable/stats.json
+++ b/data/South_Korea/National_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 447,
     "latest_term": {
       "count": 300,
+      "wikidata": 295,
       "contacts": {
         "email": 231,
         "facebook": 106,

--- a/data/South_Ossetia/Parliament/unstable/stats.json
+++ b/data/South_Ossetia/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 34,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/South_Sudan/Assembly/unstable/stats.json
+++ b/data/South_Sudan/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 167,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Spain/Congress/unstable/stats.json
+++ b/data/Spain/Congress/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 351,
     "latest_term": {
       "count": 351,
+      "wikidata": 187,
       "contacts": {
         "email": 273,
         "facebook": 124,

--- a/data/Sri_Lanka/Parliament/unstable/stats.json
+++ b/data/Sri_Lanka/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 204,
     "latest_term": {
       "count": 228,
+      "wikidata": 204,
       "contacts": {
         "email": 221,
         "facebook": 0,

--- a/data/Suriname/Assembly/unstable/stats.json
+++ b/data/Suriname/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 19,
     "latest_term": {
       "count": 57,
+      "wikidata": 12,
       "contacts": {
         "email": 57,
         "facebook": 0,

--- a/data/Swaziland/Assembly/unstable/stats.json
+++ b/data/Swaziland/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 54,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Sweden/Riksdag/unstable/stats.json
+++ b/data/Sweden/Riksdag/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 1244,
     "latest_term": {
       "count": 421,
+      "wikidata": 400,
       "contacts": {
         "email": 406,
         "facebook": 18,

--- a/data/Switzerland/National_Council/unstable/stats.json
+++ b/data/Switzerland/National_Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 549,
     "latest_term": {
       "count": 204,
+      "wikidata": 194,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Syria/Majlis/unstable/stats.json
+++ b/data/Syria/Majlis/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 274,
+      "wikidata": 0,
       "contacts": {
         "email": 59,
         "facebook": 0,

--- a/data/Taiwan/Legislative_Yuan/unstable/stats.json
+++ b/data/Taiwan/Legislative_Yuan/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 164,
     "latest_term": {
       "count": 117,
+      "wikidata": 113,
       "contacts": {
         "email": 0,
         "facebook": 1,

--- a/data/Tajikistan/Representatives/unstable/stats.json
+++ b/data/Tajikistan/Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 62,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Tanzania/Assembly/unstable/stats.json
+++ b/data/Tanzania/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 241,
     "latest_term": {
       "count": 389,
+      "wikidata": 98,
       "contacts": {
         "email": 384,
         "facebook": 0,

--- a/data/Thailand/National_Legislative_Assembly/unstable/stats.json
+++ b/data/Thailand/National_Legislative_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 70,
     "latest_term": {
       "count": 220,
+      "wikidata": 70,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Timor_Leste/Parlamento/unstable/stats.json
+++ b/data/Timor_Leste/Parlamento/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 65,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Togo/Assembly/unstable/stats.json
+++ b/data/Togo/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 5,
     "latest_term": {
       "count": 91,
+      "wikidata": 5,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Tonga/Assembly/unstable/stats.json
+++ b/data/Tonga/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 26,
+      "wikidata": 0,
       "contacts": {
         "email": 13,
         "facebook": 0,

--- a/data/Transnistria/Supreme_Council/unstable/stats.json
+++ b/data/Transnistria/Supreme_Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 43,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Trinidad_and_Tobago/Representatives/unstable/stats.json
+++ b/data/Trinidad_and_Tobago/Representatives/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 42,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Trinidad_and_Tobago/Senate/unstable/stats.json
+++ b/data/Trinidad_and_Tobago/Senate/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 31,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Tunisia/Majlis/unstable/stats.json
+++ b/data/Tunisia/Majlis/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 58,
     "latest_term": {
       "count": 224,
+      "wikidata": 58,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Turkey/Assembly/unstable/stats.json
+++ b/data/Turkey/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 4248,
     "latest_term": {
       "count": 549,
+      "wikidata": 277,
       "contacts": {
         "email": 0,
         "facebook": 10,

--- a/data/Turkmenistan/Mejlis/unstable/stats.json
+++ b/data/Turkmenistan/Mejlis/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 124,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Turks_and_Caicos_Islands/Assembly/unstable/stats.json
+++ b/data/Turks_and_Caicos_Islands/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 6,
     "latest_term": {
       "count": 18,
+      "wikidata": 6,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Tuvalu/Parliament/unstable/stats.json
+++ b/data/Tuvalu/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 27,
     "latest_term": {
       "count": 15,
+      "wikidata": 15,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/UK/Commons/unstable/stats.json
+++ b/data/UK/Commons/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 1345,
     "latest_term": {
       "count": 658,
+      "wikidata": 658,
       "contacts": {
         "email": 656,
         "facebook": 249,

--- a/data/US_Virgin_Islands/Legislature/unstable/stats.json
+++ b/data/US_Virgin_Islands/Legislature/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 15,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Uganda/Parliament/unstable/stats.json
+++ b/data/Uganda/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 109,
     "latest_term": {
       "count": 432,
+      "wikidata": 55,
       "contacts": {
         "email": 162,
         "facebook": 40,

--- a/data/Ukraine/Verkhovna_Rada/unstable/stats.json
+++ b/data/Ukraine/Verkhovna_Rada/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 459,
     "latest_term": {
       "count": 459,
+      "wikidata": 459,
       "contacts": {
         "email": 0,
         "facebook": 53,

--- a/data/United_Arab_Emirates/Federal_National_Council/unstable/stats.json
+++ b/data/United_Arab_Emirates/Federal_National_Council/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 40,
+      "wikidata": 0,
       "contacts": {
         "email": 40,
         "facebook": 0,

--- a/data/United_States_of_America/House/unstable/stats.json
+++ b/data/United_States_of_America/House/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 1638,
     "latest_term": {
       "count": 441,
+      "wikidata": 441,
       "contacts": {
         "email": 0,
         "facebook": 380,

--- a/data/United_States_of_America/Senate/unstable/stats.json
+++ b/data/United_States_of_America/Senate/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 317,
     "latest_term": {
       "count": 100,
+      "wikidata": 100,
       "contacts": {
         "email": 0,
         "facebook": 86,

--- a/data/Uruguay/Deputies/unstable/stats.json
+++ b/data/Uruguay/Deputies/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 40,
     "latest_term": {
       "count": 106,
+      "wikidata": 40,
       "contacts": {
         "email": 105,
         "facebook": 1,

--- a/data/Uzbekistan/Legislative_Chamber/unstable/stats.json
+++ b/data/Uzbekistan/Legislative_Chamber/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 147,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Vanuatu/Parliament/unstable/stats.json
+++ b/data/Vanuatu/Parliament/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 16,
     "latest_term": {
       "count": 52,
+      "wikidata": 6,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Vatican_City/Pontifical_Commission/unstable/stats.json
+++ b/data/Vatican_City/Pontifical_Commission/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 8,
     "latest_term": {
       "count": 7,
+      "wikidata": 7,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Venezuela/Assembly/unstable/stats.json
+++ b/data/Venezuela/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 57,
     "latest_term": {
       "count": 167,
+      "wikidata": 35,
       "contacts": {
         "email": 0,
         "facebook": 1,

--- a/data/Vietnam/National_Assembly/unstable/stats.json
+++ b/data/Vietnam/National_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 377,
     "latest_term": {
       "count": 492,
+      "wikidata": 377,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Wales/Assembly/unstable/stats.json
+++ b/data/Wales/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 85,
     "latest_term": {
       "count": 60,
+      "wikidata": 60,
       "contacts": {
         "email": 60,
         "facebook": 25,

--- a/data/Wallis_and_Futuna/Territorial_Assembly/unstable/stats.json
+++ b/data/Wallis_and_Futuna/Territorial_Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 6,
     "latest_term": {
       "count": 20,
+      "wikidata": 6,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Yemen/Majlis/unstable/stats.json
+++ b/data/Yemen/Majlis/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 302,
+      "wikidata": 0,
       "contacts": {
         "email": 0,
         "facebook": 0,

--- a/data/Zambia/Assembly/unstable/stats.json
+++ b/data/Zambia/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 15,
     "latest_term": {
       "count": 148,
+      "wikidata": 15,
       "contacts": {
         "email": 132,
         "facebook": 0,

--- a/data/Zimbabwe/Assembly/unstable/stats.json
+++ b/data/Zimbabwe/Assembly/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 33,
     "latest_term": {
       "count": 229,
+      "wikidata": 33,
       "contacts": {
         "email": 37,
         "facebook": 0,

--- a/data/Zimbabwe/Senate/unstable/stats.json
+++ b/data/Zimbabwe/Senate/unstable/stats.json
@@ -4,6 +4,7 @@
     "wikidata": 0,
     "latest_term": {
       "count": 67,
+      "wikidata": 0,
       "contacts": {
         "email": 11,
         "facebook": 0,

--- a/lib/legislature_stats.rb
+++ b/lib/legislature_stats.rb
@@ -36,6 +36,7 @@ class StatsFile
       wikidata:    people.select(&:wikidata).count,
       latest_term: {
         count:    current.count,
+        wikidata: current.select(&:wikidata).count,
         contacts: {
           email:    current.select(&:email).count,
           facebook: current.select(&:facebook).count,

--- a/lib/legislature_stats.rb
+++ b/lib/legislature_stats.rb
@@ -33,7 +33,7 @@ class StatsFile
     current = popolo.latest_term.memberships.map(&:person).uniq(&:id)
     {
       count:       people.count,
-      wikidata:    people_wikidata_partition.first.count,
+      wikidata:    people.select(&:wikidata).count,
       latest_term: {
         count:    current.count,
         contacts: {
@@ -79,10 +79,6 @@ class StatsFile
 
   def people
     popolo.persons
-  end
-
-  def people_wikidata_partition
-    people.partition(&:wikidata)
   end
 
   def known_parties


### PR DESCRIPTION
For countries where we have lots of historic data, our Wikidata coverage
can be thrown off. Also report on how good the coverage of the current term
is.