### PR TITLE
Add rake report on missing Wikidata members

### DIFF
--- a/rake_report/missing_wikidata.rb
+++ b/rake_report/missing_wikidata.rb
@@ -1,0 +1,8 @@
+namespace :report do
+  task :missing_wikidata do
+    popolo = Everypolitician::Popolo.read('ep-popolo-v1.0.json')
+    popolo.latest_term.memberships.map(&:person).reject(&:wikidata).sort_by(&:name).group_by(&:id).each do |id, ps|
+      puts "%s (%s)" % [ps.first.name, id]
+    end
+  end
+end


### PR DESCRIPTION
Add a rake task (rake report:missing_wikidata) to tell us which members
of the latest term aren't yet matched to Wikidata.

This will make it easier to ensure that at least the current information
is as well matched as possible.