### PR TITLE
Instruct rubocop to ignore gemspec files

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -56,3 +56,4 @@ Metrics/BlockLength:
     - 'spec/**/*'
     - 't/**/*'
     - 'test/**/*'
+    - '*.gemspec'


### PR DESCRIPTION
The rubocop config in this repo is used in other projects.

Gemspec files can contain lengthy blocks. For example:
https://github.com/everypolitician/scraped/blob/master/scraped.gemspec

Blocks of such length would not pass rubocop tests.