### PR TITLE
Report on Areas matched to Wikidata

### DIFF
--- a/rake_build/generate_final_csvs.rb
+++ b/rake_build/generate_final_csvs.rb
@@ -46,6 +46,7 @@ namespace :term_csvs do
   desc 'Add some final reporting information'
   task reports: :term_tables do
     wikidata_persons = @popolo.persons.partition(&:wikidata)
+    wikidata_areas   = @popolo.areas.partition(&:wikidata)
     wikidata_parties = @popolo.organizations.where(classification: 'party').partition(&:wikidata)
 
     matched, unmatched = wikidata_persons.map(&:count)
@@ -55,6 +56,10 @@ namespace :term_csvs do
     matched, unmatched = wikidata_parties.map(&:count)
     warn "Parties matched to Wikidata: #{matched} ✓ #{unmatched.zero? ? '' : "| #{unmatched} ✘"}"
     wikidata_parties.last.shuffle.take(5).each { |p| warn "  No wikidata: #{p.name} (#{p.id})" } unless matched.zero?
+
+    matched, unmatched = wikidata_areas.map(&:count)
+    warn "Areas matched to Wikidata: #{matched} ✓ #{unmatched.zero? ? '' : "| #{unmatched} ✘"}"
+    wikidata_areas.last.shuffle.take(5).each { |p| warn "  No wikidata: #{p.name} (#{p.id})" } unless matched.zero?
   end
 
   desc 'Build the Cabinet file'


### PR DESCRIPTION
Similarly to how we report on People and Parties matched to Wikidata, also report on Areas.

This will let us see which areas still need mapped, and also which countries we still haven't mapped at all.