### PR TITLE
Ireland (Dail): correct reconciliation for Dublin Bay South

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -4670,11 +4670,11 @@
         "slug": "Dail",
         "sources_directory": "data/Ireland/Dail/sources",
         "popolo": "data/Ireland/Dail/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b7e542edf01c9da70bc5a7efc264111ee1a21ca3/data/Ireland/Dail/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5792868d6c280ba75a9125107473c772657a96bf/data/Ireland/Dail/ep-popolo-v1.0.json",
         "names": "data/Ireland/Dail/names.csv",
-        "lastmod": "1485505262",
+        "lastmod": "1485708136",
         "person_count": 226,
-        "sha": "b7e542edf01c9da70bc5a7efc264111ee1a21ca3",
+        "sha": "5792868d6c280ba75a9125107473c772657a96bf",
         "legislative_periods": [
           {
             "id": "term/32",
@@ -4694,7 +4694,7 @@
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/453d614bba6010a410ce74f1a48727325d315935/data/Ireland/Dail/term-31.csv"
           }
         ],
-        "statement_count": 16003,
+        "statement_count": 16014,
         "type": "lower house"
       }
     ]

--- a/data/Ireland/Dail/ep-popolo-v1.0.json
+++ b/data/Ireland/Dail/ep-popolo-v1.0.json
@@ -29394,18 +29394,13 @@
     },
     {
       "id": "area/dublin_bay_north",
-      "name": "Dublin Bay North",
-      "type": "constituency"
-    },
-    {
-      "id": "area/dublin_bay_south",
       "identifiers": [
         {
           "identifier": "Q5310820",
           "scheme": "wikidata"
         }
       ],
-      "name": "Dublin Bay South",
+      "name": "Dublin Bay North",
       "other_names": [
         {
           "lang": "en",
@@ -29415,6 +29410,34 @@
         {
           "lang": "ga",
           "name": "Cuan Bhaile Átha Cliath Thuas",
+          "note": "multilingual"
+        }
+      ],
+      "type": "constituency"
+    },
+    {
+      "id": "area/dublin_bay_south",
+      "identifiers": [
+        {
+          "identifier": "Q5310822",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "Dublin Bay South",
+      "other_names": [
+        {
+          "lang": "en",
+          "name": "Dublin Bay South",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ga",
+          "name": "Cuan Bhaile Átha Cliath Theas",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh",
+          "name": "都柏林灣南 (愛爾蘭下議院選區)",
           "note": "multilingual"
         }
       ],

--- a/data/Ireland/Dail/sources/reconciliation/areas.csv
+++ b/data/Ireland/Dail/sources/reconciliation/areas.csv
@@ -11,7 +11,7 @@ donegal,Q5295599
 donegal_north_east,Q2566127
 donegal_south_west,Q2669879
 dublin_bay_north,Q5310820
-dublin_bay_south,Q5310820
+dublin_bay_south,Q5310822
 dublin_central,Q2622823
 dublin_fingal,Q20620587
 dublin_mid_west,Q2641881

--- a/data/Ireland/Dail/unstable/stats.json
+++ b/data/Ireland/Dail/unstable/stats.json
@@ -23,7 +23,7 @@
   },
   "areas": {
     "count": 55,
-    "wikidata": 54
+    "wikidata": 55
   },
   "elections": {
     "count": 32,


### PR DESCRIPTION
This was previously mis-assigned to the ID for Dublin Bay North

```
Add memberships from sources/morph/kildare31.csv
Add memberships from sources/morph/kildare32.csv
Merging with sources/morph/twitter-donie.csv
Merging with sources/morph/wikidata.csv
Data Mismatches
* 7 of 233 unmatched
	{:id=>"Q3778169", :name=>"Luke 'Ming' Flanagan"}
	{:id=>"Q13653269", :name=>"Nicky McFadden"}
	{:id=>"Q912430", :name=>"Brian Lenihan, Jnr"}
	{:id=>"Q7147356", :name=>"Patrick Nulty"}
	{:id=>"Q983508", :name=>"Phil Hogan"}
	{:id=>"Q1499408", :name=>"Shane McEntee"}
	{:id=>"Q4963985", :name=>"Brian Hayes"}
Adding GenderBalance results from sources/gender-balance/results.csv
  ⚥ data for 264; 0 added


Top identifiers:
  226 x wikidata
  108 x freebase
  39 x viaf
  7 x lcauth
  7 x sudoc

Creating names.csv
  ☇ No dates for Willie O'Dea (Q1390670) as Minister for Defence
  ☇ No dates for Simon Coveney (Q1670096) as Minister for Agriculture, Food and the Marine
  ☇ No dates for Joe Costello (Q3777446) as Minister of State for Trade and Development
  ☇ No dates for Paul Kehoe (Q3777469) as Minister of State at the Department of the Taoiseach
  ☇ No dates for John Browne (Q3777488) as Minister of State for Fisheries and Forestry
  ☇ No dates for Fergus O'Dowd (Q3777548) as Minister of State for the NewEra Project
  ☇ No dates for Tom Hayes (Q3777584) as Minister of State for Food, Horticulture and Food Safety
  ☇ No dates for Frances Fitzgerald (Q540812) as Minister for Children and Youth Affairs
  ☇ No dates for John Curran (Q6227930) as Minister of State at the Department of the Taoiseach
Persons matched to Wikidata: 226 ✓ 
Parties matched to Wikidata: 13 ✓ | 1 ✘
  No wikidata: Ceann Comhairle (CC)
Areas matched to Wikidata: 55 ✓ 
```