### PR TITLE
AI: remove spurious comma from instructions.json

### DIFF
--- a/data/Anguilla/Assembly/sources/instructions.json
+++ b/data/Anguilla/Assembly/sources/instructions.json
@@ -12,7 +12,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "wikidata/groups.json",


### PR DESCRIPTION
Trailing comma was breaking JSON parsing, this fixes it.

This PR is specific to an error in Anguilla (AI)'s `instructions.json`

Thoughts:

A wee bit surprised a bad instructions file wasn't breaking things earlier, but on reflection it would only matter when upstream data triggers a rebuild, so such errors are effectively local to legislatures. Maybe worth adding JSON linting as well as the (broadly successful imo) CSV linting?