### PR TITLE
Slovenia (National Assembly): add Wikidata for term

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -9058,11 +9058,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Slovenia/National_Assembly/sources",
         "popolo": "data/Slovenia/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/39fc37730e1c437506acc87ac2819b3cb5ce5eed/data/Slovenia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4514a9f43ceb75f62ad82106b434ea686fdd07d6/data/Slovenia/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Slovenia/National_Assembly/names.csv",
-        "lastmod": "1486467133",
+        "lastmod": "1487180327",
         "person_count": 93,
-        "sha": "39fc37730e1c437506acc87ac2819b3cb5ce5eed",
+        "sha": "4514a9f43ceb75f62ad82106b434ea686fdd07d6",
         "legislative_periods": [
           {
             "id": "term/7",
@@ -9073,7 +9073,7 @@
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/96241e2aaf7d04d879e666e93b76d6d5e1e672c7/data/Slovenia/National_Assembly/term-7.csv"
           }
         ],
-        "statement_count": 7389,
+        "statement_count": 7391,
         "type": "lower house"
       }
     ]

--- a/data/Slovenia/National_Assembly/ep-popolo-v1.0.json
+++ b/data/Slovenia/National_Assembly/ep-popolo-v1.0.json
@@ -12998,6 +12998,12 @@
     {
       "classification": "legislative period",
       "id": "term/7",
+      "identifiers": [
+        {
+          "identifier": "Q19932345",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "7th National Assembly",
       "organization_id": "318b4a81-c7a3-4d6c-a3ce-80e08345d86e",
       "start_date": "2014-08-01"

--- a/data/Slovenia/National_Assembly/sources/manual/terms.csv
+++ b/data/Slovenia/National_Assembly/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,source
-7,7th National Assembly,2014-08-01,https://sl.wikipedia.org/wiki/7._dr%C5%BEavni_zbor_Republike_Slovenije
+id,name,start_date,wikidata
+7,7th National Assembly,2014-08-01,Q19932345

--- a/data/Slovenia/National_Assembly/unstable/stats.json
+++ b/data/Slovenia/National_Assembly/unstable/stats.json
@@ -19,7 +19,7 @@
   "terms": {
     "count": 1,
     "latest": "2014-08-01",
-    "wikidata": 0
+    "wikidata": 1
   },
   "areas": {
     "count": 71,


### PR DESCRIPTION
I used quickstatements to connect up all 7 terms, including links to the lists of members.


```
Add memberships from sources/morph/data.csv
Add memberships from sources/manual/memberships.csv
Add memberships from sources/archive/official-ceased.csv
Merging with sources/morph/wikidata.csv
Data Mismatches
* 12 of 46 unmatched
	{:id=>"Q12789041", :name=>"Franc Breznik"}
	{:id=>"Q27929326", :name=>"Matjaž Nemec"}
	{:id=>"Q17117413", :name=>"Miro Cerar"}
	{:id=>"Q12793070", :name=>"Julijana Bizjak Mlakar"}
	{:id=>"Q18627734", :name=>"Margareta Guček Zakošek"}
	{:id=>"Q23418897", :name=>"Andreja Katič"}
	{:id=>"Q27651990", :name=>"Bojan Dobovšek"}
	{:id=>"Q58079", :name=>"Karl Erjavec"}
	{:id=>"Q19932345", :name=>"7. državni zbor Republike Slovenije"}
	{:id=>"Q12787433", :name=>"Dejan Židan"}
Merging with sources/manual/facebook.csv
Merging with sources/manual/twitter.csv
Adding GenderBalance results from sources/gender-balance/results.csv
  ⚥ data for 89; 56 added

Party ZaAB not in Popolo

Top identifiers:
  34 x wikidata
  14 x conor
  6 x freebase
  4 x viaf
  2 x gnd

Creating names.csv
Persons matched to Wikidata: 34 ✓ | 59 ✘
  No wikidata: Marko Ferluga (6da15273-8d67-4196-8741-f7e425c3a529)
  No wikidata: Jan Škoberne (f04e3896-aca9-4199-9d3d-0366b070df99)
  No wikidata: Nada Brinovšek (0d295a47-c43d-4536-9512-1a23829daf3b)
  No wikidata: Mag. Julijana Bizjak Mlakar (66b18b12-3a72-4ebd-ab22-cf0c3dcd58be)
  No wikidata: Mag. Bojan Krajnc (2a4c3376-1a08-47c9-9f02-b8310a820d0e)
  No wikidata: Ivan Prelog (b9e2a89c-1168-47af-8707-62715b78467e)
  No wikidata: Marinka Levičar (345917c5-88b9-4a6a-8b97-46f51de29a0e)
  No wikidata: Marija Bačič (c8b0151e-a19c-44fb-9a2c-51e738d27d0d)
  No wikidata: Mag. Branislav Rajić (bf3064fa-9612-483c-b346-c1e501be1194)
  No wikidata: Vojka Šergan (5d9f1472-c90b-4ca3-8f90-ee26f2378e16)
Parties matched to Wikidata: 7 ✓ | 2 ✘
  No wikidata: Italian and Hungarian National Communities (IMNS)
  No wikidata: of Unaffiliated Deputies (NP)
Areas matched to Wikidata: 0 ✓ | 71 ✘
```