### PR TITLE
Australia (Senate): remove Membership fields from Person source

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -698,11 +698,11 @@
         "slug": "Senate",
         "sources_directory": "data/Australia/Senate/sources",
         "popolo": "data/Australia/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9375cd59255ec5afd9ba3f35d922e3640b421da5/data/Australia/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/adb28a7ed0e7dfd5dc23fc9239047c6690aff812/data/Australia/Senate/ep-popolo-v1.0.json",
         "names": "data/Australia/Senate/names.csv",
         "lastmod": "1487198933",
         "person_count": 257,
-        "sha": "9375cd59255ec5afd9ba3f35d922e3640b421da5",
+        "sha": "adb28a7ed0e7dfd5dc23fc9239047c6690aff812",
         "legislative_periods": [
           {
             "id": "term/45",

--- a/data/Australia/Senate/sources/instructions.json
+++ b/data/Australia/Senate/sources/instructions.json
@@ -15,7 +15,7 @@
       "create": {
         "from": "morph",
         "scraper": "openaustralia/aus_mp_contact_details",
-        "query": "SELECT aph_id AS id, full_name AS name, electorate AS constituency, photo_url AS photo FROM data WHERE house = 'senate' ORDER BY aph_id"
+        "query": "SELECT aph_id AS id, full_name AS name, photo_url AS photo FROM data WHERE house = 'senate' ORDER BY aph_id"
       },
       "merge": {
         "incoming_field": "id",

--- a/data/Australia/Senate/sources/morph/contacts.csv
+++ b/data/Australia/Senate/sources/morph/contacts.csv
@@ -1,109 +1,109 @@
-id,name,constituency,photo
-008W7,Senator the Hon George Brandis QC,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/008W7/upload_ref_binary/008W7.jpg
-00AOL,Senator the Hon Richard Colbeck,Tasmania,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/00AOL/upload_ref_binary/00AOL.JPG
-00AOM,Senator the Hon Nigel Scullion,Northern Territory,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/00AOM/upload_ref_binary/00AOM.JPG
-00AON,Senator the Hon David Johnston,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/00AON/upload_ref_binary/00AON.JPG
-00AOP,Senator Gavin Marshall,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/00AOP/upload_ref_binary/00AOP.jpg
-00AOQ,Senator Claire Moore,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/00AOQ/upload_ref_binary/00AOQ.JPG
-00AOS,Senator the Hon Ursula Stephens,New South Wales,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/00AOS/upload_ref_binary/00AOS.jpg
-00AOU,Senator the Hon Penny Wong,South Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/00AOU/upload_ref_binary/00AOU.jpg
-108616,Senator Glenn Lazarus,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/108616/upload_ref_binary/108616.jpg
-111206,Senator David Leyonhjelm,New South Wales,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/111206/upload_ref_binary/111206.jpg
-112096,Senator Sue Lines,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/112096/upload_ref_binary/112096.jpg
-121628,Senator Jenny McAllister,New South Wales,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/121628/upload_ref_binary/121628.jpg
-122087,Senator Malarndirri McCarthy,Northern Territory,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/122087/upload_ref_binary/122087.jpg
-140651,Senator Deborah O'Neill,New South Wales,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/140651/upload_ref_binary/140651.jpg
-144138,Senator James Paterson,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/144138/upload_ref_binary/144138.jpg
-155410,Senator Janet Rice,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/155410/upload_ref_binary/155410.jpg
-170166,Senator Robert Simms,South Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/170166/upload_ref_binary/170166.jpg
-183342,Senator the Hon Lin Thorp,Tasmania,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/183342/upload_ref_binary/183342.jpg
-192970,Senator Larissa Waters,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/192970/upload_ref_binary/192970.jpg
-195565,Senator Peter Whish-Wilson,Tasmania,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/195565/upload_ref_binary/195565.jpg
-200287,Senator Penny Wright,South Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/200287/upload_ref_binary/200287.jpg
-204953,Senator Alex Gallacher,South Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/204953/upload_ref_binary/204953.jpg
-207807,Senator Brian Burston,New South Wales,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/207807/upload_ref_binary/207807.jpg
-207825,Senator Bridget McKenzie,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/207825/upload_ref_binary/207825.jpg
-217241,Senator the Hon James McGrath,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/217241/upload_ref_binary/217241.jpg
-217571,Senator John Madigan,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/217571/upload_ref_binary/217571.jpg
-225099,Senator Sam Dastyari,New South Wales,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/225099/upload_ref_binary/225099.jpg
-225307,Senator Sean Edwards,South Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/225307/upload_ref_binary/225307.jpg
-231199,Senator Anne Urquhart,Tasmania,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/231199/upload_ref_binary/231199.jpg
-241710,Senator Dean Smith,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/241710/upload_ref_binary/241710.jpg
-243237,Senator Joe Bullock,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/243237/upload_ref_binary/243237.jpg
-243273,Senator the Hon Anne Ruston,South Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/243273/upload_ref_binary/243273.jpg
-244247,Senator Chris Ketter,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/244247/upload_ref_binary/244247.jpg
-245212,Senator the Hon Matthew Canavan,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/245212/upload_ref_binary/245212.jpg
-245759,Senator Murray Watt,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/245759/upload_ref_binary/245759.jpg
-247512,Senator Kimberley Kitching,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/247512/upload_ref_binary/247512.jpg
-247871,Senator Barry O'Sullivan,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/247871/upload_ref_binary/247871.jpg
-249499,Senator Mehmet Tillem,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/249499/upload_ref_binary/249499.jpg
-250024,Senator Ricky Muir,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/250024/upload_ref_binary/250024.jpg
-250026,Senator Jacqui Lambie,Tasmania,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/250026/upload_ref_binary/250026.jpg
-250045,Senator Zhenya Wang,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/250045/upload_ref_binary/250045.jpg
-250216,Senator Linda Reynolds CSC,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/250216/upload_ref_binary/250216.jpg
-258337,Senator Joanna Lindgren,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/258337/upload_ref_binary/258337.jpg
-263418,Senator Jonathon Duniam,Tasmania,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/263418/upload_ref_binary/263418.jpg
-265982,Senator Skye Kakoschke-Moore,South Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/265982/upload_ref_binary/265982.jpg
-266482,Senator Rod Culleton,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/266482/upload_ref_binary/266482.jpg
-266499,Senator Jane Hume,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/266499/upload_ref_binary/266499.jpg
-266524,Senator Malcolm Roberts,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/266524/upload_ref_binary/266524.jpg
-2L6,Senator Mark Bishop,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/2L6/upload_ref_binary/2L6.jpg
-2O4,Senator Derryn Hinch,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/2O4/upload_ref_binary/2O4.jpg
-39801,Senator Anthony Chisholm,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/39801/upload_ref_binary/39801.jpg
-3L6,Senator the Hon Stephen Conroy,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/3L6/upload_ref_binary/3L6.jpg
-4L6,Senator Alan Eggleston,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/4L6/upload_ref_binary/4L6.JPG
-53369,Senator Richard Di Natale,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/53369/upload_ref_binary/53369.jpg
-5K4,Senator the Hon John Faulkner,New South Wales,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/5K4/upload_ref_binary/5K4.jpg
-76760,Senator Stirling Griff,South Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/76760/upload_ref_binary/76760.jpg
-7G6,Senator the Hon Kate Lundy,Australian Capital Territory,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/7G6/upload_ref_binary/7G6.JPG
-7L6,Senator the Hon John Hogg,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/7L6/upload_ref_binary/7L6.JPG
-84L,Senator the Hon Jan McLucas,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/84L/upload_ref_binary/84L.JPG
-84M,Senator the Hon Brett Mason,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/84M/upload_ref_binary/84M.JPG
-84N,Senator the Hon Joseph Ludwig,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/84N/upload_ref_binary/84N.jpg
-8IV,Senator Nick Xenophon,South Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/8IV/upload_ref_binary/8IV.JPG
-AI6,Senator the Hon Doug Cameron,New South Wales,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/AI6/upload_ref_binary/AI6.JPG
-AW5,Senator the Hon Kim Carr,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/AW5/upload_ref_binary/AW5.JPG
-BK6,Senator Pauline Hanson,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/BK6/upload_ref_binary/BK6.jpg
-C16,Senator the Hon Bill Heffernan,New South Wales,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/C16/upload_ref_binary/C16.jpg
-CDK,Senator Nova Peris OAM,Northern Territory,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/CDK/upload_ref_binary/CDK.jpg
-CPR,Senator Lee Rhiannon,New South Wales,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/CPR/upload_ref_binary/cpr.jpg
-D2I,Senator the Hon Mitch Fifield,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/D2I/upload_ref_binary/D2I.JPG
-DYU,Senator David Fawcett,South Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/DYU/upload_ref_binary/DYU.jpg
-F49,Senator Carol Brown,Tasmania,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/F49/upload_ref_binary/F49.JPG
-G0D,Senator Cory Bernardi,South Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/G0D/upload_ref_binary/G0D.JPG
-G1N,Senator Helen Kroger,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/G1N/upload_ref_binary/G1N.JPG
-GB6,Senator the Hon Jacinta Collins,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/GB6/upload_ref_binary/GB6.JPG
-H6V,Senator Sue Boyce,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/H6V/upload_ref_binary/H6V.jpg
-H6X,Senator the Hon Simon Birmingham,South Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/H6X/upload_ref_binary/H6X.jpg
-HDA,Senator the Hon Mathias Cormann,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/HDA/upload_ref_binary/HDA.jpg
-HLL,Senator David Bushby,Tasmania,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/HLL/upload_ref_binary/HLL.jpg
-HYG,Senator Bob Day AO,South Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/HYG/upload_ref_binary/HYG.jpg
-HZB,Senator Catryna Bilyk,Tasmania,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/HZB/upload_ref_binary/HZB.JPG
-HZE,Senator Zed Seselja,Australian Capital Territory,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/HZE/upload_ref_binary/HZE.jpg
-I07,Senator Scott Ludlam,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/I07/upload_ref_binary/I07.JPG
-I0M,Senator the Hon Michaelia Cash,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/I0M/upload_ref_binary/I0M.jpg
-I0N,Senator the Hon Don Farrell,South Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/I0N/upload_ref_binary/I0N.jpg
-I0P,Senator Mark Furner,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/I0P/upload_ref_binary/I0P.JPG
-I0Q,Senator the Hon Scott Ryan,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/I0Q/upload_ref_binary/I0Q.JPG
-I0T,Senator Louise Pratt,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/I0T/upload_ref_binary/I0T.jpg
-I0U,Senator Sarah Hanson-Young,South Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/I0U/upload_ref_binary/I0U.JPG
-I0V,Senator John Williams,New South Wales,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/I0V/upload_ref_binary/I0V.JPG
-ING,Senator Katy Gallagher,Australian Capital Territory,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/ING/upload_ref_binary/ING.jpg
-J7Q,Senator Chris Back,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/J7Q/upload_ref_binary/J7Q.JPG
-JKM,Senator Nick McKim,Tasmania,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/JKM/upload_ref_binary/JKM.jpg
-M0R,Senator the Hon Lisa Singh,Tasmania,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/M0R/upload_ref_binary/m0r.jpg
-M56,Senator the Hon Marise Payne,New South Wales,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/M56/upload_ref_binary/M56.JPG
-N26,Senator the Hon Eric Abetz,Tasmania,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/N26/upload_ref_binary/N26.jpg
-SR5,Senator Patrick Dodson,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/SR5/upload_ref_binary/SR5.jpg
-YE4,Senator the Hon Ronald Boswell,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/YE4/upload_ref_binary/YE4.JPG
-YW4,Senator the Hon Ian Macdonald,Queensland,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/YW4/upload_ref_binary/YW4.JPG
-bv7,Senator the Hon Arthur Sinodinos AO,New South Wales,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/BV7/upload_ref_binary/BV7.jpg
-e4t,Senator the Hon Concetta Fierravanti-Wells,New South Wales,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/E4T/upload_ref_binary/E4T.jpg
-e5e,Senator Anne McEwen,South Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/E5E/upload_ref_binary/E5E.jpg
-e5g,Senator the Hon Fiona Nash,New South Wales,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/E5G/upload_ref_binary/E5G.jpg
-e5v,Senator the Hon Stephen Parry,Tasmania,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/E5V/upload_ref_binary/E5V.JPG
-e5x,Senator Helen Polley,Tasmania,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/E5X/upload_ref_binary/E5X.JPG
-e5z,Senator Rachel Siewert,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/E5Z/upload_ref_binary/E5Z.JPG
-e68,Senator Glenn Sterle,Western Australia,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/E68/upload_ref_binary/E68.JPG
-ka5,Senator Christine Milne,Tasmania,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/KA5/upload_ref_binary/KA5.JPG
-xt4,Senator the Hon Michael Ronaldson,Victoria,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/XT4/upload_ref_binary/XT4.JPG
+id,name,photo
+008W7,Senator the Hon George Brandis QC,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/008W7/upload_ref_binary/008W7.jpg
+00AOL,Senator the Hon Richard Colbeck,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/00AOL/upload_ref_binary/00AOL.JPG
+00AOM,Senator the Hon Nigel Scullion,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/00AOM/upload_ref_binary/00AOM.JPG
+00AON,Senator the Hon David Johnston,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/00AON/upload_ref_binary/00AON.JPG
+00AOP,Senator Gavin Marshall,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/00AOP/upload_ref_binary/00AOP.jpg
+00AOQ,Senator Claire Moore,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/00AOQ/upload_ref_binary/00AOQ.JPG
+00AOS,Senator the Hon Ursula Stephens,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/00AOS/upload_ref_binary/00AOS.jpg
+00AOU,Senator the Hon Penny Wong,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/00AOU/upload_ref_binary/00AOU.jpg
+108616,Senator Glenn Lazarus,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/108616/upload_ref_binary/108616.jpg
+111206,Senator David Leyonhjelm,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/111206/upload_ref_binary/111206.jpg
+112096,Senator Sue Lines,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/112096/upload_ref_binary/112096.jpg
+121628,Senator Jenny McAllister,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/121628/upload_ref_binary/121628.jpg
+122087,Senator Malarndirri McCarthy,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/122087/upload_ref_binary/122087.jpg
+140651,Senator Deborah O'Neill,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/140651/upload_ref_binary/140651.jpg
+144138,Senator James Paterson,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/144138/upload_ref_binary/144138.jpg
+155410,Senator Janet Rice,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/155410/upload_ref_binary/155410.jpg
+170166,Senator Robert Simms,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/170166/upload_ref_binary/170166.jpg
+183342,Senator the Hon Lin Thorp,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/183342/upload_ref_binary/183342.jpg
+192970,Senator Larissa Waters,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/192970/upload_ref_binary/192970.jpg
+195565,Senator Peter Whish-Wilson,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/195565/upload_ref_binary/195565.jpg
+200287,Senator Penny Wright,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/200287/upload_ref_binary/200287.jpg
+204953,Senator Alex Gallacher,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/204953/upload_ref_binary/204953.jpg
+207807,Senator Brian Burston,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/207807/upload_ref_binary/207807.jpg
+207825,Senator Bridget McKenzie,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/207825/upload_ref_binary/207825.jpg
+217241,Senator the Hon James McGrath,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/217241/upload_ref_binary/217241.jpg
+217571,Senator John Madigan,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/217571/upload_ref_binary/217571.jpg
+225099,Senator Sam Dastyari,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/225099/upload_ref_binary/225099.jpg
+225307,Senator Sean Edwards,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/225307/upload_ref_binary/225307.jpg
+231199,Senator Anne Urquhart,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/231199/upload_ref_binary/231199.jpg
+241710,Senator Dean Smith,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/241710/upload_ref_binary/241710.jpg
+243237,Senator Joe Bullock,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/243237/upload_ref_binary/243237.jpg
+243273,Senator the Hon Anne Ruston,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/243273/upload_ref_binary/243273.jpg
+244247,Senator Chris Ketter,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/244247/upload_ref_binary/244247.jpg
+245212,Senator the Hon Matthew Canavan,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/245212/upload_ref_binary/245212.jpg
+245759,Senator Murray Watt,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/245759/upload_ref_binary/245759.jpg
+247512,Senator Kimberley Kitching,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/247512/upload_ref_binary/247512.jpg
+247871,Senator Barry O'Sullivan,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/247871/upload_ref_binary/247871.jpg
+249499,Senator Mehmet Tillem,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/249499/upload_ref_binary/249499.jpg
+250024,Senator Ricky Muir,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/250024/upload_ref_binary/250024.jpg
+250026,Senator Jacqui Lambie,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/250026/upload_ref_binary/250026.jpg
+250045,Senator Zhenya Wang,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/250045/upload_ref_binary/250045.jpg
+250216,Senator Linda Reynolds CSC,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/250216/upload_ref_binary/250216.jpg
+258337,Senator Joanna Lindgren,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/258337/upload_ref_binary/258337.jpg
+263418,Senator Jonathon Duniam,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/263418/upload_ref_binary/263418.jpg
+265982,Senator Skye Kakoschke-Moore,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/265982/upload_ref_binary/265982.jpg
+266482,Senator Rod Culleton,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/266482/upload_ref_binary/266482.jpg
+266499,Senator Jane Hume,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/266499/upload_ref_binary/266499.jpg
+266524,Senator Malcolm Roberts,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/266524/upload_ref_binary/266524.jpg
+2L6,Senator Mark Bishop,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/2L6/upload_ref_binary/2L6.jpg
+2O4,Senator Derryn Hinch,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/2O4/upload_ref_binary/2O4.jpg
+39801,Senator Anthony Chisholm,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/39801/upload_ref_binary/39801.jpg
+3L6,Senator the Hon Stephen Conroy,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/3L6/upload_ref_binary/3L6.jpg
+4L6,Senator Alan Eggleston,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/4L6/upload_ref_binary/4L6.JPG
+53369,Senator Richard Di Natale,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/53369/upload_ref_binary/53369.jpg
+5K4,Senator the Hon John Faulkner,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/5K4/upload_ref_binary/5K4.jpg
+76760,Senator Stirling Griff,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/76760/upload_ref_binary/76760.jpg
+7G6,Senator the Hon Kate Lundy,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/7G6/upload_ref_binary/7G6.JPG
+7L6,Senator the Hon John Hogg,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/7L6/upload_ref_binary/7L6.JPG
+84L,Senator the Hon Jan McLucas,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/84L/upload_ref_binary/84L.JPG
+84M,Senator the Hon Brett Mason,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/84M/upload_ref_binary/84M.JPG
+84N,Senator the Hon Joseph Ludwig,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/84N/upload_ref_binary/84N.jpg
+8IV,Senator Nick Xenophon,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/8IV/upload_ref_binary/8IV.JPG
+AI6,Senator the Hon Doug Cameron,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/AI6/upload_ref_binary/AI6.JPG
+AW5,Senator the Hon Kim Carr,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/AW5/upload_ref_binary/AW5.JPG
+BK6,Senator Pauline Hanson,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/BK6/upload_ref_binary/BK6.jpg
+C16,Senator the Hon Bill Heffernan,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/C16/upload_ref_binary/C16.jpg
+CDK,Senator Nova Peris OAM,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/CDK/upload_ref_binary/CDK.jpg
+CPR,Senator Lee Rhiannon,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/CPR/upload_ref_binary/cpr.jpg
+D2I,Senator the Hon Mitch Fifield,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/D2I/upload_ref_binary/D2I.JPG
+DYU,Senator David Fawcett,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/DYU/upload_ref_binary/DYU.jpg
+F49,Senator Carol Brown,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/F49/upload_ref_binary/F49.JPG
+G0D,Senator Cory Bernardi,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/G0D/upload_ref_binary/G0D.JPG
+G1N,Senator Helen Kroger,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/G1N/upload_ref_binary/G1N.JPG
+GB6,Senator the Hon Jacinta Collins,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/GB6/upload_ref_binary/GB6.JPG
+H6V,Senator Sue Boyce,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/H6V/upload_ref_binary/H6V.jpg
+H6X,Senator the Hon Simon Birmingham,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/H6X/upload_ref_binary/H6X.jpg
+HDA,Senator the Hon Mathias Cormann,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/HDA/upload_ref_binary/HDA.jpg
+HLL,Senator David Bushby,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/HLL/upload_ref_binary/HLL.jpg
+HYG,Senator Bob Day AO,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/HYG/upload_ref_binary/HYG.jpg
+HZB,Senator Catryna Bilyk,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/HZB/upload_ref_binary/HZB.JPG
+HZE,Senator Zed Seselja,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/HZE/upload_ref_binary/HZE.jpg
+I07,Senator Scott Ludlam,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/I07/upload_ref_binary/I07.JPG
+I0M,Senator the Hon Michaelia Cash,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/I0M/upload_ref_binary/I0M.jpg
+I0N,Senator the Hon Don Farrell,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/I0N/upload_ref_binary/I0N.jpg
+I0P,Senator Mark Furner,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/I0P/upload_ref_binary/I0P.JPG
+I0Q,Senator the Hon Scott Ryan,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/I0Q/upload_ref_binary/I0Q.JPG
+I0T,Senator Louise Pratt,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/I0T/upload_ref_binary/I0T.jpg
+I0U,Senator Sarah Hanson-Young,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/I0U/upload_ref_binary/I0U.JPG
+I0V,Senator John Williams,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/I0V/upload_ref_binary/I0V.JPG
+ING,Senator Katy Gallagher,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/ING/upload_ref_binary/ING.jpg
+J7Q,Senator Chris Back,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/J7Q/upload_ref_binary/J7Q.JPG
+JKM,Senator Nick McKim,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/JKM/upload_ref_binary/JKM.jpg
+M0R,Senator the Hon Lisa Singh,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/M0R/upload_ref_binary/m0r.jpg
+M56,Senator the Hon Marise Payne,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/M56/upload_ref_binary/M56.JPG
+N26,Senator the Hon Eric Abetz,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/N26/upload_ref_binary/N26.jpg
+SR5,Senator Patrick Dodson,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/SR5/upload_ref_binary/SR5.jpg
+YE4,Senator the Hon Ronald Boswell,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/YE4/upload_ref_binary/YE4.JPG
+YW4,Senator the Hon Ian Macdonald,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/YW4/upload_ref_binary/YW4.JPG
+bv7,Senator the Hon Arthur Sinodinos AO,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/BV7/upload_ref_binary/BV7.jpg
+e4t,Senator the Hon Concetta Fierravanti-Wells,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/E4T/upload_ref_binary/E4T.jpg
+e5e,Senator Anne McEwen,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/E5E/upload_ref_binary/E5E.jpg
+e5g,Senator the Hon Fiona Nash,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/E5G/upload_ref_binary/E5G.jpg
+e5v,Senator the Hon Stephen Parry,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/E5V/upload_ref_binary/E5V.JPG
+e5x,Senator Helen Polley,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/E5X/upload_ref_binary/E5X.JPG
+e5z,Senator Rachel Siewert,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/E5Z/upload_ref_binary/E5Z.JPG
+e68,Senator Glenn Sterle,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/E68/upload_ref_binary/E68.JPG
+ka5,Senator Christine Milne,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/KA5/upload_ref_binary/KA5.JPG
+xt4,Senator the Hon Michael Ronaldson,http://parlinfo.aph.gov.au/parlInfo/download/handbook/allmps/XT4/upload_ref_binary/XT4.JPG


### PR DESCRIPTION
When building Person + Membership information, we need to be very careful
not to include "Membership"-type data (party, constituency, term, start/end
date) from any Person source, as that will get merged into every membership
that the Person has had. This appears safe if there's only a single term,
and no-one changes party or area during that, but the instant someone has a
second membership, bad things start to happen.

Part of https://github.com/everypolitician/everypolitician/issues/589