### PR TITLE
Belgium (Representatives): remove Membership fields from Person source

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -1055,11 +1055,11 @@
         "slug": "Representatives",
         "sources_directory": "data/Belgium/Representatives/sources",
         "popolo": "data/Belgium/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f8bb7e919d115f7644cedd4f468c4dfa0a870db3/data/Belgium/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/342ffec93785203fa12b08c97636b26a17e5bd1f/data/Belgium/Representatives/ep-popolo-v1.0.json",
         "names": "data/Belgium/Representatives/names.csv",
         "lastmod": "1487544605",
         "person_count": 170,
-        "sha": "f8bb7e919d115f7644cedd4f468c4dfa0a870db3",
+        "sha": "342ffec93785203fa12b08c97636b26a17e5bd1f",
         "legislative_periods": [
           {
             "id": "term/54",

--- a/data/Belgium/Representatives/sources/instructions.json
+++ b/data/Belgium/Representatives/sources/instructions.json
@@ -15,7 +15,7 @@
       "create": {
         "from": "morph",
         "scraper": "tmtmtmtm/belgium-lachambre",
-        "query": "SELECT * FROM data ORDER BY id"
+        "query": "SELECT id, name, sort_name, email, website, image FROM data ORDER BY id"
       },
       "source": "http://www.lachambre.be/",
       "type": "person",

--- a/data/Belgium/Representatives/sources/morph/official.csv
+++ b/data/Belgium/Representatives/sources/morph/official.csv
@@ -1,170 +1,170 @@
-id,sort_name,party,email,website,term,name,image,source
-00090,Van Rompuy Eric,,eric.vanrompuy@dekamer.be,http://www.ericvanrompuy.be,54,Eric Van Rompuy,http://www.lachambre.be/site/wwwroot/images/cv/00090.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00090&lactivity=54
-00124,Dewael Patrick,,patrick.dewael@dekamer.be,http://www.dewael.nu,54,Patrick Dewael,http://www.lachambre.be/site/wwwroot/images/cv/00124.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00124&lactivity=54
-00439,Di Rupo Elio,,elio.dirupo@lachambre.be,"",54,Elio Di Rupo,http://www.lachambre.be/site/wwwroot/images/cv/00439.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00439&lactivity=54
-00454,Van Mechelen Dirk,,dirk.vanmechelen@dekamer.be,http://www.dirkvanmechelen.com,54,Dirk Van Mechelen,http://www.lachambre.be/site/wwwroot/images/cv/00454.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00454&lactivity=54
-00472,Dewinter Filip,,filip.dewinter@dekamer.be,http://www.fdw.nu,54,Filip Dewinter,http://www.lachambre.be/site/wwwroot/images/cv/00472.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00472&lactivity=54
-00476,Onkelinx Laurette,,laurette.onkelinx@lachambre.be,"",54,Laurette Onkelinx,http://www.lachambre.be/site/wwwroot/images/cv/00476.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00476&lactivity=54
-00565,Van der Maelen Dirk,,dirk.vandermaelen@dekamer.be,http://www.dirkvandermaelen.be,54,Dirk Van der Maelen,http://www.lachambre.be/site/wwwroot/images/cv/00565.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00565&lactivity=54
-00623,Cheron Marcel,,marcel.cheron@lachambre.be,"",54,Marcel Cheron,http://www.lachambre.be/site/wwwroot/images/cv/00623.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00623&lactivity=54
-00657,Vande Lanotte Johan,,johan.vandelanotte@dekamer.be,"",54,Johan Vande Lanotte,http://www.lachambre.be/site/wwwroot/images/cv/657.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00657&lactivity=54
-00682,Maingain Olivier,,olivier.maingain@lachambre.be,http://www.defi.be/,54,Olivier Maingain,http://www.lachambre.be/site/wwwroot/images/cv/00682.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00682&lactivity=54
-00742,Reynders Didier,,didier.reynders@lachambre.be,http://www.didier-reynders.be,54,Didier Reynders,http://www.lachambre.be/site/wwwroot/images/cv/742.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00742&lactivity=54
-00746,Delizée Jean-Marc,,jean-marc.delizee@lachambre.be,http://www.delizee.eu,54,Jean-Marc Delizée,http://www.lachambre.be/site/wwwroot/images/cv/00746.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00746&lactivity=54
-00757,Bacquelaine Daniel,,daniel.bacquelaine@lachambre.be,http://www.bacquelaine.be,54,Daniel Bacquelaine,http://www.lachambre.be/site/wwwroot/images/cv/757.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00757&lactivity=54
-00761,Flahaut André,,andre.flahaut@lachambre.be,"",54,André Flahaut,http://www.lachambre.be/site/wwwroot/images/cv/761.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00761&lactivity=54
-00795,De Crem Pieter,,pieter.DeCrem@dekamer.be,http://www.pieterdecrem.be,54,Pieter De Crem,http://www.lachambre.be/site/wwwroot/images/cv/795.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00795&lactivity=54
-00826,Verherstraeten Servais,,servais.verherstraeten@dekamer.be,http://www.servais.verherstraeten.cdenv.be,54,Servais Verherstraeten,http://www.lachambre.be/site/wwwroot/images/cv/00826.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00826&lactivity=54
-00837,Bonte Hans,,hans.bonte@dekamer.be,"",54,Hans Bonte,http://www.lachambre.be/site/wwwroot/images/cv/00837.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00837&lactivity=54
-00889,Frédéric André,,andre.frederic@lachambre.be,http://www.andrefrederic.be,54,André Frédéric,http://www.lachambre.be/site/wwwroot/images/cv/00889.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00889&lactivity=54
-00895,De Block Maggie,,maggie.deblock@dekamer.be,http://www.maggiedeblock.be,54,Maggie De Block,http://www.lachambre.be/site/wwwroot/images/cv/895.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00895&lactivity=54
-00906,Chastel Olivier,,olivier.chastel@lachambre.be,http://chastel.org,54,Olivier Chastel,http://www.lachambre.be/site/wwwroot/images/cv/00906.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00906&lactivity=54
-00909,Michel Charles,,charles.michel@lachambre.be,"",54,Charles Michel,http://www.lachambre.be/site/wwwroot/images/cv/909.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00909&lactivity=54
-00917,Vanvelthoven Peter,,peter.vanvelthoven@dekamer.be,http://www.petervanvelthoven.be,54,Peter Vanvelthoven,http://www.lachambre.be/site/wwwroot/images/cv/00917.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00917&lactivity=54
-00946,Gerkens Muriel,,muriel.gerkens@lachambre.be,http://www.murielgerkens.be,54,Muriel Gerkens,http://www.lachambre.be/site/wwwroot/images/cv/00946.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00946&lactivity=54
-00951,Dallemagne Georges,,georges.dallemagne@lachambre.be,http://www.georgesdallemagne.be,54,Georges Dallemagne,http://www.lachambre.be/site/wwwroot/images/cv/951.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00951&lactivity=54
-00972,Van Quickenborne Vincent,,vincent.vanquickenborne@dekamer.be,http://www.vincentvq.be,54,Vincent Van Quickenborne,http://www.lachambre.be/site/wwwroot/images/cv/00972.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00972&lactivity=54
-00988,Lalieux Karine,,karine.lalieux@lachambre.be,http://www.karinelalieux.be,54,Karine Lalieux,http://www.lachambre.be/site/wwwroot/images/cv/00988.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=00988&lactivity=54
-01002,Pehlivan Fatma,,fatma.pehlivan@dekamer.be,"",54,Fatma Pehlivan,http://www.lachambre.be/site/wwwroot/images/cv/01002.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01002&lactivity=54
-01016,Nollet Jean-Marc,,jean-marc.nollet@lachambre.be,http://www.nollet.info,54,Jean-Marc Nollet,http://www.lachambre.be/site/wwwroot/images/cv/01016.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01016&lactivity=54
-01030,Deseyn Roel,,roel.deseyn@dekamer.be,http://www.roeldeseyn.be,54,Roel Deseyn,http://www.lachambre.be/site/wwwroot/images/cv/01030.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01030&lactivity=54
-01032,Lahaye-Battheu Sabien,,sabien.battheu@dekamer.be,http://www.sabien-lahaye-battheu.be,54,Sabien Lahaye-Battheu,http://www.lachambre.be/site/wwwroot/images/cv/01032.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01032&lactivity=54
-01039,Bogaert Hendrik,,hendrik.bogaert@dekamer.be,http://www.hendrikbogaert.be,54,Hendrik Bogaert,http://www.lachambre.be/site/wwwroot/images/cv/01039.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01039&lactivity=54
-01042,Lanjri Nahima,,nahima.lanjri@dekamer.be,http://www.nahima.be,54,Nahima Lanjri,http://www.lachambre.be/site/wwwroot/images/cv/01042.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01042&lactivity=54
-01050,Massin Eric,,eric.massin@lachambre.be,"",54,Eric Massin,http://www.lachambre.be/site/wwwroot/images/cv/01050.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01050&lactivity=54
-01051,Mathot Alain,,alain.mathot@lachambre.be,http://www.alainmathot.be,54,Alain Mathot,http://www.lachambre.be/site/wwwroot/images/cv/01051.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01051&lactivity=54
-01056,Ducarme Denis,,denis.ducarme@lachambre.be,http://www.denisducarme.net,54,Denis Ducarme,http://www.lachambre.be/site/wwwroot/images/cv/01056.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01056&lactivity=54
-01059,Marghem Marie-Christine,,mariechristine.marghem@lachambre.be,http://www.marghem.be,54,Marie-Christine Marghem,http://www.lachambre.be/site/wwwroot/images/cv/1059.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01059&lactivity=54
-01067,Detiège Maya,,maya.detiege@dekamer.be,http://www.mayadetiege.be,54,Maya Detiège,http://www.lachambre.be/site/wwwroot/images/cv/01067.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01067&lactivity=54
-01070,Jiroflée Karin,,karin.jiroflee@dekamer.be,http://www.karinjiroflee.be,54,Karin Jiroflée,http://www.lachambre.be/site/wwwroot/images/cv/01070.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01070&lactivity=54
-01076,Fonck Catherine,,catherine.fonck@lachambre.be,"",54,Catherine Fonck,http://www.lachambre.be/site/wwwroot/images/cv/01076.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01076&lactivity=54
-01079,Wathelet Melchior,,melchior.wathelet@lachambre.be,http://www.melchiorwathelet.be,54,Melchior Wathelet,http://www.lachambre.be/site/wwwroot/images/cv/1079.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01079&lactivity=54
-01083,Schepmans Françoise,,francoise.schepmans@lachambre.be,http://www.schepmans.be,54,Françoise Schepmans,http://www.lachambre.be/site/wwwroot/images/cv/01083.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01083&lactivity=54
-01094,Brotcorne Christian,,christian.brotcorne@lachambre.be,http://www.brotcorne.be,54,Christian Brotcorne,http://www.lachambre.be/site/wwwroot/images/cv/01094.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01094&lactivity=54
-01102,Turtelboom Annemie,,annemie.turtelboom@dekamer.be,http://www.annemieturtelboom.be,54,Annemie Turtelboom,http://www.lachambre.be/site/wwwroot/images/cv/01102.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01102&lactivity=54
-01123,Gustin Luc,,luc.gustin@lachambre.be,"",54,Luc Gustin,http://www.lachambre.be/site/wwwroot/images/cv/1123.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01123&lactivity=54
-01127,Geerts David,,david.geerts@dekamer.be,http://www.davidgeerts.be,54,David Geerts,http://www.lachambre.be/site/wwwroot/images/cv/01127.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01127&lactivity=54
-01130,Muylle Nathalie,,nathalie.muylle@dekamer.be,http://www.nathalie.muylle.cdenv.be,54,Nathalie Muylle,http://www.lachambre.be/site/wwwroot/images/cv/01130.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01130&lactivity=54
-01131,Van den Bergh Jef,,jef.vandenbergh@dekamer.be,http://www.jefvandenbergh.be,54,Jef Van den Bergh,http://www.lachambre.be/site/wwwroot/images/cv/01131.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01131&lactivity=54
-01134,Delpérée Francis,,francis.delperee@lachambre.be,http://www.delperee.be,54,Francis Delpérée,http://www.lachambre.be/site/wwwroot/images/cv/01134.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01134&lactivity=54
-01139,Van Biesen Luk,,luk.vanbiesen@dekamer.be,http://www.lukvanbiesen.be,54,Luk Van Biesen,http://www.lachambre.be/site/wwwroot/images/cv/01139.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01139&lactivity=54
-01145,Lutgen Benoît,,benoit.lutgen@lachambre.be,"",54,Benoît Lutgen,http://www.lachambre.be/site/wwwroot/images/cv/01145.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01145&lactivity=54
-01149,Beke Wouter,,wouter.beke@dekamer.be,http://www.wouterbeke.be,54,Wouter Beke,http://www.lachambre.be/site/wwwroot/images/cv/01149.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01149&lactivity=54
-01179,Lijnen Nele,,nele.lijnen@dekamer.be,http://www.nelelijnen.be,54,Nele Lijnen,http://www.lachambre.be/site/wwwroot/images/cv/01179.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01179&lactivity=54
-01183,De Coninck Monica,,monica.deconinck@dekamer.be,"",54,Monica De Coninck,http://www.lachambre.be/site/wwwroot/images/cv/01183.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01183&lactivity=54
-01189,Almaci Meyrem,,meyrem.almaci@dekamer.be,http://www.meyremalmaci.be,54,Meyrem Almaci,http://www.lachambre.be/site/wwwroot/images/cv/01189.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01189&lactivity=54
-01190,Becq Sonja,,sonja.becq@dekamer.be,http://www.sonjabecq.be,54,Sonja Becq,http://www.lachambre.be/site/wwwroot/images/cv/01190.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01190&lactivity=54
-01199,De Vriendt Wouter,,wouter.de.vriendt@dekamer.be,http://www.wouterdevriendt.be,54,Wouter De Vriendt,http://www.lachambre.be/site/wwwroot/images/cv/01199.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01199&lactivity=54
-01200,De Wever Bart,,bart.dewever@dekamer.be,"",54,Bart De Wever,http://www.lachambre.be/site/wwwroot/images/cv/01200.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01200&lactivity=54
-01201,Dierick Leen,,leen.dierick@dekamer.be,"",54,Leen Dierick,http://www.lachambre.be/site/wwwroot/images/cv/01201.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01201&lactivity=54
-01203,Flahaux Jean-Jacques,,jean-jacques.flahaux@lachambre.be,http://www.flahaux.be,54,Jean-Jacques Flahaux,http://www.lachambre.be/site/wwwroot/images/cv/01203.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01203&lactivity=54
-01205,Gilkinet Georges,,georges.gilkinet@lachambre.be,"",54,Georges Gilkinet,http://www.lachambre.be/site/wwwroot/images/cv/01205.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01205&lactivity=54
-01207,Jadin Kattrin,,kattrin.jadin@lachambre.be,http://www.jadin.be,54,Kattrin Jadin,http://www.lachambre.be/site/wwwroot/images/cv/01207.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01207&lactivity=54
-01209,Kitir Meryame,,meryame.kitir@dekamer.be,http://www.kitir.be,54,Meryame Kitir,http://www.lachambre.be/site/wwwroot/images/cv/01209.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01209&lactivity=54
-01219,Smeyers Sarah,,sarah.smeyers@dekamer.be,http://www.sarahsmeyers.be,54,Sarah Smeyers,http://www.lachambre.be/site/wwwroot/images/cv/01219.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01219&lactivity=54
-01222,Thiébaut Eric,,eric.thiebaut@lachambre.be,http://www.ericthiebaut.be,54,Eric Thiébaut,http://www.lachambre.be/site/wwwroot/images/cv/01222.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01222&lactivity=54
-01227,Van Hecke Stefaan,,stefaan.vanhecke@dekamer.be,http://www.stefaanvanhecke.be,54,Stefaan Van Hecke,http://www.lachambre.be/site/wwwroot/images/cv/01227.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01227&lactivity=54
-01230,Van Cauter Carina,,carina.vancauter@dekamer.be,http://www.carinavancauter.be,54,Carina Van Cauter,http://www.lachambre.be/site/wwwroot/images/cv/01230.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01230&lactivity=54
-01231,Vercamer Stefaan,,stefaan.vercamer@dekamer.be,http://www.stefaanvercamer.be,54,Stefaan Vercamer,http://www.lachambre.be/site/wwwroot/images/cv/01231.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01231&lactivity=54
-01236,Pas Barbara,,barbara.pas@dekamer.be,http://www.barbarapas.org,54,Barbara Pas,http://www.lachambre.be/site/wwwroot/images/cv/01236.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01236&lactivity=54
-01238,Jambon Jan,,jan.jambon@dekamer.be,http://www.janjambon.be,54,Jan Jambon,http://www.lachambre.be/site/wwwroot/images/cv/1238.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01238&lactivity=54
-01239,Van de Velde Robert,,rob.vandevelde@dekamer.be,"",54,Robert Van de Velde,http://www.lachambre.be/site/wwwroot/images/cv/01239.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01239&lactivity=54
-01240,Terwingen Raf,,raf.terwingen@dekamer.be,http://www.rafterwingen.be,54,Raf Terwingen,http://www.lachambre.be/site/wwwroot/images/cv/01240.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01240&lactivity=54
-01259,Clarinval David,,david.clarinval@lachambre.be,http://www.davidclarinval.be,54,David Clarinval,http://www.lachambre.be/site/wwwroot/images/cv/01259.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01259&lactivity=54
-01260,Luykx Peter,,peter.luykx@dekamer.be,http://www.peterluykx.be,54,Peter Luykx,http://www.lachambre.be/site/wwwroot/images/cv/01260.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01260&lactivity=54
-01279,Fernandez Fernandez Julie,,julie.fernandez@lachambre.be,http://www.juliefernandez.be,54,Julie Fernandez Fernandez,http://www.lachambre.be/site/wwwroot/images/cv/01279.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01279&lactivity=54
-01281,Matz Vanessa,,vanessa.matz@lachambre.be,http://www.vanessamatz.be,54,Vanessa Matz,http://www.lachambre.be/site/wwwroot/images/cv/01281.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01281&lactivity=54
-01284,Somers Ine,,ine.somers@dekamer.be,http://www.inesomers.be,54,Ine Somers,http://www.lachambre.be/site/wwwroot/images/cv/01284.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01284&lactivity=54
-01288,Blanchart Philippe,,philippe.blanchart@lachambre.be,http://www.philblanchart.be,54,Philippe Blanchart,http://www.lachambre.be/site/wwwroot/images/cv/01288.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01288&lactivity=54
-01297,Fremault Céline,,celine.fremault@lachambre.be,"",54,Céline Fremault,http://www.lachambre.be/site/wwwroot/images/cv/1297.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01297&lactivity=54
-01303,Hellings Benoit,,benoit.hellings@lachambre.be,http://www.benoithellings.be,54,Benoit Hellings,http://www.lachambre.be/site/wwwroot/images/cv/01303.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01303&lactivity=54
-01310,Khattabi Zakia,,zakia.khattabi@lachambre.be,"",54,Zakia Khattabi,http://www.lachambre.be/site/wwwroot/images/cv/1310.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=01310&lactivity=54
-04491,Wilrycx Frank,,frank.wilrycx@dekamer.be,http://www.frankwilrycx.be,54,Frank Wilrycx,http://www.lachambre.be/site/wwwroot/images/cv/4491.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=04491&lactivity=54
-04666,Francken Theo,,theo.francken@dekamer.be,http://www.theofrancken.eu,54,Theo Francken,http://www.lachambre.be/site/wwwroot/images/cv/4666.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=04666&lactivity=54
-04726,Grosemans Karolien,,karolien.grosemans@dekamer.be,http://www.karolien-grosemans.be,54,Karolien Grosemans,http://www.lachambre.be/site/wwwroot/images/cv/04726.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=04726&lactivity=54
-06018,Grovonius Gwenaëlle,,gwenaelle.grovonius@lachambre.be,http://www.gwenaellegrovonius.be,54,Gwenaëlle Grovonius,http://www.lachambre.be/site/wwwroot/images/cv/06018.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06018&lactivity=54
-06022,Yüksel Veli,,veli.yuksel@dekamer.be,http://www.veliyuksel.be,54,Veli Yüksel,http://www.lachambre.be/site/wwwroot/images/cv/06022.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06022&lactivity=54
-06025,Bracke Siegfried,,siegfried.bracke@dekamer.be,http://www.siegfriedbracke.be,54,Siegfried Bracke,http://www.lachambre.be/site/wwwroot/images/cv/06025.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06025&lactivity=54
-06027,Dedecker Peter,,peter.dedecker@dekamer.be,http://peterdedecker.eu,54,Peter Dedecker,http://www.lachambre.be/site/wwwroot/images/cv/06027.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06027&lactivity=54
-06030,Buysrogge Peter,,peter.buysrogge@dekamer.be,"",54,Peter Buysrogge,http://www.lachambre.be/site/wwwroot/images/cv/06030.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06030&lactivity=54
-06047,Temmerman Karin,,karin.temmerman@dekamer.be,http://www.karintemmerman.be,54,Karin Temmerman,http://www.lachambre.be/site/wwwroot/images/cv/06047.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06047&lactivity=54
-06086,Dumery Daphné,,daphne.dumery@dekamer.be,http://www.daphnedumery.be,54,Daphné Dumery,http://www.lachambre.be/site/wwwroot/images/cv/06086.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06086&lactivity=54
-06088,Degroote Koenraad,,koenraad.degroote@dekamer.be,"",54,Koenraad Degroote,http://www.lachambre.be/site/wwwroot/images/cv/06088.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06088&lactivity=54
-06106,Vanheste Ann,,ann.vanheste@dekamer.be,http://www.annvanheste.be,54,Ann Vanheste,http://www.lachambre.be/site/wwwroot/images/cv/06106.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06106&lactivity=54
-06109,Top Alain,,alain.top@dekamer.be,"",54,Alain Top,http://www.lachambre.be/site/wwwroot/images/cv/06109.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06109&lactivity=54
-06122,Smaers Griet,,griet.smaers@dekamer.be,http://www.grietsmaers.be,54,Griet Smaers,http://www.lachambre.be/site/wwwroot/images/cv/06122.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06122&lactivity=54
-06128,Calvo Kristof,,kristof.calvo@dekamer.be,"",54,Kristof Calvo,http://www.lachambre.be/site/wwwroot/images/cv/06128.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06128&lactivity=54
-06141,De Wit Sophie,,sophie.dewit@dekamer.be,http://www.sophiedewit.be,54,Sophie De Wit,http://www.lachambre.be/site/wwwroot/images/cv/06141.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06141&lactivity=54
-06142,Demir Zuhal,,zuhal.demir@dekamer.be,http://www.zuhaldemir.be,54,Zuhal Demir,http://www.lachambre.be/site/wwwroot/images/cv/06142.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06142&lactivity=54
-06147,Wollants Bert,,bert.wollants@dekamer.be,http://www.bertwollants.be,54,Bert Wollants,http://www.lachambre.be/site/wwwroot/images/cv/06147.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06147&lactivity=54
-06183,Penris Jan,,jan.penris@dekamer.be,http://www.vlaamsbelang.be,54,Jan Penris,http://www.lachambre.be/site/wwwroot/images/cv/06183.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06183&lactivity=54
-06219,Thiéry Damien,,damien.thiery@lachambre.be,http://www.damienthiery.be,54,Damien Thiéry,http://www.lachambre.be/site/wwwroot/images/cv/06219.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06219&lactivity=54
-06230,Van Vaerenbergh Kristien,,kristien.vanvaerenbergh@dekamer.be,http://www.kristienvanvaerenbergh.be,54,Kristien Van Vaerenbergh,http://www.lachambre.be/site/wwwroot/images/cv/06230.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06230&lactivity=54
-06286,de Coster-Bauchau Sybille,,sybille.bauchau@lachambre.be,http://www.sybilledecoster-bauchau.be/,54,Sybille de Coster-Bauchau,http://www.lachambre.be/site/wwwroot/images/cv/06286.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06286&lactivity=54
-06287,Scourneau Vincent,,vincent.scourneau@lachambre.be,http://www.vincentscourneau.be/,54,Vincent Scourneau,http://www.lachambre.be/site/wwwroot/images/cv/6287.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06287&lactivity=54
-06325,Devin Laurent,,laurent.devin@lachambre.be,"",54,Laurent Devin,http://www.lachambre.be/site/wwwroot/images/cv/6325.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06325&lactivity=54
-06326,Özen Özlem,,ozlem.ozen@lachambre.be,"",54,Özlem Özen,http://www.lachambre.be/site/wwwroot/images/cv/06326.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06326&lactivity=54
-06383,Goffin Philippe,,philippe.goffin@lachambre.be,http://www.philippegoffin.be,54,Philippe Goffin,http://www.lachambre.be/site/wwwroot/images/cv/06383.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06383&lactivity=54
-06385,Cassart-Mailleux Caroline,,caroline.mailleux@lachambre.be,http://www.caroline-cassart.be,54,Caroline Cassart-Mailleux,http://www.lachambre.be/site/wwwroot/images/cv/06385.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06385&lactivity=54
-06400,Vandeput Steven,,steven.vandeput@dekamer.be,http://www.stevenvandeput.be,54,Steven Vandeput,http://www.lachambre.be/site/wwwroot/images/cv/6400.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06400&lactivity=54
-06401,Wouters Veerle,,veerle.wouters@dekamer.be,http://www.veerlewouters.be,54,Veerle Wouters,http://www.lachambre.be/site/wwwroot/images/cv/06401.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06401&lactivity=54
-06423,Piedboeuf Benoît,,benoit.piedboeuf@lachambre.be,http://www.benoitpiedboeuf.be,54,Benoît Piedboeuf,http://www.lachambre.be/site/wwwroot/images/cv/06423.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06423&lactivity=54
-06435,Dispa Benoît,,benoit.dispa@lachambre.be,"",54,Benoît Dispa,http://www.lachambre.be/site/wwwroot/images/cv/06435.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06435&lactivity=54
-06447,De Croo Alexander,,alexander.decroo@dekamer.be,http://www.alexanderdecroo.be,54,Alexander De Croo,http://www.lachambre.be/site/wwwroot/images/cv/6447.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06447&lactivity=54
-06455,Winckel Fabienne,,fabienne.winckel@lachambre.be,"",54,Fabienne Winckel,http://www.lachambre.be/site/wwwroot/images/cv/06455.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06455&lactivity=54
-06456,Demeyer Willy,,willy.demeyer@lachambre.be,http://www.willydemeyer.be,54,Willy Demeyer,http://www.lachambre.be/site/wwwroot/images/cv/06456.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06456&lactivity=54
-06461,Laaouej Ahmed,,ahmed.laaouej@lachambre.be,http://www.laaouej.be,54,Ahmed Laaouej,http://www.lachambre.be/site/wwwroot/images/cv/06461.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06461&lactivity=54
-06497,Janssen Werner,,werner.janssen@dekamer.be,http://www.wernerjanssen.be,54,Werner Janssen,http://www.lachambre.be/site/wwwroot/images/cv/06497.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06497&lactivity=54
-06498,Raskin Wouter,,wouter.raskin@dekamer.be,"",54,Wouter Raskin,http://www.lachambre.be/site/wwwroot/images/cv/6498.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06498&lactivity=54
-06536,Crusnière Stéphane,,stephane.crusniere@lachambre.be,"",54,Stéphane Crusnière,http://www.lachambre.be/site/wwwroot/images/cv/6536.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06536&lactivity=54
-06588,De Roover Peter,,peter.deroover@dekamer.be,http://www.peterderoover.be,54,Peter De Roover,http://www.lachambre.be/site/wwwroot/images/cv/06588.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06588&lactivity=54
-06589,Van Peel Valerie,,valerie.vanpeel@dekamer.be,http://www.valerievanpeel.be,54,Valerie Van Peel,http://www.lachambre.be/site/wwwroot/images/cv/06589.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06589&lactivity=54
-06590,Van Camp Yoleen,,yoleen.vancamp@dekamer.be,http://www.yoleenvancamp.be/,54,Yoleen Van Camp,http://www.lachambre.be/site/wwwroot/images/cv/06590.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06590&lactivity=54
-06591,Metsu Koen,,koen.metsu@dekamer.be,http://www.koenmetsu.be,54,Koen Metsu,http://www.lachambre.be/site/wwwroot/images/cv/06591.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06591&lactivity=54
-06592,Bellens Rita,,rita.bellens@dekamer.be,"",54,Rita Bellens,http://www.lachambre.be/site/wwwroot/images/cv/06592.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06592&lactivity=54
-06593,Klaps Johan,,johan.klaps@dekamer.be,http://www.johanklaps.be,54,Johan Klaps,http://www.lachambre.be/site/wwwroot/images/cv/6593.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06593&lactivity=54
-06618,Pivin Philippe,,philippe.pivin@lachambre.be,http://www.pivin.be,54,Philippe Pivin,http://www.lachambre.be/site/wwwroot/images/cv/06618.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06618&lactivity=54
-06619,Wilmès Sophie,,sophie.wilmes@lachambre.be,http://www.sophiewilmes.be,54,Sophie Wilmès,http://www.lachambre.be/site/wwwroot/images/cv/6619.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06619&lactivity=54
-06620,Calomne Gautier,,gautier.calomne@lachambre.be,http://www.gautiercalomne.be,54,Gautier Calomne,http://www.lachambre.be/site/wwwroot/images/cv/06620.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06620&lactivity=54
-06627,Caprasse Véronique,,veronique.caprasse@lachambre.be,"",54,Véronique Caprasse,http://www.lachambre.be/site/wwwroot/images/cv/06627.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06627&lactivity=54
-06638,Vanden Burre Gilles,,gilles.vandenburre@lachambre.be,http://www.ecolo.be,54,Gilles Vanden Burre,http://www.lachambre.be/site/wwwroot/images/cv/6638.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06638&lactivity=54
-06645,Kir Emir,,emir.kir@lachambre.be,http://emirkir.be/,54,Emir Kir,http://www.lachambre.be/site/wwwroot/images/cv/06645.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06645&lactivity=54
-06647,Ben Hamou Nawal,,nawal.benhamou@lachambre.be,http://www.nawalbenhamou.be/,54,Nawal Ben Hamou,http://www.lachambre.be/site/wwwroot/images/cv/06647.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06647&lactivity=54
-06663,Friart Benoît,,benoit.friart@lachambre.be,http://www.benoitfriart.be,54,Benoît Friart,http://www.lachambre.be/site/wwwroot/images/cv/06663.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06663&lactivity=54
-06664,Miller Richard,,richard.miller@lachambre.be,http://millerrichard.be,54,Richard Miller,http://www.lachambre.be/site/wwwroot/images/cv/6664.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06664&lactivity=54
-06682,Senesael Daniel,,daniel.senesael@lachambre.be,http://www.danielsenesael.be,54,Daniel Senesael,http://www.lachambre.be/site/wwwroot/images/cv/06682.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06682&lactivity=54
-06701,Van Hees Marco,,marco.vanhees@lachambre.be,"",54,Marco Van Hees,http://www.lachambre.be/site/wwwroot/images/cv/06701.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06701&lactivity=54
-06712,Foret Gilles,,gilles.foret@lachambre.be,http://www.gillesforet.eu,54,Gilles Foret,http://www.lachambre.be/site/wwwroot/images/cv/06712.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06712&lactivity=54
-06731,Daerden Frédéric,,frederic.daerden@lachambre.be,"",54,Frédéric Daerden,http://www.lachambre.be/site/wwwroot/images/cv/06731.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06731&lactivity=54
-06749,Carcaci Aldo,,aldo.carcaci@lachambre.be,"",54,Aldo Carcaci,http://www.lachambre.be/site/wwwroot/images/cv/06749.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06749&lactivity=54
-06759,Hedebouw Raoul,,raoul.hedebouw@lachambre.be,http://www.ptb.be,54,Raoul Hedebouw,http://www.lachambre.be/site/wwwroot/images/cv/06759.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06759&lactivity=54
-06785,Lambrecht Annick,,annick.lambrecht@dekamer.be,"",54,Annick Lambrecht,http://www.lachambre.be/site/wwwroot/images/cv/06785.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06785&lactivity=54
-06793,Vermeulen Brecht,,brecht.vermeulen@dekamer.be,http://www.brechtvermeulen.be,54,Brecht Vermeulen,http://www.lachambre.be/site/wwwroot/images/cv/06793.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06793&lactivity=54
-06794,Vercammen Jan,,jan.vercammen@dekamer.be,http://www.jan-vercammen.be,54,Jan Vercammen,http://www.lachambre.be/site/wwwroot/images/cv/06794.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06794&lactivity=54
-06795,Gantois Rita,,rita.gantois@dekamer.be,"",54,Rita Gantois,http://www.lachambre.be/site/wwwroot/images/cv/06795.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06795&lactivity=54
-06796,Capoen An,,an.capoen@dekamer.be,http://www.ancapoen.be,54,An Capoen,http://www.lachambre.be/site/wwwroot/images/cv/06796.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06796&lactivity=54
-06805,Demon Franky,,franky.demon@dekamer.be,http://www.frankydemon.be,54,Franky Demon,http://www.lachambre.be/site/wwwroot/images/cv/06805.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06805&lactivity=54
-06813,Dedry Anne,,anne.dedry@dekamer.be,"",54,Anne Dedry,http://www.lachambre.be/site/wwwroot/images/cv/06813.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06813&lactivity=54
-06823,Vandenput Tim,,tim.vandenput@dekamer.be,http://www.timvandenput.be,54,Tim Vandenput,http://www.lachambre.be/site/wwwroot/images/cv/06823.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06823&lactivity=54
-06824,Janssens Dirk,,dirk.janssens@dekamer.be,"",54,Dirk Janssens,http://www.lachambre.be/site/wwwroot/images/cv/6824.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06824&lactivity=54
-06840,Vuye Hendrik,,hendrik.vuye@dekamer.be,http://www.hendrikvuye.be,54,Hendrik Vuye,http://www.lachambre.be/site/wwwroot/images/cv/6840.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06840&lactivity=54
-06841,Spooren Jan,,jan.spooren@dekamer.be,"",54,Jan Spooren,http://www.lachambre.be/site/wwwroot/images/cv/06841.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06841&lactivity=54
-06842,De Coninck Inez,,inez.deconinck@dekamer.be,http://www.inezdeconinck.be,54,Inez De Coninck,http://www.lachambre.be/site/wwwroot/images/cv/06842.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06842&lactivity=54
-06843,Hufkens Renate,,renate.hufkens@dekamer.be,http://www.renatehufkens.be,54,Renate Hufkens,http://www.lachambre.be/site/wwwroot/images/cv/6843.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06843&lactivity=54
-06850,Geens Koen,,koen.geens@dekamer.be,http://www.koengeens.be,54,Koen Geens,http://www.lachambre.be/site/wwwroot/images/cv/6850.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06850&lactivity=54
-06852,Van Hoof Els,,els.vanhoof@dekamer.be,http://www.elsvanhoof.be,54,Els Van Hoof,http://www.lachambre.be/site/wwwroot/images/cv/6852.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06852&lactivity=54
-06861,Willaert Evita,,evita.willaert@dekamer.be,http://www.evitawillaert.be,54,Evita Willaert,http://www.lachambre.be/site/wwwroot/images/cv/06861.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06861&lactivity=54
-06884,Lachaert Egbert,,egbert.lachaert@dekamer.be,http://www.egbertlachaert.be,54,Egbert Lachaert,http://www.lachambre.be/site/wwwroot/images/cv/06884.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06884&lactivity=54
-06885,Gabriëls Katja,,katja.gabriels@dekamer.be,http://www.katjagabriels.be,54,Katja Gabriëls,http://www.lachambre.be/site/wwwroot/images/cv/6885.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06885&lactivity=54
-06907,D'Haese Christoph,,christoph.dhaese@dekamer.be,"",54,Christoph D'Haese,http://www.lachambre.be/site/wwwroot/images/cv/06907.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06907&lactivity=54
-06918,Claerhout Sarah,,sarah.claerhout@dekamer.be,"",54,Sarah Claerhout,http://www.lachambre.be/site/wwwroot/images/cv/6918.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06918&lactivity=54
-06919,Van Peteghem Vincent,,Vincent.VanPeteghem@dekamer.be,http://www.vincentvanpeteghem.be,54,Vincent Van Peteghem,http://www.lachambre.be/site/wwwroot/images/cv/6919.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06919&lactivity=54
-06929,Thoron Stéphanie,,stephanie.thoron@lachambre.be,"",54,Stéphanie Thoron,http://www.lachambre.be/site/wwwroot/images/cv/06929.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=06929&lactivity=54
-O1057,Burton Emmanuel,,emmanuel.burton@lachambre.be,"",54,Emmanuel Burton,http://www.lachambre.be/site/wwwroot/images/cv/O1057.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=O1057&lactivity=54
-O1388,Uyttersprot Goedele,,goedele.uyttersprot@dekamer.be,http://www.goedeleuyttersprot.be,54,Goedele Uyttersprot,http://www.lachambre.be/site/wwwroot/images/cv/O1388.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=O1388&lactivity=54
-O1846,Delannois Paul-Olivier,,paul.delannois@lachambre.be,"",54,Paul-Olivier Delannois,http://www.lachambre.be/site/wwwroot/images/cv/O1846.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=O1846&lactivity=54
-O2028,de Lamotte Michel,,michel.delamotte@lachambre.be,http://www.micheldelamotte.be,54,Michel de Lamotte,http://www.lachambre.be/site/wwwroot/images/cv/O2028.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=O2028&lactivity=54
-O2321,Heeren Veerle,,veerle.heeren@dekamer.be,"",54,Veerle Heeren,http://www.lachambre.be/site/wwwroot/images/cv/O2321.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=O2321&lactivity=54
-O2466,Poncelet Isabelle,,isabelle.poncelet@lachambre.be,"",54,Isabelle Poncelet,http://www.lachambre.be/site/wwwroot/images/cv/O2466.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=O2466&lactivity=54
-O2516,Pirlot Sébastian,,sebastian.pirlot@lachambre.be,http://www.ps.be/pagetype1/ps/vos-elus/sebastian-pirlot.aspx,54,Sébastian Pirlot,http://www.lachambre.be/site/wwwroot/images/cv/O2516.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=O2516&lactivity=54
-O937,Ceysens Patricia,,patricia.ceysens@dekamer.be,"",54,Patricia Ceysens,http://www.lachambre.be/site/wwwroot/images/cv/O937.gif,http://www.lachambre.be/kvvcr/showpage.cfm?section=/depute&language=fr&cfm=cvview54.cfm?key=O937&lactivity=54
+id,name,sort_name,email,website,image
+00090,Eric Van Rompuy,Van Rompuy Eric,eric.vanrompuy@dekamer.be,http://www.ericvanrompuy.be,http://www.lachambre.be/site/wwwroot/images/cv/00090.gif
+00124,Patrick Dewael,Dewael Patrick,patrick.dewael@dekamer.be,http://www.dewael.nu,http://www.lachambre.be/site/wwwroot/images/cv/00124.gif
+00439,Elio Di Rupo,Di Rupo Elio,elio.dirupo@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/00439.gif
+00454,Dirk Van Mechelen,Van Mechelen Dirk,dirk.vanmechelen@dekamer.be,http://www.dirkvanmechelen.com,http://www.lachambre.be/site/wwwroot/images/cv/00454.gif
+00472,Filip Dewinter,Dewinter Filip,filip.dewinter@dekamer.be,http://www.fdw.nu,http://www.lachambre.be/site/wwwroot/images/cv/00472.gif
+00476,Laurette Onkelinx,Onkelinx Laurette,laurette.onkelinx@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/00476.gif
+00565,Dirk Van der Maelen,Van der Maelen Dirk,dirk.vandermaelen@dekamer.be,http://www.dirkvandermaelen.be,http://www.lachambre.be/site/wwwroot/images/cv/00565.gif
+00623,Marcel Cheron,Cheron Marcel,marcel.cheron@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/00623.gif
+00657,Johan Vande Lanotte,Vande Lanotte Johan,johan.vandelanotte@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/657.gif
+00682,Olivier Maingain,Maingain Olivier,olivier.maingain@lachambre.be,http://www.defi.be/,http://www.lachambre.be/site/wwwroot/images/cv/00682.gif
+00742,Didier Reynders,Reynders Didier,didier.reynders@lachambre.be,http://www.didier-reynders.be,http://www.lachambre.be/site/wwwroot/images/cv/742.gif
+00746,Jean-Marc Delizée,Delizée Jean-Marc,jean-marc.delizee@lachambre.be,http://www.delizee.eu,http://www.lachambre.be/site/wwwroot/images/cv/00746.gif
+00757,Daniel Bacquelaine,Bacquelaine Daniel,daniel.bacquelaine@lachambre.be,http://www.bacquelaine.be,http://www.lachambre.be/site/wwwroot/images/cv/757.gif
+00761,André Flahaut,Flahaut André,andre.flahaut@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/761.gif
+00795,Pieter De Crem,De Crem Pieter,pieter.DeCrem@dekamer.be,http://www.pieterdecrem.be,http://www.lachambre.be/site/wwwroot/images/cv/795.gif
+00826,Servais Verherstraeten,Verherstraeten Servais,servais.verherstraeten@dekamer.be,http://www.servais.verherstraeten.cdenv.be,http://www.lachambre.be/site/wwwroot/images/cv/00826.gif
+00837,Hans Bonte,Bonte Hans,hans.bonte@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/00837.gif
+00889,André Frédéric,Frédéric André,andre.frederic@lachambre.be,http://www.andrefrederic.be,http://www.lachambre.be/site/wwwroot/images/cv/00889.gif
+00895,Maggie De Block,De Block Maggie,maggie.deblock@dekamer.be,http://www.maggiedeblock.be,http://www.lachambre.be/site/wwwroot/images/cv/895.gif
+00906,Olivier Chastel,Chastel Olivier,olivier.chastel@lachambre.be,http://chastel.org,http://www.lachambre.be/site/wwwroot/images/cv/00906.gif
+00909,Charles Michel,Michel Charles,charles.michel@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/909.gif
+00917,Peter Vanvelthoven,Vanvelthoven Peter,peter.vanvelthoven@dekamer.be,http://www.petervanvelthoven.be,http://www.lachambre.be/site/wwwroot/images/cv/00917.gif
+00946,Muriel Gerkens,Gerkens Muriel,muriel.gerkens@lachambre.be,http://www.murielgerkens.be,http://www.lachambre.be/site/wwwroot/images/cv/00946.gif
+00951,Georges Dallemagne,Dallemagne Georges,georges.dallemagne@lachambre.be,http://www.georgesdallemagne.be,http://www.lachambre.be/site/wwwroot/images/cv/951.gif
+00972,Vincent Van Quickenborne,Van Quickenborne Vincent,vincent.vanquickenborne@dekamer.be,http://www.vincentvq.be,http://www.lachambre.be/site/wwwroot/images/cv/00972.gif
+00988,Karine Lalieux,Lalieux Karine,karine.lalieux@lachambre.be,http://www.karinelalieux.be,http://www.lachambre.be/site/wwwroot/images/cv/00988.gif
+01002,Fatma Pehlivan,Pehlivan Fatma,fatma.pehlivan@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/01002.gif
+01016,Jean-Marc Nollet,Nollet Jean-Marc,jean-marc.nollet@lachambre.be,http://www.nollet.info,http://www.lachambre.be/site/wwwroot/images/cv/01016.gif
+01030,Roel Deseyn,Deseyn Roel,roel.deseyn@dekamer.be,http://www.roeldeseyn.be,http://www.lachambre.be/site/wwwroot/images/cv/01030.gif
+01032,Sabien Lahaye-Battheu,Lahaye-Battheu Sabien,sabien.battheu@dekamer.be,http://www.sabien-lahaye-battheu.be,http://www.lachambre.be/site/wwwroot/images/cv/01032.gif
+01039,Hendrik Bogaert,Bogaert Hendrik,hendrik.bogaert@dekamer.be,http://www.hendrikbogaert.be,http://www.lachambre.be/site/wwwroot/images/cv/01039.gif
+01042,Nahima Lanjri,Lanjri Nahima,nahima.lanjri@dekamer.be,http://www.nahima.be,http://www.lachambre.be/site/wwwroot/images/cv/01042.gif
+01050,Eric Massin,Massin Eric,eric.massin@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/01050.gif
+01051,Alain Mathot,Mathot Alain,alain.mathot@lachambre.be,http://www.alainmathot.be,http://www.lachambre.be/site/wwwroot/images/cv/01051.gif
+01056,Denis Ducarme,Ducarme Denis,denis.ducarme@lachambre.be,http://www.denisducarme.net,http://www.lachambre.be/site/wwwroot/images/cv/01056.gif
+01059,Marie-Christine Marghem,Marghem Marie-Christine,mariechristine.marghem@lachambre.be,http://www.marghem.be,http://www.lachambre.be/site/wwwroot/images/cv/1059.gif
+01067,Maya Detiège,Detiège Maya,maya.detiege@dekamer.be,http://www.mayadetiege.be,http://www.lachambre.be/site/wwwroot/images/cv/01067.gif
+01070,Karin Jiroflée,Jiroflée Karin,karin.jiroflee@dekamer.be,http://www.karinjiroflee.be,http://www.lachambre.be/site/wwwroot/images/cv/01070.gif
+01076,Catherine Fonck,Fonck Catherine,catherine.fonck@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/01076.gif
+01079,Melchior Wathelet,Wathelet Melchior,melchior.wathelet@lachambre.be,http://www.melchiorwathelet.be,http://www.lachambre.be/site/wwwroot/images/cv/1079.gif
+01083,Françoise Schepmans,Schepmans Françoise,francoise.schepmans@lachambre.be,http://www.schepmans.be,http://www.lachambre.be/site/wwwroot/images/cv/01083.gif
+01094,Christian Brotcorne,Brotcorne Christian,christian.brotcorne@lachambre.be,http://www.brotcorne.be,http://www.lachambre.be/site/wwwroot/images/cv/01094.gif
+01102,Annemie Turtelboom,Turtelboom Annemie,annemie.turtelboom@dekamer.be,http://www.annemieturtelboom.be,http://www.lachambre.be/site/wwwroot/images/cv/01102.gif
+01123,Luc Gustin,Gustin Luc,luc.gustin@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/1123.gif
+01127,David Geerts,Geerts David,david.geerts@dekamer.be,http://www.davidgeerts.be,http://www.lachambre.be/site/wwwroot/images/cv/01127.gif
+01130,Nathalie Muylle,Muylle Nathalie,nathalie.muylle@dekamer.be,http://www.nathalie.muylle.cdenv.be,http://www.lachambre.be/site/wwwroot/images/cv/01130.gif
+01131,Jef Van den Bergh,Van den Bergh Jef,jef.vandenbergh@dekamer.be,http://www.jefvandenbergh.be,http://www.lachambre.be/site/wwwroot/images/cv/01131.gif
+01134,Francis Delpérée,Delpérée Francis,francis.delperee@lachambre.be,http://www.delperee.be,http://www.lachambre.be/site/wwwroot/images/cv/01134.gif
+01139,Luk Van Biesen,Van Biesen Luk,luk.vanbiesen@dekamer.be,http://www.lukvanbiesen.be,http://www.lachambre.be/site/wwwroot/images/cv/01139.gif
+01145,Benoît Lutgen,Lutgen Benoît,benoit.lutgen@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/01145.gif
+01149,Wouter Beke,Beke Wouter,wouter.beke@dekamer.be,http://www.wouterbeke.be,http://www.lachambre.be/site/wwwroot/images/cv/01149.gif
+01179,Nele Lijnen,Lijnen Nele,nele.lijnen@dekamer.be,http://www.nelelijnen.be,http://www.lachambre.be/site/wwwroot/images/cv/01179.gif
+01183,Monica De Coninck,De Coninck Monica,monica.deconinck@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/01183.gif
+01189,Meyrem Almaci,Almaci Meyrem,meyrem.almaci@dekamer.be,http://www.meyremalmaci.be,http://www.lachambre.be/site/wwwroot/images/cv/01189.gif
+01190,Sonja Becq,Becq Sonja,sonja.becq@dekamer.be,http://www.sonjabecq.be,http://www.lachambre.be/site/wwwroot/images/cv/01190.gif
+01199,Wouter De Vriendt,De Vriendt Wouter,wouter.de.vriendt@dekamer.be,http://www.wouterdevriendt.be,http://www.lachambre.be/site/wwwroot/images/cv/01199.gif
+01200,Bart De Wever,De Wever Bart,bart.dewever@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/01200.gif
+01201,Leen Dierick,Dierick Leen,leen.dierick@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/01201.gif
+01203,Jean-Jacques Flahaux,Flahaux Jean-Jacques,jean-jacques.flahaux@lachambre.be,http://www.flahaux.be,http://www.lachambre.be/site/wwwroot/images/cv/01203.gif
+01205,Georges Gilkinet,Gilkinet Georges,georges.gilkinet@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/01205.gif
+01207,Kattrin Jadin,Jadin Kattrin,kattrin.jadin@lachambre.be,http://www.jadin.be,http://www.lachambre.be/site/wwwroot/images/cv/01207.gif
+01209,Meryame Kitir,Kitir Meryame,meryame.kitir@dekamer.be,http://www.kitir.be,http://www.lachambre.be/site/wwwroot/images/cv/01209.gif
+01219,Sarah Smeyers,Smeyers Sarah,sarah.smeyers@dekamer.be,http://www.sarahsmeyers.be,http://www.lachambre.be/site/wwwroot/images/cv/01219.gif
+01222,Eric Thiébaut,Thiébaut Eric,eric.thiebaut@lachambre.be,http://www.ericthiebaut.be,http://www.lachambre.be/site/wwwroot/images/cv/01222.gif
+01227,Stefaan Van Hecke,Van Hecke Stefaan,stefaan.vanhecke@dekamer.be,http://www.stefaanvanhecke.be,http://www.lachambre.be/site/wwwroot/images/cv/01227.gif
+01230,Carina Van Cauter,Van Cauter Carina,carina.vancauter@dekamer.be,http://www.carinavancauter.be,http://www.lachambre.be/site/wwwroot/images/cv/01230.gif
+01231,Stefaan Vercamer,Vercamer Stefaan,stefaan.vercamer@dekamer.be,http://www.stefaanvercamer.be,http://www.lachambre.be/site/wwwroot/images/cv/01231.gif
+01236,Barbara Pas,Pas Barbara,barbara.pas@dekamer.be,http://www.barbarapas.org,http://www.lachambre.be/site/wwwroot/images/cv/01236.gif
+01238,Jan Jambon,Jambon Jan,jan.jambon@dekamer.be,http://www.janjambon.be,http://www.lachambre.be/site/wwwroot/images/cv/1238.gif
+01239,Robert Van de Velde,Van de Velde Robert,rob.vandevelde@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/01239.gif
+01240,Raf Terwingen,Terwingen Raf,raf.terwingen@dekamer.be,http://www.rafterwingen.be,http://www.lachambre.be/site/wwwroot/images/cv/01240.gif
+01259,David Clarinval,Clarinval David,david.clarinval@lachambre.be,http://www.davidclarinval.be,http://www.lachambre.be/site/wwwroot/images/cv/01259.gif
+01260,Peter Luykx,Luykx Peter,peter.luykx@dekamer.be,http://www.peterluykx.be,http://www.lachambre.be/site/wwwroot/images/cv/01260.gif
+01279,Julie Fernandez Fernandez,Fernandez Fernandez Julie,julie.fernandez@lachambre.be,http://www.juliefernandez.be,http://www.lachambre.be/site/wwwroot/images/cv/01279.gif
+01281,Vanessa Matz,Matz Vanessa,vanessa.matz@lachambre.be,http://www.vanessamatz.be,http://www.lachambre.be/site/wwwroot/images/cv/01281.gif
+01284,Ine Somers,Somers Ine,ine.somers@dekamer.be,http://www.inesomers.be,http://www.lachambre.be/site/wwwroot/images/cv/01284.gif
+01288,Philippe Blanchart,Blanchart Philippe,philippe.blanchart@lachambre.be,http://www.philblanchart.be,http://www.lachambre.be/site/wwwroot/images/cv/01288.gif
+01297,Céline Fremault,Fremault Céline,celine.fremault@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/1297.gif
+01303,Benoit Hellings,Hellings Benoit,benoit.hellings@lachambre.be,http://www.benoithellings.be,http://www.lachambre.be/site/wwwroot/images/cv/01303.gif
+01310,Zakia Khattabi,Khattabi Zakia,zakia.khattabi@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/1310.gif
+04491,Frank Wilrycx,Wilrycx Frank,frank.wilrycx@dekamer.be,http://www.frankwilrycx.be,http://www.lachambre.be/site/wwwroot/images/cv/4491.gif
+04666,Theo Francken,Francken Theo,theo.francken@dekamer.be,http://www.theofrancken.eu,http://www.lachambre.be/site/wwwroot/images/cv/4666.gif
+04726,Karolien Grosemans,Grosemans Karolien,karolien.grosemans@dekamer.be,http://www.karolien-grosemans.be,http://www.lachambre.be/site/wwwroot/images/cv/04726.gif
+06018,Gwenaëlle Grovonius,Grovonius Gwenaëlle,gwenaelle.grovonius@lachambre.be,http://www.gwenaellegrovonius.be,http://www.lachambre.be/site/wwwroot/images/cv/06018.gif
+06022,Veli Yüksel,Yüksel Veli,veli.yuksel@dekamer.be,http://www.veliyuksel.be,http://www.lachambre.be/site/wwwroot/images/cv/06022.gif
+06025,Siegfried Bracke,Bracke Siegfried,siegfried.bracke@dekamer.be,http://www.siegfriedbracke.be,http://www.lachambre.be/site/wwwroot/images/cv/06025.gif
+06027,Peter Dedecker,Dedecker Peter,peter.dedecker@dekamer.be,http://peterdedecker.eu,http://www.lachambre.be/site/wwwroot/images/cv/06027.gif
+06030,Peter Buysrogge,Buysrogge Peter,peter.buysrogge@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06030.gif
+06047,Karin Temmerman,Temmerman Karin,karin.temmerman@dekamer.be,http://www.karintemmerman.be,http://www.lachambre.be/site/wwwroot/images/cv/06047.gif
+06086,Daphné Dumery,Dumery Daphné,daphne.dumery@dekamer.be,http://www.daphnedumery.be,http://www.lachambre.be/site/wwwroot/images/cv/06086.gif
+06088,Koenraad Degroote,Degroote Koenraad,koenraad.degroote@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06088.gif
+06106,Ann Vanheste,Vanheste Ann,ann.vanheste@dekamer.be,http://www.annvanheste.be,http://www.lachambre.be/site/wwwroot/images/cv/06106.gif
+06109,Alain Top,Top Alain,alain.top@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06109.gif
+06122,Griet Smaers,Smaers Griet,griet.smaers@dekamer.be,http://www.grietsmaers.be,http://www.lachambre.be/site/wwwroot/images/cv/06122.gif
+06128,Kristof Calvo,Calvo Kristof,kristof.calvo@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06128.gif
+06141,Sophie De Wit,De Wit Sophie,sophie.dewit@dekamer.be,http://www.sophiedewit.be,http://www.lachambre.be/site/wwwroot/images/cv/06141.gif
+06142,Zuhal Demir,Demir Zuhal,zuhal.demir@dekamer.be,http://www.zuhaldemir.be,http://www.lachambre.be/site/wwwroot/images/cv/06142.gif
+06147,Bert Wollants,Wollants Bert,bert.wollants@dekamer.be,http://www.bertwollants.be,http://www.lachambre.be/site/wwwroot/images/cv/06147.gif
+06183,Jan Penris,Penris Jan,jan.penris@dekamer.be,http://www.vlaamsbelang.be,http://www.lachambre.be/site/wwwroot/images/cv/06183.gif
+06219,Damien Thiéry,Thiéry Damien,damien.thiery@lachambre.be,http://www.damienthiery.be,http://www.lachambre.be/site/wwwroot/images/cv/06219.gif
+06230,Kristien Van Vaerenbergh,Van Vaerenbergh Kristien,kristien.vanvaerenbergh@dekamer.be,http://www.kristienvanvaerenbergh.be,http://www.lachambre.be/site/wwwroot/images/cv/06230.gif
+06286,Sybille de Coster-Bauchau,de Coster-Bauchau Sybille,sybille.bauchau@lachambre.be,http://www.sybilledecoster-bauchau.be/,http://www.lachambre.be/site/wwwroot/images/cv/06286.gif
+06287,Vincent Scourneau,Scourneau Vincent,vincent.scourneau@lachambre.be,http://www.vincentscourneau.be/,http://www.lachambre.be/site/wwwroot/images/cv/6287.gif
+06325,Laurent Devin,Devin Laurent,laurent.devin@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/6325.gif
+06326,Özlem Özen,Özen Özlem,ozlem.ozen@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06326.gif
+06383,Philippe Goffin,Goffin Philippe,philippe.goffin@lachambre.be,http://www.philippegoffin.be,http://www.lachambre.be/site/wwwroot/images/cv/06383.gif
+06385,Caroline Cassart-Mailleux,Cassart-Mailleux Caroline,caroline.mailleux@lachambre.be,http://www.caroline-cassart.be,http://www.lachambre.be/site/wwwroot/images/cv/06385.gif
+06400,Steven Vandeput,Vandeput Steven,steven.vandeput@dekamer.be,http://www.stevenvandeput.be,http://www.lachambre.be/site/wwwroot/images/cv/6400.gif
+06401,Veerle Wouters,Wouters Veerle,veerle.wouters@dekamer.be,http://www.veerlewouters.be,http://www.lachambre.be/site/wwwroot/images/cv/06401.gif
+06423,Benoît Piedboeuf,Piedboeuf Benoît,benoit.piedboeuf@lachambre.be,http://www.benoitpiedboeuf.be,http://www.lachambre.be/site/wwwroot/images/cv/06423.gif
+06435,Benoît Dispa,Dispa Benoît,benoit.dispa@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06435.gif
+06447,Alexander De Croo,De Croo Alexander,alexander.decroo@dekamer.be,http://www.alexanderdecroo.be,http://www.lachambre.be/site/wwwroot/images/cv/6447.gif
+06455,Fabienne Winckel,Winckel Fabienne,fabienne.winckel@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06455.gif
+06456,Willy Demeyer,Demeyer Willy,willy.demeyer@lachambre.be,http://www.willydemeyer.be,http://www.lachambre.be/site/wwwroot/images/cv/06456.gif
+06461,Ahmed Laaouej,Laaouej Ahmed,ahmed.laaouej@lachambre.be,http://www.laaouej.be,http://www.lachambre.be/site/wwwroot/images/cv/06461.gif
+06497,Werner Janssen,Janssen Werner,werner.janssen@dekamer.be,http://www.wernerjanssen.be,http://www.lachambre.be/site/wwwroot/images/cv/06497.gif
+06498,Wouter Raskin,Raskin Wouter,wouter.raskin@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/6498.gif
+06536,Stéphane Crusnière,Crusnière Stéphane,stephane.crusniere@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/6536.gif
+06588,Peter De Roover,De Roover Peter,peter.deroover@dekamer.be,http://www.peterderoover.be,http://www.lachambre.be/site/wwwroot/images/cv/06588.gif
+06589,Valerie Van Peel,Van Peel Valerie,valerie.vanpeel@dekamer.be,http://www.valerievanpeel.be,http://www.lachambre.be/site/wwwroot/images/cv/06589.gif
+06590,Yoleen Van Camp,Van Camp Yoleen,yoleen.vancamp@dekamer.be,http://www.yoleenvancamp.be/,http://www.lachambre.be/site/wwwroot/images/cv/06590.gif
+06591,Koen Metsu,Metsu Koen,koen.metsu@dekamer.be,http://www.koenmetsu.be,http://www.lachambre.be/site/wwwroot/images/cv/06591.gif
+06592,Rita Bellens,Bellens Rita,rita.bellens@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06592.gif
+06593,Johan Klaps,Klaps Johan,johan.klaps@dekamer.be,http://www.johanklaps.be,http://www.lachambre.be/site/wwwroot/images/cv/6593.gif
+06618,Philippe Pivin,Pivin Philippe,philippe.pivin@lachambre.be,http://www.pivin.be,http://www.lachambre.be/site/wwwroot/images/cv/06618.gif
+06619,Sophie Wilmès,Wilmès Sophie,sophie.wilmes@lachambre.be,http://www.sophiewilmes.be,http://www.lachambre.be/site/wwwroot/images/cv/6619.gif
+06620,Gautier Calomne,Calomne Gautier,gautier.calomne@lachambre.be,http://www.gautiercalomne.be,http://www.lachambre.be/site/wwwroot/images/cv/06620.gif
+06627,Véronique Caprasse,Caprasse Véronique,veronique.caprasse@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06627.gif
+06638,Gilles Vanden Burre,Vanden Burre Gilles,gilles.vandenburre@lachambre.be,http://www.ecolo.be,http://www.lachambre.be/site/wwwroot/images/cv/6638.gif
+06645,Emir Kir,Kir Emir,emir.kir@lachambre.be,http://emirkir.be/,http://www.lachambre.be/site/wwwroot/images/cv/06645.gif
+06647,Nawal Ben Hamou,Ben Hamou Nawal,nawal.benhamou@lachambre.be,http://www.nawalbenhamou.be/,http://www.lachambre.be/site/wwwroot/images/cv/06647.gif
+06663,Benoît Friart,Friart Benoît,benoit.friart@lachambre.be,http://www.benoitfriart.be,http://www.lachambre.be/site/wwwroot/images/cv/06663.gif
+06664,Richard Miller,Miller Richard,richard.miller@lachambre.be,http://millerrichard.be,http://www.lachambre.be/site/wwwroot/images/cv/6664.gif
+06682,Daniel Senesael,Senesael Daniel,daniel.senesael@lachambre.be,http://www.danielsenesael.be,http://www.lachambre.be/site/wwwroot/images/cv/06682.gif
+06701,Marco Van Hees,Van Hees Marco,marco.vanhees@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06701.gif
+06712,Gilles Foret,Foret Gilles,gilles.foret@lachambre.be,http://www.gillesforet.eu,http://www.lachambre.be/site/wwwroot/images/cv/06712.gif
+06731,Frédéric Daerden,Daerden Frédéric,frederic.daerden@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06731.gif
+06749,Aldo Carcaci,Carcaci Aldo,aldo.carcaci@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06749.gif
+06759,Raoul Hedebouw,Hedebouw Raoul,raoul.hedebouw@lachambre.be,http://www.ptb.be,http://www.lachambre.be/site/wwwroot/images/cv/06759.gif
+06785,Annick Lambrecht,Lambrecht Annick,annick.lambrecht@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06785.gif
+06793,Brecht Vermeulen,Vermeulen Brecht,brecht.vermeulen@dekamer.be,http://www.brechtvermeulen.be,http://www.lachambre.be/site/wwwroot/images/cv/06793.gif
+06794,Jan Vercammen,Vercammen Jan,jan.vercammen@dekamer.be,http://www.jan-vercammen.be,http://www.lachambre.be/site/wwwroot/images/cv/06794.gif
+06795,Rita Gantois,Gantois Rita,rita.gantois@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06795.gif
+06796,An Capoen,Capoen An,an.capoen@dekamer.be,http://www.ancapoen.be,http://www.lachambre.be/site/wwwroot/images/cv/06796.gif
+06805,Franky Demon,Demon Franky,franky.demon@dekamer.be,http://www.frankydemon.be,http://www.lachambre.be/site/wwwroot/images/cv/06805.gif
+06813,Anne Dedry,Dedry Anne,anne.dedry@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06813.gif
+06823,Tim Vandenput,Vandenput Tim,tim.vandenput@dekamer.be,http://www.timvandenput.be,http://www.lachambre.be/site/wwwroot/images/cv/06823.gif
+06824,Dirk Janssens,Janssens Dirk,dirk.janssens@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/6824.gif
+06840,Hendrik Vuye,Vuye Hendrik,hendrik.vuye@dekamer.be,http://www.hendrikvuye.be,http://www.lachambre.be/site/wwwroot/images/cv/6840.gif
+06841,Jan Spooren,Spooren Jan,jan.spooren@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06841.gif
+06842,Inez De Coninck,De Coninck Inez,inez.deconinck@dekamer.be,http://www.inezdeconinck.be,http://www.lachambre.be/site/wwwroot/images/cv/06842.gif
+06843,Renate Hufkens,Hufkens Renate,renate.hufkens@dekamer.be,http://www.renatehufkens.be,http://www.lachambre.be/site/wwwroot/images/cv/6843.gif
+06850,Koen Geens,Geens Koen,koen.geens@dekamer.be,http://www.koengeens.be,http://www.lachambre.be/site/wwwroot/images/cv/6850.gif
+06852,Els Van Hoof,Van Hoof Els,els.vanhoof@dekamer.be,http://www.elsvanhoof.be,http://www.lachambre.be/site/wwwroot/images/cv/6852.gif
+06861,Evita Willaert,Willaert Evita,evita.willaert@dekamer.be,http://www.evitawillaert.be,http://www.lachambre.be/site/wwwroot/images/cv/06861.gif
+06884,Egbert Lachaert,Lachaert Egbert,egbert.lachaert@dekamer.be,http://www.egbertlachaert.be,http://www.lachambre.be/site/wwwroot/images/cv/06884.gif
+06885,Katja Gabriëls,Gabriëls Katja,katja.gabriels@dekamer.be,http://www.katjagabriels.be,http://www.lachambre.be/site/wwwroot/images/cv/6885.gif
+06907,Christoph D'Haese,D'Haese Christoph,christoph.dhaese@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06907.gif
+06918,Sarah Claerhout,Claerhout Sarah,sarah.claerhout@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/6918.gif
+06919,Vincent Van Peteghem,Van Peteghem Vincent,Vincent.VanPeteghem@dekamer.be,http://www.vincentvanpeteghem.be,http://www.lachambre.be/site/wwwroot/images/cv/6919.gif
+06929,Stéphanie Thoron,Thoron Stéphanie,stephanie.thoron@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/06929.gif
+O1057,Emmanuel Burton,Burton Emmanuel,emmanuel.burton@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/O1057.gif
+O1388,Goedele Uyttersprot,Uyttersprot Goedele,goedele.uyttersprot@dekamer.be,http://www.goedeleuyttersprot.be,http://www.lachambre.be/site/wwwroot/images/cv/O1388.gif
+O1846,Paul-Olivier Delannois,Delannois Paul-Olivier,paul.delannois@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/O1846.gif
+O2028,Michel de Lamotte,de Lamotte Michel,michel.delamotte@lachambre.be,http://www.micheldelamotte.be,http://www.lachambre.be/site/wwwroot/images/cv/O2028.gif
+O2321,Veerle Heeren,Heeren Veerle,veerle.heeren@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/O2321.gif
+O2466,Isabelle Poncelet,Poncelet Isabelle,isabelle.poncelet@lachambre.be,"",http://www.lachambre.be/site/wwwroot/images/cv/O2466.gif
+O2516,Sébastian Pirlot,Pirlot Sébastian,sebastian.pirlot@lachambre.be,http://www.ps.be/pagetype1/ps/vos-elus/sebastian-pirlot.aspx,http://www.lachambre.be/site/wwwroot/images/cv/O2516.gif
+O937,Patricia Ceysens,Ceysens Patricia,patricia.ceysens@dekamer.be,"",http://www.lachambre.be/site/wwwroot/images/cv/O937.gif


### PR DESCRIPTION
When building Person + Membership information, we need to be very careful
not to include "Membership"-type data (party, constituency, term, start/end
date) from any Person source, as that will get merged into every membership
that the Person has had. This appears safe if there's only a single term,
and no-one changes party or area during that, but the instant someone has a
second membership, bad things start to happen.

Part of https://github.com/everypolitician/everypolitician/issues/589