### PR TITLE
Falkland Islands (Assembly): remove Membership fields from Person source

### DIFF
--- a/data/Falkland_Islands/Assembly/sources/instructions.json
+++ b/data/Falkland_Islands/Assembly/sources/instructions.json
@@ -15,7 +15,7 @@
       "create": {
         "from": "morph",
         "scraper": "tmtmtmtm/falkland-islands-assembly",
-        "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data ORDER BY name"
+        "query": "SELECT REPLACE(LOWER(name),' ','_') AS id, name, image FROM data ORDER BY name"
       },
       "source": "http://www.falklands.gov.fk/self-governance/legislative/assembly-members/",
       "type": "person",

--- a/data/Falkland_Islands/Assembly/sources/morph/official.csv
+++ b/data/Falkland_Islands/Assembly/sources/morph/official.csv
@@ -1,9 +1,9 @@
-name,area,image,term,source,id
-Dr Barry Elsby,Stanley,http://www.falklands.gov.fk/assets/Barry-Elsby-22-257x300.jpg,2013,http://www.falklands.gov.fk/self-governance/legislative/assembly-members/the-honourable-dr-barry-elsby-mla/,dr_barry_elsby
-Gavin Short,Stanley,http://www.falklands.gov.fk/assets/GS-2-199x300.jpg,2013,http://www.falklands.gov.fk/self-governance/legislative/assembly-members/the-honourable-gavin-short-mla/,gavin_short
-Ian Hansen,Camp,http://www.falklands.gov.fk/assets/IH-1-232x300.jpg,2013,http://www.falklands.gov.fk/self-governance/legislative/assembly-members/the-honourable-ian-hansen-mla/,ian_hansen
-Jan Cheek,Stanley,http://www.falklands.gov.fk/assets/DSC_04761-211x300.jpg,2013,http://www.falklands.gov.fk/self-governance/legislative/assembly-members/the-honourable-jan-cheek-mla/,jan_cheek
-Michael Poole,Stanley,http://www.falklands.gov.fk/assets/Michael-Poole4-187x300.jpg,2013,http://www.falklands.gov.fk/self-governance/legislative/assembly-members/the-honourable-michael-poole-mla/,michael_poole
-Mike Summers OBE,Stanley,http://www.falklands.gov.fk/assets/Mike-Summers-1-233x300.jpg,2013,http://www.falklands.gov.fk/self-governance/legislative/assembly-members/the-honourable-mike-summers-obe-mla/,mike_summers_obe
-Phyl Rendell MBE,Camp,http://www.falklands.gov.fk/assets/Phyl-Rendell-1-173x300.jpg,2013,http://www.falklands.gov.fk/self-governance/legislative/assembly-members/the-honourable-phyl-rendell-mbe-mla/,phyl_rendell_mbe
-Roger Edwards,Camp,http://www.falklands.gov.fk/assets/Roger-Edwards-2-209x300.jpg,2013,http://www.falklands.gov.fk/self-governance/legislative/assembly-members/the-honourable-roger-edwards-mla/,roger_edwards
+id,name,image
+dr_barry_elsby,Dr Barry Elsby,http://www.falklands.gov.fk/assets/Barry-Elsby-22-257x300.jpg
+gavin_short,Gavin Short,http://www.falklands.gov.fk/assets/GS-2-199x300.jpg
+ian_hansen,Ian Hansen,http://www.falklands.gov.fk/assets/IH-1-232x300.jpg
+jan_cheek,Jan Cheek,http://www.falklands.gov.fk/assets/DSC_04761-211x300.jpg
+michael_poole,Michael Poole,http://www.falklands.gov.fk/assets/Michael-Poole4-187x300.jpg
+mike_summers_obe,Mike Summers OBE,http://www.falklands.gov.fk/assets/Mike-Summers-1-233x300.jpg
+phyl_rendell_mbe,Phyl Rendell MBE,http://www.falklands.gov.fk/assets/Phyl-Rendell-1-173x300.jpg
+roger_edwards,Roger Edwards,http://www.falklands.gov.fk/assets/Roger-Edwards-2-209x300.jpg


### PR DESCRIPTION
When building Person + Membership information, we need to be very careful
not to include "Membership"-type data (party, constituency, term, start/end
date) from any Person source, as that will get merged into every membership
that the Person has had. This appears safe if there's only a single term,
and no-one changes party or area during that, but the instant someone has a
second membership, bad things start to happen.

Part of https://github.com/everypolitician/everypolitician/issues/589