### PR TITLE
Solomon Islands (Parliament): rebuild data

### DIFF
--- a/data/Solomon_Islands/Parliament/sources/instructions.json
+++ b/data/Solomon_Islands/Parliament/sources/instructions.json
@@ -15,7 +15,7 @@
       "create": {
         "from": "morph",
         "scraper": "tmtmtmtm/solomon-islands-parliament",
-        "query": "SELECT * FROM data ORDER BY id"
+        "query": "SELECT id, name, sort_name, phone, image FROM data ORDER BY id"
       },
       "source": "http://www.parliament.gov.sb/index.php?q=node/833",
       "type": "person",

--- a/data/Solomon_Islands/Parliament/sources/morph/gov.csv
+++ b/data/Solomon_Islands/Parliament/sources/morph/gov.csv
@@ -1,51 +1,51 @@
-name,sort_name,constituency,term,source,id,party,phone,image
-Horst Heinz Bodo Dettke,"Dettke, Hon. Horst Heinz Bodo",North-West Guadalcanal,10,http://www.parliament.gov.sb/index.php?q=node/503,503,Kadere Party,+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Bodo%20Dettke.jpg
-Jackson Fiulaua,"Fiulaua, Hon. Jackson",Central Kwara’ae,10,http://www.parliament.gov.sb/index.php?q=node/506,506,United Democratic Party,+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Jackson_Fiulaua.JPG
-John Moffat Fugui,"Fugui, Hon. John Moffat",Central Honiara,10,http://www.parliament.gov.sb/index.php?q=node/507,507,United Democratic Party,+677 28803,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Moffat_Fugui.JPG
-Moses Garu,"Garu, Hon. Moses",West Guadalcanal,10,http://www.parliament.gov.sb/index.php?q=node/521,521,Kadere Party,+677 21551,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Moses_Garu.JPG
-Douglas Ete,"Ete, Hon. Douglas",East Honiara,10,http://www.parliament.gov.sb/index.php?q=node/532,532,Kadere Party,+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Douglas_Ete.JPG
-Peter Shanel Agovaka,"Agovaka, Hon. Peter Shanel",Central Guadalcanal,10,http://www.parliament.gov.sb/index.php?q=node/591,591,United Democratic Party,+677 36720,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Peter_Shanel_Agovaka.JPG
-Bartholomew Parapolo,"Parapolo, Hon. Bartholomew",Ngella,10,http://www.parliament.gov.sb/index.php?q=node/592,592,Kadere Party,+677 28603,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Bartholomew_Parapolo.jpg
-Alfred Ghiro,"Ghiro, Hon. Alfred",East Makira,10,http://www.parliament.gov.sb/index.php?q=node/845,845,"",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Alfred_Ghiro.JPG
-Manasseh Damukana Sogavare,"Sogavare, Hon. Manasseh Damukana",East Choiseul,10,http://www.parliament.gov.sb/index.php?q=node/846,846,United Democratic Party,+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Manasseh%20Sogavare.JPG
-Ishmael Mali Avui,"Avui, Hon. Ishmael Mali",East Central Guadalcanal,10,http://www.parliament.gov.sb/index.php?q=node/848,848,United Democratic Party,+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Ismael_Avui.jpg
-Snyder Rini,"Rini, Hon. Snyder",Marovo,10,http://www.parliament.gov.sb/index.php?q=node/849,849,United Democratic Party,+677 22556/22557/22558,http://www.parliament.gov.sb/memberfiles%5Cmemberpics%5Crini.jpg
-Nestor Giro,"Giro, Hon. Nestor",Central Makira,10,http://www.parliament.gov.sb/index.php?q=node/851,851,Kadere Party,+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Nesto_Ghiro.JPG
-Rick Nelson Houenipwela,"Houenipwela, Hon. Rick Nelson",Small Malaita,10,http://www.parliament.gov.sb/index.php?q=node/852,852,Democratic Alliance Party,+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Rick_Houenipwela.JPG
-Sam Shemuel Iduri,"Iduri, Hon. Sam Shemuel",West Kwara’ae,10,http://www.parliament.gov.sb/index.php?q=node/853,853,United Democratic Party,+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20ShemuelSam%20Iduri.jpg
-Martin Kealoe,"Kealoe, Hon. Martin",Malaita Outer Islands,10,http://www.parliament.gov.sb/index.php?q=node/855,855,"",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Martin%20Kealoe.jpg
-Christopher Laore,"Laore, Hon. Christopher",Shortlands,10,http://www.parliament.gov.sb/index.php?q=node/856,856,"",+677 22263,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Christopher%20Laore.jpg
-Manasseh Maelanga,"Maelanga, Hon. Manasseh",East Malaita,10,http://www.parliament.gov.sb/index.php?q=node/857,857,"",+677 28602,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Manasseh%20Maelanga.jpg
-John Maneniaru,"Maneniaru, Hon. John",West Are’Are,10,http://www.parliament.gov.sb/index.php?q=node/858,858,Kadere Party,+677 28604,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20John%20Mane.jpg
-Andrew Manepora’a,"Manepora’a, Hon Andrew",East Are’Are,10,http://www.parliament.gov.sb/index.php?q=node/859,859,"",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Andrew%20Manepora'a.jpg
-Samuel Manetoali,"Manetoali, Hon. Samuel",Gao-Bugotu,10,http://www.parliament.gov.sb/index.php?q=node/860,860,United Democratic Party,+677 23031/23032,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Samuel_Manetoali.JPG
-Commins Aston Mewa,"Mewa, Hon. Commins Aston",Temotu Nende,10,http://www.parliament.gov.sb/index.php?q=node/861,861,"",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Commins%20Aston%20Mewa.jpg
-Elijah Doro Muala,"Muala, Hon. Elijah Doro",South Choiseul,10,http://www.parliament.gov.sb/index.php?q=node/862,862,"",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Elijah%20Doro%20Muala.jpg
-David Day Pacha,"Pacha, Hon. David Day",South Guadalcanal,10,http://www.parliament.gov.sb/index.php?q=node/863,863,"",+677 21552,http://www.parliament.gov.sb/memberfiles/memberpics/pacha.jpg
-Dickson Mua Panakitasi,"Panakitasi, Hon. Dickson Mua",Savo-Russells,10,http://www.parliament.gov.sb/index.php?q=node/864,864,"",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Dickson%20Mua.jpg
-Danny Philip,"Philip, Hon. Danny",South New Georgia-Rendova-Tetepari,10,http://www.parliament.gov.sb/index.php?q=node/865,865,"",+677 38255/38256,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Danny%20Philip.jpg
-Lionel Alex Qora,"Qora, Hon. Lionel Alex",South Vella Lavella,10,http://www.parliament.gov.sb/index.php?q=node/866,866,Solomon Islands Party for Rural Advancement,+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Lionel%20Alex.jpg
-Connelly Mathew Sadakabatu,"Sadakabatu, Hon. Connelly Mathew",North-West Choiseul,10,http://www.parliament.gov.sb/index.php?q=node/867,867,"",,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Connelly%20Sandakabatu.jpg
-Charles Sigoto,"Sigoto, Hon. Charles",Rannonga-Simbo,10,http://www.parliament.gov.sb/index.php?q=node/871,871,Solomon Islands Party for Rural Advancement,+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Charles%20Sigoto.jpg
-Dr. Derek Sikua,"Sikua, Hon. Dr. Derek",North-East Guadalcanal,10,http://www.parliament.gov.sb/index.php?q=node/872,872,United Democratic Party,+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Dr.%20Derek%20Sikua.JPG
-Stanley Festus Sofu,"Sofu, Hon. Stanley Festus",East Kwaio,10,http://www.parliament.gov.sb/index.php?q=node/873,873,"",+677 22208/28421,http://www.parliament.gov.sb/memberfiles/memberpics/sofu.jpg
-Silas Kerry Vaqara Tausinga,"Tausinga, Hon. Silas Kerry Vaqara",West New Georgia-Vona Vona,10,http://www.parliament.gov.sb/index.php?q=node/874,874,"",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Silas%20Tausinga.JPG
-Peter Tom,"Tom, Hon. Peter",West Kwaio,10,http://www.parliament.gov.sb/index.php?q=node/875,875,"",+677 28520,http://www.parliament.gov.sb/memberfiles/memberpics/tom.jpg
-David Wanesiofa Tome,"Tome, Hon. David Wanesiofa",Baegu/Asifola,10,http://www.parliament.gov.sb/index.php?q=node/876,876,"",+677 28709,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics%5CHon.%20David%20Tome.jpg
-Dr. Tautai Angikimua Kaitu’u,"Kaitu’u, Hon. Dr. Tautai Angikimua",Rennell-Bellona,10,http://www.parliament.gov.sb/index.php?q=node/915,915,"",+677 20830,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon.%20Dr.%20Tautai%20Angikimua%20Kaitu%E2%80%99u.jpg
-Duddley Kopu,"Kopu, Hon. Duddley",Temotu Pele,10,http://www.parliament.gov.sb/index.php?q=node/916,916,"",+677 22143,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon.%20Duddley%20Kopu.JPG
-John Dean Kuku,"Kuku, Hon. John Dean",North New Georgia,10,http://www.parliament.gov.sb/index.php?q=node/920,920,"",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_John_Dean_Kuku.JPG
-Jimmy Lusibaea,"Lusibaea, Hon. Jimmy",North Malaita,10,http://www.parliament.gov.sb/index.php?q=node/929,929,"",+677 21141,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon.%20Jimmy%20Lusibaea.jpg
-Augustine Auga Maeue,"Maeue, Hon. Augustine Auga",Lau-Mbaelelea,10,http://www.parliament.gov.sb/index.php?q=node/930,930,"",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon.%20Augustine%20Auga.JPG
-Samson Maneka,"Maneka, Hon. Samson",North Guadalcanal,10,http://www.parliament.gov.sb/index.php?q=node/931,931,"",+677 23015,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon.%20Sam%20Maneka.JPG
-Jeremiah Manele,"Manele, Hon. Jeremiah",Hograno-Kia-Havulei,10,http://www.parliament.gov.sb/index.php?q=node/935,935,"",+677 28052,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon.%20Jeremiah%20Manele.jpg
-Jimson Fiau Tanangada,"Tanangada, Hon. Jimson Fiau",Gizo-Kolombangara,10,http://www.parliament.gov.sb/index.php?q=node/956,956,United Democratic Party,+677 25238,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Jimson_Fiau%20Tanangada.jpg
-Dr. Culwick Togamana,"Togamana, Hon. Dr. Culwick",Maringe-Kokota,10,http://www.parliament.gov.sb/index.php?q=node/958,958,Democratic Alliance Party,+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Dr%20Calwick_Togamana.JPG
-Freda A.B. Tuki Soriacomua,"Soriacomua, Hon. Freda A.B. Tuki",Temotu Vatud,10,http://www.parliament.gov.sb/index.php?q=node/959,959,United Democratic Party,+677 23544,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_FredaTuki_Soriocomua.JPG
-Steve William Abana,"Abana, Hon. Steve William",Fataleka,10,http://www.parliament.gov.sb/index.php?q=node/961,961,Democratic Alliance Party,+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Steve_Abana.jpg
-Matthew C. Wale,"Wale, Hon. Matthew C.",Aoke/Langa Langa,10,http://www.parliament.gov.sb/index.php?q=node/962,962,"",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics%5CHon_Matthew_C_Wale.jpg
-Namson Tran,"Tran, Hon. Namson",West Honiara,10,http://www.parliament.gov.sb/index.php?q=node/963,963,"",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics%5CHon_Namson_Tran.jpg
-Milner Tozaka,"Tozaka, Hon. Milner",North Vella la Vella,10,http://www.parliament.gov.sb/index.php?q=node/964,964,"",+677 21250,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics%5CHon_Milner_Tozaka.JPG
-Bradley Tovosia,"Tovosia, Hon. Bradley",East Guadalcanal,10,http://www.parliament.gov.sb/index.php?q=node/965,965,"",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics%5CHon_Bradley_Tovosia.jpg
-William Bradford Marau,"Marau, Hon. William Bradford",Ulawa-Ugi,10,http://www.parliament.gov.sb/index.php?q=node/966,966,"",+677 28176,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics%5CHon_Willie_Bradford_Marau.JPG
-Derick Rawcliff Manu’ari,"Manu’ari, Hon. Derick Rawcliff",West Makira,10,http://www.parliament.gov.sb/index.php?q=node/967,967,"",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics%5CHon_Derrick_Manuari.JPG
+id,name,sort_name,phone,image
+503,Horst Heinz Bodo Dettke,"Dettke, Hon. Horst Heinz Bodo",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Bodo%20Dettke.jpg
+506,Jackson Fiulaua,"Fiulaua, Hon. Jackson",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Jackson_Fiulaua.JPG
+507,John Moffat Fugui,"Fugui, Hon. John Moffat",+677 28803,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Moffat_Fugui.JPG
+521,Moses Garu,"Garu, Hon. Moses",+677 21551,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Moses_Garu.JPG
+532,Douglas Ete,"Ete, Hon. Douglas",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Douglas_Ete.JPG
+591,Peter Shanel Agovaka,"Agovaka, Hon. Peter Shanel",+677 36720,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Peter_Shanel_Agovaka.JPG
+592,Bartholomew Parapolo,"Parapolo, Hon. Bartholomew",+677 28603,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Bartholomew_Parapolo.jpg
+845,Alfred Ghiro,"Ghiro, Hon. Alfred",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Alfred_Ghiro.JPG
+846,Manasseh Damukana Sogavare,"Sogavare, Hon. Manasseh Damukana",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Manasseh%20Sogavare.JPG
+848,Ishmael Mali Avui,"Avui, Hon. Ishmael Mali",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Ismael_Avui.jpg
+849,Snyder Rini,"Rini, Hon. Snyder",+677 22556/22557/22558,http://www.parliament.gov.sb/memberfiles%5Cmemberpics%5Crini.jpg
+851,Nestor Giro,"Giro, Hon. Nestor",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Nesto_Ghiro.JPG
+852,Rick Nelson Houenipwela,"Houenipwela, Hon. Rick Nelson",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Rick_Houenipwela.JPG
+853,Sam Shemuel Iduri,"Iduri, Hon. Sam Shemuel",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20ShemuelSam%20Iduri.jpg
+855,Martin Kealoe,"Kealoe, Hon. Martin",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Martin%20Kealoe.jpg
+856,Christopher Laore,"Laore, Hon. Christopher",+677 22263,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Christopher%20Laore.jpg
+857,Manasseh Maelanga,"Maelanga, Hon. Manasseh",+677 28602,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Manasseh%20Maelanga.jpg
+858,John Maneniaru,"Maneniaru, Hon. John",+677 28604,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20John%20Mane.jpg
+859,Andrew Manepora’a,"Manepora’a, Hon Andrew",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Andrew%20Manepora'a.jpg
+860,Samuel Manetoali,"Manetoali, Hon. Samuel",+677 23031/23032,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Samuel_Manetoali.JPG
+861,Commins Aston Mewa,"Mewa, Hon. Commins Aston",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Commins%20Aston%20Mewa.jpg
+862,Elijah Doro Muala,"Muala, Hon. Elijah Doro",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Elijah%20Doro%20Muala.jpg
+863,David Day Pacha,"Pacha, Hon. David Day",+677 21552,http://www.parliament.gov.sb/memberfiles/memberpics/pacha.jpg
+864,Dickson Mua Panakitasi,"Panakitasi, Hon. Dickson Mua",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Dickson%20Mua.jpg
+865,Danny Philip,"Philip, Hon. Danny",+677 38255/38256,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Danny%20Philip.jpg
+866,Lionel Alex Qora,"Qora, Hon. Lionel Alex",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Lionel%20Alex.jpg
+867,Connelly Mathew Sadakabatu,"Sadakabatu, Hon. Connelly Mathew",,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Connelly%20Sandakabatu.jpg
+871,Charles Sigoto,"Sigoto, Hon. Charles",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Charles%20Sigoto.jpg
+872,Dr. Derek Sikua,"Sikua, Hon. Dr. Derek",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Dr.%20Derek%20Sikua.JPG
+873,Stanley Festus Sofu,"Sofu, Hon. Stanley Festus",+677 22208/28421,http://www.parliament.gov.sb/memberfiles/memberpics/sofu.jpg
+874,Silas Kerry Vaqara Tausinga,"Tausinga, Hon. Silas Kerry Vaqara",+677 28520,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics/Hon.%20Silas%20Tausinga.JPG
+875,Peter Tom,"Tom, Hon. Peter",+677 28520,http://www.parliament.gov.sb/memberfiles/memberpics/tom.jpg
+876,David Wanesiofa Tome,"Tome, Hon. David Wanesiofa",+677 28709,http://www.parliament.gov.sb/memberfiles/9th_Parliament/memberpics%5CHon.%20David%20Tome.jpg
+915,Dr. Tautai Angikimua Kaitu’u,"Kaitu’u, Hon. Dr. Tautai Angikimua",+677 20830,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon.%20Dr.%20Tautai%20Angikimua%20Kaitu%E2%80%99u.jpg
+916,Duddley Kopu,"Kopu, Hon. Duddley",+677 22143,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon.%20Duddley%20Kopu.JPG
+920,John Dean Kuku,"Kuku, Hon. John Dean",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_John_Dean_Kuku.JPG
+929,Jimmy Lusibaea,"Lusibaea, Hon. Jimmy",+677 21141,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon.%20Jimmy%20Lusibaea.jpg
+930,Augustine Auga Maeue,"Maeue, Hon. Augustine Auga",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon.%20Augustine%20Auga.JPG
+931,Samson Maneka,"Maneka, Hon. Samson",+677 23015,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon.%20Sam%20Maneka.JPG
+935,Jeremiah Manele,"Manele, Hon. Jeremiah",+677 28052,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon.%20Jeremiah%20Manele.jpg
+956,Jimson Fiau Tanangada,"Tanangada, Hon. Jimson Fiau",+677 25238,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Jimson_Fiau%20Tanangada.jpg
+958,Dr. Culwick Togamana,"Togamana, Hon. Dr. Culwick",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Dr%20Calwick_Togamana.JPG
+959,Freda A.B. Tuki Soriacomua,"Soriacomua, Hon. Freda A.B. Tuki",+677 23544,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_FredaTuki_Soriocomua.JPG
+961,Steve William Abana,"Abana, Hon. Steve William",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics/Hon_Steve_Abana.jpg
+962,Matthew C. Wale,"Wale, Hon. Matthew C.",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics%5CHon_Matthew_C_Wale.jpg
+963,Namson Tran,"Tran, Hon. Namson",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics%5CHon_Namson_Tran.jpg
+964,Milner Tozaka,"Tozaka, Hon. Milner",+677 21250,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics%5CHon_Milner_Tozaka.JPG
+965,Bradley Tovosia,"Tovosia, Hon. Bradley",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics%5CHon_Bradley_Tovosia.jpg
+966,William Bradford Marau,"Marau, Hon. William Bradford",+677 28176,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics%5CHon_Willie_Bradford_Marau.JPG
+967,Derick Rawcliff Manu’ari,"Manu’ari, Hon. Derick Rawcliff",+677 28520,http://www.parliament.gov.sb/memberfiles/10th_Parliament/memberpics%5CHon_Derrick_Manuari.JPG


### PR DESCRIPTION
When building Person + Membership information, we need to be very careful
not to include "Membership"-type data (party, constituency, term, start/end
date) from any Person source, as that will get merged into every membership
that the Person has had. This appears safe if there's only a single term,
and no-one changes party or area during that, but the instant someone has a
second membership, bad things start to happen.

Part of https://github.com/everypolitician/everypolitician/issues/589