### PR TITLE
Saint Kitts and Nevis (Assembly): remove Membership fields from Person source

### DIFF
--- a/data/Saint_Kitts_and_Nevis/Assembly/sources/instructions.json
+++ b/data/Saint_Kitts_and_Nevis/Assembly/sources/instructions.json
@@ -120,7 +120,7 @@
       "create": {
         "from": "morph",
         "scraper": "tmtmtmtm/saint-kitts-and-nevis-elections-wikipedia",
-        "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data ORDER BY name"
+        "query": "SELECT REPLACE(LOWER(name),' ','_') AS id, name, wikiname FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org/wiki/Saint_Kitts_and_Nevis_general_election,_2015",
       "type": "person",

--- a/data/Saint_Kitts_and_Nevis/Assembly/sources/morph/wikipedia.csv
+++ b/data/Saint_Kitts_and_Nevis/Assembly/sources/morph/wikipedia.csv
@@ -1,12 +1,12 @@
-name,wikiname,party,area,term,id
-Denzil Douglas,Denzil Douglas,Saint Kitts and Nevis Labour Party,St Christopher #6,2015,denzil_douglas
-Eugene Hamilton,Eugene Hamilton (politician),People's Action Movement,St Christopher #8,2015,eugene_hamilton
-Ian Liburd,"",People's Action Movement,St Christopher #1,2015,ian_liburd
-Konris Maynard,Konris Maynard,Saint Kitts and Nevis Labour Party,St Christopher #3,2015,konris_maynard
-Lindsay Grant,Lindsay Grant,People's Action Movement,St Christopher #4,2015,lindsay_grant
-Marcella Liburd,"",Saint Kitts and Nevis Labour Party,St Christopher #2,2015,marcella_liburd
-Mark Brantley,"",Concerned Citizens' Movement,Nevis #9,2015,mark_brantley
-Patrice Nisbett,Patrice Nisbett,Nevis Reformation Party,Nevis #11,2015,patrice_nisbett
-Shawn Richards,Shawn Richards,People's Action Movement,St Christopher #5,2015,shawn_richards
-Timothy Harris,Timothy Harris,People's Labour Party,St Christopher #7,2015,timothy_harris
-Vance Amory,Vance Amory,Concerned Citizens' Movement,Nevis #10,2015,vance_amory
+id,name,wikiname
+denzil_douglas,Denzil Douglas,Denzil Douglas
+eugene_hamilton,Eugene Hamilton,Eugene Hamilton (politician)
+ian_liburd,Ian Liburd,""
+konris_maynard,Konris Maynard,Konris Maynard
+lindsay_grant,Lindsay Grant,Lindsay Grant
+marcella_liburd,Marcella Liburd,""
+mark_brantley,Mark Brantley,""
+patrice_nisbett,Patrice Nisbett,Patrice Nisbett
+shawn_richards,Shawn Richards,Shawn Richards
+timothy_harris,Timothy Harris,Timothy Harris
+vance_amory,Vance Amory,Vance Amory


### PR DESCRIPTION
When building Person + Membership information, we need to be very careful
not to include "Membership"-type data (party, constituency, term, start/end
date) from any Person source, as that will get merged into every membership
that the Person has had. This appears safe if there's only a single term,
and no-one changes party or area during that, but the instant someone has a
second membership, bad things start to happen.

Part of https://github.com/everypolitician/everypolitician/issues/589