### PR TITLE
Turks and Caicos (Assembly): Amend wikipedia query to import person data only from 2012

### DIFF
--- a/data/Turks_and_Caicos_Islands/Assembly/sources/instructions.json
+++ b/data/Turks_and_Caicos_Islands/Assembly/sources/instructions.json
@@ -10,7 +10,7 @@
       "create": {
         "from": "morph",
         "scraper": "tmtmtmtm/turks-and-caicos-assembly-wikipedia",
-        "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data ORDER BY name"
+        "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data WHERE term=2012 ORDER BY name"
       },
       "merge": {
         "incoming_field": "name",


### PR DESCRIPTION
In a forthcoming PR, Wikipedia will be the source for term 2016 membership data. 2016 person data will come from the official source.

This is a step towards that.

Part of: https://github.com/everypolitician/everypolitician-data/issues/25274