### PR TITLE
Turks and Caicos (assembly) import only term 2012 from wikipedia

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -10472,11 +10472,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Turks_and_Caicos_Islands/Assembly/sources",
         "popolo": "data/Turks_and_Caicos_Islands/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/11c024630e290ea45e773346700581ec350c780e/data/Turks_and_Caicos_Islands/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8d90fb66a8a495200656902c8bdf270b3f0b3b98/data/Turks_and_Caicos_Islands/Assembly/ep-popolo-v1.0.json",
         "names": "data/Turks_and_Caicos_Islands/Assembly/names.csv",
         "lastmod": "1488200668",
         "person_count": 18,
-        "sha": "11c024630e290ea45e773346700581ec350c780e",
+        "sha": "8d90fb66a8a495200656902c8bdf270b3f0b3b98",
         "legislative_periods": [
           {
             "end_date": "2016-12-14",
@@ -10485,7 +10485,7 @@
             "start_date": "2012-11-09",
             "slug": "2012",
             "csv": "data/Turks_and_Caicos_Islands/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/11c024630e290ea45e773346700581ec350c780e/data/Turks_and_Caicos_Islands/Assembly/term-2012.csv"
+            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8d90fb66a8a495200656902c8bdf270b3f0b3b98/data/Turks_and_Caicos_Islands/Assembly/term-2012.csv"
           }
         ],
         "statement_count": 591,

--- a/data/Turks_and_Caicos_Islands/Assembly/sources/instructions.json
+++ b/data/Turks_and_Caicos_Islands/Assembly/sources/instructions.json
@@ -15,7 +15,7 @@
       "create": {
         "from": "morph",
         "scraper": "tmtmtmtm/turks-and-caicos-assembly-wikipedia",
-        "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data ORDER BY name"
+        "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data WHERE term=2012 ORDER BY name"
       },
       "merge": {
         "incoming_field": "name",

--- a/data/Turks_and_Caicos_Islands/Assembly/sources/morph/wikipedia.csv
+++ b/data/Turks_and_Caicos_Islands/Assembly/sources/morph/wikipedia.csv
@@ -1,16 +1,16 @@
 name,wikiname,party,area,term,id
 Akierra M. Missick,Akierra Missick,PNP,Leeward,2012,akierra_m._missick
-Amanda A. Misick,"",PNP,Cheshire Hall & Richmond Hill (results voided in February 2013),2012,amanda_a._misick
-Charles Washington Misick,Washington Misick,PNP,Wheeland,2012,charles_washington_misick
-Derek Taylor,Derek Hugh Taylor,PDM,Wheeland,2012,derek_taylor
+Amanda A. Misick,"",PNP,Cheshire Hall & Richmond Hill,2012,amanda_a._misick
+Charles Washington Misick,Washington Misick,PNP,All Island District,2012,charles_washington_misick
+Derek Taylor,Derek Hugh Taylor,PDM,All Island District,2012,derek_taylor
 Edwin Astwood,"",PDM,Grand Turk South,2012,edwin_astwood
 George Alexander Lightbourne,"",PNP,Grand Turk North,2012,george_alexander_lightbourne
 Goldray McMillin Ewing,"",PDM,Blue Hills,2012,goldray_mcmillin_ewing
-Josephine Connolly,"",PDM,Wheeland,2012,josephine_connolly
+Josephine Connolly,Josephine Connolly,PDM,All Island District,2012,josephine_connolly
 Norman Benjamin Saunders,Norman Saunders (politician),PNP,South Caicos,2012,norman_benjamin_saunders
 Porsha Monique Stubbs Smith,"",PNP,The Bight,2012,porsha_monique_stubbs_smith
 Ricardo Don Hue Gardiner,"",PNP,North & Middle Caicos,2012,ricardo_don_hue_gardiner
-Rufus Washington Ewing,Rufus Ewing,PNP,Wheeland,2012,rufus_washington_ewing
+Rufus Washington Ewing,Rufus Ewing,PNP,All Island District,2012,rufus_washington_ewing
 Sean Rickard Astwood,"",PDM,Five Cays,2012,sean_rickard_astwood
-Sharlene Linette Cartwright Robinson,Sharlene Cartwright-Robinson,PDM,Wheeland,2012,sharlene_linette_cartwright_robinson
+Sharlene Linette Cartwright Robinson,Sharlene Cartwright-Robinson,PDM,All Island District,2012,sharlene_linette_cartwright_robinson
 Vaden Delroy Williams,"",PDM,Wheeland,2012,vaden_delroy_williams


### PR DESCRIPTION
The wikipedia source contains data for both the 2012 and 2016 terms. This PR prepares for a forthcoming PR in which I will change the wikipedia source type from person to membership (WIP: https://github.com/everypolitician/everypolitician-data/pull/26967).

I am limiting the incoming data to term 2012 otherwise, in the forthcoming PR, the Wikidata upstream source will add membership data for term 2016 too -- which I don't want as the legislature is not yet ready for the new term.

Part of: https://github.com/everypolitician/everypolitician-data/issues/25274

```
Add memberships from sources/archive/official-2012-appointed-members.csv
Add memberships from sources/archive/official-2012-elected-members.csv
Merging with sources/morph/wikipedia.csv
Data Mismatches
* 1 of 15 unmatched
	{:name=>"Edwin Astwood", :id=>"edwin_astwood"}
Merging with sources/morph/wikidata.csv
Adding GenderBalance results from sources/gender-balance/results.csv
  ⚥ data for 12; 12 added


Top identifiers:
  6 x wikidata
  1 x freebase

Creating names.csv
Persons matched to Wikidata: 6 ✓ | 12 ✘
  No wikidata: Josephine Conolly (962d6976-377d-4758-bb66-bb47638aeef5)
  No wikidata: Clarence Selver (b036609e-30da-4c49-82bd-219d51f7ac2c)
  No wikidata: Ruth Delores Blackman (f6d8ace4-f66c-4260-a906-b17938a4dfdf)
  No wikidata: Amanda Missick (0bab1627-2702-4bd3-a4e5-a4e9a262fa90)
  No wikidata: Ricardo Don-Hue Gardiner (ffdcdd70-e20a-4892-adcf-aeb38cddfa3d)
  No wikidata: Lillian Swann-Misick (43db9919-439e-4a90-82c4-8f94c9f1be8b)
  No wikidata: John Philips (3e8718af-2588-44ef-9516-551a19be3f13)
  No wikidata: George Alexander Lightbourne (dc1c0d1b-bcd4-483a-8be0-9bd8754e35f4)
  No wikidata: Vaden Delroy Williams (ed3f718c-b43a-4f6a-9558-6b329aae764d)
  No wikidata: Sean Rickard Astwood (0c52f20d-9d0b-45c9-82cc-e95b9c1dec1c)
Parties matched to Wikidata: 2 ✓ | 1 ✘
  No wikidata: unknown (party/unknown)
Areas matched to Wikidata: 0 ✓ | 10 ✘
```