### PR TITLE
Moldova (Parlamentul): connect Term to Wikidata

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -6258,11 +6258,11 @@
         "slug": "Parlamentul",
         "sources_directory": "data/Moldova/Parlamentul/sources",
         "popolo": "data/Moldova/Parlamentul/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e688de761968700768833ba631776e6a1cb62df1/data/Moldova/Parlamentul/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7603f157f9767a4af64e61ef600259a1288ad57d/data/Moldova/Parlamentul/ep-popolo-v1.0.json",
         "names": "data/Moldova/Parlamentul/names.csv",
-        "lastmod": "1486479740",
+        "lastmod": "1488529141",
         "person_count": 116,
-        "sha": "e688de761968700768833ba631776e6a1cb62df1",
+        "sha": "7603f157f9767a4af64e61ef600259a1288ad57d",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -6273,7 +6273,7 @@
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/18749616ad2a9fa935e01deda143e6e35749c1c3/data/Moldova/Parlamentul/term-2014.csv"
           }
         ],
-        "statement_count": 6355,
+        "statement_count": 6357,
         "type": "unicameral legislature"
       }
     ]

--- a/data/Moldova/Parlamentul/ep-popolo-v1.0.json
+++ b/data/Moldova/Parlamentul/ep-popolo-v1.0.json
@@ -12223,6 +12223,12 @@
     {
       "classification": "legislative period",
       "id": "term/2014",
+      "identifiers": [
+        {
+          "identifier": "Q20431862",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "Legislatura XX",
       "organization_id": "cb459823-f905-4d88-a0cb-c420eb796e33",
       "start_date": "2014-12-29"

--- a/data/Moldova/Parlamentul/sources/manual/terms.csv
+++ b/data/Moldova/Parlamentul/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date
-2014,Legislatura XX,2014-12-29
+id,name,start_date,wikidata
+2014,Legislatura XX,2014-12-29,Q20431862

--- a/data/Moldova/Parlamentul/unstable/stats.json
+++ b/data/Moldova/Parlamentul/unstable/stats.json
@@ -19,7 +19,7 @@
   "terms": {
     "count": 1,
     "latest": "2014-12-29",
-    "wikidata": 0
+    "wikidata": 1
   },
   "areas": {
     "count": 0,


### PR DESCRIPTION
Part of https://github.com/everypolitician/everypolitician/issues/590

```
Add memberships from sources/morph/data.csv
Add memberships from sources/manual/gone.csv
Merging with sources/morph/wikidata.csv
Data Mismatches
* 14 of 107 unmatched
	{:id=>"Q5609021", :name=>"Grigore Belostecinic"}
	{:id=>"Q6968023", :name=>"Natalia Gherman"}
	{:id=>"Q21746906", :name=>"Veronica Herța"}
	{:id=>"Q20431851", :name=>"Oleg Balan"}
	{:id=>"Q7155601", :name=>"Pavel Filip"}
	{:id=>"Q1110215", :name=>"Dorin Chirtoacă"}
	{:id=>"Q12731069", :name=>"Irina Vlah"}
	{:id=>"Q15071201", :name=>"Monica Babuc"}
	{:id=>"Q13428691", :name=>"Vasile Botnari"}
	{:id=>"Q15071069", :name=>"Maia Sandu"}
Adding GenderBalance results from sources/gender-balance/results.csv
  ⚥ data for 0; 0 added


Top identifiers:
  93 x wikidata
  15 x freebase
  5 x viaf
  2 x sudoc
  2 x lcauth

Creating names.csv
Persons matched to Wikidata: 93 ✓ | 23 ✘
  No wikidata: Oleg Ogor (572707cb-0242-4cfb-bd91-c5384d0ab7df)
  No wikidata: Igor Vremea (6e280b9a-a7ed-42c9-bdd2-a3805cc2a653)
  No wikidata: Elena Gudumac (7ac868dd-f9ea-4b82-8dfc-a48a159df088)
  No wikidata: Corneliu Mihalache (d62316d8-8d11-4f62-bdd0-511c2fe60a5b)
  No wikidata: Roman Boțan (6b3d355a-6e9c-460a-909d-3f66c869f748)
  No wikidata: Corneliu Padnevici (d3a34a5a-513f-45cf-b950-08087ceea54d)
  No wikidata: Vladimir Andronachi (6569db12-3b84-49d9-a8f2-a4cce694e3d0)
  No wikidata: Eugeniu Nichiforciuc (ab3587af-d070-43e3-847a-06656e209696)
  No wikidata: Munteanu Valeriu (14121c5f-f09f-4e97-b312-df9533b9768d)
  No wikidata: Valentina Rotaru (8d8652e2-9c83-45bf-bd8f-93cab12f4678)
Parties matched to Wikidata: 6 ✓ 
Areas matched to Wikidata: 0 ✓ 
```