### PR TITLE
Puerto Rico (House of Representatives): fix term dates

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -8014,11 +8014,11 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Puerto_Rico/House_of_Representatives/sources",
         "popolo": "data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8925c2a843c2d6cf0aa42ca1028f0485c91452cd/data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e0cd3714564ea552dbd464b4843c2aa0beb9d9ea/data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Puerto_Rico/House_of_Representatives/names.csv",
-        "lastmod": "1487198635",
+        "lastmod": "1489660504",
         "person_count": 74,
-        "sha": "8925c2a843c2d6cf0aa42ca1028f0485c91452cd",
+        "sha": "e0cd3714564ea552dbd464b4843c2aa0beb9d9ea",
         "legislative_periods": [
           {
             "end_date": "2020-01-01",
@@ -8030,10 +8030,10 @@
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d407d253b79ba863423127e521226b680c3f0785/data/Puerto_Rico/House_of_Representatives/term-30.csv"
           },
           {
-            "end_date": "2017-01-08",
+            "end_date": "2017-01-01",
             "id": "term/29",
             "name": "29th House of Representatives of Puerto Rico",
-            "start_date": "2013-01-14",
+            "start_date": "2013-01-02",
             "slug": "29",
             "csv": "data/Puerto_Rico/House_of_Representatives/term-29.csv",
             "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a5db8c8a2707c4e3c3342c6cb72554d5bb30c76/data/Puerto_Rico/House_of_Representatives/term-29.csv"

--- a/data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json
+++ b/data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json
@@ -8771,7 +8771,7 @@
     },
     {
       "classification": "legislative period",
-      "end_date": "2017-01-08",
+      "end_date": "2017-01-01",
       "id": "term/29",
       "identifiers": [
         {
@@ -8781,7 +8781,7 @@
       ],
       "name": "29th House of Representatives of Puerto Rico",
       "organization_id": "d82e59cc-6c1f-4cb0-bc75-49e69a785ac7",
-      "start_date": "2013-01-14"
+      "start_date": "2013-01-02"
     },
     {
       "classification": "general election",

--- a/data/Puerto_Rico/House_of_Representatives/sources/manual/terms.csv
+++ b/data/Puerto_Rico/House_of_Representatives/sources/manual/terms.csv
@@ -1,4 +1,4 @@
 id,name,start_date,end_date,wikidata
 30,30th House of Representatives of Puerto Rico,2017-01-02,2020-01-01,Q28152279
-29,29th House of Representatives of Puerto Rico,2013-01-14,2017-01-08,Q4632940
-28,28th House of Representatives of Puerto Rico,2009-01-14,2013-01-08,Q16823608
+29,29th House of Representatives of Puerto Rico,2013-01-02,2017-01-01,Q4632940
+28,28th House of Representatives of Puerto Rico,2009-01-02,2013-01-01,Q16823608


### PR DESCRIPTION
The terms were overlapping in a bad way, so I've fixed up the data in
Wikidata, and then rebuilt this using using
`generate_terms_from_wikidata.rb Q28152279`

Part of https://github.com/everypolitician/everypolitician/issues/594

```
Add memberships from sources/morph/official29.csv
Add memberships from sources/morph/official30.csv
Merging with sources/morph/wikidata.csv
Adding GenderBalance results from sources/gender-balance/results.csv
  ⚥ data for 0; 0 added


Top identifiers:
  56 x wikidata
  1 x fec
  1 x freebase
  1 x opensecrets
  1 x uscongress

Creating names.csv
Persons matched to Wikidata: 56 ✓ | 18 ✘
  No wikidata: Guillermo Miranda Rivera (85759a70-565c-416a-87c0-7b32bbbf188e)
  No wikidata: Eddie Charbonier Chinea (29702730-fe12-4853-af21-53a536db2d94)
  No wikidata: Félix G. Lassalle Toro (93e8147b-fa83-4171-ab81-4af0058e7629)
  No wikidata: Samuel Pagán Cuadrado (73a5949a-03e1-490c-b76b-668c89f503fe)
  No wikidata: Víctor M. Torres González (3577eccc-9c4c-4260-92ce-4454ed05e9e9)
  No wikidata: José J. Pérez Cordero (742b84a4-51df-4e46-aba2-42cd4db18e63)
  No wikidata: Ramón L. Rodríguez Ruiz (8e5fb139-78c5-41f3-88c1-d36205633224)
  No wikidata: José A. Díaz Collazo (c39485f0-5095-458d-b361-ef6bede22dac)
  No wikidata: Joel I. Franqui Atiles (f72006ec-99fd-4347-a24b-28399f4ccc4f)
  No wikidata: José A. Banchs Alemán (c5a7f266-8b84-4b3d-8920-8538ceb95a45)
Parties matched to Wikidata: 3 ✓ 
Areas matched to Wikidata: 0 ✓ | 41 ✘
```