### PR TITLE
Travis: Don't send 'success' notifications to Slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ env:
     secure: ZCQVQdKDUyPY/BM1FYriv6h+rNF+PqQETnj5FwU/jQKNz8utvaUVjXD/pIMwEmO5orzng5/MnZvErkr2+JZBs+0JghXWtjDxQHxJzfBTZJnaiAY9hWZBC9Kgbl1/mJvUvK132W5GzQ5xS9lw/pyKFGRba9A7rfoYFfkaJKmgq1U=
 notifications:
   slack:
+    on_success: never
     secure: KGGTh4XFNqQ4TrQB90B++X4q4jOohQxsZatRk54cYqZOSsrLm8CEJU4eBFVfhQ0p/iiYIBwfZlECyjMgKR+3OUYAAcHGuPSuE5q9M9KUi+c5O11Lx02lQAwhMzUXR0/BmKiUYWssOdV7RsfG3VXOu7vUKmapcT+oQUHmbRd+b8U=


### PR DESCRIPTION
There's a lot of noise in the Travis channel on Slack, and we almost
never want to know when a build succeeded — only when it fails. So turn
off success notifications.

See: https://docs.travis-ci.com/user/notifications/#Changing-notification-frequency