### PR TITLE
Egypt Parliament correct data source

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -2796,11 +2796,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Egypt/Parliament/sources",
         "popolo": "data/Egypt/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d6b1d90ff0be3b1bb2c416ea06e9236f2da41ac5/data/Egypt/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e457f3cacece794ae3c2c333918da662d470b312/data/Egypt/Parliament/ep-popolo-v1.0.json",
         "names": "data/Egypt/Parliament/names.csv",
-        "lastmod": "1487917656",
+        "lastmod": "1490198515",
         "person_count": 600,
-        "sha": "d6b1d90ff0be3b1bb2c416ea06e9236f2da41ac5",
+        "sha": "e457f3cacece794ae3c2c333918da662d470b312",
         "legislative_periods": [
           {
             "id": "term/2015",

--- a/data/Egypt/Parliament/ep-popolo-v1.0.json
+++ b/data/Egypt/Parliament/ep-popolo-v1.0.json
@@ -7357,7 +7357,7 @@
   ],
   "meta": {
     "sources": [
-      "http://www.assemblee-nationale.tg/",
+      "http://www.parliament.gov.eg/",
       "http://wikidata.org/"
     ]
   },

--- a/data/Egypt/Parliament/sources/instructions.json
+++ b/data/Egypt/Parliament/sources/instructions.json
@@ -7,7 +7,7 @@
         "scraper": "struan/egypt_parliament_members",
         "query": "SELECT *, cons AS area, 2015 AS term FROM data ORDER BY id"
       },
-      "source": "http://www.assemblee-nationale.tg/",
+      "source": "http://www.parliament.gov.eg/",
       "type": "membership"
     },
     {


### PR DESCRIPTION
Fixes: https://github.com/everypolitician/everypolitician-data/issues/29058

The source for the data was recorded as `http://www.assemblee-nationale.tg`. This PR corrects it to: `http://www.parliament.gov.eg/`