### PR TITLE
Give the travis 'secure' token somewhere to live

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ env:
     secure: ZCQVQdKDUyPY/BM1FYriv6h+rNF+PqQETnj5FwU/jQKNz8utvaUVjXD/pIMwEmO5orzng5/MnZvErkr2+JZBs+0JghXWtjDxQHxJzfBTZJnaiAY9hWZBC9Kgbl1/mJvUvK132W5GzQ5xS9lw/pyKFGRba9A7rfoYFfkaJKmgq1U=
 notifications:
   slack:
+    rooms:
+      - secure: KGGTh4XFNqQ4TrQB90B++X4q4jOohQxsZatRk54cYqZOSsrLm8CEJU4eBFVfhQ0p/iiYIBwfZlECyjMgKR+3OUYAAcHGuPSuE5q9M9KUi+c5O11Lx02lQAwhMzUXR0/BmKiUYWssOdV7RsfG3VXOu7vUKmapcT+oQUHmbRd+b8U=
     on_success: never
-    secure: KGGTh4XFNqQ4TrQB90B++X4q4jOohQxsZatRk54cYqZOSsrLm8CEJU4eBFVfhQ0p/iiYIBwfZlECyjMgKR+3OUYAAcHGuPSuE5q9M9KUi+c5O11Lx02lQAwhMzUXR0/BmKiUYWssOdV7RsfG3VXOu7vUKmapcT+oQUHmbRd+b8U=


### PR DESCRIPTION
The way travis expands 'secure' (https://docs.travis-ci.com/user/encryption-keys/#Detailed-Discussion) converts the hash to a plain string, and thus can’t be left dangling at the existing level of nesting, but instead needs a section it can live within. The "This is how a setup with encrypted credentials could look like" (sic) at https://docs.travis-ci.com/user/notifications/#Configuring-slack-notifications suggests putting it into 'rooms'.

Continues from https://github.com/everypolitician/everypolitician-data/pull/28717