### PR TITLE
Lesotho Assembly: reference second source in import instruction

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -5511,11 +5511,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Lesotho/Assembly/sources",
         "popolo": "data/Lesotho/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/92ae3fa880c9bd3761e1c93f36bba4fca584be01/data/Lesotho/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b18b14be2f7beb4e9faafd84b2b29a515fe9d250/data/Lesotho/Assembly/ep-popolo-v1.0.json",
         "names": "data/Lesotho/Assembly/names.csv",
-        "lastmod": "1487155378",
+        "lastmod": "1490289742",
         "person_count": 120,
-        "sha": "92ae3fa880c9bd3761e1c93f36bba4fca584be01",
+        "sha": "b18b14be2f7beb4e9faafd84b2b29a515fe9d250",
         "legislative_periods": [
           {
             "id": "term/9",

--- a/data/Lesotho/Assembly/ep-popolo-v1.0.json
+++ b/data/Lesotho/Assembly/ep-popolo-v1.0.json
@@ -2251,6 +2251,7 @@
   "meta": {
     "sources": [
       "http://www.parliament.ls",
+      "http://candidates.iec.org.ls",
       "http://wikidata.org/"
     ]
   },

--- a/data/Lesotho/Assembly/sources/instructions.json
+++ b/data/Lesotho/Assembly/sources/instructions.json
@@ -7,7 +7,7 @@
         "scraper": "tmtmtmtm/lesotho-assembly",
         "query": "SELECT * FROM data ORDER BY name"
       },
-      "source": "http://www.parliament.ls",
+      "source": ["http://www.parliament.ls", "http://candidates.iec.org.ls"],
       "type": "membership"
     },
     {


### PR DESCRIPTION
The scraper pulls data from two separate sources.

The instruction was written when it was not possible to cite multiple sources. This PR adds the second source, now that it is possible to do so.

(This change is being made in advance of renaming the source file: https://github.com/everypolitician/everypolitician-data/pull/29050)