### PR TITLE
Armenia (Assembly): Change wikidata scraper url

### DIFF
--- a/data/Armenia/Assembly/sources/instructions.json
+++ b/data/Armenia/Assembly/sources/instructions.json
@@ -14,7 +14,7 @@
       "file": "morph/wikidata.csv",
       "create": {
         "from": "morph",
-        "scraper": "tmtmtmtm/armenia-assembly-wikidata",
+        "scraper": "everypolitician-scrapers/armenia-assembly-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://wikidata.org/",


### PR DESCRIPTION
The has moved on morph and now lives in https://morph.io/everypolitician-scrapers/

### Note to merger
https://morph.io/tmtmtmtm/armenia-assembly-wikidata can now be removed.
