### PR TITLE
Deploy: Report if countries.json has changed

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -41,6 +41,7 @@ deploy_viewer_static() {
 
 main() {
   if [[ "$TRAVIS_PULL_REQUEST" == false && "$TRAVIS_BRANCH" == master ]]; then
+    git diff --name-only $TRAVIS_COMMIT_RANGE -- countries.json
     start_viewer_sinatra
     build_viewer_static
     deploy_viewer_static


### PR DESCRIPTION
There is little point in rebuilding the site unless `countries.json` has
changed since the last build (as otherwise we'll be building from the
same source files, and thus there shouldn't be any changes[1])

In theory that should mean that we only need to do the build & deploy if
we have a commit to `master`, and it includes `countries.json` (assuming
we're doing (rebase and merge, rather than merge-commits)

Checking TRAVIS_COMMIT_RANGE _should_ tell us this, though as this is a
little difficult to test other than by just doing it, we'll start by
simply outputting whether it contains `countries.json` or not, rather
than switching any of the logic yet to do anything based on that. Then
we can check travis logs to make sure it's doing the right thing before
starting to actually use it.

[1] Unless something about the _site_ rather than the _data_ has
changed, but that will be taken care of by the deploy script in
`viewer-sinatra`