### PR TITLE
Run ruby 2.3.3 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ after_success:
   - scripts/deploy.sh
 cache: bundler
 rvm:
-  - 2.3.1
+  - 2.3.3
 env:
   global:
     secure: ZCQVQdKDUyPY/BM1FYriv6h+rNF+PqQETnj5FwU/jQKNz8utvaUVjXD/pIMwEmO5orzng5/MnZvErkr2+JZBs+0JghXWtjDxQHxJzfBTZJnaiAY9hWZBC9Kgbl1/mJvUvK132W5GzQ5xS9lw/pyKFGRba9A7rfoYFfkaJKmgq1U=


### PR DESCRIPTION
This repo only really cares about being > 2.3, but viewer-sinatra is
running 2.3.3, and we install that when we trigger `deploy.sh` from
travis. So we need to keep these in sync.