### PR TITLE
Only deploy when countries.json changes

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -41,7 +41,10 @@ deploy_viewer_static() {
 
 main() {
   if [[ "$TRAVIS_PULL_REQUEST" == false && "$TRAVIS_BRANCH" == master ]]; then
-    git diff --name-only $TRAVIS_COMMIT_RANGE -- countries.json
+    if git diff --name-only "$TRAVIS_COMMIT_RANGE" | fgrep --quiet --invert-match countries.json; then
+      echo "No changes to countries.json detected, skipping deploy."
+      exit
+    fi
     start_viewer_sinatra
     build_viewer_static
     deploy_viewer_static


### PR DESCRIPTION
We don't want to deploy everypolitician.org unless there has been a change to `countries.json`.

This uses the "TRAVIS_COMMIT_RANGE" environment variable to check if there has been a change to `countries.json` in the commit being built. If not then the deploy is skipped to avoid unnecessary spidering.

Follows on from https://github.com/everypolitician/everypolitician-data/pull/30681