### PR TITLE
Always deploy when countries.json changes

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -41,7 +41,7 @@ deploy_viewer_static() {
 
 main() {
   if [[ "$TRAVIS_PULL_REQUEST" == false && "$TRAVIS_BRANCH" == master ]]; then
-    if git diff --name-only "$TRAVIS_COMMIT_RANGE" | fgrep --quiet --invert-match countries.json; then
+    if [[ -z $(git diff --name-only "$TRAVIS_COMMIT_RANGE" -- countries.json) ]]; then
       echo "No changes to countries.json detected, skipping deploy."
       exit
     fi


### PR DESCRIPTION
Previously we were deploying when the _only_ file that changed was `countries.json`, but we also want to handle the case where `countries.json` and a bunch of other files all change at once.

I've changed this check to use the [`-z` operand](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html) to test for zero length output from the diff command, which indicates that `countries.json` wasn't changed.

Follows on from https://github.com/everypolitician/everypolitician-data/pull/30686#pullrequestreview-30237792