### PR TITLE
Cabo Verde (Assembly): map terms to Wikidata

### DIFF
--- a/data/Cabo_Verde/Assembly/ep-popolo-v1.0.json
+++ b/data/Cabo_Verde/Assembly/ep-popolo-v1.0.json
@@ -4336,6 +4336,12 @@
       "classification": "legislative period",
       "end_date": "2016-03-20",
       "id": "term/8",
+      "identifiers": [
+        {
+          "identifier": "Q29158393",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "VIII Legislatura",
       "organization_id": "33b73eeb-ccb7-480a-87fa-d0728966d2b9",
       "start_date": "2011-03-11"
@@ -4356,6 +4362,12 @@
     {
       "classification": "legislative period",
       "id": "term/9",
+      "identifiers": [
+        {
+          "identifier": "Q29158331",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "IX Legislatura",
       "organization_id": "33b73eeb-ccb7-480a-87fa-d0728966d2b9",
       "start_date": "2016-04-20"

--- a/data/Cabo_Verde/Assembly/sources/manual/terms.csv
+++ b/data/Cabo_Verde/Assembly/sources/manual/terms.csv
@@ -1,3 +1,3 @@
-id,name,start_date,end_date
-8,VIII Legislatura,2011-03-11,2016-03-20
-9,IX Legislatura,2016-04-20,
+id,name,start_date,end_date,wikidata
+8,VIII Legislatura,2011-03-11,2016-03-20,Q29158393
+9,IX Legislatura,2016-04-20,,Q29158331

--- a/data/Cabo_Verde/Assembly/unstable/stats.json
+++ b/data/Cabo_Verde/Assembly/unstable/stats.json
@@ -19,7 +19,7 @@
   "terms": {
     "count": 2,
     "latest": "2016-04-20",
-    "wikidata": 0
+    "wikidata": 2
   },
   "areas": {
     "count": 13,


### PR DESCRIPTION
Part of https://github.com/everypolitician/everypolitician/issues/590

```
Add memberships from sources/morph/offical-8.csv
Add memberships from sources/morph/offical-9.csv
Add memberships from sources/manual/memberships.csv
Adding GenderBalance results from sources/gender-balance/results.csv
  ⚥ data for 149; 149 added

Creating names.csv
Persons matched to Wikidata: 0 ✓ | 127 ✘
Parties matched to Wikidata: 3 ✓ | 1 ✘
  No wikidata: unknown (party/_unknown)
Areas matched to Wikidata: 0 ✓ | 13 ✘
```