### PR TITLE
Thailand Assembly: switch away from personal scraper on morph.io

### DIFF
--- a/data/Thailand/National_Legislative_Assembly/sources/instructions.json
+++ b/data/Thailand/National_Legislative_Assembly/sources/instructions.json
@@ -4,7 +4,7 @@
       "file": "morph/official.csv",
       "create": {
         "from": "morph",
-        "scraper": "davewhiteland/thailand-national-assembly",
+        "scraper": "everypolitician-scrapers/thailand-national-assembly",
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.senate.go.th/",


### PR DESCRIPTION
Moved scraper from https://morph.io/davewhiteland/thailand-national-assembly to https://morph.io/everypolitician-scrapers/thailand-national-assembly

There's no legacy data up there: the CSV being generated is identical in both cases, so this should be a seamless transfer.

Also set rebuilder webhook on the new scraper.


