### PR TITLE
Denmark (Folketing): move to EP-scrapers source

### DIFF
--- a/data/Denmark/Folketing/sources/instructions.json
+++ b/data/Denmark/Folketing/sources/instructions.json
@@ -9,7 +9,7 @@
       "file": "morph/official.csv",
       "create": {
         "from": "morph",
-        "scraper": "tmtmtmtm/denmark-folketing",
+        "scraper": "everypolitician-scrapers/denmark-folketing",
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.thedanishparliament.dk",


### PR DESCRIPTION
```
Add memberships from sources/archive/official-vanished.csv
Add memberships from sources/morph/official.csv
Add memberships from sources/morph/wikipedia-historic.csv
Merging with sources/morph/wikidata.csv
Data Mismatches
* 21 of 588 unmatched
	{:id=>"Q12301843", :name=>"Anne Marie Geisler Andersen"}
	{:id=>"Q12331302", :name=>"Per Dalgaard Christiansen"}
	{:id=>"Q5738260", :name=>"Alexander Foss"}
	{:id=>"Q12331626", :name=>"Peter Laigaard"}
	{:id=>"Q12331644", :name=>"Peter Madsen"}
	{:id=>"Q18199370", :name=>"Helge Vagn Jacobsen"}
	{:id=>"Q15944298", :name=>"Vibeke Grave"}
	{:id=>"Q17610849", :name=>"Helle Løvgreen Mølvig"}
	{:id=>"Q556712", :name=>"Aksel V. Johannesen"}
	{:id=>"Q12316018", :name=>"Helge Dohrmann"}
Merging with sources/morph/genderbalance.csv
Data Mismatches
* 4 of 254 unmatched
	{}
Party E126D66A-4A42-4A86-A96B-764D1D368A1C not in Popolo

Top identifiers:
  567 x wikidata
  135 x freebase
  120 x viaf
  44 x lcauth
  39 x isni

gCreating names.csv
  ☇ No dates for Knud Enggaard (Q11126408) as Finance Minister of Denmark
  ☇ No dates for Esben Lunde Larsen (Q12310565) as Education and Research Minister
  ☇ No dates for Henning Dyremose (Q12316220) as Finance Minister of Denmark
  ☇ No dates for Henrik Sass Larsen (Q12316446) as Danish Minister for Commerce
  ☇ No dates for Magnus Heunicke (Q12325727) as Danish Minister of Transport
  ☇ No dates for Svend Auken (Q1424299) as Minister for the Environment
  ☇ No dates for Connie Hedegaard (Q237797) as Minister for the Environment
  ☇ No dates for Connie Hedegaard (Q237797) as Minister for Climate and Energy
  ☇ No dates for Margrethe Vestager (Q270820) as Education Minister of Denmark
  ☇ No dates for Pia Gjellerup (Q273942) as Finance Minister of Denmark
  ☇ No dates for Claus Hjort Frederiksen (Q2978598) as Danish Minister for Labour
  ☇ No dates for Lene Espersen (Q299352) as Deputy Prime Minister
  ☇ No dates for Søren Pind (Q3078007) as Education and Research Minister
  ☇ No dates for Peter Brixtofte (Q3321283) as Tax Minister of Denmark
  ☇ No dates for Erik Ninn-Hansen (Q3375922) as Finance Minister of Denmark
  ☇ No dates for Niels Helveg Petersen (Q425708) as Minister of Economic and Business Affairs
  ☇ No dates for Ida Auken (Q441594) as Minister for the Environment
  ☇ No dates for Karen Hækkerup (Q512386) as Minister for Food, Agriculture and Fisheries
  ☇ No dates for Karen Hækkerup (Q512386) as Minister of Social Affairs
  ☇ No dates for Carsten Hansen (Q531748) as Minister for Nordic Co-operation
  ☇ No dates for Bendt Bendtsen (Q816805) as Minister of Economic and Business Affairs
  ☇ No dates for Brian Mikkelsen (Q912762) as Culture Minister of Denmark
  ☇ No dates for Lars Barfoed (Q917179) as Minister of Economic and Business Affairs
Persons matched to Wikidata: 567 ✓ | 50 ✘
  No wikidata: Morten Marinus Jørgensen (9c3d534b-d3c8-4b31-a3c7-de1b80b1870d)
  No wikidata: Erling Christensen (544f66a3-e4a9-4e8f-b72f-34ab3733addc)
  No wikidata: Arne Jensen (47753aa2-d934-42f0-930c-aa7e4e903d33)
  No wikidata: Birgitte Husmark (8d9552a2-317f-4580-a137-5ad0d1bcb29d)
  No wikidata: Pernille Forchhammer (78922825-8bae-46bd-a4e1-b8aa2e16d549)
  No wikidata: Niels Højland (8e2c7bae-7f9f-4e70-8c9d-efa4ff9d3b1f)
  No wikidata: Erik B. Smidt (b43d2fbc-1407-4424-b48b-bc8891779aea)
  No wikidata: Henning Nielsen (6b08bb03-c4d3-4da4-bbd3-6b1fd216091e)
  No wikidata: Egil Møller (ac6883a9-56e8-4f2b-8414-8fd53ac85809)
  No wikidata: Ole Glahn (fb45d933-5932-488f-bf90-8cc53c79aa9b)
Parties matched to Wikidata: 37 ✓ | 2 ✘
  No wikidata: unknown (B)
  No wikidata: Outside the parliamentary groups (1C1343ED-BA71-463F-A912-A6A07FCA9EF8)
Areas matched to Wikidata: 0 ✓ | 13 ✘
```