### PR TITLE
Add image count to legislature stats

### DIFF
--- a/data/Estonia/Riigikogu/unstable/stats.json
+++ b/data/Estonia/Riigikogu/unstable/stats.json
@@ -5,6 +5,7 @@
     "latest_term": {
       "count": 145,
       "wikidata": 145,
+      "images": 134,
       "contacts": {
         "email": 133,
         "facebook": 88,

--- a/lib/legislature_stats.rb
+++ b/lib/legislature_stats.rb
@@ -38,6 +38,7 @@ class StatsFile
       latest_term: {
         count:    current.count,
         wikidata: current.select(&:wikidata).count,
+        images:   current.select(&:image).count,
         contacts: {
           email:    current.select(&:email).count,
           facebook: current.select(&:facebook).count,


### PR DESCRIPTION
For now, only count the people within the current term; we can add the full
count later if required.