### PR TITLE
Fallback to 'en' for Areas with identical labels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 ﻿# This file documents substantial changes to the format of data files
 
+2017-08-15
+
+To reduce data bloat, we will no longer be including 'lang__xx' data where that
+is identical to 'lang__en'.
+
+This currently only applies to Areas, but will be applied to other
+collections over time.
+
+Other language fallback chains may be implemented later.
+
 2016-12-12
 
 Information on 'sources' is now provided on `Membership` rather than

--- a/lib/source/area.rb
+++ b/lib/source/area.rb
@@ -20,7 +20,9 @@ module Source
       end
 
       field :other_names do
-        area.select { |k, v| v && k.to_s.start_with?('name__') }.map do |k, v|
+        area.select { |k, v| v && k.to_s.start_with?('name__') }
+            .reject { |k, v| (v == area[:name__en]) && (k != :name__en) }
+            .map do |k, v|
           {
             lang: k.to_s[/name__(\w+)/, 1],
             name: v,


### PR DESCRIPTION
If an area has a 'name__xx' field that is identical to the 'name__en' field, we don't need to include it, as clients can fall back to the English version.

Later we will add parallel fallbacks for other language chains (see https://meta.wikimedia.org/wiki/Wikidata/Notes/Language_fallback), and apply this to other collections.