### PR TITLE
Move andylolz scrapers to everypolitician-scrapers

### DIFF
--- a/data/Gibraltar/Parliament/sources/instructions.json
+++ b/data/Gibraltar/Parliament/sources/instructions.json
@@ -4,7 +4,7 @@
       "file": "morph/official.csv",
       "create": {
         "from": "morph",
-        "scraper": "andylolz/gibraltar-parliament",
+        "scraper": "everypolitician-scrapers/gibraltar-parliament",
         "query": "SELECT * FROM data"
       },
       "source": "http://www.parliament.gi/",
@@ -14,7 +14,7 @@
       "file": "morph/wikipedia.csv",
       "create": {
         "from": "morph",
-        "scraper": "andylolz/gibraltar-wikipedia",
+        "scraper": "everypolitician-scrapers/gibraltar-wikipedia",
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data"
       },
       "source": "https://en.wikipedia.org/",
@@ -30,7 +30,7 @@
       "file": "morph/terms.csv",
       "create": {
         "from": "morph",
-        "scraper": "andylolz/gibraltar-parliament",
+        "scraper": "everypolitician-scrapers/gibraltar-parliament",
         "query": "SELECT * FROM terms ORDER BY id"
       },
       "source": "http://www.parliament.gi/",

--- a/data/Italy/House/sources/instructions.json
+++ b/data/Italy/House/sources/instructions.json
@@ -4,7 +4,7 @@
       "file": "morph/camera.csv",
       "create": {
         "from": "morph",
-        "scraper": "andylolz/italy-camera",
+        "scraper": "everypolitician-scrapers/italy-camera",
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.camera.it/leg17/313",


### PR DESCRIPTION
This assumes the following repos have been forked over to everypolitician-scrapers:

 * https://github.com/andylolz/gibraltar-parliament
 * https://github.com/andylolz/gibraltar-wikipedia
 * https://github.com/andylolz/italy-camera

…and the relevant https://morph.io scrapers set up.