### PR TITLE
work around Wikisnakker problem with to_s returning nil

### DIFF
--- a/lib/wikidata_lookup.rb
+++ b/lib/wikidata_lookup.rb
@@ -116,7 +116,9 @@ class P39sLookup < WikidataLookup
         [p.to_s, qualifiers[p].value.to_s]
       end]
 
-      title = label = posn.value.to_s
+      # Wikisnakker sometimes returns 'nil' from `to_s`
+      # TODO: ensure that gets fixed upstream
+      title = label = posn.value.to_s.to_s
       title += " (of #{qual_data['P642']})" if qual_data['P642']
 
       {


### PR DESCRIPTION
The build fails for a few countries (e.g. France and Japan), when rebuilding the position data, because `posn.value.to_s` sometimes returns `nil`. We'll want to fix that upstream in Wikisnakker, but for now work around it by calling `to_s` again(!)

https://github.com/everypolitician/wikisnakker/issues/58