### PR TITLE
Show source URL in missing_wikidata

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,9 +14,9 @@ GIT
 
 GIT
   remote: https://github.com/everypolitician/everypolitician-popolo.git
-  revision: 1de2a997faef47d745679b343a7b1978dc50a542
+  revision: 4d8aa382e9de4b3eed122cdb4a487c8f1943eff2
   specs:
-    everypolitician-popolo (0.8.1)
+    everypolitician-popolo (0.9.0)
       require_all
 
 GIT

--- a/rake_report/missing_wikidata.rb
+++ b/rake_report/missing_wikidata.rb
@@ -3,8 +3,8 @@
 namespace :report do
   task :missing_wikidata do
     popolo = Everypolitician::Popolo.read('ep-popolo-v1.0.json')
-    popolo.latest_term.memberships.map(&:person).reject(&:wikidata).sort_by(&:name).group_by(&:id).each do |id, ps|
-      puts '%s (%s)' % [ps.first.name, id]
+    popolo.latest_term.memberships.reject { |mem| mem.person.wikidata }.uniq(&:person).each do |mem|
+      puts '%s (%s) %s' % [mem.person.name, mem.person.id, mem.sources.first&.[](:url)]
     end
   end
 end


### PR DESCRIPTION
When displaying the list of current members with no Wikidata, it's handy to
also see the source URL, to make it easier to add the person.