### PR TITLE
Colombia (Representatives): add term end date and Wikidata

### DIFF
--- a/data/Colombia/Representatives/ep-popolo-v1.0.json
+++ b/data/Colombia/Representatives/ep-popolo-v1.0.json
@@ -10296,8 +10296,15 @@
     },
     {
       "classification": "legislative period",
+      "end_date": "2018-07-19",
       "id": "term/2014",
-      "name": "2014–",
+      "identifiers": [
+        {
+          "identifier": "Q51685953",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "2014–2018",
       "organization_id": "b11bc579-09d0-49d9-b80c-7d64eaf36bf2",
       "start_date": "2014-07-20"
     }

--- a/data/Colombia/Representatives/ep-popolo-v1.0.json
+++ b/data/Colombia/Representatives/ep-popolo-v1.0.json
@@ -10307,6 +10307,19 @@
       "name": "2014–2018",
       "organization_id": "b11bc579-09d0-49d9-b80c-7d64eaf36bf2",
       "start_date": "2014-07-20"
+    },
+    {
+      "classification": "general election",
+      "end_date": "2018-03-11",
+      "id": "Q20014725",
+      "identifiers": [
+        {
+          "identifier": "Q20014725",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "Colombian parliamentary election, 2018",
+      "start_date": "2018-03-11"
     }
   ],
   "areas": [

--- a/data/Colombia/Representatives/sources/manual/terms.csv
+++ b/data/Colombia/Representatives/sources/manual/terms.csv
@@ -1,2 +1,2 @@
-id,name,start_date,end_date
-2014,2014–,2014-07-20,
+id,name,start_date,end_date,wikidata
+2014,2014–2018,2014-07-20,2018-07-19,Q51685953

--- a/data/Colombia/Representatives/sources/wikidata/elections.json
+++ b/data/Colombia/Representatives/sources/wikidata/elections.json
@@ -661,7 +661,8 @@
     "dates": [
       "2014-03-09"
     ],
-    "follows": "Colombian parliamentary election, 2010"
+    "follows": "Colombian parliamentary election, 2010",
+    "followed_by": "Colombian parliamentary election, 2018"
   },
   "Q14624917": {
     "identifiers": [
@@ -988,10 +989,18 @@
         "name": "الانتخابات البرلمانية الكولومبية 2018",
         "note": "multilingual",
         "source": "wikidata-label"
+      },
+      {
+        "lang": "en",
+        "name": "Colombian parliamentary election, 2018",
+        "note": "multilingual",
+        "source": "wikidata-label"
       }
     ],
     "dates": [
       "2018-03-11"
-    ]
+    ],
+    "follows": "Colombian parliamentary election, 2014",
+    "office": "member of the Chamber of Representatives of Colombia"
   }
 }

--- a/data/Colombia/Representatives/unstable/stats.json
+++ b/data/Colombia/Representatives/unstable/stats.json
@@ -27,8 +27,8 @@
     "wikidata": 0
   },
   "elections": {
-    "count": 32,
-    "latest": "2014-03-09"
+    "count": 33,
+    "latest": "2018-03-11"
   },
   "positions": {
     "cabinet": 0

--- a/data/Colombia/Representatives/unstable/stats.json
+++ b/data/Colombia/Representatives/unstable/stats.json
@@ -20,7 +20,7 @@
   "terms": {
     "count": 1,
     "latest": "2014-07-20",
-    "wikidata": 0
+    "wikidata": 1
   },
   "areas": {
     "count": 36,


### PR DESCRIPTION
Part of https://github.com/everypolitician/everypolitician/issues/590

```
Add memberships from sources/morph/official.csv
Merging with sources/morph/wikidata.csv
Data Mismatches
* 2 of 61 unmatched
	{:id=>"Q20022295", :name=>"Yahir Acuña"}
	{:id=>"Q6005013", :name=>"María del Socorro Bustamante"}
Merging with sources/morph/genderbalance.csv
Applying local corrections from sources/manual/corrections.csv

Top identifiers:
  59 x wikidata
  1 x bnf
  1 x fast
  1 x freebase
  1 x gnd

Creating names.csv
Persons matched to Wikidata: 59 ✓ | 112 ✘
  No wikidata: EDUARDO JOSÉ TOUS DE LA OSSA (0ef7dc5c-3b41-41ed-8fac-c37c3318f3a5)
  No wikidata: CANDELARIA PATRICIA ROJAS VERGARA (e97e2cbc-f8ac-4535-87bf-862b3e18f161)
  No wikidata: JULIO EUGENIO GALLARDO ARCHBOLD (9ed3248d-170f-4e39-ac7c-4d10957220c2)
  No wikidata: JAIME ENRIQUE SERRANO PÉREZ (3cfc42cd-cda7-4243-b8aa-9b90b6c27693)
  No wikidata: ÁLVARO GUSTAVO ROSADO ARAGÓN (1210c52c-74e8-49c1-8fcf-ac9cac9f9044)
  No wikidata: JOSÉ EDILBERTO CAICEDO SASTOQUE (a6e273e9-27fd-4b95-aa05-369540a3ebf2)
  No wikidata: AIDA MERLANO REBOLLEDO (5c472b3f-efe3-4bd0-b6b9-338631850370)
  No wikidata: JAIR ARANGO TORRES (bc0fa546-3cf3-48b4-a324-14e456a919bf)
  No wikidata: CARLOS ALBERTO CUERO VALENCIA (14fd3935-3853-4572-a6d6-526c88112e3a)
  No wikidata: ALEXANDER GARCIA RODRIGUEZ (3d79f8a8-e0ff-4091-b6ba-684767ef0f28)
Parties matched to Wikidata: 13 ✓ | 1 ✘
  No wikidata: Por Un Huila Mejor (party/por_un_huila_mejor)
Areas matched to Wikidata: 0 ✓ | 36 ✘
```