### PR TITLE
remove OCD::IDs

### DIFF
--- a/lib/source.rb
+++ b/lib/source.rb
@@ -11,7 +11,6 @@ module Source
       'person'             => Source::Person,
       'wikidata'           => Source::Wikidata,
       'group'              => Source::Group,
-      'ocd-ids'            => Source::OCD::IDs,
       'ocd-names'          => Source::OCD::Names,
       'area-wikidata'      => Source::Area,
       'gender'             => Source::Gender,

--- a/lib/source/ocd.rb
+++ b/lib/source/ocd.rb
@@ -9,39 +9,15 @@ module Source
       %i[area area_id]
     end
 
-    def fuzzy_match?
-      i(:merge)[:fuzzy]
-    end
-
-    def overrides
-      return {} unless i(:merge)
-      return {} unless i(:merge).key? :overrides
-      i(:merge)[:overrides]
-    end
-
     def generate
       i(:generate)
     end
   end
 
-  class OCD::IDs < OCD
-    def merged_with(csv)
-      ocds = as_table.group_by { |r| r[:id] }
-      overrides_with_string_keys = Hash[overrides.map { |k, v| [k.to_s, v] }]
-      lookup_class = fuzzy_match? ? ::OCD::Lookup::Fuzzy : ::OCD::Lookup::Plain
-      ocd_ids = lookup_class.new(as_table, overrides_with_string_keys)
-      csv.select { |r| r[:area_id].nil? }.each do |r|
-        area = ocd_ids.from_name(r[:area])
-        if area.nil?
-          add_warning "  No area match for #{r[:area]}"
-          next
-        end
-        r[:area_id] = area
-      end
-      csv
-    end
-  end
-
+  # we used to also have an OCD::IDs subclass, but it's no longer used.
+  # We could get rid of the need for _this_ subclass, by pushing
+  # everything up into the parent, but the longer term goal is to get
+  # rid of all OCD-handling entirely, so we'll put up with this for now.
   class OCD::Names < OCD
     def merged_with(csv)
       ocds = as_table.group_by { |r| r[:id] }

--- a/rake_build/merge_members.rb
+++ b/rake_build/merge_members.rb
@@ -60,16 +60,6 @@ namespace :merge_members do
       end
     end
 
-    # OCD names -> IDs
-    @INSTRUCTIONS.sources_of_type('ocd-ids').each do |source|
-      warn "Adding OCD ids from #{source.filename}".green
-      merged_rows = source.merged_with(merged_rows)
-      if source.warnings.any?
-        warn 'Unmatched areas'
-        warn source.warnings.to_a.join("\n")
-      end
-    end
-
     # Any local corrections in manual/corrections.csv
     @INSTRUCTIONS.sources_of_type('corrections').each do |source|
       warn "Applying local corrections from #{source.filename}".green


### PR DESCRIPTION
We no longer have any legislatures doing this sort of build.

We can't get rid of *all* the OCD code yet, as the US Congress is
looking things up the other way around. But we'll get there eventually!

Closes https://github.com/everypolitician/everypolitician/issues/599