### PR TITLE
Report missing wikidata from latest applicable term

### DIFF
--- a/rake_report/missing_wikidata.rb
+++ b/rake_report/missing_wikidata.rb
@@ -3,7 +3,13 @@
 namespace :report do
   task :missing_wikidata do
     popolo = Everypolitician::Popolo.read('ep-popolo-v1.0.json')
-    popolo.latest_term.memberships.reject { |mem| mem.person.wikidata }.uniq(&:person).each do |mem|
+
+    # Find the latest term that has anyone unmapped to Wikidata
+    latest_missing = popolo.terms.map do |term|
+      term.memberships.reject { |mem| mem.person.wikidata }
+    end.reject(&:empty?).last
+
+    latest_missing.uniq { |mem| mem.person.id }.each do |mem|
       puts '%s (%s) %s' % [mem.person.name, mem.person.id, mem.sources.first&.[](:url)]
     end
   end


### PR DESCRIPTION
Rather than only reporting on missing Wikidata identiiers for members of
the most recent term (with an empty report if everyone in that term has
been reconciled), report on everyone unreconciled in the most recent
term that has not yet been fully reconciled.

In other words, if the most recent term has been fully reconciled, step
back to the previous terms, until it in turn is fully reconciled, and so
on.