### PR TITLE
Mongolia (Assembly): generate constituency IDs

### DIFF
--- a/data/Mongolia/Assembly/sources/instructions.json
+++ b/data/Mongolia/Assembly/sources/instructions.json
@@ -5,7 +5,7 @@
       "create": {
         "from": "morph",
         "scraper": "everypolitician-scrapers/mongolia-khurai-wp-multiple-terms",
-        "query": "SELECT * FROM data"
+        "query": "SELECT *, REPLACE(LOWER(constituency),' ','_') AS constituency_id FROM data"
       },
       "source": "https://en.wikipedia.org/",
       "type": "membership"

--- a/data/Mongolia/Assembly/sources/morph/wikipedia.csv
+++ b/data/Mongolia/Assembly/sources/morph/wikipedia.csv
@@ -1,230 +1,230 @@
-name,name__mn,party,wikiname,constituency,term,source
-Ganzorigiin Temüülen,Ганзоригийн Тэмүүлэн,Mongolian People's Party,"",Arkhangai,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Yondonperenlein Baatarbileg,Ёндонпэрэнлэйн Баатарбилэг,Mongolian People's Party,"",Arkhangai,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Jamyangiin Mönkhbat,Жамъянгийн Мөнхбат,Mongolian People's Party,Jamyangiin Mönkhbat,Arkhangai,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Gombojain Soltan,Гомбожайн Солтан,Mongolian People's Party,"",Bayan-Ölgii,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Khavdislamyn Badyelkhan,Хавдисламын Баделхан,Mongolian People's Party,"",Bayan-Ölgii,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Dakein Murat,Дакейн Мурат,Mongolian Democratic Party,"",Bayan-Ölgii,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Gombojavyn Zandanshatar,Гомбожавын Занданшатар,Mongolian People's Party,Gombojavyn Zandanshatar,Bayankhongor,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Magvany Bilegt,Магваны Билэгт,Mongolian People's Party,"",Bayankhongor,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Lkhagvaagiin Eldev-Ochir,Лхагваагийн Элдэв-Очир,Mongolian People's Party,"",Bayankhongor,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Jadambyn Bat-Erdene,Жадамбын Бат-Эрдэнэ,Mongolian People's Party,"",Bulgan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Shatarbalyn Radnaased,Шатарбалын Раднаасэд,Mongolian People's Party,"",Govi-Altai,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Gompildoogiin Mönkhtsetseg,Гомпилдоогийн Мөнхцэцэг,Mongolian People's Party,"",Govisümber•Dornogovi,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Borkhüügiin Delgersaikhan,Борхүүгийн Дэлгэрсайхан,Mongolian People's Party,"",Govisümber•Dornogovi,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Khayangaagiin Bolorchuluun,Хаянгаагийн Болорчулуун,Mongolian People's Party,"",Dornod,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Borkhüüyamtaishiryn Nomtoibayar,Нямтайширын Номтойбаяр,Mongolian People's Party,"",Dornod,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Batsükhiin Narankhüü,Батсүхийн Наранхүү,Mongolian Democratic Party,"",Dundgovi,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Yadamsürengiin Sanjmyatav,Ядамсүрэнгийн Санжмятав,Mongolian Democratic Party,"",Zavkhan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Zagdkhüügiin Narantuya,Загдхүүгийн Нарантуя,Mongolian Democratic Party,"",Zavkhan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Yangugiin Sodbaatar,Янгугийн Содбаатар,Mongolian People's Party,"",Övörkhangai,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Dulamdorjiin Togtokhsüren,Дуламдоржийн Тогтохсүрэн,Mongolian People's Party,"",Övörkhangai,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Sodnomyn Chinzorig,Содномын Чинзориг,Mongolian People's Party,"",Övörkhangai,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Namsrain Amarzayaa,Намсрайн Амарзаяа,Mongolian People's Party,"",Ömnögovi,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Luvsangiin Enkhbold,Лувсангийн Энхболд,Mongolian People's Party,"",Ömnögovi,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Chültemiin Ulaan,Чүлтэмийн Улаан,Mongolian People's Party,"",Sükhbaatar,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Navaan-Yundengiin Oyundari,Наваан-Юндэнгийн Оюндарь,Mongolian People's Party,Navaan-Yundengiin Oyundari,Selenge,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Jargaltulgyn Erdenebat,Жаргалтулгын Эрдэнэбат,Mongolian People's Party,Jargaltulgyn Erdenebat,Selenge,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Dondogdorjiin Erdenebat,Дондогдоржийн Эрдэнэбат,Mongolian Democratic Party,"",Selenge,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Miyeegombyn Enkhbold,Миеэгомбын Энхболд,Mongolian People's Party,Miyeegombyn Enkhbold,Töv,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Agvaansamdangiin Sükhbat,Агваансамдагийн Сүхбат,Mongolian People's Party,Agvaansamdangiin Sükhbat,Töv,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Nyamaagiin Enkhbold,Нямаагийн Энхболд,Mongolian People's Party,Nyamaagiin Enkhbold,Töv,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Battogtokhyn Choijilsüren,Баттогтохын Чойжилсүрэн,Mongolian People's Party,"",Uvs,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Namsrain Tserenbat,Намсрайн Цэрэнбат,Mongolian People's Party,"",Uvs,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Chimediin Khürelbaatar,Чимэдийн Хүрэлбаатар,Mongolian People's Party,"",Uvs,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Bökhchuluuny Pürevdorj,Бөхчулууны Пүрэвдорж,Mongolian Democratic Party,"",Khovd,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Sandagiin Byambatsogt,Сандагийн Бямбацогт,Mongolian People's Party,"",Khovd,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Otgoogiin Batnasan,Отгоогийн Батнасан,Mongolian People's Party,"",Khovd,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Lkhagvyn Mönkhbaatar,Лхагвын Мөнхбаатар,Mongolian People's Party,"",Khövsgöl,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Tserenpiliin Davaasüren,Цэрэнпилийн Даваасүрэн,Mongolian People's Party,"",Khövsgöl,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Luvsantserengiin Enkh-Amgalan,Лувсанцэрэнгийн Энх-Амгалан,Mongolian People's Party,"",Khövsgöl,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Badmaanyambuugiin Bat-Erdene,Бадмаанямбуурийн Бат-Эрдэнэ,Mongolian People's Party,Badmaanyambuugiin Bat-Erdene,Khentii,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Luvsannamsarin Oyuun-Erdene,Лувсаннамсрайн Оюун-Эрдэнэ,Mongolian People's Party,"",Khentii,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Dorjdugaryn Gantulga,Дорждугарын Гантулга,Mongolian People's Party,"",Khentii,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Baagaagiin Battömör,Баагаагийн Баттөмөр,Mongolian People's Party,"",Darkhan-Uul,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Boldyn Javkhlan,Болдын Жавхлан,Mongolian People's Party,"",Darkhan-Uul,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Damdiny Khayankhyarvaa,Дамдины Хаянхярваа,Mongolian People's Party,"",Darkhan-Uul,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Otgonbilegiin Sodbileg,Отгонбилэгийн Содбилэг,Mongolian People's Party,"",Orkhon,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Oktyabriin Baasankhüü,Октябрийн Баасанхүү,Mongolian People's Revolutionary Party,"",Orkhon,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Dorjdambyn Damba-Ochir,Дорждамбын Дамба-Очир,Mongolian People's Party,"",Orkhon,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Dulamsürengiin Oyuunkhorol,Дүламсүрэнгийн Оюунхорол,Mongolian People's Party,"",Ulaanbaatar — Bayanzürkh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Jadambyn Enkhbayar,Жадамбын Энхбаяр,Mongolian People's Party,"",Ulaanbaatar — Bayanzürkh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Batsükhiin Saranchimeg,Батсүхийн Саранчимэг,Mongolian People's Party,"",Ulaanbaatar — Bayanzürkh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Batjargalyn Batzorig,Батжаргалын Батзориг,Mongolian People's Party,"",Ulaanbaatar — Bayanzürkh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Jalbasürengiin Batzandan,Жалбасүрэнгийн Батзандан,Mongolian Democratic Party,"",Ulaanbaatar — Bayanzürkh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Samandyn Javkhlan,Самандын Жавхлан,Independent,"",Ulaanbaatar — Bayanzürkh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Davaajantsangiin Sarangerel,Даваажанцангийн Сарангэрэл,Mongolian People's Party,"",Ulaanbaatar — Bagakhangai•Khan Uul,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Tsendiin Nyamdorj,Цэндийн Нямдорж,Mongolian People's Party,Tsendiin Nyamdorj,Ulaanbaatar — Bagakhangai•Khan Uul,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Luvsanvandangiin Bold,Лувсанвандангийн Болд,Mongolian Democratic Party,"",Ulaanbaatar — Bagakhangai•Khan Uul,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Byambasürengiin Enkh-Amgalan,Бямбасүрэнгийн Энх-Амгалан,Mongolian People's Party,"",Ulaanbaatar — Bagakhangai•Khan Uul,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Damdiny Tsogtbaatar,Дамдины Цогтбаатар,Mongolian People's Party,"",Ulaanbaatar — Baganuur•Sükhbaatar,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Tsendiin Mönkh-Orgil,Цэндийн Мөнх-Оргил,Mongolian People's Party,"",Ulaanbaatar — Baganuur•Sükhbaatar,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Sükhbaataryn Batbold,Сүхбаатарын Батболд,Mongolian People's Party,Sükhbaataryn Batbold,Ulaanbaatar — Baganuur•Sükhbaatar,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Tsedenbalyn Tsogzolmaa,Цэдэнбалын Цогзолмаа,Mongolian People's Party,"",Ulaanbaatar — Baganuur•Sükhbaatar,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Tömörbaataryn Ayuursaikhan,Төмөрбаатарын Аюурсайхан,Mongolian People's Party,"",Ulaanbaatar — Chingeltei•Nalaikh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Mönkhöögiin Oyuunchimeg,Мөнхөөгийн Оюунчимэг,Mongolian People's Party,"",Ulaanbaatar — Chingeltei•Nalaikh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Ölziisaikhany Enkhtüvshin,Өлзийсайханы Энхтүвшин,Mongolian People's Party,"",Ulaanbaatar — Chingeltei•Nalaikh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Davaagiin Ganbold,Даваагийн Ганболд,Mongolian People's Party,"",Ulaanbaatar — Chingeltei•Nalaikh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Agvaanluvsangiin Undraa,Агваанлувсангийн Ундраа,Mongolian People's Party,"",Ulaanbaatar — Bayangol,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Jambalyn Ganbaatar,Жамбалын Ганбаатар,Mongolian People's Party,"",Ulaanbaatar — Bayangol,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Sodnomzunduin Erdene,Содномзундуйн Эрдэнэ,Mongolian Democratic Party,"",Ulaanbaatar — Bayangol,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Danzangiin Lündeejantsan,Данзангийн Лүндээжанцан,Mongolian People's Party,"",Ulaanbaatar — Bayangol,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Tsedengiin Garamjav,Цэдэнгийн Гарамжав,Mongolian People's Party,"",Ulaanbaatar — Songino Khairkhan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Nyam-Osoryn Uchral,Ням-Осорын Учрал,Mongolian People's Party,"",Ulaanbaatar — Songino Khairkhan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Dolgorsürengiin Sumyaabazar,Долгорсүрэнгийн Сумъяабазар,Mongolian People's Party,Dolgorsürengiin Sumyaabazar,Ulaanbaatar — Songino Khairkhan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Dendeviin Terbishdagva,Дэндэвийн Тэрбишдагва,Mongolian People's Party,"",Ulaanbaatar — Songino Khairkhan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Batbayaryn Undarmaa,Батбаярын Ундармаа,Mongolian People's Party,"",Ulaanbaatar — Songino Khairkhan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Khishgeegiin Nyambaatar,Хишгээгийн Нямбаатар,Mongolian People's Party,"",Ulaanbaatar — Songino Khairkhan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016"
-Nyamjavyn Batbayar,Нямжавын Батбаяр,Democratic Party,Nyamjavyn Batbayar,Arkhangai,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Bayarbaataryn Bolor,Баярбаатарын Болор,Democratic Party,"",Arkhangai,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Almalikyn Tleikhan,Алмаликын Тлейхан,Mongolian People's Party,"",Bayan-Ölgii,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Agilapyn Bakei,Агипарын Бакей,Democratic Party,"",Bayan-Ölgii,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Khaltmaagiin Battulga,Халтмаагийн Баттулга,Democratic Party,"",Bayankhongor,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Dashdondogiin Ganbat,Дашдондогийн Ганбат,Democratic Party,"",Bayankhongor,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Yondongiin Otgonbayar,Ёндонгийн Отгонбаяр,Mongolian People's Party,"",Bulgan,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Tsedeviin Dashdorj,Цэдэвийн Дашдорж,Mongolian People's Party,"",Govi-Altai,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Jamyansürengiin Batsuuri,Жамъянсүрэнгийн Батсуурь,Mongolian People's Party,"",Govisümber•Dornogovi,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Khayangaagiin Bolorchuluun,Хаянгаагийн Болорчулуун,Independent,"",Dornod,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Nyamtaishirgiin Nomtoibayar,Нямтайширийн Номтойбаяр,Mongolian People's Party,"",Dornod,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Batsükhiin Narankhüü,Батсүхийн Наранхүү,Democratic Party,"",Dundgovi,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Yadamsürengiin Sanjmyatav,Ядамсүрэнгийн Санжмятав,Democratic Party,"",Zavkhan,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Dulamsürengiin Oyuunkhorol,Дуламсүрэнгийн Оюунхорол,Mongolian People's Party,"",Zavkhan,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Gavaagiin Batkhüü,Гаваагийн Батхүү,Democratic Party,"",Övörkhangai,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Dashzevegiin Zorigt,Дашзэвэгийн Зоригт,Democratic Party,"",Övörkhangai,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Dashdembereliin Bat-Erdene,Дашдэмбэрэлийн Бат-Эрдэнэ,Democratic Party,"",Ömnögovi,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Mönkhchuluuny Zorigt,Мөнхчулууны Зоригт,Democratic Party,Mönkhchuluuny Zorigt,Sükhbaatar,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Sangajavyn Bayarzsogt,Сангажавын Баярцогт,Democratic Party,"",Selenge,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Jargaltulgyn Erdenebat,Жаргалтулгын Эрдэнэбат,Mongolian People's Party,Jargaltulgyn Erdenebat,Selenge,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Miyeegombyn Enkhbold,Миеэгомбо Энхболд,Mongolian People's Party,Miyeegombyn Enkhbold,Töv,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Sükhbaataryn Batbold,Сүхбаатарын Батболд,Mongolian People's Party,Sükhbaataryn Batbold,Töv,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Chimediin Khürelbaatar,Чимэдийн Хүрэлбаатар,Mongolian People's Party,"",Uvs,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Battogtokhyn Choijilsüren,Баттогтохын Чойжилсүрэн,Mongolian People's Party,"",Uvs,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Sandagiin Byambatsogt,Сандагийн Бямбацогт,Mongolian People's Party,"",Khovd,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Dogsomyn Battsogt,Догсомын Батцогт,Justice Coalition,"",Khovd,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Luvsantserengiin Enkh-Amgalan,Лувсанцэрэнгийн Энх-Амгалан,Mongolian People's Party,"",Khövsgöl,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Tserenpiliin Davaasüren,Цэрэнпилийн Даваасүрэн,Independent,"",Khövsgöl,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Badmaanyambuugiin Bat-Erdene,Бадмаанямбуугийн Бат-Эрдэнэ,Mongolian People's Party,Badmaanyambuugiin Bat-Erdene,Khentii,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Batkhüügiin Garamgaibaatar,Батхүүгийн Гарамгайбаатар,Democratic Party,"",Khentii,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Sainkhüügiin Ganbaatar,Сайнхүүгийн Ганбаатар,Independent,"",Darkhan-Uul,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Damdingiin Khayankhyarvaa,Дамдингийн Хаянхярваа,Mongolian People's Party,"",Darkhan-Uul,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Otgonbilegiin Sodbileg,Отгонбилэгийн Содбилэг,Mongolian People's Party,"",Orkhon,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Logiin Tsog,Логийн Цог,Justice Coalition,"",Orkhon,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Tsedevdambyn Oyuungerel,Цэдэвдамбын Оюунгэрэл,Democratic Party,"",Ulaanbaatar — Baganuur•Bagakhangai•Khan-Uul,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Luvsanvandangiin Bold,Лувсанвандангийн Болд,Democratic Party,"",Ulaanbaatar — Baganuur•Bagakhangai•Khan-Uul,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Jalbasürengiin Batzandan,Жалбасүрэнгийн Батзандан,Democratic Party,"",Ulaanbaatar — Bayanzürkh•Nalaikh,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Davaajavyn Gankhuyag,Даваажавын Ганхуяг,Democratic Party,"",Ulaanbaatar — Bayanzürkh•Nalaikh,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Dashjamtsyn Arvin,Дашжамцын Арвин,Democratic Party,"",Ulaanbaatar — Bayanzürkh•Nalaikh,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Luvsannyamyn Gantömör,Лувсаннямын Гантөмөр,Democratic Party,"",Ulaanbaatar — Sükhbaatar,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Rinchinnyamyn Amarjargal,Ринчиннямын Амаржаргал,Democratic Party,Rinchinnyamyn Amarjargal,Ulaanbaatar — Sükhbaatar,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Sodnomzunduin Erdene,Содномзундуйн Эрдэнэ,Democratic Party,"",Ulaanbaatar — Bayangol,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Saldangiin Odontuyaa,Салдангийн Одонтуяа,Democratic Party,"",Ulaanbaatar — Bayangol,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Luvsangiin Erdenechimeg,Лувсангийн Эрдэнэчимэг,Democratic Party,"",Ulaanbaatar — Songino Khairkhan,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Dolgorsürengiin Sumyaabazar,Долгорсүрэнгийн Сумъяабазар,Mongolian People's Party,Dolgorsürengiin Sumyaabazar,Ulaanbaatar — Songino Khairkhan,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Gantömöriin Uyanga,Гантөмөрийн Уянга,Justice Coalition,"",Ulaanbaatar — Chingeltei,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Garidkhüügiin Bayarsaikhan,Гарьдхүүгийн Баярсайхан,Democratic Party,"",Ulaanbaatar — Chingeltei,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Norovyn Altankhuyag,Норовын Алтанхуяг,Democratic Party,Norovyn Altankhuyag,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Migeddorjiin Batchimeg,Мигэддоржийн Батчимэг,Democratic Party,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Radnaagiin Burmaa,Раднаагийн Бурмаа,Democratic Party,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Radnaasümbereliin Gonchigdorj,Раднаасүмбэрэлийн Гончигдорж,Democratic Party,Radnaasümbereliin Gonchigdorj,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Chimediin Saikhanbileg,Чимэдийн Сайханбилэг,Democratic Party,Chimediin Saikhanbileg,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Khishigdembereliin Temüüjin,Хишигдэмбэрэлийн Тэмүүжин,Democratic Party,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Sharavdorjiin Tüvdendorj,Шаравдоржийн Түвдэндорж,Democratic Party,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Zandaakhüügiin Enkhbold,Зандаахүүгийн Энхболд,Democratic Party,Zandaakhüügiin Enkhbold,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Dondogdorjiin Erdenebat,Дондогдоржийн Эрдэнэбат,Democratic Party,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Tsevelmaagiin Bayarsaikhan,Цэвэлмаагийн Баярсайхан,Democratic Party,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Damdingiin Demberel,Дамдингийн Дэмбэрэл,Mongolian People's Party,Damdingiin Demberel,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Nyamaagiin Enkhbold,Нямаагийн Энхболд,Mongolian People's Party,Nyamaagiin Enkhbold,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Sunduin Batbold,Сундуйн Батболд,Mongolian People's Party,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Danzangiin Lündeejantsan,Данзангийн Лүндээжанцан,Mongolian People's Party,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Tsendiin Nyamdorj,Цэндийн Нямдорж,Mongolian People's Party,Tsendiin Nyamdorj,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Yangugiin Sodbaatar,Янгугийн Содбаатар,Mongolian People's Party,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Ukhnaagiin Xürelsükh,Ухнаагийн Хүрэлсүх,Mongolian People's Party,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Jadambyn Enkhbayar,Жадамбын Энхбаяр,Mongolian People's Party,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Ölziisaikhany Enkhtüvshin,Өлзийсайханы Энхтүвшин,Mongolian People's Party,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Mishigiin Sonompil,Мишигийн Сономпил,Justice Coalition,Mishigiin Sonompil,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Namdagiin Battsereg,Намдагийн Батцэрэг,Justice Coalition,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Zangadyn Bayanselenge,Зангадын Баянсэлэнгэ,Justice Coalition,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Dendeviin Terbishdagva,Дэндэвийн Тэрбишдагва,Justice Coalition,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Chültemiin Ulaan,Чүлтэмийн Улаан,Justice Coalition,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Tserendashiin Tsolmon,Цэрэндашийн Цолмон,Justice Coalition,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Oktyabriin Baasankhüü,Октябрийн Баасанхүү,Justice Coalition,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Tserendashiin Oyuunbaatar,Цэрэндашийн Оюунбаатар,Justice Coalition,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Sanjaasürengiin Oyuun,Санжаасүрэнгийн Оюун,Civil Will-Green Party,Sanjaasürengiin Oyuun,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Sambuugiin Demberel,Самбуугийн Дэмбэрэл,Civil Will-Green Party,"",,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012"
-Nyamjavyn Batbayar,Нямжавын Батбаяр,Democratic Party,Nyamjavyn Batbayar,Arkhangai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Radnaasümbereliin Gonchigdorj,Раднаасүмбэрэлийн Гончигдорж,Democratic Party,Radnaasümbereliin Gonchigdorj,Arkhangai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Sambuugiin Lambaa,Самбуугийн Ламбаа,Democratic Party,"",Arkhangai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Khalidoldain Jekei,Халидолдайн Жекей,Mongolian People's Party,"",Bayan-Ölgii,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Almalikyn Tleikhan,Алмаликын Тлейхан,Mongolian People's Party,"",Bayan-Ölgii,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Khavdislamyn Badyelkhan,Хавдисламын Баделхан,Mongolian People's Party,"",Bayan-Ölgii,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Gombojavyn Zandanshatar,Гомбожавын Занданшатар,Mongolian People's Party,Gombojavyn Zandanshatar,Bayankhongor,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Batjargalyn Batbayar,Батжаргалын Батбаяр,Democratic Party,Batjargalyn Batbayar,Bayankhongor,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Khaltmaagiin Battulga,Халтмаагийн Баттулга,Democratic Party,"",Bayankhongor,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Enebishiin Mönkh-Ochir,Энэбишийн Мөнх-Очир,Mongolian People's Party,"",Bulgan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Tsegmidiin Tsengel,Цэгмидийн Цэнгэл,Mongolian People's Party,"",Bulgan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Tsedeviin Dashdorj,Цэдэвийн Дашдорж,Mongolian People's Party,"",Govi-Altai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Jadambyn Enkhbayar,Жадамбын Энхбаяр,Mongolian People's Party,"",Govi-Altai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Jamyansürengiin Batsuuri,Жамъянсүрэнгийн Батсуурь,Mongolian People's Party,"",Govisümber•Dornogovi,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Yaichiliin Batsuuri,Яйчилийн Батсуурь,Democratic Party,"",Govisümber•Dornogovi,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Dorjiin Odbayar,Доржийн Одбаяр,Mongolian People's Party,"",Dornod,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Tsendiin Shinebayar,Цэндийн Шинэбаяр,Mongolian People's Party,"",Dornod,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Püreviin Altangerel,Пүрэвийн Алтангэрэл,Democratic Party,"",Dornod,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Khalzkhüügiin Narankhüü,Халзхүүгийн Наранхүү,Mongolian People's Party,"",Dundgovi,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Radnaabazaryn Rash,Раднаабазарын Раш,Mongolian People's Party,"",Dundgovi,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Dogsomjavyn Baldan-Ochir,Догсомжавын Балдан-Очир,Mongolian People's Party,"",Zavkhan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Dulamsürengiin Oyuunkhorol,Дуламсүрэнгийн Оюунхорол,Mongolian People's Party,"",Zavkhan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Shinensambuugiin Saikhansambuu,Шинэнсамбуугийн Сайхансамбуу,Mongolian People's Party,"",Zavkhan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Danzangiin Lündeejantsan,Данзангийн Лүндээжанцан,Mongolian People's Party,"",Övörkhangai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Gavaagiin Batkhüü,Гаваагийн Батхүү,Democratic Party,"",Övörkhangai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Dashzevegiin Zorigt,Дашзэвэгийн Зоригт,Democratic Party,"",Övörkhangai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Zandaakhüügiin Enkhbold,Зандаахүүгийн Энхболд,Democratic Party,Zandaakhüügiin Enkhbold,Övörkhangai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Khookhoryn Badamsüren,Хоохорын Бадамсүрэн,Mongolian People's Party,"",Ömnögovi,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Tsevelmaagiin Bayarsaikhan,Цэвэлмаагийн Баярсайхан,Democratic Party,"",Ömnögovi,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Chültemiin Ulaan,Чүлтэмийн Улаан,Mongolian People's Party,"",Sükhbaatar,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Rentsengiin Bud,Рэнцэнгийн Буд,Mongolian People's Party,"",Sükhbaatar,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Ochirbatyn Chuluunbat,Очирбатын Чулуунбат,Mongolian People's Party,"",Selenge,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Erdeniin Bat-Uul,Эрдэнийн Бат-Үүл,Democratic Party,Erdeniin Bat-Uul,Selenge,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Sangajavyn Bayartsogt,Сангажавын Баярцогт,Democratic Party,"",Selenge,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Sunduin Batbold,Сундуйн Батболд,Mongolian People's Party,"",Töv,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Doltsongiin Dondog,Долцонгийн Дондог,Mongolian People's Party,"",Töv,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Miyegombyn Enkhbold,Миеэгомбын Энхболд,Mongolian People's Party,"",Töv,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Nyamaagiin Enkhbold,Нямаагийн Энхболд,Mongolian People's Party,Nyamaagiin Enkhbold,Töv,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Battogtokhyn Choijilsüren,Баттогтохын Чойжилсүрэн,Mongolian People's Party,"",Uvs,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Tsendiin Nyamdorj,Цэндийн Нямдорж,Mongolian People's Party,Tsendiin Nyamdorj,Uvs,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Chimediin Khürelbaatar,Чимэдийн Хүрэлбаатар,Mongolian People's Party,"",Uvs,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Sandagiin Byambatsogt,Сандагийн Бямбацогт,Mongolian People's Party,"",Khovd,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Damdiny Demberel,Дамдины Дэмбэрэл,Mongolian People's Party,Damdiny Demberel,Khovd,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Rinchinnyamyn Amarjargal,Ринчиннямын Амаржаргал,Democratic Party,Rinchinnyamyn Amarjargal,Khovd,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Tserenpiliin Davaasüren,Цэрэнпилийн Даваасүрэн,Mongolian People's Party,"",Khövsgöl,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Ölziisaikhany Enkhtüvshin,Өлзийсайханы Энхтүвшин,Mongolian People's Party,"",Khövsgöl,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Lamjavyn Gundalai,Ламжавын Гүндалай,Democratic Party,Lamjavyn Gundalai,Khövsgöl,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Tserenbatyn Sedvanchig,Цэрэнбатын Сэдванчиг,Democratic Party,"",Khövsgöl,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Dashjamtsyn Arvin,Дашжамцын Арвин,Mongolian People's Party,"",Khentii,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Badmaanyambuugiin Bat-Erdene,Бадмаанямбуугийн Бат-Эрдэнэ,Mongolian People's Party,Badmaanyambuugiin Bat-Erdene,Khentii,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Navaansamdangiin Ganbyamba,Наваансамдангийн Ганбямба,Mongolian People's Party,"",Khentii,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Jamyankhorloogiin Sükhbaatar,Жамъянхорлоогийн Сүхбаатар,Mongolian People's Party,"",Darkhan-Uul,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Damdiny Khayankhyarvaa,Дамдины Хаянхярваа,Mongolian People's Party,"",Darkhan-Uul,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Lüimediin Gansükh,Лүймэдийн Гансүх,Democratic Party,"",Darkhan-Uul,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Dorjdambyn Damba-Ochir,Дорждамбын Дамба-Очир,Mongolian People's Party,"",Orkhon,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Dürzeegiin Odkhüü,Дүрзээгийн Одхүү,Democratic Party,"",Orkhon,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Delegiin Zagdjav,Дэлэгийн Загджав,Mongolian People's Party,"",Ulan Bator — Baganuur•Bagakhangai•Khan-Uul,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Luvsanvandangiin Bold,Лувсанвандангийн Болд,Democratic Party,"",Ulan Bator — Baganuur•Bagakhangai•Khan-Uul,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Tsogtyn Batbayar,Цогтын Батбаяр,Mongolian People's Party,Tsogtyn Batbayar,Ulan Bator — Bayanzürkh•Nalaikh,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Davaajavyn Gankhuyag,Даваажавын Ганхуяг,Democratic Party,"",Ulan Bator — Bayanzürkh•Nalaikh,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Chimediin Saikhanbileg,Чимэдийн Сайханбилэг,Democratic Party,Chimediin Saikhanbileg,Ulan Bator — Bayanzürkh•Nalaikh,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Zorigiin Altai,Зоригийн Алтай,Independent,"",Ulan Bator — Bayanzürkh•Nalaikh,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Sanjaagiin Bayar,Санжаагийн Баяр,Mongolian People's Party,Sanjaagiin Bayar,Ulan Bator — Sükhbaatar,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Sükhbaataryn Batbold,Сүхбаатарын Батболд,Mongolian People's Party,Sükhbaataryn Batbold,Ulan Bator — Sükhbaatar,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Luvsannyamyn Gantömör,Лувсаннямын Гантөмөр,Democratic Party,"",Ulan Bator — Sükhbaatar,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Tsakhiagiin Elbegdorj,Цахиагийн Элбэгдорж,Democratic Party,Tsakhiagiin Elbegdorj,Ulan Bator — Chingeltei,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Garidkhüügiin Bayarsaikhan,Гарьдхүүгийн Баярсайхан,Democratic Party,"",Ulan Bator — Chingeltei,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Dagvadorjiin Ochirbat,Дагвадоржийн Очирбат,Mongolian People's Party,"",Ulan Bator — Chingeltei,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Dashdorjiin Zorigt,Дашдоржийн Зоригт,Mongolian People's Party,"",Ulan Bator — Chingeltei,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Tsendiin Mönkh-Orgil,Цэндийн Мөнх-Оргил,Mongolian People's Party,"",Ulan Bator — Bayangol,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Khishigdembereliin Temüüjin,Хишигдэмбэрэлийн Тэмүүжин,Democratic Party,"",Ulan Bator — Bayangol,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Dangaasurengiin Enkhbat,Дангаасүрэнгийн Энхбат,Civil Will-Green Party,"",Ulan Bator — Bayangol,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Sodnomzunduin Erdene,Содномзундуйн Эрдэнэ,Democratic Party,"",Ulan Bator — Bayangol,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Dendeviin Terbishdagva,Дэндэвийн Тэрбишдагва,Mongolian People's Party,"",Ulan Bator — Songino Khairkhan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Norovyn Altankhuyag,Норовын Алтанхуяг,Democratic Party,Norovyn Altankhuyag,Ulan Bator — Songino Khairkhan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Davaagiin Batbayar,Даваагийн Батбаяр,Democratic Party,Kyokushūzan Noboru,Ulan Bator — Songino Khairkhan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
-Sanjaasürengiin Oyuun,Санжаасүрэнгийн Оюун,Civil Will-Green Party,Sanjaasürengiin Oyuun,Ulan Bator — Songino Khairkhan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008"
+name,name__mn,party,wikiname,constituency,term,source,constituency_id
+Ganzorigiin Temüülen,Ганзоригийн Тэмүүлэн,Mongolian People's Party,,Arkhangai,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",arkhangai
+Yondonperenlein Baatarbileg,Ёндонпэрэнлэйн Баатарбилэг,Mongolian People's Party,,Arkhangai,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",arkhangai
+Jamyangiin Mönkhbat,Жамъянгийн Мөнхбат,Mongolian People's Party,Jamyangiin Mönkhbat,Arkhangai,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",arkhangai
+Gombojain Soltan,Гомбожайн Солтан,Mongolian People's Party,,Bayan-Ölgii,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",bayan-Ölgii
+Khavdislamyn Badyelkhan,Хавдисламын Баделхан,Mongolian People's Party,,Bayan-Ölgii,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",bayan-Ölgii
+Dakein Murat,Дакейн Мурат,Mongolian Democratic Party,,Bayan-Ölgii,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",bayan-Ölgii
+Gombojavyn Zandanshatar,Гомбожавын Занданшатар,Mongolian People's Party,Gombojavyn Zandanshatar,Bayankhongor,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",bayankhongor
+Magvany Bilegt,Магваны Билэгт,Mongolian People's Party,,Bayankhongor,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",bayankhongor
+Lkhagvaagiin Eldev-Ochir,Лхагваагийн Элдэв-Очир,Mongolian People's Party,,Bayankhongor,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",bayankhongor
+Jadambyn Bat-Erdene,Жадамбын Бат-Эрдэнэ,Mongolian People's Party,,Bulgan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",bulgan
+Shatarbalyn Radnaased,Шатарбалын Раднаасэд,Mongolian People's Party,,Govi-Altai,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",govi-altai
+Gompildoogiin Mönkhtsetseg,Гомпилдоогийн Мөнхцэцэг,Mongolian People's Party,,Govisümber•Dornogovi,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",govisümber•dornogovi
+Borkhüügiin Delgersaikhan,Борхүүгийн Дэлгэрсайхан,Mongolian People's Party,,Govisümber•Dornogovi,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",govisümber•dornogovi
+Khayangaagiin Bolorchuluun,Хаянгаагийн Болорчулуун,Mongolian People's Party,,Dornod,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",dornod
+Borkhüüyamtaishiryn Nomtoibayar,Нямтайширын Номтойбаяр,Mongolian People's Party,,Dornod,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",dornod
+Batsükhiin Narankhüü,Батсүхийн Наранхүү,Mongolian Democratic Party,,Dundgovi,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",dundgovi
+Yadamsürengiin Sanjmyatav,Ядамсүрэнгийн Санжмятав,Mongolian Democratic Party,,Zavkhan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",zavkhan
+Zagdkhüügiin Narantuya,Загдхүүгийн Нарантуя,Mongolian Democratic Party,,Zavkhan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",zavkhan
+Yangugiin Sodbaatar,Янгугийн Содбаатар,Mongolian People's Party,,Övörkhangai,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",Övörkhangai
+Dulamdorjiin Togtokhsüren,Дуламдоржийн Тогтохсүрэн,Mongolian People's Party,,Övörkhangai,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",Övörkhangai
+Sodnomyn Chinzorig,Содномын Чинзориг,Mongolian People's Party,,Övörkhangai,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",Övörkhangai
+Namsrain Amarzayaa,Намсрайн Амарзаяа,Mongolian People's Party,,Ömnögovi,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",Ömnögovi
+Luvsangiin Enkhbold,Лувсангийн Энхболд,Mongolian People's Party,,Ömnögovi,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",Ömnögovi
+Chültemiin Ulaan,Чүлтэмийн Улаан,Mongolian People's Party,,Sükhbaatar,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",sükhbaatar
+Navaan-Yundengiin Oyundari,Наваан-Юндэнгийн Оюндарь,Mongolian People's Party,Navaan-Yundengiin Oyundari,Selenge,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",selenge
+Jargaltulgyn Erdenebat,Жаргалтулгын Эрдэнэбат,Mongolian People's Party,Jargaltulgyn Erdenebat,Selenge,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",selenge
+Dondogdorjiin Erdenebat,Дондогдоржийн Эрдэнэбат,Mongolian Democratic Party,,Selenge,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",selenge
+Miyeegombyn Enkhbold,Миеэгомбын Энхболд,Mongolian People's Party,Miyeegombyn Enkhbold,Töv,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",töv
+Agvaansamdangiin Sükhbat,Агваансамдагийн Сүхбат,Mongolian People's Party,Agvaansamdangiin Sükhbat,Töv,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",töv
+Nyamaagiin Enkhbold,Нямаагийн Энхболд,Mongolian People's Party,Nyamaagiin Enkhbold,Töv,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",töv
+Battogtokhyn Choijilsüren,Баттогтохын Чойжилсүрэн,Mongolian People's Party,,Uvs,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",uvs
+Namsrain Tserenbat,Намсрайн Цэрэнбат,Mongolian People's Party,,Uvs,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",uvs
+Chimediin Khürelbaatar,Чимэдийн Хүрэлбаатар,Mongolian People's Party,,Uvs,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",uvs
+Bökhchuluuny Pürevdorj,Бөхчулууны Пүрэвдорж,Mongolian Democratic Party,,Khovd,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",khovd
+Sandagiin Byambatsogt,Сандагийн Бямбацогт,Mongolian People's Party,,Khovd,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",khovd
+Otgoogiin Batnasan,Отгоогийн Батнасан,Mongolian People's Party,,Khovd,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",khovd
+Lkhagvyn Mönkhbaatar,Лхагвын Мөнхбаатар,Mongolian People's Party,,Khövsgöl,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",khövsgöl
+Tserenpiliin Davaasüren,Цэрэнпилийн Даваасүрэн,Mongolian People's Party,,Khövsgöl,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",khövsgöl
+Luvsantserengiin Enkh-Amgalan,Лувсанцэрэнгийн Энх-Амгалан,Mongolian People's Party,,Khövsgöl,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",khövsgöl
+Badmaanyambuugiin Bat-Erdene,Бадмаанямбуурийн Бат-Эрдэнэ,Mongolian People's Party,Badmaanyambuugiin Bat-Erdene,Khentii,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",khentii
+Luvsannamsarin Oyuun-Erdene,Лувсаннамсрайн Оюун-Эрдэнэ,Mongolian People's Party,,Khentii,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",khentii
+Dorjdugaryn Gantulga,Дорждугарын Гантулга,Mongolian People's Party,,Khentii,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",khentii
+Baagaagiin Battömör,Баагаагийн Баттөмөр,Mongolian People's Party,,Darkhan-Uul,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",darkhan-uul
+Boldyn Javkhlan,Болдын Жавхлан,Mongolian People's Party,,Darkhan-Uul,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",darkhan-uul
+Damdiny Khayankhyarvaa,Дамдины Хаянхярваа,Mongolian People's Party,,Darkhan-Uul,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",darkhan-uul
+Otgonbilegiin Sodbileg,Отгонбилэгийн Содбилэг,Mongolian People's Party,,Orkhon,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",orkhon
+Oktyabriin Baasankhüü,Октябрийн Баасанхүү,Mongolian People's Revolutionary Party,,Orkhon,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",orkhon
+Dorjdambyn Damba-Ochir,Дорждамбын Дамба-Очир,Mongolian People's Party,,Orkhon,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",orkhon
+Dulamsürengiin Oyuunkhorol,Дүламсүрэнгийн Оюунхорол,Mongolian People's Party,,Ulaanbaatar — Bayanzürkh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_bayanzürkh
+Jadambyn Enkhbayar,Жадамбын Энхбаяр,Mongolian People's Party,,Ulaanbaatar — Bayanzürkh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_bayanzürkh
+Batsükhiin Saranchimeg,Батсүхийн Саранчимэг,Mongolian People's Party,,Ulaanbaatar — Bayanzürkh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_bayanzürkh
+Batjargalyn Batzorig,Батжаргалын Батзориг,Mongolian People's Party,,Ulaanbaatar — Bayanzürkh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_bayanzürkh
+Jalbasürengiin Batzandan,Жалбасүрэнгийн Батзандан,Mongolian Democratic Party,,Ulaanbaatar — Bayanzürkh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_bayanzürkh
+Samandyn Javkhlan,Самандын Жавхлан,Independent,,Ulaanbaatar — Bayanzürkh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_bayanzürkh
+Davaajantsangiin Sarangerel,Даваажанцангийн Сарангэрэл,Mongolian People's Party,,Ulaanbaatar — Bagakhangai•Khan Uul,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_bagakhangai•khan_uul
+Tsendiin Nyamdorj,Цэндийн Нямдорж,Mongolian People's Party,Tsendiin Nyamdorj,Ulaanbaatar — Bagakhangai•Khan Uul,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_bagakhangai•khan_uul
+Luvsanvandangiin Bold,Лувсанвандангийн Болд,Mongolian Democratic Party,,Ulaanbaatar — Bagakhangai•Khan Uul,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_bagakhangai•khan_uul
+Byambasürengiin Enkh-Amgalan,Бямбасүрэнгийн Энх-Амгалан,Mongolian People's Party,,Ulaanbaatar — Bagakhangai•Khan Uul,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_bagakhangai•khan_uul
+Damdiny Tsogtbaatar,Дамдины Цогтбаатар,Mongolian People's Party,,Ulaanbaatar — Baganuur•Sükhbaatar,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_baganuur•sükhbaatar
+Tsendiin Mönkh-Orgil,Цэндийн Мөнх-Оргил,Mongolian People's Party,,Ulaanbaatar — Baganuur•Sükhbaatar,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_baganuur•sükhbaatar
+Sükhbaataryn Batbold,Сүхбаатарын Батболд,Mongolian People's Party,Sükhbaataryn Batbold,Ulaanbaatar — Baganuur•Sükhbaatar,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_baganuur•sükhbaatar
+Tsedenbalyn Tsogzolmaa,Цэдэнбалын Цогзолмаа,Mongolian People's Party,,Ulaanbaatar — Baganuur•Sükhbaatar,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_baganuur•sükhbaatar
+Tömörbaataryn Ayuursaikhan,Төмөрбаатарын Аюурсайхан,Mongolian People's Party,,Ulaanbaatar — Chingeltei•Nalaikh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_chingeltei•nalaikh
+Mönkhöögiin Oyuunchimeg,Мөнхөөгийн Оюунчимэг,Mongolian People's Party,,Ulaanbaatar — Chingeltei•Nalaikh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_chingeltei•nalaikh
+Ölziisaikhany Enkhtüvshin,Өлзийсайханы Энхтүвшин,Mongolian People's Party,,Ulaanbaatar — Chingeltei•Nalaikh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_chingeltei•nalaikh
+Davaagiin Ganbold,Даваагийн Ганболд,Mongolian People's Party,,Ulaanbaatar — Chingeltei•Nalaikh,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_chingeltei•nalaikh
+Agvaanluvsangiin Undraa,Агваанлувсангийн Ундраа,Mongolian People's Party,,Ulaanbaatar — Bayangol,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_bayangol
+Jambalyn Ganbaatar,Жамбалын Ганбаатар,Mongolian People's Party,,Ulaanbaatar — Bayangol,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_bayangol
+Sodnomzunduin Erdene,Содномзундуйн Эрдэнэ,Mongolian Democratic Party,,Ulaanbaatar — Bayangol,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_bayangol
+Danzangiin Lündeejantsan,Данзангийн Лүндээжанцан,Mongolian People's Party,,Ulaanbaatar — Bayangol,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_bayangol
+Tsedengiin Garamjav,Цэдэнгийн Гарамжав,Mongolian People's Party,,Ulaanbaatar — Songino Khairkhan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_songino_khairkhan
+Nyam-Osoryn Uchral,Ням-Осорын Учрал,Mongolian People's Party,,Ulaanbaatar — Songino Khairkhan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_songino_khairkhan
+Dolgorsürengiin Sumyaabazar,Долгорсүрэнгийн Сумъяабазар,Mongolian People's Party,Dolgorsürengiin Sumyaabazar,Ulaanbaatar — Songino Khairkhan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_songino_khairkhan
+Dendeviin Terbishdagva,Дэндэвийн Тэрбишдагва,Mongolian People's Party,,Ulaanbaatar — Songino Khairkhan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_songino_khairkhan
+Batbayaryn Undarmaa,Батбаярын Ундармаа,Mongolian People's Party,,Ulaanbaatar — Songino Khairkhan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_songino_khairkhan
+Khishgeegiin Nyambaatar,Хишгээгийн Нямбаатар,Mongolian People's Party,,Ulaanbaatar — Songino Khairkhan,2016,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2016",ulaanbaatar_—_songino_khairkhan
+Nyamjavyn Batbayar,Нямжавын Батбаяр,Democratic Party,Nyamjavyn Batbayar,Arkhangai,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",arkhangai
+Bayarbaataryn Bolor,Баярбаатарын Болор,Democratic Party,,Arkhangai,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",arkhangai
+Almalikyn Tleikhan,Алмаликын Тлейхан,Mongolian People's Party,,Bayan-Ölgii,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",bayan-Ölgii
+Agilapyn Bakei,Агипарын Бакей,Democratic Party,,Bayan-Ölgii,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",bayan-Ölgii
+Khaltmaagiin Battulga,Халтмаагийн Баттулга,Democratic Party,,Bayankhongor,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",bayankhongor
+Dashdondogiin Ganbat,Дашдондогийн Ганбат,Democratic Party,,Bayankhongor,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",bayankhongor
+Yondongiin Otgonbayar,Ёндонгийн Отгонбаяр,Mongolian People's Party,,Bulgan,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",bulgan
+Tsedeviin Dashdorj,Цэдэвийн Дашдорж,Mongolian People's Party,,Govi-Altai,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",govi-altai
+Jamyansürengiin Batsuuri,Жамъянсүрэнгийн Батсуурь,Mongolian People's Party,,Govisümber•Dornogovi,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",govisümber•dornogovi
+Khayangaagiin Bolorchuluun,Хаянгаагийн Болорчулуун,Independent,,Dornod,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",dornod
+Nyamtaishirgiin Nomtoibayar,Нямтайширийн Номтойбаяр,Mongolian People's Party,,Dornod,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",dornod
+Batsükhiin Narankhüü,Батсүхийн Наранхүү,Democratic Party,,Dundgovi,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",dundgovi
+Yadamsürengiin Sanjmyatav,Ядамсүрэнгийн Санжмятав,Democratic Party,,Zavkhan,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",zavkhan
+Dulamsürengiin Oyuunkhorol,Дуламсүрэнгийн Оюунхорол,Mongolian People's Party,,Zavkhan,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",zavkhan
+Gavaagiin Batkhüü,Гаваагийн Батхүү,Democratic Party,,Övörkhangai,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",Övörkhangai
+Dashzevegiin Zorigt,Дашзэвэгийн Зоригт,Democratic Party,,Övörkhangai,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",Övörkhangai
+Dashdembereliin Bat-Erdene,Дашдэмбэрэлийн Бат-Эрдэнэ,Democratic Party,,Ömnögovi,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",Ömnögovi
+Mönkhchuluuny Zorigt,Мөнхчулууны Зоригт,Democratic Party,Mönkhchuluuny Zorigt,Sükhbaatar,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",sükhbaatar
+Sangajavyn Bayarzsogt,Сангажавын Баярцогт,Democratic Party,,Selenge,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",selenge
+Jargaltulgyn Erdenebat,Жаргалтулгын Эрдэнэбат,Mongolian People's Party,Jargaltulgyn Erdenebat,Selenge,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",selenge
+Miyeegombyn Enkhbold,Миеэгомбо Энхболд,Mongolian People's Party,Miyeegombyn Enkhbold,Töv,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",töv
+Sükhbaataryn Batbold,Сүхбаатарын Батболд,Mongolian People's Party,Sükhbaataryn Batbold,Töv,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",töv
+Chimediin Khürelbaatar,Чимэдийн Хүрэлбаатар,Mongolian People's Party,,Uvs,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",uvs
+Battogtokhyn Choijilsüren,Баттогтохын Чойжилсүрэн,Mongolian People's Party,,Uvs,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",uvs
+Sandagiin Byambatsogt,Сандагийн Бямбацогт,Mongolian People's Party,,Khovd,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",khovd
+Dogsomyn Battsogt,Догсомын Батцогт,Justice Coalition,,Khovd,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",khovd
+Luvsantserengiin Enkh-Amgalan,Лувсанцэрэнгийн Энх-Амгалан,Mongolian People's Party,,Khövsgöl,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",khövsgöl
+Tserenpiliin Davaasüren,Цэрэнпилийн Даваасүрэн,Independent,,Khövsgöl,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",khövsgöl
+Badmaanyambuugiin Bat-Erdene,Бадмаанямбуугийн Бат-Эрдэнэ,Mongolian People's Party,Badmaanyambuugiin Bat-Erdene,Khentii,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",khentii
+Batkhüügiin Garamgaibaatar,Батхүүгийн Гарамгайбаатар,Democratic Party,,Khentii,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",khentii
+Sainkhüügiin Ganbaatar,Сайнхүүгийн Ганбаатар,Independent,,Darkhan-Uul,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",darkhan-uul
+Damdingiin Khayankhyarvaa,Дамдингийн Хаянхярваа,Mongolian People's Party,,Darkhan-Uul,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",darkhan-uul
+Otgonbilegiin Sodbileg,Отгонбилэгийн Содбилэг,Mongolian People's Party,,Orkhon,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",orkhon
+Logiin Tsog,Логийн Цог,Justice Coalition,,Orkhon,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",orkhon
+Tsedevdambyn Oyuungerel,Цэдэвдамбын Оюунгэрэл,Democratic Party,,Ulaanbaatar — Baganuur•Bagakhangai•Khan-Uul,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",ulaanbaatar_—_baganuur•bagakhangai•khan-uul
+Luvsanvandangiin Bold,Лувсанвандангийн Болд,Democratic Party,,Ulaanbaatar — Baganuur•Bagakhangai•Khan-Uul,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",ulaanbaatar_—_baganuur•bagakhangai•khan-uul
+Jalbasürengiin Batzandan,Жалбасүрэнгийн Батзандан,Democratic Party,,Ulaanbaatar — Bayanzürkh•Nalaikh,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",ulaanbaatar_—_bayanzürkh•nalaikh
+Davaajavyn Gankhuyag,Даваажавын Ганхуяг,Democratic Party,,Ulaanbaatar — Bayanzürkh•Nalaikh,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",ulaanbaatar_—_bayanzürkh•nalaikh
+Dashjamtsyn Arvin,Дашжамцын Арвин,Democratic Party,,Ulaanbaatar — Bayanzürkh•Nalaikh,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",ulaanbaatar_—_bayanzürkh•nalaikh
+Luvsannyamyn Gantömör,Лувсаннямын Гантөмөр,Democratic Party,,Ulaanbaatar — Sükhbaatar,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",ulaanbaatar_—_sükhbaatar
+Rinchinnyamyn Amarjargal,Ринчиннямын Амаржаргал,Democratic Party,Rinchinnyamyn Amarjargal,Ulaanbaatar — Sükhbaatar,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",ulaanbaatar_—_sükhbaatar
+Sodnomzunduin Erdene,Содномзундуйн Эрдэнэ,Democratic Party,,Ulaanbaatar — Bayangol,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",ulaanbaatar_—_bayangol
+Saldangiin Odontuyaa,Салдангийн Одонтуяа,Democratic Party,,Ulaanbaatar — Bayangol,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",ulaanbaatar_—_bayangol
+Luvsangiin Erdenechimeg,Лувсангийн Эрдэнэчимэг,Democratic Party,,Ulaanbaatar — Songino Khairkhan,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",ulaanbaatar_—_songino_khairkhan
+Dolgorsürengiin Sumyaabazar,Долгорсүрэнгийн Сумъяабазар,Mongolian People's Party,Dolgorsürengiin Sumyaabazar,Ulaanbaatar — Songino Khairkhan,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",ulaanbaatar_—_songino_khairkhan
+Gantömöriin Uyanga,Гантөмөрийн Уянга,Justice Coalition,,Ulaanbaatar — Chingeltei,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",ulaanbaatar_—_chingeltei
+Garidkhüügiin Bayarsaikhan,Гарьдхүүгийн Баярсайхан,Democratic Party,,Ulaanbaatar — Chingeltei,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",ulaanbaatar_—_chingeltei
+Norovyn Altankhuyag,Норовын Алтанхуяг,Democratic Party,Norovyn Altankhuyag,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Migeddorjiin Batchimeg,Мигэддоржийн Батчимэг,Democratic Party,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Radnaagiin Burmaa,Раднаагийн Бурмаа,Democratic Party,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Radnaasümbereliin Gonchigdorj,Раднаасүмбэрэлийн Гончигдорж,Democratic Party,Radnaasümbereliin Gonchigdorj,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Chimediin Saikhanbileg,Чимэдийн Сайханбилэг,Democratic Party,Chimediin Saikhanbileg,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Khishigdembereliin Temüüjin,Хишигдэмбэрэлийн Тэмүүжин,Democratic Party,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Sharavdorjiin Tüvdendorj,Шаравдоржийн Түвдэндорж,Democratic Party,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Zandaakhüügiin Enkhbold,Зандаахүүгийн Энхболд,Democratic Party,Zandaakhüügiin Enkhbold,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Dondogdorjiin Erdenebat,Дондогдоржийн Эрдэнэбат,Democratic Party,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Tsevelmaagiin Bayarsaikhan,Цэвэлмаагийн Баярсайхан,Democratic Party,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Damdingiin Demberel,Дамдингийн Дэмбэрэл,Mongolian People's Party,Damdingiin Demberel,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Nyamaagiin Enkhbold,Нямаагийн Энхболд,Mongolian People's Party,Nyamaagiin Enkhbold,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Sunduin Batbold,Сундуйн Батболд,Mongolian People's Party,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Danzangiin Lündeejantsan,Данзангийн Лүндээжанцан,Mongolian People's Party,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Tsendiin Nyamdorj,Цэндийн Нямдорж,Mongolian People's Party,Tsendiin Nyamdorj,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Yangugiin Sodbaatar,Янгугийн Содбаатар,Mongolian People's Party,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Ukhnaagiin Xürelsükh,Ухнаагийн Хүрэлсүх,Mongolian People's Party,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Jadambyn Enkhbayar,Жадамбын Энхбаяр,Mongolian People's Party,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Ölziisaikhany Enkhtüvshin,Өлзийсайханы Энхтүвшин,Mongolian People's Party,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Mishigiin Sonompil,Мишигийн Сономпил,Justice Coalition,Mishigiin Sonompil,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Namdagiin Battsereg,Намдагийн Батцэрэг,Justice Coalition,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Zangadyn Bayanselenge,Зангадын Баянсэлэнгэ,Justice Coalition,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Dendeviin Terbishdagva,Дэндэвийн Тэрбишдагва,Justice Coalition,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Chültemiin Ulaan,Чүлтэмийн Улаан,Justice Coalition,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Tserendashiin Tsolmon,Цэрэндашийн Цолмон,Justice Coalition,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Oktyabriin Baasankhüü,Октябрийн Баасанхүү,Justice Coalition,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Tserendashiin Oyuunbaatar,Цэрэндашийн Оюунбаатар,Justice Coalition,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Sanjaasürengiin Oyuun,Санжаасүрэнгийн Оюун,Civil Will-Green Party,Sanjaasürengiin Oyuun,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Sambuugiin Demberel,Самбуугийн Дэмбэрэл,Civil Will-Green Party,,,2012,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2012",
+Nyamjavyn Batbayar,Нямжавын Батбаяр,Democratic Party,Nyamjavyn Batbayar,Arkhangai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",arkhangai
+Radnaasümbereliin Gonchigdorj,Раднаасүмбэрэлийн Гончигдорж,Democratic Party,Radnaasümbereliin Gonchigdorj,Arkhangai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",arkhangai
+Sambuugiin Lambaa,Самбуугийн Ламбаа,Democratic Party,,Arkhangai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",arkhangai
+Khalidoldain Jekei,Халидолдайн Жекей,Mongolian People's Party,,Bayan-Ölgii,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",bayan-Ölgii
+Almalikyn Tleikhan,Алмаликын Тлейхан,Mongolian People's Party,,Bayan-Ölgii,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",bayan-Ölgii
+Khavdislamyn Badyelkhan,Хавдисламын Баделхан,Mongolian People's Party,,Bayan-Ölgii,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",bayan-Ölgii
+Gombojavyn Zandanshatar,Гомбожавын Занданшатар,Mongolian People's Party,Gombojavyn Zandanshatar,Bayankhongor,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",bayankhongor
+Batjargalyn Batbayar,Батжаргалын Батбаяр,Democratic Party,Batjargalyn Batbayar,Bayankhongor,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",bayankhongor
+Khaltmaagiin Battulga,Халтмаагийн Баттулга,Democratic Party,,Bayankhongor,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",bayankhongor
+Enebishiin Mönkh-Ochir,Энэбишийн Мөнх-Очир,Mongolian People's Party,,Bulgan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",bulgan
+Tsegmidiin Tsengel,Цэгмидийн Цэнгэл,Mongolian People's Party,,Bulgan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",bulgan
+Tsedeviin Dashdorj,Цэдэвийн Дашдорж,Mongolian People's Party,,Govi-Altai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",govi-altai
+Jadambyn Enkhbayar,Жадамбын Энхбаяр,Mongolian People's Party,,Govi-Altai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",govi-altai
+Jamyansürengiin Batsuuri,Жамъянсүрэнгийн Батсуурь,Mongolian People's Party,,Govisümber•Dornogovi,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",govisümber•dornogovi
+Yaichiliin Batsuuri,Яйчилийн Батсуурь,Democratic Party,,Govisümber•Dornogovi,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",govisümber•dornogovi
+Dorjiin Odbayar,Доржийн Одбаяр,Mongolian People's Party,,Dornod,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",dornod
+Tsendiin Shinebayar,Цэндийн Шинэбаяр,Mongolian People's Party,,Dornod,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",dornod
+Püreviin Altangerel,Пүрэвийн Алтангэрэл,Democratic Party,,Dornod,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",dornod
+Khalzkhüügiin Narankhüü,Халзхүүгийн Наранхүү,Mongolian People's Party,,Dundgovi,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",dundgovi
+Radnaabazaryn Rash,Раднаабазарын Раш,Mongolian People's Party,,Dundgovi,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",dundgovi
+Dogsomjavyn Baldan-Ochir,Догсомжавын Балдан-Очир,Mongolian People's Party,,Zavkhan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",zavkhan
+Dulamsürengiin Oyuunkhorol,Дуламсүрэнгийн Оюунхорол,Mongolian People's Party,,Zavkhan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",zavkhan
+Shinensambuugiin Saikhansambuu,Шинэнсамбуугийн Сайхансамбуу,Mongolian People's Party,,Zavkhan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",zavkhan
+Danzangiin Lündeejantsan,Данзангийн Лүндээжанцан,Mongolian People's Party,,Övörkhangai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",Övörkhangai
+Gavaagiin Batkhüü,Гаваагийн Батхүү,Democratic Party,,Övörkhangai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",Övörkhangai
+Dashzevegiin Zorigt,Дашзэвэгийн Зоригт,Democratic Party,,Övörkhangai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",Övörkhangai
+Zandaakhüügiin Enkhbold,Зандаахүүгийн Энхболд,Democratic Party,Zandaakhüügiin Enkhbold,Övörkhangai,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",Övörkhangai
+Khookhoryn Badamsüren,Хоохорын Бадамсүрэн,Mongolian People's Party,,Ömnögovi,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",Ömnögovi
+Tsevelmaagiin Bayarsaikhan,Цэвэлмаагийн Баярсайхан,Democratic Party,,Ömnögovi,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",Ömnögovi
+Chültemiin Ulaan,Чүлтэмийн Улаан,Mongolian People's Party,,Sükhbaatar,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",sükhbaatar
+Rentsengiin Bud,Рэнцэнгийн Буд,Mongolian People's Party,,Sükhbaatar,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",sükhbaatar
+Ochirbatyn Chuluunbat,Очирбатын Чулуунбат,Mongolian People's Party,,Selenge,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",selenge
+Erdeniin Bat-Uul,Эрдэнийн Бат-Үүл,Democratic Party,Erdeniin Bat-Uul,Selenge,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",selenge
+Sangajavyn Bayartsogt,Сангажавын Баярцогт,Democratic Party,,Selenge,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",selenge
+Sunduin Batbold,Сундуйн Батболд,Mongolian People's Party,,Töv,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",töv
+Doltsongiin Dondog,Долцонгийн Дондог,Mongolian People's Party,,Töv,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",töv
+Miyegombyn Enkhbold,Миеэгомбын Энхболд,Mongolian People's Party,,Töv,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",töv
+Nyamaagiin Enkhbold,Нямаагийн Энхболд,Mongolian People's Party,Nyamaagiin Enkhbold,Töv,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",töv
+Battogtokhyn Choijilsüren,Баттогтохын Чойжилсүрэн,Mongolian People's Party,,Uvs,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",uvs
+Tsendiin Nyamdorj,Цэндийн Нямдорж,Mongolian People's Party,Tsendiin Nyamdorj,Uvs,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",uvs
+Chimediin Khürelbaatar,Чимэдийн Хүрэлбаатар,Mongolian People's Party,,Uvs,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",uvs
+Sandagiin Byambatsogt,Сандагийн Бямбацогт,Mongolian People's Party,,Khovd,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",khovd
+Damdiny Demberel,Дамдины Дэмбэрэл,Mongolian People's Party,Damdiny Demberel,Khovd,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",khovd
+Rinchinnyamyn Amarjargal,Ринчиннямын Амаржаргал,Democratic Party,Rinchinnyamyn Amarjargal,Khovd,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",khovd
+Tserenpiliin Davaasüren,Цэрэнпилийн Даваасүрэн,Mongolian People's Party,,Khövsgöl,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",khövsgöl
+Ölziisaikhany Enkhtüvshin,Өлзийсайханы Энхтүвшин,Mongolian People's Party,,Khövsgöl,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",khövsgöl
+Lamjavyn Gundalai,Ламжавын Гүндалай,Democratic Party,Lamjavyn Gundalai,Khövsgöl,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",khövsgöl
+Tserenbatyn Sedvanchig,Цэрэнбатын Сэдванчиг,Democratic Party,,Khövsgöl,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",khövsgöl
+Dashjamtsyn Arvin,Дашжамцын Арвин,Mongolian People's Party,,Khentii,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",khentii
+Badmaanyambuugiin Bat-Erdene,Бадмаанямбуугийн Бат-Эрдэнэ,Mongolian People's Party,Badmaanyambuugiin Bat-Erdene,Khentii,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",khentii
+Navaansamdangiin Ganbyamba,Наваансамдангийн Ганбямба,Mongolian People's Party,,Khentii,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",khentii
+Jamyankhorloogiin Sükhbaatar,Жамъянхорлоогийн Сүхбаатар,Mongolian People's Party,,Darkhan-Uul,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",darkhan-uul
+Damdiny Khayankhyarvaa,Дамдины Хаянхярваа,Mongolian People's Party,,Darkhan-Uul,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",darkhan-uul
+Lüimediin Gansükh,Лүймэдийн Гансүх,Democratic Party,,Darkhan-Uul,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",darkhan-uul
+Dorjdambyn Damba-Ochir,Дорждамбын Дамба-Очир,Mongolian People's Party,,Orkhon,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",orkhon
+Dürzeegiin Odkhüü,Дүрзээгийн Одхүү,Democratic Party,,Orkhon,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",orkhon
+Delegiin Zagdjav,Дэлэгийн Загджав,Mongolian People's Party,,Ulan Bator — Baganuur•Bagakhangai•Khan-Uul,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_baganuur•bagakhangai•khan-uul
+Luvsanvandangiin Bold,Лувсанвандангийн Болд,Democratic Party,,Ulan Bator — Baganuur•Bagakhangai•Khan-Uul,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_baganuur•bagakhangai•khan-uul
+Tsogtyn Batbayar,Цогтын Батбаяр,Mongolian People's Party,Tsogtyn Batbayar,Ulan Bator — Bayanzürkh•Nalaikh,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_bayanzürkh•nalaikh
+Davaajavyn Gankhuyag,Даваажавын Ганхуяг,Democratic Party,,Ulan Bator — Bayanzürkh•Nalaikh,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_bayanzürkh•nalaikh
+Chimediin Saikhanbileg,Чимэдийн Сайханбилэг,Democratic Party,Chimediin Saikhanbileg,Ulan Bator — Bayanzürkh•Nalaikh,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_bayanzürkh•nalaikh
+Zorigiin Altai,Зоригийн Алтай,Independent,,Ulan Bator — Bayanzürkh•Nalaikh,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_bayanzürkh•nalaikh
+Sanjaagiin Bayar,Санжаагийн Баяр,Mongolian People's Party,Sanjaagiin Bayar,Ulan Bator — Sükhbaatar,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_sükhbaatar
+Sükhbaataryn Batbold,Сүхбаатарын Батболд,Mongolian People's Party,Sükhbaataryn Batbold,Ulan Bator — Sükhbaatar,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_sükhbaatar
+Luvsannyamyn Gantömör,Лувсаннямын Гантөмөр,Democratic Party,,Ulan Bator — Sükhbaatar,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_sükhbaatar
+Tsakhiagiin Elbegdorj,Цахиагийн Элбэгдорж,Democratic Party,Tsakhiagiin Elbegdorj,Ulan Bator — Chingeltei,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_chingeltei
+Garidkhüügiin Bayarsaikhan,Гарьдхүүгийн Баярсайхан,Democratic Party,,Ulan Bator — Chingeltei,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_chingeltei
+Dagvadorjiin Ochirbat,Дагвадоржийн Очирбат,Mongolian People's Party,,Ulan Bator — Chingeltei,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_chingeltei
+Dashdorjiin Zorigt,Дашдоржийн Зоригт,Mongolian People's Party,,Ulan Bator — Chingeltei,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_chingeltei
+Tsendiin Mönkh-Orgil,Цэндийн Мөнх-Оргил,Mongolian People's Party,,Ulan Bator — Bayangol,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_bayangol
+Khishigdembereliin Temüüjin,Хишигдэмбэрэлийн Тэмүүжин,Democratic Party,,Ulan Bator — Bayangol,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_bayangol
+Dangaasurengiin Enkhbat,Дангаасүрэнгийн Энхбат,Civil Will-Green Party,,Ulan Bator — Bayangol,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_bayangol
+Sodnomzunduin Erdene,Содномзундуйн Эрдэнэ,Democratic Party,,Ulan Bator — Bayangol,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_bayangol
+Dendeviin Terbishdagva,Дэндэвийн Тэрбишдагва,Mongolian People's Party,,Ulan Bator — Songino Khairkhan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_songino_khairkhan
+Norovyn Altankhuyag,Норовын Алтанхуяг,Democratic Party,Norovyn Altankhuyag,Ulan Bator — Songino Khairkhan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_songino_khairkhan
+Davaagiin Batbayar,Даваагийн Батбаяр,Democratic Party,Kyokushūzan Noboru,Ulan Bator — Songino Khairkhan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_songino_khairkhan
+Sanjaasürengiin Oyuun,Санжаасүрэнгийн Оюун,Civil Will-Green Party,Sanjaasürengiin Oyuun,Ulan Bator — Songino Khairkhan,2008,"https://en.wikipedia.org/wiki/List_of_MPs_elected_in_the_Mongolian_legislative_election,_2008",ulan_bator_—_songino_khairkhan


### PR DESCRIPTION
We want to give cosntituencies UUIDs, and for that they need IDs. It
doesn't really matter _what_ these are, as long as they stay fairly
consistent.

Generating these via SQL makes no difference to the output.

```
Add memberships from sources/morph/wikipedia.csv
Merging with sources/morph/official.csv
Data Mismatches
* 48 of 119 unmatched
	{:id=>"225", :name=>"Dolgorsuren Sumiyabazar"}
	{:id=>"414", :name=>"Nyam-Osor Uchral"}
	{:id=>"55", :name=>"Khayangaa Bolorchuluun"}
	{:id=>"396", :name=>"Jamiyan Munkhbat"}
	{:id=>"388", :name=>"Davaa Ganbold"}
	{:id=>"397", :name=>"Gompildoo Munkhtsetseg"}
	{:id=>"387", :name=>"Jambal Ganbaatar"}
	{:id=>"385", :name=>"Magvan Bilegt"}
	{:id=>"389", :name=>"Dorjdugar Gantulga"}
	{:id=>"383", :name=>"Baagaa Battumur"}
Merging with sources/morph/wikidata.csv
Data Mismatches
* 2 of 53 unmatched
	{:id=>"Q4053765", :name=>"Ёндонгийн Отгонбаяр"}
	{:id=>"Q42934448", :name=>"Даваажанцангийн Сарангэрэл"}
Merging with sources/morph/genderbalance.csv

Top identifiers:
  51 x wikidata
  10 x freebase
  7 x viaf
  6 x lcauth
  1 x nukat

Creating names.csv
Persons matched to Wikidata: 51 ✓ | 109 ✘
  No wikidata: Dondogdorjiin Erdenebat (19444af9-ff6c-46c3-95cc-cc90be718fbf)
  No wikidata: Enebishiin Mönkh-Ochir (e62d790c-29a7-4482-abe7-d78ddb7af5e1)
  No wikidata: Jamyansürengiin Batsuuri (08f5f1a8-e3e7-4cd6-b437-f574d81fef03)
  No wikidata: Gombojain Soltan (da5f58f7-b83f-4c69-a9fd-e6056e1cdb90)
  No wikidata: Zangadyn Bayanselenge (a8f70505-03c1-4ebe-b6ef-2b459f3fe714)
  No wikidata: Khavdislamyn Badyelkhan (0de0e663-1792-4ea8-8320-43d78fff631f)
  No wikidata: Boldyn Javkhlan (a7047065-77ce-4b69-9538-99b18dd67a58)
  No wikidata: Bökhchuluuny Pürevdorj (8f55cc81-0e8c-448c-8ad9-872089084a4c)
  No wikidata: Otgoogiin Batnasan (b029b6e8-f5a6-46ae-8ee2-1d170b430ca7)
  No wikidata: Shinensambuugiin Saikhansambuu (fcedf776-8306-4e2e-be00-40383fca81aa)
Parties matched to Wikidata: 7 ✓ 
Areas matched to Wikidata: 0 ✓ | 36 ✘
```