### PR TITLE
Japan (House of Representatives): end 47th term

### DIFF
--- a/data/Japan/House_of_Representatives/ep-popolo-v1.0.json
+++ b/data/Japan/House_of_Representatives/ep-popolo-v1.0.json
@@ -49351,6 +49351,7 @@
     },
     {
       "classification": "legislative period",
+      "end_date": "2017-09-28",
       "id": "term/47",
       "identifiers": [
         {

--- a/data/Japan/House_of_Representatives/sources/manual/terms.csv
+++ b/data/Japan/House_of_Representatives/sources/manual/terms.csv
@@ -1,2 +1,3 @@
 id,name,start_date,end_date,wikidata
-47,The 47th House of Representatives,2014-12-14,,Q41654707
+47,The 47th House of Representatives,2014-12-14,2017-09-28,Q41654707
+48,The 48th House of Representatives,2017-11-01,,Q41655079


### PR DESCRIPTION
```
Add memberships from sources/morph/official.csv
Add memberships from sources/archive/official-vanished.csv
Merging with sources/morph/wikidata.csv
Data Mismatches
* 268 of 541 unmatched
	{:id=>"Q26044181", :name=>"Makoto Hamaguchi"}
	{:id=>"Q11418015", :name=>"Masamune Wada"}
	{:id=>"Q7677127", :name=>"Takamaro Fukuoka"}
	{:id=>"Q17220804", :name=>"Shōji Maitachi"}
	{:id=>"Q28682170", :name=>"Masaru Miyazaki"}
	{:id=>"Q28682073", :name=>"Kei Satō"}
	{:id=>"Q937682", :name=>"Hirofumi Nakasone"}
	{:id=>"Q11533971", :name=>"Yoshifumi Tsuge"}
	{:id=>"Q8056133", :name=>"Yoshiki Yamashita"}
	{:id=>"Q8062688", :name=>"Yōsuke Tsuruho"}
Merging with sources/morph/genderbalance.csv
Party plptyf not in Popolo
Party nippon_ishin_no_kai not in Popolo

Top identifiers:
  273 x wikidata
  160 x freebase
  127 x viaf
  122 x ndl
  84 x isni

Creating names.csv
Persons matched to Wikidata: 273 ✓ | 206 ✘
  No wikidata: YOSHIDA Nobuhiro (b54c4829-6ad2-45a6-b4fe-c62928a575e3)
  No wikidata: KAMIYAMA Yosuke (0540534f-8c8e-45d1-9a75-d4d044db32c9)
  No wikidata: KIUCHI Minoru (066b31e2-97d2-4c08-9eb9-47919d1f6350)
  No wikidata: FUKUSHIMA Nobuyuki (124e6211-1fc8-447d-9c5c-b28de6e32e09)
  No wikidata: FUJIMARU Satoshi (b78728c4-b6a6-4659-8d80-d3b60cbd44a3)
  No wikidata: OCHIAI Takayuki (77a71635-c460-4fef-9e04-104ae4395c33)
  No wikidata: BABA Nobuyuki (3b9a5157-41d9-437c-ab80-b51b1f44d585)
  No wikidata: TAKEUCHI Yuzuru (fe4c8baf-254f-4700-a263-8492ae3245f1)
  No wikidata: OTA Kazumi (aa8f65e5-cbcf-4f0e-b0ed-0fd7587196ac)
  No wikidata: OGUCHI Yoshinori (ea2e5623-9fcd-48c0-b198-6205ea7f61f1)
Parties matched to Wikidata: 8 ✓ 
Areas matched to Wikidata: 297 ✓ | 10 ✘
  No wikidata: Kita Kanto Bloc (kita_kanto_bloc)
  No wikidata: Shikoku Bloc (shikoku_bloc)
  No wikidata: Tohoku Bloc (tohoku_bloc)
  No wikidata: Kyushu Bloc (kyushu_bloc)
  No wikidata: Minami Kanto Bloc (minami_kanto_bloc)
```