### PR TITLE
Add POPOLO_JSON and ep_popolo helpers

### DIFF
--- a/rake_build/generate_ep_popolo.rb
+++ b/rake_build/generate_ep_popolo.rb
@@ -12,15 +12,15 @@ require 'deep_merge'
 #   - merge term data from terms.csv
 #-----------------------------------------------------------------------
 namespace :transform do
-  file 'ep-popolo-v1.0.json' => :write
-  CLEAN.include('ep-popolo-v1.0.json', 'final.json')
+  file POPOLO_JSON => :write
+  CLEAN.include(POPOLO_JSON, 'final.json')
 
   task load: MERGED_JSON do
     @json = JSON.parse(MERGED_JSON.read, symbolize_names: true)
   end
 
   task :write do
-    popolo_write('ep-popolo-v1.0.json', @json)
+    popolo_write(POPOLO_JSON, @json)
   end
 
   #---------------------------------------------------------------------

--- a/rake_build/generate_final_csvs.rb
+++ b/rake_build/generate_final_csvs.rb
@@ -11,8 +11,8 @@ CLEAN.include('term-*.csv', 'names.csv')
 
 namespace :term_csvs do
   desc 'Generate the Term Tables'
-  task term_tables: 'ep-popolo-v1.0.json' do
-    @popolo = popolo = EveryPolitician::Popolo.read('ep-popolo-v1.0.json')
+  task term_tables: POPOLO_JSON do
+    @popolo = popolo = EveryPolitician::Popolo.read(POPOLO_JSON)
     terms = EveryPolitician::Dataview::Terms.new(popolo: @popolo).terms
     terms.each do |term|
       path = Pathname.new('term-%s.csv' % term.id)
@@ -76,7 +76,7 @@ namespace :term_csvs do
   end
 
   desc 'Build the Cabinet file'
-  task positions: ['ep-popolo-v1.0.json'] do
+  task positions: [POPOLO_JSON] do
     src = @INSTRUCTIONS.sources_of_type('wikidata-cabinet').first or next
 
     data = src.filtered(position_map: POSITION_FILTER_CSV)

--- a/rake_build/generate_stats.rb
+++ b/rake_build/generate_stats.rb
@@ -8,9 +8,7 @@ STATSFILE = Pathname.new('unstable/stats.json')
 
 namespace :stats do
   task :regenerate do
-    popolo = Everypolitician::Popolo.read('ep-popolo-v1.0.json')
-    stats = StatsFile.new(popolo: popolo, position_file: POSITION_CSV).stats
-
+    stats = StatsFile.new(popolo: ep_popolo, position_file: POSITION_CSV).stats
     STATSFILE.dirname.mkpath
     STATSFILE.write(JSON.pretty_generate(stats))
   end

--- a/rake_config/wikidata.rb
+++ b/rake_config/wikidata.rb
@@ -17,7 +17,7 @@ desc 'Report on orphaned Wikidata reconciliation records'
 namespace :wikidata do
   task :remove_orphans do
     rfile = (@INSTRUCTIONS.sources_of_type('wikidata').first or next).reconciliation_file
-    known = Everypolitician::Popolo.read('ep-popolo-v1.0.json').persons.map(&:id)
+    known = ep_popolo.persons.map(&:id)
 
     orphaned = rfile.to_h.values - known
     next unless orphaned.any?

--- a/rake_generate/area_reconciliation.rb
+++ b/rake_generate/area_reconciliation.rb
@@ -6,15 +6,11 @@ require 'pathname'
 
 desc 'Generate an Area reconcilation file'
 namespace :reconciliation do
-  POPOLO = Pathname.new('ep-popolo-v1.0.json')
-
   task :generate_areas do
-    abort 'No Popolo file' unless POPOLO.exist?
+    abort 'No Popolo file' unless EP_POPOLO.exist?
     recfile = @INSTRUCTIONS.sources_of_type('area-wikidata').first.reconciliation_file
     abort "#{recfile} already exists" if recfile.exist?
-    areas = EveryPolitician::Popolo.read(POPOLO).areas.map do |a|
-      { id: a.id, name: a.name }
-    end
+    areas = ep_popolo.areas.map { |a| { id: a.id, name: a.name } }
     header = %w[id wikidata].to_csv
     body = areas.map { |a| [a[:id].split('/').last, "??? #{a[:name]}"].to_csv }.join
     recfile.write(header + body)

--- a/rake_report/area_list.rb
+++ b/rake_report/area_list.rb
@@ -2,7 +2,7 @@
 
 namespace :report do
   task :area_list do
-    areas = EveryPolitician::Popolo.read('ep-popolo-v1.0.json').memberships.select(&:area_id).group_by(&:area_id)
+    areas = ep_popolo.memberships.select(&:area_id).group_by(&:area_id)
     puts %w[id wikidata].to_csv
     puts areas.map do |id, ms|
       ts = ms.map(&:legislative_period).sort_by(&:id)

--- a/rake_report/missing_parties.rb
+++ b/rake_report/missing_parties.rb
@@ -2,6 +2,6 @@
 
 namespace :report do
   task :missing_parties do
-    puts EveryPolitician::Popolo.read('ep-popolo-v1.0.json').organizations.reject(&:wikidata).map { |p| [p.id, p.name].to_csv }
+    puts ep_popolo.organizations.reject(&:wikidata).map { |p| [p.id, p.name].to_csv }
   end
 end

--- a/rake_report/missing_wikidata.rb
+++ b/rake_report/missing_wikidata.rb
@@ -2,16 +2,14 @@
 
 namespace :report do
   task :missing_wikidata do
-    popolo = Everypolitician::Popolo.read('ep-popolo-v1.0.json')
-
     # Find the latest term that has anyone unmapped to Wikidata
-    latest_missing = popolo.terms.map do |term|
+    latest_missing = ep_popolo.terms.map do |term|
       term.memberships.reject { |mem| mem.person.wikidata }
     end.reject(&:empty?).last
 
     puts latest_missing.first.term.id
     latest_missing.uniq { |mem| mem.person.id }.each do |mem|
-      puts '%s (%s) %s' % [mem.person.name, mem.person.id, mem.sources.first&.[](:url)]
+      puts '%s (%s) %s @ %s' % [mem.person.name, mem.person.id, mem.area.name, mem.sources.first&.[](:url)]
     end
   end
 end

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -54,6 +54,7 @@ POSITION_FILTER_CSV = Pathname.new('sources/manual/position-filter.csv')
 POSITION_HTML = Pathname.new('sources/manual/.position-filter.html')
 POSITION_RAW = Pathname.new('sources/wikidata/positions.json')
 POSITION_CSV = Pathname.new('unstable/positions.csv')
+POPOLO_JSON  = Pathname.new('ep-popolo-v1.0.json')
 
 CLEAN.include MERGED_CSV
 CLEAN.include MERGED_JSON
@@ -82,6 +83,10 @@ def json_load(file)
   JSON.parse(File.read(file), symbolize_names: true)
 end
 
+def ep_popolo
+  EveryPolitician::Popolo.read(POPOLO_JSON)
+end
+
 def json_write(file, json)
   File.write(file, JSON.pretty_generate(json))
 end
@@ -95,7 +100,7 @@ module Enumerable
   end
 end
 
-def popolo_write(file, json)
+def popolo_write(pathname, json)
   json[:persons] = json[:persons].portable_sort_by { |p| p[:id] }
   json[:persons].each do |p|
     p[:identifiers]     &&= p[:identifiers].portable_sort_by { |i| [i[:scheme], i[:identifier]] }
@@ -116,7 +121,7 @@ def popolo_write(file, json)
   end
 
   final = Hash[deep_sort(json).sort_by { |k, _| k }.reverse]
-  File.write(file, JSON.pretty_generate(final))
+  pathname.write(JSON.pretty_generate(final))
 end
 
 @SOURCE_DIR = 'sources/manual'

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -133,7 +133,7 @@ raise("Can't read #{@INSTRUCTIONS_FILE}") unless @INSTRUCTIONS_FILE.exist?
 @SOURCES = @INSTRUCTIONS.sources
 
 desc 'Rebuild from source data'
-task rebuild: [:clobber, 'ep-popolo-v1.0.json']
+task rebuild: [:clobber, POPOLO_JSON]
 task default: ['csvlint:validate', :csvs, 'stats:regenerate']
 
 Dir[File.dirname(__FILE__) + '/rake_*/*.rb'].each { |file| require file }


### PR DESCRIPTION
Rather than having to repeat these everywhere, make the Pathname, and the EveryPolitician::Popolo parsed form available throughout the build process.

NB: We could probably optimise this by caching the Popolo file, but I've skipped that for now in case there are cases where there might cause subtle bugs. This change will make it much easier to add that later if required/useful.