### PR TITLE
Japan (House of Representatives): rebuild areas

### DIFF
--- a/data/Japan/House_of_Representatives/ep-popolo-v1.0.json
+++ b/data/Japan/House_of_Representatives/ep-popolo-v1.0.json
@@ -49627,11 +49627,6 @@
       "name": "Aichi 5th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Aichi 5th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "cinquième circonscription de la préfecture d'Aichi",
           "note": "multilingual"
@@ -49665,11 +49660,6 @@
       "name": "Aichi 6th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Aichi 6th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "sixième circonscription de la préfecture d'Aichi",
           "note": "multilingual"
@@ -49692,11 +49682,6 @@
       ],
       "name": "Aichi 7th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Aichi 7th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "septième circonscription de la préfecture d'Aichi",
@@ -49725,11 +49710,6 @@
       ],
       "name": "Aichi 8th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Aichi 8th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "huitième circonscription de la préfecture d'Aichi",
@@ -49781,11 +49761,6 @@
       ],
       "name": "Akita 1st District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Akita 1st District",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "première circonscription de la préfecture d'Akita",
@@ -49886,11 +49861,6 @@
       "name": "Aomori 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Aomori 1st district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture d'Aomori",
           "note": "multilingual"
@@ -49923,11 +49893,6 @@
       ],
       "name": "Aomori 2nd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Aomori 2nd district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture d'Aomori",
@@ -50203,11 +50168,6 @@
       "name": "Chiba 3rd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Chiba 3rd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "troisième circonscription de la préfecture de Chiba",
           "note": "multilingual"
@@ -50240,11 +50200,6 @@
       ],
       "name": "Chiba 4th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Chiba 4th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "quatrième circonscription de la préfecture de Chiba",
@@ -50401,11 +50356,6 @@
       "name": "Chiba 9th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Chiba 9th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "neuvième circonscription de la préfecture de Chiba",
           "note": "multilingual"
@@ -50443,11 +50393,6 @@
       ],
       "name": "Ehime 1st District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Ehime 1st District",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "première circonscription de la préfecture d'Ehime",
@@ -50560,11 +50505,6 @@
       ],
       "name": "Fukui 1st District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Fukui 1st District",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Fukui",
@@ -50805,11 +50745,6 @@
       "name": "Fukuoka 5th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Fukuoka 5th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "cinquième circonscription de la préfecture de Fukuoka",
           "note": "multilingual"
@@ -50837,11 +50772,6 @@
       ],
       "name": "Fukuoka 6th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Fukuoka 6th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "sixième circonscription de la préfecture de Fukuoka",
@@ -50898,11 +50828,6 @@
       ],
       "name": "Fukuoka 8th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Fukuoka 8th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "huitième circonscription de la préfecture de Fukuoka",
@@ -51026,11 +50951,6 @@
       "name": "Fukushima 3rd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Fukushima 3rd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "troisième circonscription de la préfecture de Fukushima",
           "note": "multilingual"
@@ -51129,11 +51049,6 @@
       ],
       "name": "Gifu 1st District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Gifu 1st district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Gifu",
@@ -51236,11 +51151,6 @@
       ],
       "name": "Gifu 5th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Gifu 5th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "cinquième circonscription de la préfecture de Gifu",
@@ -51473,11 +51383,6 @@
       "name": "Hiroshima 2nd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Hiroshima 2nd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture de Hiroshima",
           "note": "multilingual"
@@ -51580,11 +51485,6 @@
       "name": "Hiroshima 6th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Hiroshima 6th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "sixième circonscription de la préfecture de Hiroshima",
           "note": "multilingual"
@@ -51613,11 +51513,6 @@
       "name": "Hiroshima 7th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Hiroshima 7th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "septième circonscription de la préfecture de Hiroshima",
           "note": "multilingual"
@@ -51645,11 +51540,6 @@
       ],
       "name": "Hokkaido 10th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Hokkaido 10th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "dixième circonscription de Hokkaidō",
@@ -51684,11 +51574,6 @@
       "name": "Hokkaido 11th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Hokkaido 11th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "onzième circonscription de Hokkaidō",
           "note": "multilingual"
@@ -51721,11 +51606,6 @@
       ],
       "name": "Hokkaido 12th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Hokkaido 12th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "douzième circonscription de Hokkaidō",
@@ -51760,11 +51640,6 @@
       "name": "Hokkaido 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Hokkaido 1st district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de Hokkaidō",
           "note": "multilingual"
@@ -51797,11 +51672,6 @@
       ],
       "name": "Hokkaido 2nd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Hokkaido 2nd district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "deuxième circonscription de Hokkaidō",
@@ -51836,11 +51706,6 @@
       "name": "Hokkaido 3rd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Hokkaido 3rd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "troisième circonscription de Hokkaidō",
           "note": "multilingual"
@@ -51873,11 +51738,6 @@
       ],
       "name": "Hokkaido 4th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Hokkaido 4th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "quatrième circonscription de Hokkaidō",
@@ -51912,11 +51772,6 @@
       "name": "Hokkaido 5th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Hokkaido 5th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "cinquième circonscription de Hokkaidō",
           "note": "multilingual"
@@ -51949,11 +51804,6 @@
       ],
       "name": "Hokkaido 6th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Hokkaido 6th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "sixième circonscription de Hokkaidō",
@@ -51988,11 +51838,6 @@
       "name": "Hokkaido 7th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Hokkaido 7th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "septième circonscription de Hokkaidō",
           "note": "multilingual"
@@ -52025,11 +51870,6 @@
       ],
       "name": "Hokkaido 8th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Hokkaido 8th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "huitième circonscription de Hokkaidō",
@@ -52067,11 +51907,6 @@
       ],
       "name": "Hokkaido 9th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Hokkaido 9th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "neuvième circonscription de Hokkaidō",
@@ -52144,11 +51979,6 @@
       "name": "Hyogo 10th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Hyogo 10th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "dixième circonscription de la préfecture de Hyōgo",
           "note": "multilingual"
@@ -52176,11 +52006,6 @@
       ],
       "name": "Hyogo 11th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Hyogo 11th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "onzième circonscription de la préfecture de Hyōgo",
@@ -52210,11 +52035,6 @@
       "name": "Hyogo 12th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Hyogo 12th District",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "douzième circonscription de la préfecture de Hyōgo",
           "note": "multilingual"
@@ -52242,11 +52062,6 @@
       ],
       "name": "Hyogo 1st District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Hyogo 1st district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Hyōgo",
@@ -52276,11 +52091,6 @@
       "name": "Hyogo 2nd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Hyogo 2nd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture de Hyōgo",
           "note": "multilingual"
@@ -52308,11 +52118,6 @@
       ],
       "name": "Hyogo 3rd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Hyogo 3rd District",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "troisième circonscription de la préfecture de Hyōgo",
@@ -52342,11 +52147,6 @@
       "name": "Hyogo 4th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Hyogo 4th District",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "quatrième circonscription de la préfecture de Hyōgo",
           "note": "multilingual"
@@ -52375,11 +52175,6 @@
       "name": "Hyogo 5th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Hyogo 5th District",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "cinquième circonscription de la préfecture de Hyōgo",
           "note": "multilingual"
@@ -52402,11 +52197,6 @@
       ],
       "name": "Hyogo 6th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Hyogo 6th District",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "sixième circonscription de la préfecture de Hyōgo",
@@ -52436,11 +52226,6 @@
       "name": "Hyogo 7th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Hyogo 7th District",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "septième circonscription de la préfecture de Hyōgo",
           "note": "multilingual"
@@ -52469,11 +52254,6 @@
       "name": "Hyogo 8th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Hyogo 8th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "es",
           "name": "8.º distrito de Hyogo",
           "note": "multilingual"
@@ -52501,11 +52281,6 @@
       ],
       "name": "Hyogo 9th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Hyogo 9th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "neuvième circonscription de la préfecture de Hyōgo",
@@ -52596,11 +52371,6 @@
       "name": "Ibaraki 3rd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Ibaraki 3rd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "troisième circonscription de la préfecture d'Ibaraki",
           "note": "multilingual"
@@ -52628,11 +52398,6 @@
       ],
       "name": "Ibaraki 4th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Ibaraki 4th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "quatrième circonscription de la préfecture d'Ibaraki",
@@ -52756,11 +52521,6 @@
       "name": "Ishikawa 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Ishikawa 1st district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture d'Ishikawa",
           "note": "multilingual"
@@ -52788,11 +52548,6 @@
       ],
       "name": "Ishikawa 2nd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Ishikawa 2nd district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture d'Ishikawa",
@@ -52849,11 +52604,6 @@
       ],
       "name": "Iwate 1st District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Iwate 1st district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "première circonscription de la préfecture d'Iwate",
@@ -52936,11 +52686,6 @@
       "name": "Iwate 3rd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Iwate 3rd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "troisième circonscription de la préfecture d'Iwate",
           "note": "multilingual"
@@ -52973,11 +52718,6 @@
       ],
       "name": "Iwate 4th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Iwate 4th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "quatrième circonscription de la préfecture d'Iwate",
@@ -53017,11 +52757,6 @@
       "name": "Kagawa 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Kagawa 1st District",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Kagawa",
           "note": "multilingual"
@@ -53049,11 +52784,6 @@
       ],
       "name": "Kagawa 2nd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Kagawa 2nd district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture de Kagawa",
@@ -53134,11 +52864,6 @@
       "name": "Kagoshima 2nd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Kagoshima 2nd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture de Kagoshima",
           "note": "multilingual"
@@ -53161,11 +52886,6 @@
       ],
       "name": "Kagoshima 3rd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Kagoshima 3rd district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "troisième circonscription de la préfecture de Kagoshima",
@@ -53246,11 +52966,6 @@
       "name": "Kanagawa 10th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Kanagawa 10th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "dixième circonscription de la préfecture de Kanagawa",
           "note": "multilingual"
@@ -53283,11 +52998,6 @@
       ],
       "name": "Kanagawa 11th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Kanagawa 11th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "onzième circonscription de la préfecture de Kanagawa",
@@ -53383,11 +53093,6 @@
       "name": "Kanagawa 14th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Kanagawa 14th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "quatorzième circonscription de la préfecture de Kanagawa",
           "note": "multilingual"
@@ -53420,11 +53125,6 @@
       ],
       "name": "Kanagawa 15th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Kanagawa 15th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "quinzième circonscription de la préfecture de Kanagawa",
@@ -53481,11 +53181,6 @@
       ],
       "name": "Kanagawa 17th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Kanagawa 17th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "dix-septième circonscription de la préfecture de Kanagawa",
@@ -53548,11 +53243,6 @@
       "name": "Kanagawa 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Kanagawa 1st district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Kanagawa",
           "note": "multilingual"
@@ -53585,11 +53275,6 @@
       ],
       "name": "Kanagawa 2nd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Kanagawa 2nd district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture de Kanagawa",
@@ -53657,11 +53342,6 @@
       "name": "Kanagawa 4th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Kanagawa 4th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "quatrième circonscription de la préfecture de Kanagawa",
           "note": "multilingual"
@@ -53728,11 +53408,6 @@
       "name": "Kanagawa 6th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Kanagawa 6th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "sixième circonscription de la préfecture de Kanagawa",
           "note": "multilingual"
@@ -53798,11 +53473,6 @@
       ],
       "name": "Kanagawa 8th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Kanagawa 8th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "huitième circonscription de la préfecture de Kanagawa",
@@ -53913,11 +53583,6 @@
       "name": "Kochi 1st district",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Kochi 1st district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Kōchi",
           "note": "multilingual"
@@ -54002,11 +53667,6 @@
       "name": "Kumamoto 2nd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Kumamoto 2nd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture de Kumamoto",
           "note": "multilingual"
@@ -54058,11 +53718,6 @@
       "name": "Kumamoto 4th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Kumamoto 4th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "quatrième circonscription de la préfecture de Kumamoto",
           "note": "multilingual"
@@ -54109,11 +53764,6 @@
       "name": "Kyoto 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Kyoto 1st District",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de Kyōto",
           "note": "multilingual"
@@ -54141,11 +53791,6 @@
       ],
       "name": "Kyoto 2nd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Kyoto 2nd district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "deuxième circonscription de Kyōto",
@@ -54180,11 +53825,6 @@
       "name": "Kyoto 3rd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Kyoto 3rd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "troisième circonscription de Kyōto",
           "note": "multilingual"
@@ -54212,11 +53852,6 @@
       ],
       "name": "Kyoto 4th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Kyoto 4th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "quatrième circonscription de Kyōto",
@@ -54246,11 +53881,6 @@
       "name": "Kyoto 5th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Kyoto 5th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "cinquième circonscription de Kyōto",
           "note": "multilingual"
@@ -54278,11 +53908,6 @@
       ],
       "name": "Kyoto 6th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Kyoto 6th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "sixième circonscription de Kyōto",
@@ -54312,11 +53937,6 @@
       "name": "Mie 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Mie 1st District",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Mie",
           "note": "multilingual"
@@ -54344,11 +53964,6 @@
       ],
       "name": "Mie 2nd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Mie 2nd District",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture de Mie",
@@ -54383,11 +53998,6 @@
       "name": "Mie 3rd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Mie 3rd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "troisième circonscription de la préfecture de Mie",
           "note": "multilingual"
@@ -54420,11 +54030,6 @@
       ],
       "name": "Mie 4th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Mie 4th District",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "quatrième circonscription de la préfecture de Mie",
@@ -54459,11 +54064,6 @@
       "name": "Mie 5th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Mie 5th District",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "cinquième circonscription de la préfecture de Mie",
           "note": "multilingual"
@@ -54492,11 +54092,6 @@
       "name": "Miyagi 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Miyagi 1st District",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Miyagi",
           "note": "multilingual"
@@ -54524,11 +54119,6 @@
       ],
       "name": "Miyagi 2nd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Miyagi 2nd district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture de Miyagi",
@@ -54619,11 +54209,6 @@
       "name": "Miyagi 5th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Miyagi 5th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "cinquième circonscription de la préfecture de Miyagi",
           "note": "multilingual"
@@ -54690,11 +54275,6 @@
       "name": "Miyazaki 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Miyazaki 1st District",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Miyazaki",
           "note": "multilingual"
@@ -54723,11 +54303,6 @@
       "name": "Miyazaki 2nd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Miyazaki 2nd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture de Miyazaki",
           "note": "multilingual"
@@ -54751,11 +54326,6 @@
       "name": "Miyazaki 3rd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Miyazaki 3rd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "troisième circonscription de la préfecture de Miyazaki",
           "note": "multilingual"
@@ -54778,11 +54348,6 @@
       ],
       "name": "Nagano 1st District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Nagano 1st District",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Nagano",
@@ -54868,11 +54433,6 @@
       "name": "Nagano 4th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Nagano 4th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "quatrième circonscription de la préfecture de Nagano",
           "note": "multilingual"
@@ -54929,11 +54489,6 @@
       "name": "Nagasaki 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Nagasaki 1st district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Nagasaki",
           "note": "multilingual"
@@ -54962,11 +54517,6 @@
       "name": "Nagasaki 2nd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Nagasaki 2nd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture de Nagasaki",
           "note": "multilingual"
@@ -54994,11 +54544,6 @@
       ],
       "name": "Nagasaki 3rd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Nagasaki 3rd district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "troisième circonscription de la préfecture de Nagasaki",
@@ -55051,11 +54596,6 @@
       "name": "Nara 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Nara 1st district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Nara",
           "note": "multilingual"
@@ -55084,11 +54624,6 @@
       "name": "Nara 2nd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Nara 2nd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture de Nara",
           "note": "multilingual"
@@ -55116,11 +54651,6 @@
       ],
       "name": "Nara 3rd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Nara 3rd district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "troisième circonscription de la préfecture de Nara",
@@ -55177,11 +54707,6 @@
       ],
       "name": "Niigata 1st District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Niigata 1st district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Niigata",
@@ -55295,11 +54820,6 @@
       "name": "Niigata 5th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Niigata 5th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "cinquième circonscription de la préfecture de Niigata",
           "note": "multilingual"
@@ -55355,11 +54875,6 @@
       ],
       "name": "Oita 1st District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Oita 1st District",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "première circonscription de la préfecture d'Ōita",
@@ -55450,11 +54965,6 @@
       "name": "Okayama 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Okayama 1st district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture d'Okayama",
           "note": "multilingual"
@@ -55482,11 +54992,6 @@
       ],
       "name": "Okayama 2nd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Okayama 2nd district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture d'Okayama",
@@ -55516,11 +55021,6 @@
       "name": "Okayama 3rd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Okayama 3rd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "troisième circonscription de la préfecture d'Okayama",
           "note": "multilingual"
@@ -55548,11 +55048,6 @@
       ],
       "name": "Okayama 4th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Okayama 4th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "quatrième circonscription de la préfecture d'Okayama",
@@ -55610,11 +55105,6 @@
       "name": "Okinawa 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Okinawa 1st District",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture d'Okinawa",
           "note": "multilingual"
@@ -55642,11 +55132,6 @@
       ],
       "name": "Okinawa 2nd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Okinawa 2nd district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture d'Okinawa",
@@ -55676,11 +55161,6 @@
       "name": "Okinawa 3rd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Okinawa 3rd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "troisième circonscription de la préfecture d'Okinawa",
           "note": "multilingual"
@@ -55703,11 +55183,6 @@
       ],
       "name": "Okinawa 4th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Okinawa 4th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "quatrième circonscription de la préfecture d'Okinawa",
@@ -55736,11 +55211,6 @@
       ],
       "name": "Osaka 10th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Osaka 10th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "dixième circonscription d'Ōsaka",
@@ -55792,11 +55262,6 @@
       ],
       "name": "Osaka 12th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Osaka 12th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "Douzième circonscription d'Ōsaka",
@@ -55923,11 +55388,6 @@
       "name": "Osaka 17th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Osaka 17th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "dix-septième circonscription d'Ōsaka",
           "note": "multilingual"
@@ -55983,11 +55443,6 @@
       ],
       "name": "Osaka 19th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Osaka 19th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "dix-neuvième circonscription d'Ōsaka",
@@ -56180,11 +55635,6 @@
       "name": "Osaka 7th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Osaka 7th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "septième circonscription d'Ōsaka",
           "note": "multilingual"
@@ -56236,11 +55686,6 @@
       "name": "Osaka 9th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Osaka 9th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "neuvième circonscription d'Ōsaka",
           "note": "multilingual"
@@ -56263,11 +55708,6 @@
       ],
       "name": "Saga 1st District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Saga 1st district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Saga",
@@ -56296,11 +55736,6 @@
       ],
       "name": "Saga 2nd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Saga 2nd District",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture de Saga",
@@ -56564,11 +55999,6 @@
       "name": "Saitama 3rd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Saitama 3rd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "troisième circonscription de la préfecture de Saitama",
           "note": "multilingual"
@@ -56629,11 +56059,6 @@
       ],
       "name": "Saitama 5th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Saitama 5th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "cinquième circonscription de la préfecture de Saitama",
@@ -56795,11 +56220,6 @@
       "name": "Shiga 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Shiga 1st district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Shiga",
           "note": "multilingual"
@@ -56827,11 +56247,6 @@
       ],
       "name": "Shiga 2nd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Shiga 2nd district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture de Shiga",
@@ -56907,11 +56322,6 @@
       "name": "Shimane 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Shimane 1st District",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Shimane",
           "note": "multilingual"
@@ -56967,11 +56377,6 @@
       ],
       "name": "Shizuoka 1st District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Shizuoka 1st District",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Shizuoka",
@@ -57084,11 +56489,6 @@
       ],
       "name": "Shizuoka 5th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Shizuoka 5th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "cinquième circonscription de la préfecture de Shizuoka",
@@ -57240,11 +56640,6 @@
       "name": "Tochigi 2nd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Tochigi 2nd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture de Tochigi",
           "note": "multilingual"
@@ -57277,11 +56672,6 @@
       ],
       "name": "Tochigi 3rd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Tochigi 3rd district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "troisième circonscription de la préfecture de Tochigi",
@@ -57392,11 +56782,6 @@
       "name": "Tokushima 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Tokushima 1st district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Tokushima",
           "note": "multilingual"
@@ -57458,11 +56843,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "en",
-          "name": "Tokyo 10th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "dixième circonscription de Tōkyō",
           "note": "multilingual"
@@ -57495,11 +56875,6 @@
       ],
       "name": "Tokyo 11th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Tokyo 11th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "onzième circonscription de Tōkyō",
@@ -57674,11 +57049,6 @@
       "name": "Tokyo 17th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Tokyo 17th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "dix-septième circonscription de Tōkyō",
           "note": "multilingual"
@@ -57706,11 +57076,6 @@
       ],
       "name": "Tokyo 18th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Tokyo 18th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "dix-huitième circonscription de Tōkyō",
@@ -57772,11 +57137,6 @@
       ],
       "name": "Tokyo 1st District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Tokyo 1st district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "première circonscription de Tōkyō",
@@ -57872,11 +57232,6 @@
       "name": "Tokyo 22nd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Tokyo 22nd District",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "vingt-deuxième circonscription de Tōkyō",
           "note": "multilingual"
@@ -57961,11 +57316,6 @@
       "name": "Tokyo 25th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Tokyo 25th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "vingt-cinquième circonscription de Tōkyō",
           "note": "multilingual"
@@ -57993,11 +57343,6 @@
       ],
       "name": "Tokyo 2nd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Tokyo 2nd district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "deuxième circonscription de Tōkyō",
@@ -58032,11 +57377,6 @@
       "name": "Tokyo 3rd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Tokyo 3rd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "troisième circonscription de Tōkyō",
           "note": "multilingual"
@@ -58070,11 +57410,6 @@
       "name": "Tokyo 4th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Tokyo 4th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "quatrième circonscription de Tōkyō",
           "note": "multilingual"
@@ -58102,11 +57437,6 @@
       ],
       "name": "Tokyo 5th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Tokyo 5th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "cinquième circonscription de Tōkyō",
@@ -58136,11 +57466,6 @@
       "name": "Tokyo 6th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Tokyo 6th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "sixième circonscription de Tōkyō",
           "note": "multilingual"
@@ -58168,11 +57493,6 @@
       ],
       "name": "Tokyo 7th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Tokyo 7th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "septième circonscription de Tōkyō",
@@ -58207,11 +57527,6 @@
       "name": "Tokyo 8th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Tokyo 8th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "huitième circonscription de Tōkyō",
           "note": "multilingual"
@@ -58244,11 +57559,6 @@
       ],
       "name": "Tokyo 9th District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Tokyo 9th district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "neuvième circonscription de Tōkyō",
@@ -58311,11 +57621,6 @@
       "name": "Tottori 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Tottori 1st district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Tottori",
           "note": "multilingual"
@@ -58371,11 +57676,6 @@
       ],
       "name": "Toyama 1st District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Toyama 1st District",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Toyama",
@@ -58479,11 +57779,6 @@
       "name": "Wakayama 2nd District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Wakayama 2nd district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "deuxième circonscription de la préfecture de Wakayama",
           "note": "multilingual"
@@ -58506,11 +57801,6 @@
       ],
       "name": "Wakayama 3rd District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Wakayama 3rd district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "troisième circonscription de la préfecture de Wakayama",
@@ -58539,11 +57829,6 @@
       ],
       "name": "Yamagata 1st District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Yamagata 1st district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Yamagata",
@@ -58644,11 +57929,6 @@
       "name": "Yamaguchi 1st District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Yamaguchi 1st district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Yamaguchi",
           "note": "multilingual"
@@ -58738,11 +58018,6 @@
       "name": "Yamaguchi 4th District",
       "other_names": [
         {
-          "lang": "en",
-          "name": "Yamaguchi 4th district",
-          "note": "multilingual"
-        },
-        {
           "lang": "fr",
           "name": "quatrième circonscription de la préfecture de Yamaguchi",
           "note": "multilingual"
@@ -58775,11 +58050,6 @@
       ],
       "name": "Yamanashi 1st District",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Yamanashi 1st district",
-          "note": "multilingual"
-        },
         {
           "lang": "fr",
           "name": "première circonscription de la préfecture de Yamanashi",


### PR DESCRIPTION
```
Add memberships from sources/morph/official.csv
Add memberships from sources/archive/official-vanished.csv
Merging with sources/morph/wikidata.csv
Data Mismatches
* 268 of 541 unmatched
	{:id=>"Q11434490", :name=>"Satoshi Ōie"}
	{:id=>"Q7497821", :name=>"Shinya Adachi"}
	{:id=>"Q263703", :name=>"Seiko Hashimoto"}
	{:id=>"Q11652175", :name=>"Makoto Nagamine"}
	{:id=>"Q7677198", :name=>"Takanori Kawai"}
	{:id=>"Q11360463", :name=>"Michiko Ueno"}
	{:id=>"Q6313056", :name=>"Junichi Ishii"}
	{:id=>"Q28682170", :name=>"Masaru Miyazaki"}
	{:id=>"Q26043802", :name=>"小鑓隆史"}
	{:id=>"Q3056615", :name=>"Eriko Imai"}
Merging with sources/morph/genderbalance.csv
Party plptyf not in Popolo
Party nippon_ishin_no_kai not in Popolo

Top identifiers:
  273 x wikidata
  160 x freebase
  127 x viaf
  122 x ndl
  84 x isni

Creating names.csv
Persons matched to Wikidata: 273 ✓ | 206 ✘
  No wikidata: YOSHIMURA Hirofumi (9bf9d636-2df4-46bd-88e9-9bcdc604d80a)
  No wikidata: ITO Yoshitaka (52b68d26-9109-424c-bb90-556853c2fed6)
  No wikidata: KUMADA Hiromichi (bacc466d-c452-435d-a3de-e584c81b3a5d)
  No wikidata: TANIGAWA Tomu (616c4b6e-67f3-4da7-b50c-329c0eaa6806)
  No wikidata: TABATA Hiroaki (ac4d272a-7770-4c28-ab35-15a2c50bcd54)
  No wikidata: BANNO Yutaka (a5f12ded-45ee-4506-af5b-92cd85546dcf)
  No wikidata: HIRANO Hirofumi (72b9626d-6f8f-41df-a74f-96688d773324)
  No wikidata: MOTOMURA Kentaro (1a9d0b8f-b851-4ed6-8f93-fe233a46dc5e)
  No wikidata: MURAI Hideki (9c065d6d-4205-45a3-aaf8-088452f9bb88)
  No wikidata: ANAMI Yoichi (8677a6a9-3342-4889-9af7-7448cefd24a1)
Parties matched to Wikidata: 8 ✓ 
Areas matched to Wikidata: 297 ✓ | 10 ✘
  No wikidata: Kyushu Bloc (kyushu_bloc)
  No wikidata: Shikoku Bloc (shikoku_bloc)
  No wikidata: Hokuriku-Shinetsu Bloc (hokuriku-shinetsu_bloc)
  No wikidata: Kita Kanto Bloc (kita_kanto_bloc)
  No wikidata: Kinki Bloc (kinki_bloc)
```