### PR TITLE
Portugal (Assembly): rebuild areas

### DIFF
--- a/data/Portugal/Assembly/ep-popolo-v1.0.json
+++ b/data/Portugal/Assembly/ep-popolo-v1.0.json
@@ -84848,11 +84848,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "eu",
-          "name": "Leiria",
-          "note": "multilingual"
-        },
-        {
           "lang": "fa",
           "name": "استان لیریا",
           "note": "multilingual"
@@ -84880,11 +84875,6 @@
         {
           "lang": "hi",
           "name": "लीरिया जिला",
-          "note": "multilingual"
-        },
-        {
-          "lang": "hu",
-          "name": "Leiria",
           "note": "multilingual"
         },
         {
@@ -84918,16 +84908,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "lad",
-          "name": "Leiria",
-          "note": "multilingual"
-        },
-        {
-          "lang": "li",
-          "name": "Leiria",
-          "note": "multilingual"
-        },
-        {
           "lang": "lt",
           "name": "Leirijos apskritis",
           "note": "multilingual"
@@ -84955,16 +84935,6 @@
         {
           "lang": "nan",
           "name": "Leiria Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Leiria",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Leiria",
           "note": "multilingual"
         },
         {
@@ -85018,11 +84988,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sv",
-          "name": "Leiria",
-          "note": "multilingual"
-        },
-        {
           "lang": "ta",
           "name": "லேரியா  மாவட்டம்",
           "note": "multilingual"
@@ -85045,16 +85010,6 @@
         {
           "lang": "ur",
           "name": "لائریا ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Leiria",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Leiria",
           "note": "multilingual"
         },
         {
@@ -85204,11 +85159,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "eu",
-          "name": "Guarda",
-          "note": "multilingual"
-        },
-        {
           "lang": "fi",
           "name": "Guardan piiri",
           "note": "multilingual"
@@ -85221,11 +85171,6 @@
         {
           "lang": "gl",
           "name": "Distrito da Guarda",
-          "note": "multilingual"
-        },
-        {
-          "lang": "hu",
-          "name": "Guarda",
           "note": "multilingual"
         },
         {
@@ -85254,16 +85199,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "lad",
-          "name": "Guarda",
-          "note": "multilingual"
-        },
-        {
-          "lang": "li",
-          "name": "Guarda",
-          "note": "multilingual"
-        },
-        {
           "lang": "ms",
           "name": "Daerah Guarda",
           "note": "multilingual"
@@ -85276,16 +85211,6 @@
         {
           "lang": "nan",
           "name": "Guarda Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Guarda",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Guarda",
           "note": "multilingual"
         },
         {
@@ -85339,11 +85264,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sv",
-          "name": "Guarda",
-          "note": "multilingual"
-        },
-        {
           "lang": "uk",
           "name": "Гуарда",
           "note": "multilingual"
@@ -85351,16 +85271,6 @@
         {
           "lang": "ur",
           "name": "گواردا ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Guarda",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Guarda",
           "note": "multilingual"
         },
         {
@@ -85506,11 +85416,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "eu",
-          "name": "Lisboa",
-          "note": "multilingual"
-        },
-        {
           "lang": "fa",
           "name": "ناحیه لیسبون",
           "note": "multilingual"
@@ -85561,11 +85466,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "lad",
-          "name": "Lisboa",
-          "note": "multilingual"
-        },
-        {
           "lang": "li",
           "name": "Lissabon",
           "note": "multilingual"
@@ -85586,11 +85486,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "nb",
-          "name": "Lisboa",
-          "note": "multilingual"
-        },
-        {
           "lang": "nl",
           "name": "Lissabon",
           "note": "multilingual"
@@ -85608,11 +85503,6 @@
         {
           "lang": "pt",
           "name": "Distrito de Lisboa",
-          "note": "multilingual"
-        },
-        {
-          "lang": "pt_br",
-          "name": "Lisboa",
           "note": "multilingual"
         },
         {
@@ -85673,11 +85563,6 @@
         {
           "lang": "vi",
           "name": "Lisbon",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Lisboa",
           "note": "multilingual"
         },
         {
@@ -85824,11 +85709,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "eu",
-          "name": "Coimbra",
-          "note": "multilingual"
-        },
-        {
           "lang": "fi",
           "name": "Coimbran piiri",
           "note": "multilingual"
@@ -85851,11 +85731,6 @@
         {
           "lang": "hi",
           "name": "कोइम्ब्रा जिला",
-          "note": "multilingual"
-        },
-        {
-          "lang": "hu",
-          "name": "Coimbra",
           "note": "multilingual"
         },
         {
@@ -85889,16 +85764,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "lad",
-          "name": "Coimbra",
-          "note": "multilingual"
-        },
-        {
-          "lang": "li",
-          "name": "Coimbra",
-          "note": "multilingual"
-        },
-        {
           "lang": "lt",
           "name": "Koimbros apskritis",
           "note": "multilingual"
@@ -85926,16 +85791,6 @@
         {
           "lang": "nan",
           "name": "Coimbra Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Coimbra",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Coimbra",
           "note": "multilingual"
         },
         {
@@ -85994,11 +85849,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sv",
-          "name": "Coimbra",
-          "note": "multilingual"
-        },
-        {
           "lang": "ta",
           "name": "கொய்ம்ப்ரா  மாவட்டம்",
           "note": "multilingual"
@@ -86021,16 +85871,6 @@
         {
           "lang": "ur",
           "name": "کویمبرا ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Coimbra",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Coimbra",
           "note": "multilingual"
         },
         {
@@ -86085,11 +85925,6 @@
       ],
       "name": "Ponta Delgada",
       "other_names": [
-        {
-          "lang": "en",
-          "name": "Ponta Delgada",
-          "note": "multilingual"
-        },
         {
           "lang": "es",
           "name": "Distrito de Ponta Delgada",
@@ -86199,11 +86034,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "eu",
-          "name": "Vila Real",
-          "note": "multilingual"
-        },
-        {
           "lang": "fi",
           "name": "Vila Realin piiri",
           "note": "multilingual"
@@ -86244,16 +86074,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "lad",
-          "name": "Vila Real",
-          "note": "multilingual"
-        },
-        {
-          "lang": "li",
-          "name": "Vila Real",
-          "note": "multilingual"
-        },
-        {
           "lang": "ms",
           "name": "Daerah Vila Real",
           "note": "multilingual"
@@ -86266,16 +86086,6 @@
         {
           "lang": "nan",
           "name": "Vila Real Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Vila Real",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Vila Real",
           "note": "multilingual"
         },
         {
@@ -86319,16 +86129,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sr_el",
-          "name": "Vila Real",
-          "note": "multilingual"
-        },
-        {
-          "lang": "sv",
-          "name": "Vila Real",
-          "note": "multilingual"
-        },
-        {
           "lang": "uk",
           "name": "Віла-Реал",
           "note": "multilingual"
@@ -86336,16 +86136,6 @@
         {
           "lang": "ur",
           "name": "ویلا ریال ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Vila Real",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Vila Real",
           "note": "multilingual"
         },
         {
@@ -86500,11 +86290,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "eu",
-          "name": "Castelo Branco",
-          "note": "multilingual"
-        },
-        {
           "lang": "fi",
           "name": "Castelo Brancon piiri",
           "note": "multilingual"
@@ -86527,11 +86312,6 @@
         {
           "lang": "hi",
           "name": "कास्टेलो ब्रैंको जिला",
-          "note": "multilingual"
-        },
-        {
-          "lang": "hu",
-          "name": "Castelo Branco",
           "note": "multilingual"
         },
         {
@@ -86565,16 +86345,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "lad",
-          "name": "Castelo Branco",
-          "note": "multilingual"
-        },
-        {
-          "lang": "li",
-          "name": "Castelo Branco",
-          "note": "multilingual"
-        },
-        {
           "lang": "lt",
           "name": "Kastelo Branko apskritis",
           "note": "multilingual"
@@ -86602,16 +86372,6 @@
         {
           "lang": "nan",
           "name": "Castelo Branco Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Castelo Branco",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Castelo Branco",
           "note": "multilingual"
         },
         {
@@ -86670,11 +86430,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sv",
-          "name": "Castelo Branco",
-          "note": "multilingual"
-        },
-        {
           "lang": "ta",
           "name": "காஸ்டெல்லோ  ப்ரான்க்கோ  மாவட்டம்",
           "note": "multilingual"
@@ -86702,16 +86457,6 @@
         {
           "lang": "ur",
           "name": "کاشتیلو برانکو ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Castelo Branco",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Castelo Branco",
           "note": "multilingual"
         },
         {
@@ -86860,11 +86605,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "eu",
-          "name": "Viana do Castelo",
-          "note": "multilingual"
-        },
-        {
           "lang": "fi",
           "name": "Viana do Castelon piiri",
           "note": "multilingual"
@@ -86887,11 +86627,6 @@
         {
           "lang": "hi",
           "name": "वियाना डो कैस्टेलो जिला",
-          "note": "multilingual"
-        },
-        {
-          "lang": "hu",
-          "name": "Viana do Castelo",
           "note": "multilingual"
         },
         {
@@ -86925,16 +86660,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "lad",
-          "name": "Viana do Castelo",
-          "note": "multilingual"
-        },
-        {
-          "lang": "li",
-          "name": "Viana do Castelo",
-          "note": "multilingual"
-        },
-        {
           "lang": "lt",
           "name": "Vijanos de Kastelo apskritis",
           "note": "multilingual"
@@ -86962,16 +86687,6 @@
         {
           "lang": "nan",
           "name": "Viana do Castelo Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Viana do Castelo",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Viana do Castelo",
           "note": "multilingual"
         },
         {
@@ -87030,11 +86745,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sv",
-          "name": "Viana do Castelo",
-          "note": "multilingual"
-        },
-        {
           "lang": "ta",
           "name": "வியான டூ  காஸ்டெல்லோ  மாவட்டம்",
           "note": "multilingual"
@@ -87062,16 +86772,6 @@
         {
           "lang": "ur",
           "name": "ویانا دو کاشتیلو ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Viana do Castelo",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Viana do Castelo",
           "note": "multilingual"
         },
         {
@@ -87201,11 +86901,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "da",
-          "name": "Faro",
-          "note": "multilingual"
-        },
-        {
           "lang": "de",
           "name": "Distrikt Faro",
           "note": "multilingual"
@@ -87236,11 +86931,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "eu",
-          "name": "Faro",
-          "note": "multilingual"
-        },
-        {
           "lang": "fi",
           "name": "Faron piiri",
           "note": "multilingual"
@@ -87263,11 +86953,6 @@
         {
           "lang": "hi",
           "name": "फ़ारो जिला",
-          "note": "multilingual"
-        },
-        {
-          "lang": "hu",
-          "name": "Faro",
           "note": "multilingual"
         },
         {
@@ -87301,16 +86986,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "lad",
-          "name": "Faro",
-          "note": "multilingual"
-        },
-        {
-          "lang": "li",
-          "name": "Faro",
-          "note": "multilingual"
-        },
-        {
           "lang": "lt",
           "name": "Faro apskritis",
           "note": "multilingual"
@@ -87338,16 +87013,6 @@
         {
           "lang": "nan",
           "name": "Faro Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Faro",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Faro",
           "note": "multilingual"
         },
         {
@@ -87411,16 +87076,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sr_el",
-          "name": "Faro",
-          "note": "multilingual"
-        },
-        {
-          "lang": "sv",
-          "name": "Faro",
-          "note": "multilingual"
-        },
-        {
           "lang": "ta",
           "name": "பாரோ  மாவட்டம்",
           "note": "multilingual"
@@ -87443,16 +87098,6 @@
         {
           "lang": "ur",
           "name": "فارو ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Faro",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Faro",
           "note": "multilingual"
         },
         {
@@ -87607,11 +87252,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "eu",
-          "name": "Viseu",
-          "note": "multilingual"
-        },
-        {
           "lang": "fi",
           "name": "Viseun piiri",
           "note": "multilingual"
@@ -87634,11 +87274,6 @@
         {
           "lang": "hi",
           "name": "विसू जिला",
-          "note": "multilingual"
-        },
-        {
-          "lang": "hu",
-          "name": "Viseu",
           "note": "multilingual"
         },
         {
@@ -87672,16 +87307,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "lad",
-          "name": "Viseu",
-          "note": "multilingual"
-        },
-        {
-          "lang": "li",
-          "name": "Viseu",
-          "note": "multilingual"
-        },
-        {
           "lang": "lt",
           "name": "Vizou apskritis",
           "note": "multilingual"
@@ -87709,16 +87334,6 @@
         {
           "lang": "nan",
           "name": "Viseu Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Viseu",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Viseu",
           "note": "multilingual"
         },
         {
@@ -87777,11 +87392,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sv",
-          "name": "Viseu",
-          "note": "multilingual"
-        },
-        {
           "lang": "ta",
           "name": "விஸு  மாவட்டம்",
           "note": "multilingual"
@@ -87804,16 +87414,6 @@
         {
           "lang": "ur",
           "name": "ویزیو ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Viseu",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Viseu",
           "note": "multilingual"
         },
         {
@@ -87978,11 +87578,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "hu",
-          "name": "Bragança",
-          "note": "multilingual"
-        },
-        {
           "lang": "id",
           "name": "Distrik Bragança",
           "note": "multilingual"
@@ -88013,11 +87608,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "li",
-          "name": "Bragança",
-          "note": "multilingual"
-        },
-        {
           "lang": "ms",
           "name": "Daerah Bragança",
           "note": "multilingual"
@@ -88030,16 +87620,6 @@
         {
           "lang": "nan",
           "name": "Bragance Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Bragança",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Bragança",
           "note": "multilingual"
         },
         {
@@ -88093,11 +87673,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sv",
-          "name": "Bragança",
-          "note": "multilingual"
-        },
-        {
           "lang": "uk",
           "name": "Браґанса",
           "note": "multilingual"
@@ -88105,11 +87680,6 @@
         {
           "lang": "ur",
           "name": "براگانسا ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Bragança",
           "note": "multilingual"
         },
         {
@@ -88259,11 +87829,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "ca",
-          "name": "Açores",
-          "note": "multilingual"
-        },
-        {
           "lang": "ce",
           "name": "Азоран гӀайренаш",
           "note": "multilingual"
@@ -88334,11 +87899,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "fr",
-          "name": "Açores",
-          "note": "multilingual"
-        },
-        {
           "lang": "frr",
           "name": "Azoren",
           "note": "multilingual"
@@ -88366,11 +87926,6 @@
         {
           "lang": "gu",
           "name": "એઝોર્સ",
-          "note": "multilingual"
-        },
-        {
-          "lang": "hak",
-          "name": "Açores",
           "note": "multilingual"
         },
         {
@@ -88504,16 +88059,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "mwl",
-          "name": "Açores",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nan",
-          "name": "Açores",
-          "note": "multilingual"
-        },
-        {
           "lang": "nb",
           "name": "Asorene",
           "note": "multilingual"
@@ -88551,11 +88096,6 @@
         {
           "lang": "pnb",
           "name": "ازور",
-          "note": "multilingual"
-        },
-        {
-          "lang": "pt",
-          "name": "Açores",
           "note": "multilingual"
         },
         {
@@ -88676,11 +88216,6 @@
         {
           "lang": "uz",
           "name": "Azor orollari",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Açores",
           "note": "multilingual"
         },
         {
@@ -88870,11 +88405,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "hu",
-          "name": "Évora",
-          "note": "multilingual"
-        },
-        {
           "lang": "id",
           "name": "Distrik Évora",
           "note": "multilingual"
@@ -88905,16 +88435,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "lad",
-          "name": "Évora",
-          "note": "multilingual"
-        },
-        {
-          "lang": "li",
-          "name": "Évora",
-          "note": "multilingual"
-        },
-        {
           "lang": "lt",
           "name": "Evoros apskritis",
           "note": "multilingual"
@@ -88942,16 +88462,6 @@
         {
           "lang": "nan",
           "name": "Évora Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Évora",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Évora",
           "note": "multilingual"
         },
         {
@@ -89005,11 +88515,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sv",
-          "name": "Évora",
-          "note": "multilingual"
-        },
-        {
           "lang": "ta",
           "name": "ஏவோரா   மாவட்டம்",
           "note": "multilingual"
@@ -89037,16 +88542,6 @@
         {
           "lang": "ur",
           "name": "ایورا ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Évora",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Évora",
           "note": "multilingual"
         },
         {
@@ -89161,11 +88656,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "ca",
-          "name": "Setúbal",
-          "note": "multilingual"
-        },
-        {
           "lang": "ceb",
           "name": "Distrito de Setúbal",
           "note": "multilingual"
@@ -89191,11 +88681,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "es",
-          "name": "Setúbal",
-          "note": "multilingual"
-        },
-        {
           "lang": "eu",
           "name": "Setubal",
           "note": "multilingual"
@@ -89211,11 +88696,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "gl",
-          "name": "Setúbal",
-          "note": "multilingual"
-        },
-        {
           "lang": "gu",
           "name": "સેતુબલ જિલ્લો",
           "note": "multilingual"
@@ -89223,11 +88703,6 @@
         {
           "lang": "hi",
           "name": "सेतुबल जिला",
-          "note": "multilingual"
-        },
-        {
-          "lang": "hu",
-          "name": "Setúbal",
           "note": "multilingual"
         },
         {
@@ -89261,16 +88736,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "lad",
-          "name": "Setúbal",
-          "note": "multilingual"
-        },
-        {
-          "lang": "li",
-          "name": "Setúbal",
-          "note": "multilingual"
-        },
-        {
           "lang": "lt",
           "name": "Setubalo apskritis",
           "note": "multilingual"
@@ -89298,16 +88763,6 @@
         {
           "lang": "nan",
           "name": "Setúbal Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Setúbal",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Setúbal",
           "note": "multilingual"
         },
         {
@@ -89366,11 +88821,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sv",
-          "name": "Setúbal",
-          "note": "multilingual"
-        },
-        {
           "lang": "ta",
           "name": "சேட்டுபால் மாவட்டம்",
           "note": "multilingual"
@@ -89398,16 +88848,6 @@
         {
           "lang": "ur",
           "name": "سیتوبال ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Setúbal",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Setúbal",
           "note": "multilingual"
         },
         {
@@ -89551,11 +88991,6 @@
         {
           "lang": "el",
           "name": "Μαδέρα",
-          "note": "multilingual"
-        },
-        {
-          "lang": "en",
-          "name": "Madeira",
           "note": "multilingual"
         },
         {
@@ -89886,11 +89321,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "eu",
-          "name": "Portalegre",
-          "note": "multilingual"
-        },
-        {
           "lang": "fi",
           "name": "Portalegren piiri",
           "note": "multilingual"
@@ -89903,11 +89333,6 @@
         {
           "lang": "gl",
           "name": "Distrito de Portalegre",
-          "note": "multilingual"
-        },
-        {
-          "lang": "hu",
-          "name": "Portalegre",
           "note": "multilingual"
         },
         {
@@ -89936,11 +89361,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "li",
-          "name": "Portalegre",
-          "note": "multilingual"
-        },
-        {
           "lang": "ms",
           "name": "Daerah Portalegre",
           "note": "multilingual"
@@ -89953,16 +89373,6 @@
         {
           "lang": "nan",
           "name": "Portalegre Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Portalegre",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Portalegre",
           "note": "multilingual"
         },
         {
@@ -90001,11 +89411,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sv",
-          "name": "Portalegre",
-          "note": "multilingual"
-        },
-        {
           "lang": "uk",
           "name": "Порталеґрі",
           "note": "multilingual"
@@ -90013,16 +89418,6 @@
         {
           "lang": "ur",
           "name": "پورتالیگرے ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Portalegre",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Portalegre",
           "note": "multilingual"
         },
         {
@@ -90146,11 +89541,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "eu",
-          "name": "Beja",
-          "note": "multilingual"
-        },
-        {
           "lang": "fi",
           "name": "Bejan piiri",
           "note": "multilingual"
@@ -90178,11 +89568,6 @@
         {
           "lang": "hi",
           "name": "बेजा जिला",
-          "note": "multilingual"
-        },
-        {
-          "lang": "hu",
-          "name": "Beja",
           "note": "multilingual"
         },
         {
@@ -90216,16 +89601,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "lad",
-          "name": "Beja",
-          "note": "multilingual"
-        },
-        {
-          "lang": "li",
-          "name": "Beja",
-          "note": "multilingual"
-        },
-        {
           "lang": "lt",
           "name": "Bežos apskritis",
           "note": "multilingual"
@@ -90253,16 +89628,6 @@
         {
           "lang": "nan",
           "name": "Beja Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Beja",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Beja",
           "note": "multilingual"
         },
         {
@@ -90326,11 +89691,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sv",
-          "name": "Beja",
-          "note": "multilingual"
-        },
-        {
           "lang": "ta",
           "name": "பெஜா மாவட்டம்",
           "note": "multilingual"
@@ -90353,16 +89713,6 @@
         {
           "lang": "ur",
           "name": "بیجا ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Beja",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Beja",
           "note": "multilingual"
         },
         {
@@ -90548,11 +89898,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "hu",
-          "name": "Santarém",
-          "note": "multilingual"
-        },
-        {
           "lang": "id",
           "name": "Distrik Santarém",
           "note": "multilingual"
@@ -90583,16 +89928,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "lad",
-          "name": "Santarém",
-          "note": "multilingual"
-        },
-        {
-          "lang": "li",
-          "name": "Santarém",
-          "note": "multilingual"
-        },
-        {
           "lang": "lt",
           "name": "Santaremo apskritis",
           "note": "multilingual"
@@ -90620,16 +89955,6 @@
         {
           "lang": "nan",
           "name": "Santarém Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Santarém",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Santarém",
           "note": "multilingual"
         },
         {
@@ -90693,11 +90018,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sv",
-          "name": "Santarém",
-          "note": "multilingual"
-        },
-        {
           "lang": "ta",
           "name": "சண்டரெம்  மாவட்டம்",
           "note": "multilingual"
@@ -90720,16 +90040,6 @@
         {
           "lang": "ur",
           "name": "سانتارامی ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Santarém",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Santarém",
           "note": "multilingual"
         },
         {
@@ -90884,11 +90194,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "eu",
-          "name": "Braga",
-          "note": "multilingual"
-        },
-        {
           "lang": "fi",
           "name": "Bragan piiri",
           "note": "multilingual"
@@ -90911,11 +90216,6 @@
         {
           "lang": "hi",
           "name": "ब्रागा जिला",
-          "note": "multilingual"
-        },
-        {
-          "lang": "hu",
-          "name": "Braga",
           "note": "multilingual"
         },
         {
@@ -90949,16 +90249,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "lad",
-          "name": "Braga",
-          "note": "multilingual"
-        },
-        {
-          "lang": "li",
-          "name": "Braga",
-          "note": "multilingual"
-        },
-        {
           "lang": "lt",
           "name": "Bragos apskritis",
           "note": "multilingual"
@@ -90986,16 +90276,6 @@
         {
           "lang": "nan",
           "name": "Braga Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Braga",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Braga",
           "note": "multilingual"
         },
         {
@@ -91049,16 +90329,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sr_el",
-          "name": "Braga",
-          "note": "multilingual"
-        },
-        {
-          "lang": "sv",
-          "name": "Braga",
-          "note": "multilingual"
-        },
-        {
           "lang": "ta",
           "name": "ப்ராக மாவட்டம்",
           "note": "multilingual"
@@ -91081,16 +90351,6 @@
         {
           "lang": "ur",
           "name": "براگا ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Braga",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Braga",
           "note": "multilingual"
         },
         {
@@ -91236,11 +90496,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "eu",
-          "name": "Porto",
-          "note": "multilingual"
-        },
-        {
           "lang": "fi",
           "name": "Porton piiri",
           "note": "multilingual"
@@ -91286,11 +90541,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "li",
-          "name": "Porto",
-          "note": "multilingual"
-        },
-        {
           "lang": "mk",
           "name": "Порто",
           "note": "multilingual"
@@ -91308,16 +90558,6 @@
         {
           "lang": "nan",
           "name": "Porto Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Porto",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Porto",
           "note": "multilingual"
         },
         {
@@ -91366,16 +90606,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sr_el",
-          "name": "Porto",
-          "note": "multilingual"
-        },
-        {
-          "lang": "sv",
-          "name": "Porto",
-          "note": "multilingual"
-        },
-        {
           "lang": "uk",
           "name": "Порту",
           "note": "multilingual"
@@ -91383,16 +90613,6 @@
         {
           "lang": "ur",
           "name": "پورتو ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Porto",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Porto",
           "note": "multilingual"
         },
         {
@@ -91542,11 +90762,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "eu",
-          "name": "Aveiro",
-          "note": "multilingual"
-        },
-        {
           "lang": "fi",
           "name": "Aveiron piiri",
           "note": "multilingual"
@@ -91559,11 +90774,6 @@
         {
           "lang": "gl",
           "name": "Distrito de Aveiro",
-          "note": "multilingual"
-        },
-        {
-          "lang": "hu",
-          "name": "Aveiro",
           "note": "multilingual"
         },
         {
@@ -91597,16 +90807,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "lad",
-          "name": "Aveiro",
-          "note": "multilingual"
-        },
-        {
-          "lang": "li",
-          "name": "Aveiro",
-          "note": "multilingual"
-        },
-        {
           "lang": "ms",
           "name": "Daerah Aveiro",
           "note": "multilingual"
@@ -91619,16 +90819,6 @@
         {
           "lang": "nan",
           "name": "Aveiro Koān",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nb",
-          "name": "Aveiro",
-          "note": "multilingual"
-        },
-        {
-          "lang": "nl",
-          "name": "Aveiro",
           "note": "multilingual"
         },
         {
@@ -91677,16 +90867,6 @@
           "note": "multilingual"
         },
         {
-          "lang": "sr_el",
-          "name": "Aveiro",
-          "note": "multilingual"
-        },
-        {
-          "lang": "sv",
-          "name": "Aveiro",
-          "note": "multilingual"
-        },
-        {
           "lang": "uk",
           "name": "Авейру",
           "note": "multilingual"
@@ -91694,16 +90874,6 @@
         {
           "lang": "ur",
           "name": "آواریو ضلع",
-          "note": "multilingual"
-        },
-        {
-          "lang": "vi",
-          "name": "Aveiro",
-          "note": "multilingual"
-        },
-        {
-          "lang": "war",
-          "name": "Aveiro",
           "note": "multilingual"
         },
         {


### PR DESCRIPTION
```
Add memberships from sources/morph/centraldedados.csv
Merging with sources/morph/democratica.csv
Merging with sources/morph/wikidata.csv
Data Mismatches
  ☁ Mismatch in birth_date for 100ea2cc-58f1-4b0b-97a8-8ca6e9881e7c (2009-01-01) vs 1962-03-14 (for Q10284869)
  ☁ Mismatch in birth_date for 04fa6992-ec8f-468e-9ee7-a5b8b33b5815 (1955-06-28) vs 1920-06-12 (for Q10285168)
  ☁ Mismatch in birth_date for 4470d035-b9f2-4d75-bbcb-489866c67a2e (1952-02-18) vs 1952-01-17 (for Q10307408)
  ☁ Mismatch in birth_date for 2825283d-270b-40f1-a190-f9e664157335 (1975-04-19) vs 1974-04-19 (for Q10322008)
  ☁ Mismatch in birth_date for 0a9700bc-31ed-4928-8519-592d99e4c4af (1965-05-23) vs 1899-09-06 (for Q1339831)
  ☁ Mismatch in birth_date for 5c26770e-1bdf-4285-a1b8-98ae91a94ab2 (1937-01-01) vs 1936-11-21 (for Q16336718)
  ☁ Mismatch in birth_date for 1a0878d5-3b94-4908-8d50-5b4e88da0674 (2009-01-01) vs 1952 (for Q16498018)
  ☁ Mismatch in birth_date for 48e13e7c-ab4f-47ae-ac48-f8eddb04536a (1947-01-01) vs 1946-09-25 (for Q21065064)
  ☁ Mismatch in birth_date for c092e452-1d2a-4fa4-a2e4-55a81c142759 (1949-09-23) vs 1950 (for Q482868)
  ☁ Mismatch in birth_date for 8f9d2c5f-48f0-47f0-a448-2ae4d6745bee (1965-04-28) vs 1965-05-28 (for Q7155277)
* 114 of 396 unmatched
	{:id=>"Q10395753", :name=>"Álvaro Augusto Veiga de Oliveira"}
	{:id=>"Q10308185", :name=>"Jorge Miranda"}
	{:id=>"Q5041671", :name=>"Carlos Aboim Inglez"}
	{:id=>"Q1606377", :name=>"Henrique Galvão"}
	{:id=>"Q1709063", :name=>"José Caeiro da Mata"}
	{:id=>"Q3041550", :name=>"Miguel Portas"}
	{:id=>"Q10388226", :name=>"Urbano Rodrigues"}
	{:id=>"Q5716802", :name=>"Henrique de Barros Gomes"}
	{:id=>"Q5483712", :name=>"Francisco Miguel Duarte"}
	{:id=>"Q4852623", :name=>"Baltasar Rebelo de Sousa"}
Merging with sources/morph/genderbalance.csv

Top identifiers:
  1356 x parlamento
  282 x wikidata
  130 x isni
  129 x viaf
  59 x sudoc

Creating names.csv
  ☇ No dates for Rui Machete (Q10365280) as Minister of National Defence
  ☇ No dates for Luís Amado (Q1382641) as Minister of National Defence
  ☇ No dates for Luís Amado (Q1382641) as Minister of Foreign Affairs
  ☇ No dates for José Sócrates (Q182367) as Prime Minister of Portugal
  ☇ No dates for José Sócrates (Q182367) as Minister of Social Infrastructure
  ☇ No dates for Pedro Santana Lopes (Q239248) as Prime Minister of Portugal
  ☇ No dates for Freitas do Amaral (Q438868) as Minister of Foreign Affairs
  ☇ No dates for Jaime Gama (Q472589) as Minister of Foreign Affairs
  ☇ No dates for Paulo Portas (Q58161) as Minister of Foreign Affairs
  ☇ No dates for Maria de Belém Roseira (Q6761683) as Minister of Health
  ☇ No dates for Maria de Belém Roseira (Q6761683) as Minister for Women and Equalities
Persons matched to Wikidata: 282 ✓ | 1074 ✘
  No wikidata: Acácio Pinto (c0f9f8e7-a1d7-41ad-913e-1a898b479fd3)
  No wikidata: Sérgio Vieira (c566a953-65e7-42cc-8be8-0c556dd065a3)
  No wikidata: Pedro Saraiva (b6646f0f-75ab-465b-8726-9de186a50d8b)
  No wikidata: Afonso Candal (815d3591-3d63-4b61-b893-bd19be7971d5)
  No wikidata: David Santos (12d6c4b7-dfd6-4027-bf3e-113b3400ff0a)
  No wikidata: António Manuel Campos (b4f63ae2-d997-4061-8332-3f7ecedd7352)
  No wikidata: Bravo Nico (c9a63060-0d40-4852-a12b-83bc70edb2de)
  No wikidata: Bruno Coimbra (81461a39-3e35-44b3-97e3-e1a9b1e58b86)
  No wikidata: Armando Soares (c449f93a-2a62-4293-99e0-9045a29000e2)
  No wikidata: Gonçalo Nuno Santos (25d27bfa-04d3-476b-9651-15c0d4d70b8e)
Parties matched to Wikidata: 16 ✓ 
Areas matched to Wikidata: 21 ✓ | 2 ✘
  No wikidata: Europa (europa)
  No wikidata: Fora da Europa (fora_da_europa)
```