### PR TITLE
Order Area identifiers stably

### DIFF
--- a/data/Argentina/Diputados/ep-popolo-v1.0.json
+++ b/data/Argentina/Diputados/ep-popolo-v1.0.json
@@ -28489,20 +28489,20 @@
       "id": "buenos_aires",
       "identifiers": [
         {
-          "identifier": "/m/01ly8d",
-          "scheme": "freebase"
+          "identifier": "place/Buenos-Aires-province-Argentina",
+          "scheme": "britannica"
         },
         {
           "identifier": "AR01",
           "scheme": "fips"
         },
         {
-          "identifier": "3435907",
-          "scheme": "geonames"
+          "identifier": "/m/01ly8d",
+          "scheme": "freebase"
         },
         {
-          "identifier": "place/Buenos-Aires-province-Argentina",
-          "scheme": "britannica"
+          "identifier": "3435907",
+          "scheme": "geonames"
         },
         {
           "identifier": "Q44754",
@@ -28878,12 +28878,12 @@
       "id": "catamarca",
       "identifiers": [
         {
-          "identifier": "/m/02k_5z",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR02",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02k_5z",
+          "scheme": "freebase"
         },
         {
           "identifier": "3862286",
@@ -29227,28 +29227,28 @@
       "id": "chaco",
       "identifiers": [
         {
-          "identifier": "/m/026txb",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "AR03",
-          "scheme": "fips"
-        },
-        {
-          "identifier": "3861887",
-          "scheme": "geonames"
+          "identifier": "11979422w",
+          "scheme": "bnf"
         },
         {
           "identifier": "place/Chaco-province-Argentina",
           "scheme": "britannica"
         },
         {
-          "identifier": "1001195",
-          "scheme": "tgn"
+          "identifier": "AR03",
+          "scheme": "fips"
         },
         {
-          "identifier": "11979422w",
-          "scheme": "bnf"
+          "identifier": "/m/026txb",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "3861887",
+          "scheme": "geonames"
+        },
+        {
+          "identifier": "1001195",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q44757",
@@ -29554,16 +29554,8 @@
       "id": "chubut",
       "identifiers": [
         {
-          "identifier": "/m/029gv7",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "AR04",
-          "scheme": "fips"
-        },
-        {
-          "identifier": "3861244",
-          "scheme": "geonames"
+          "identifier": "121329366",
+          "scheme": "bnf"
         },
         {
           "identifier": "place/Chubut",
@@ -29574,12 +29566,20 @@
           "scheme": "dmoz"
         },
         {
-          "identifier": "1001203",
-          "scheme": "tgn"
+          "identifier": "AR04",
+          "scheme": "fips"
         },
         {
-          "identifier": "121329366",
-          "scheme": "bnf"
+          "identifier": "/m/029gv7",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "3861244",
+          "scheme": "geonames"
+        },
+        {
+          "identifier": "1001203",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q45007",
@@ -29890,16 +29890,8 @@
       "id": "ciudad_de_buenos_aires",
       "identifiers": [
         {
-          "identifier": "/m/01ly5m",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "AR07",
-          "scheme": "fips"
-        },
-        {
-          "identifier": "3433955",
-          "scheme": "geonames"
+          "identifier": "118659776",
+          "scheme": "bnf"
         },
         {
           "identifier": "place/Buenos-Aires",
@@ -29910,6 +29902,30 @@
           "scheme": "dmoz"
         },
         {
+          "identifier": "AR07",
+          "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01ly5m",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "3433955",
+          "scheme": "geonames"
+        },
+        {
+          "identifier": "4008756-6",
+          "scheme": "gnd"
+        },
+        {
+          "identifier": "n79079054",
+          "scheme": "lcauth"
+        },
+        {
+          "identifier": "1224652",
+          "scheme": "openstreetmap"
+        },
+        {
           "identifier": "Buenos-Aires-Argentina-4",
           "scheme": "quora"
         },
@@ -29918,24 +29934,8 @@
           "scheme": "tgn"
         },
         {
-          "identifier": "118659776",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "4008756-6",
-          "scheme": "gnd"
-        },
-        {
-          "identifier": "1224652",
-          "scheme": "openstreetmap"
-        },
-        {
           "identifier": "155960902",
           "scheme": "viaf"
-        },
-        {
-          "identifier": "n79079054",
-          "scheme": "lcauth"
         },
         {
           "identifier": "Q1486",
@@ -30431,28 +30431,28 @@
       "id": "cordoba",
       "identifiers": [
         {
-          "identifier": "/m/01y4fb",
-          "scheme": "freebase"
+          "identifier": "place/Cordoba-province-Argentina",
+          "scheme": "britannica"
         },
         {
           "identifier": "AR05",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01y4fb",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3860255",
           "scheme": "geonames"
         },
         {
-          "identifier": "place/Cordoba-province-Argentina",
-          "scheme": "britannica"
+          "identifier": "4216637-8",
+          "scheme": "gnd"
         },
         {
           "identifier": "1001169",
           "scheme": "tgn"
-        },
-        {
-          "identifier": "4216637-8",
-          "scheme": "gnd"
         },
         {
           "identifier": "Q44759",
@@ -30868,16 +30868,8 @@
       "id": "corrientes",
       "identifiers": [
         {
-          "identifier": "/m/02k_8j",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "AR06",
-          "scheme": "fips"
-        },
-        {
-          "identifier": "3435214",
-          "scheme": "geonames"
+          "identifier": "12131836p",
+          "scheme": "bnf"
         },
         {
           "identifier": "place/Corrientes-province-Argentina",
@@ -30888,16 +30880,24 @@
           "scheme": "dmoz"
         },
         {
+          "identifier": "AR06",
+          "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02k_8j",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "3435214",
+          "scheme": "geonames"
+        },
+        {
           "identifier": "Corrientes-Argentina",
           "scheme": "quora"
         },
         {
           "identifier": "1001210",
           "scheme": "tgn"
-        },
-        {
-          "identifier": "12131836p",
-          "scheme": "bnf"
         },
         {
           "identifier": "Q44758",
@@ -31203,20 +31203,24 @@
       "id": "entre_rios",
       "identifiers": [
         {
-          "identifier": "/m/02kgpq",
-          "scheme": "freebase"
+          "identifier": "11952773h",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Entre-Rios",
+          "scheme": "britannica"
         },
         {
           "identifier": "AR08",
           "scheme": "fips"
         },
         {
-          "identifier": "3434137",
-          "scheme": "geonames"
+          "identifier": "/m/02kgpq",
+          "scheme": "freebase"
         },
         {
-          "identifier": "place/Entre-Rios",
-          "scheme": "britannica"
+          "identifier": "3434137",
+          "scheme": "geonames"
         },
         {
           "identifier": "Entre-Ríos",
@@ -31225,10 +31229,6 @@
         {
           "identifier": "1001237",
           "scheme": "tgn"
-        },
-        {
-          "identifier": "11952773h",
-          "scheme": "bnf"
         },
         {
           "identifier": "Q44762",
@@ -31594,12 +31594,12 @@
       "id": "formosa",
       "identifiers": [
         {
-          "identifier": "/m/01qsrc",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR09",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01qsrc",
+          "scheme": "freebase"
         },
         {
           "identifier": "3433896",
@@ -31893,12 +31893,12 @@
       "id": "jujuy",
       "identifiers": [
         {
-          "identifier": "/m/02k_cf",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR10",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02k_cf",
+          "scheme": "freebase"
         },
         {
           "identifier": "3853404",
@@ -32217,12 +32217,12 @@
       "id": "la_pampa",
       "identifiers": [
         {
-          "identifier": "/m/02l5nz",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR11",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02l5nz",
+          "scheme": "freebase"
         },
         {
           "identifier": "3849574",
@@ -32491,20 +32491,20 @@
       "id": "la_rioja",
       "identifiers": [
         {
-          "identifier": "/m/02l61s",
-          "scheme": "freebase"
+          "identifier": "place/La-Rioja-province-Argentina",
+          "scheme": "britannica"
         },
         {
           "identifier": "AR12",
           "scheme": "fips"
         },
         {
-          "identifier": "3848949",
-          "scheme": "geonames"
+          "identifier": "/m/02l61s",
+          "scheme": "freebase"
         },
         {
-          "identifier": "place/La-Rioja-province-Argentina",
-          "scheme": "britannica"
+          "identifier": "3848949",
+          "scheme": "geonames"
         },
         {
           "identifier": "1001376",
@@ -32804,20 +32804,20 @@
       "id": "mendoza",
       "identifiers": [
         {
-          "identifier": "/m/01jh76",
-          "scheme": "freebase"
+          "identifier": "place/Mendoza-province-Argentina",
+          "scheme": "britannica"
         },
         {
           "identifier": "AR13",
           "scheme": "fips"
         },
         {
-          "identifier": "3844419",
-          "scheme": "geonames"
+          "identifier": "/m/01jh76",
+          "scheme": "freebase"
         },
         {
-          "identifier": "place/Mendoza-province-Argentina",
-          "scheme": "britannica"
+          "identifier": "3844419",
+          "scheme": "geonames"
         },
         {
           "identifier": "1001427",
@@ -33132,32 +33132,32 @@
       "id": "misiones",
       "identifiers": [
         {
-          "identifier": "/m/01hyw7",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "AR14",
-          "scheme": "fips"
-        },
-        {
-          "identifier": "3430657",
-          "scheme": "geonames"
+          "identifier": "122900359",
+          "scheme": "bnf"
         },
         {
           "identifier": "Regional/South_America/Argentina/Provinces/Misiones/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "1001434",
-          "scheme": "tgn"
+          "identifier": "AR14",
+          "scheme": "fips"
         },
         {
-          "identifier": "122900359",
-          "scheme": "bnf"
+          "identifier": "/m/01hyw7",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "3430657",
+          "scheme": "geonames"
         },
         {
           "identifier": "153553",
           "scheme": "openstreetmap"
+        },
+        {
+          "identifier": "1001434",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q44798",
@@ -33453,20 +33453,20 @@
       "id": "neuquen",
       "identifiers": [
         {
-          "identifier": "/m/02k_k5",
-          "scheme": "freebase"
+          "identifier": "Regional/South_America/Argentina/Provinces/Neuquén/",
+          "scheme": "dmoz"
         },
         {
           "identifier": "AR15",
           "scheme": "fips"
         },
         {
-          "identifier": "3843122",
-          "scheme": "geonames"
+          "identifier": "/m/02k_k5",
+          "scheme": "freebase"
         },
         {
-          "identifier": "Regional/South_America/Argentina/Provinces/Neuquén/",
-          "scheme": "dmoz"
+          "identifier": "3843122",
+          "scheme": "geonames"
         },
         {
           "identifier": "1001450",
@@ -33861,20 +33861,20 @@
       "id": "rio_negro",
       "identifiers": [
         {
-          "identifier": "/m/01trw6",
-          "scheme": "freebase"
+          "identifier": "Regional/South_America/Argentina/Provinces/Rio_Negro/",
+          "scheme": "dmoz"
         },
         {
           "identifier": "AR16",
           "scheme": "fips"
         },
         {
-          "identifier": "3838830",
-          "scheme": "geonames"
+          "identifier": "/m/01trw6",
+          "scheme": "freebase"
         },
         {
-          "identifier": "Regional/South_America/Argentina/Provinces/Rio_Negro/",
-          "scheme": "dmoz"
+          "identifier": "3838830",
+          "scheme": "geonames"
         },
         {
           "identifier": "7006348",
@@ -34249,12 +34249,12 @@
       "id": "salta",
       "identifiers": [
         {
-          "identifier": "/m/02k_fp",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR17",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02k_fp",
+          "scheme": "freebase"
         },
         {
           "identifier": "3838231",
@@ -34558,12 +34558,12 @@
       "id": "san_juan",
       "identifiers": [
         {
-          "identifier": "/m/02l5yd",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR18",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02l5yd",
+          "scheme": "freebase"
         },
         {
           "identifier": "3837152",
@@ -35147,28 +35147,28 @@
       "id": "santa_cruz",
       "identifiers": [
         {
-          "identifier": "/m/02k_hk",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "AR20",
-          "scheme": "fips"
-        },
-        {
-          "identifier": "3836350",
-          "scheme": "geonames"
+          "identifier": "121418346",
+          "scheme": "bnf"
         },
         {
           "identifier": "Regional/South_America/Argentina/Provinces/Santa_Cruz/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "1001522",
-          "scheme": "tgn"
+          "identifier": "AR20",
+          "scheme": "fips"
         },
         {
-          "identifier": "121418346",
-          "scheme": "bnf"
+          "identifier": "/m/02k_hk",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "3836350",
+          "scheme": "geonames"
+        },
+        {
+          "identifier": "1001522",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q44821",
@@ -35469,12 +35469,12 @@
       "id": "santa_fe",
       "identifiers": [
         {
-          "identifier": "/m/02k_px",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR21",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02k_px",
+          "scheme": "freebase"
         },
         {
           "identifier": "3836276",
@@ -35788,12 +35788,16 @@
       "id": "santiago_del_estero",
       "identifiers": [
         {
-          "identifier": "/m/02k_p3",
-          "scheme": "freebase"
+          "identifier": "123138483",
+          "scheme": "bnf"
         },
         {
           "identifier": "AR22",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02k_p3",
+          "scheme": "freebase"
         },
         {
           "identifier": "3835868",
@@ -35802,10 +35806,6 @@
         {
           "identifier": "1001526",
           "scheme": "tgn"
-        },
-        {
-          "identifier": "123138483",
-          "scheme": "bnf"
         },
         {
           "identifier": "154771432",
@@ -36130,12 +36130,12 @@
       "id": "tierra_del_fuego",
       "identifiers": [
         {
-          "identifier": "/m/024vn9",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR23",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/024vn9",
+          "scheme": "freebase"
         },
         {
           "identifier": "3834450",
@@ -36545,28 +36545,28 @@
       "id": "tucuman",
       "identifiers": [
         {
-          "identifier": "/m/02k_9q",
-          "scheme": "freebase"
+          "identifier": "Regional/South_America/Argentina/Provinces/Tucumán/",
+          "scheme": "dmoz"
         },
         {
           "identifier": "AR24",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/02k_9q",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3833578",
           "scheme": "geonames"
         },
         {
-          "identifier": "Regional/South_America/Argentina/Provinces/Tucumán/",
-          "scheme": "dmoz"
+          "identifier": "4061144-9",
+          "scheme": "gnd"
         },
         {
           "identifier": "1001579",
           "scheme": "tgn"
-        },
-        {
-          "identifier": "4061144-9",
-          "scheme": "gnd"
         },
         {
           "identifier": "141885296",

--- a/data/Argentina/Senado/ep-popolo-v1.0.json
+++ b/data/Argentina/Senado/ep-popolo-v1.0.json
@@ -8843,12 +8843,12 @@
       "id": "buenos_aires",
       "identifiers": [
         {
-          "identifier": "/m/01ly8d",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR01",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01ly8d",
+          "scheme": "freebase"
         },
         {
           "identifier": "3435907",
@@ -9198,12 +9198,12 @@
       "id": "catamarca",
       "identifiers": [
         {
-          "identifier": "/m/02k_5z",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR02",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02k_5z",
+          "scheme": "freebase"
         },
         {
           "identifier": "3862286",
@@ -9542,20 +9542,20 @@
       "id": "chaco",
       "identifiers": [
         {
-          "identifier": "/m/026txb",
-          "scheme": "freebase"
+          "identifier": "11979422w",
+          "scheme": "bnf"
         },
         {
           "identifier": "AR03",
           "scheme": "fips"
         },
         {
-          "identifier": "3861887",
-          "scheme": "geonames"
+          "identifier": "/m/026txb",
+          "scheme": "freebase"
         },
         {
-          "identifier": "11979422w",
-          "scheme": "bnf"
+          "identifier": "3861887",
+          "scheme": "geonames"
         },
         {
           "identifier": "Q44757",
@@ -9856,24 +9856,24 @@
       "id": "chubut",
       "identifiers": [
         {
-          "identifier": "/m/029gv7",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "AR04",
-          "scheme": "fips"
-        },
-        {
-          "identifier": "3861244",
-          "scheme": "geonames"
+          "identifier": "121329366",
+          "scheme": "bnf"
         },
         {
           "identifier": "Regional/South_America/Argentina/Provinces/Chubut/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "121329366",
-          "scheme": "bnf"
+          "identifier": "AR04",
+          "scheme": "fips"
+        },
+        {
+          "identifier": "/m/029gv7",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "3861244",
+          "scheme": "geonames"
         },
         {
           "identifier": "Q45007",
@@ -10174,36 +10174,36 @@
       "id": "ciudad_autónoma_de_buenos_aires",
       "identifiers": [
         {
-          "identifier": "/m/01ly5m",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "AR07",
-          "scheme": "fips"
-        },
-        {
-          "identifier": "3433955",
-          "scheme": "geonames"
+          "identifier": "118659776",
+          "scheme": "bnf"
         },
         {
           "identifier": "Regional/South_America/Argentina/Provinces/Buenos_Aires_City/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "118659776",
-          "scheme": "bnf"
+          "identifier": "AR07",
+          "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01ly5m",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "3433955",
+          "scheme": "geonames"
         },
         {
           "identifier": "4008756-6",
           "scheme": "gnd"
         },
         {
-          "identifier": "7593303",
-          "scheme": "tgn"
-        },
-        {
           "identifier": "1224652",
           "scheme": "openstreetmap"
+        },
+        {
+          "identifier": "7593303",
+          "scheme": "tgn"
         },
         {
           "identifier": "155960902",
@@ -10693,24 +10693,24 @@
       "id": "corrientes",
       "identifiers": [
         {
-          "identifier": "/m/02k_8j",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "AR06",
-          "scheme": "fips"
-        },
-        {
-          "identifier": "3435214",
-          "scheme": "geonames"
+          "identifier": "12131836p",
+          "scheme": "bnf"
         },
         {
           "identifier": "Regional/South_America/Argentina/Provinces/Corrientes/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "12131836p",
-          "scheme": "bnf"
+          "identifier": "AR06",
+          "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02k_8j",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "3435214",
+          "scheme": "geonames"
         },
         {
           "identifier": "Q44758",
@@ -11011,12 +11011,12 @@
       "id": "córdoba",
       "identifiers": [
         {
-          "identifier": "/m/01y4fb",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR05",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01y4fb",
+          "scheme": "freebase"
         },
         {
           "identifier": "3860255",
@@ -11365,20 +11365,20 @@
       "id": "entre_ríos",
       "identifiers": [
         {
-          "identifier": "/m/02kgpq",
-          "scheme": "freebase"
+          "identifier": "11952773h",
+          "scheme": "bnf"
         },
         {
           "identifier": "AR08",
           "scheme": "fips"
         },
         {
-          "identifier": "3434137",
-          "scheme": "geonames"
+          "identifier": "/m/02kgpq",
+          "scheme": "freebase"
         },
         {
-          "identifier": "11952773h",
-          "scheme": "bnf"
+          "identifier": "3434137",
+          "scheme": "geonames"
         },
         {
           "identifier": "Q44762",
@@ -11649,12 +11649,12 @@
       "id": "formosa",
       "identifiers": [
         {
-          "identifier": "/m/01qsrc",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR09",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01qsrc",
+          "scheme": "freebase"
         },
         {
           "identifier": "3433896",
@@ -11944,12 +11944,12 @@
       "id": "jujuy",
       "identifiers": [
         {
-          "identifier": "/m/02k_cf",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR10",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02k_cf",
+          "scheme": "freebase"
         },
         {
           "identifier": "3853404",
@@ -12264,12 +12264,12 @@
       "id": "la_pampa",
       "identifiers": [
         {
-          "identifier": "/m/02l5nz",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR11",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02l5nz",
+          "scheme": "freebase"
         },
         {
           "identifier": "3849574",
@@ -12529,12 +12529,12 @@
       "id": "la_rioja",
       "identifiers": [
         {
-          "identifier": "/m/02l61s",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR12",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02l61s",
+          "scheme": "freebase"
         },
         {
           "identifier": "3848949",
@@ -12834,12 +12834,12 @@
       "id": "mendoza",
       "identifiers": [
         {
-          "identifier": "/m/01jh76",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR13",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01jh76",
+          "scheme": "freebase"
         },
         {
           "identifier": "3844419",
@@ -13149,24 +13149,24 @@
       "id": "misiones",
       "identifiers": [
         {
-          "identifier": "/m/01hyw7",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "AR14",
-          "scheme": "fips"
-        },
-        {
-          "identifier": "3430657",
-          "scheme": "geonames"
+          "identifier": "122900359",
+          "scheme": "bnf"
         },
         {
           "identifier": "Regional/South_America/Argentina/Provinces/Misiones/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "122900359",
-          "scheme": "bnf"
+          "identifier": "AR14",
+          "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01hyw7",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "3430657",
+          "scheme": "geonames"
         },
         {
           "identifier": "153553",
@@ -13456,20 +13456,20 @@
       "id": "neuquén",
       "identifiers": [
         {
-          "identifier": "/m/02k_k5",
-          "scheme": "freebase"
+          "identifier": "Regional/South_America/Argentina/Provinces/Neuquén/",
+          "scheme": "dmoz"
         },
         {
           "identifier": "AR15",
           "scheme": "fips"
         },
         {
-          "identifier": "3843122",
-          "scheme": "geonames"
+          "identifier": "/m/02k_k5",
+          "scheme": "freebase"
         },
         {
-          "identifier": "Regional/South_America/Argentina/Provinces/Neuquén/",
-          "scheme": "dmoz"
+          "identifier": "3843122",
+          "scheme": "geonames"
         },
         {
           "identifier": "Q44800",
@@ -13770,20 +13770,20 @@
       "id": "río_negro",
       "identifiers": [
         {
-          "identifier": "/m/01trw6",
-          "scheme": "freebase"
+          "identifier": "Regional/South_America/Argentina/Provinces/Rio_Negro/",
+          "scheme": "dmoz"
         },
         {
           "identifier": "AR16",
           "scheme": "fips"
         },
         {
-          "identifier": "3838830",
-          "scheme": "geonames"
+          "identifier": "/m/01trw6",
+          "scheme": "freebase"
         },
         {
-          "identifier": "Regional/South_America/Argentina/Provinces/Rio_Negro/",
-          "scheme": "dmoz"
+          "identifier": "3838830",
+          "scheme": "geonames"
         },
         {
           "identifier": "Q44802",
@@ -14074,12 +14074,12 @@
       "id": "salta",
       "identifiers": [
         {
-          "identifier": "/m/02k_fp",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR17",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02k_fp",
+          "scheme": "freebase"
         },
         {
           "identifier": "3838231",
@@ -14374,12 +14374,12 @@
       "id": "san_juan",
       "identifiers": [
         {
-          "identifier": "/m/02l5yd",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR18",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02l5yd",
+          "scheme": "freebase"
         },
         {
           "identifier": "3837152",
@@ -14940,24 +14940,24 @@
       "id": "santa_cruz",
       "identifiers": [
         {
-          "identifier": "/m/02k_hk",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "AR20",
-          "scheme": "fips"
-        },
-        {
-          "identifier": "3836350",
-          "scheme": "geonames"
+          "identifier": "121418346",
+          "scheme": "bnf"
         },
         {
           "identifier": "Regional/South_America/Argentina/Provinces/Santa_Cruz/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "121418346",
-          "scheme": "bnf"
+          "identifier": "AR20",
+          "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02k_hk",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "3836350",
+          "scheme": "geonames"
         },
         {
           "identifier": "Q44821",
@@ -15258,12 +15258,12 @@
       "id": "santa_fe",
       "identifiers": [
         {
-          "identifier": "/m/02k_px",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR21",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02k_px",
+          "scheme": "freebase"
         },
         {
           "identifier": "3836276",
@@ -15568,20 +15568,20 @@
       "id": "santiago_del_estero",
       "identifiers": [
         {
-          "identifier": "/m/02k_p3",
-          "scheme": "freebase"
+          "identifier": "123138483",
+          "scheme": "bnf"
         },
         {
           "identifier": "AR22",
           "scheme": "fips"
         },
         {
-          "identifier": "3835868",
-          "scheme": "geonames"
+          "identifier": "/m/02k_p3",
+          "scheme": "freebase"
         },
         {
-          "identifier": "123138483",
-          "scheme": "bnf"
+          "identifier": "3835868",
+          "scheme": "geonames"
         },
         {
           "identifier": "154771432",
@@ -15901,12 +15901,12 @@
       "id": "tierra_del_fuego,_antártida_e_islas_del_atlántico_sur",
       "identifiers": [
         {
-          "identifier": "/m/024vn9",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AR23",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/024vn9",
+          "scheme": "freebase"
         },
         {
           "identifier": "3834450",
@@ -16300,20 +16300,20 @@
       "id": "tucumán",
       "identifiers": [
         {
-          "identifier": "/m/02k_9q",
-          "scheme": "freebase"
+          "identifier": "Regional/South_America/Argentina/Provinces/Tucumán/",
+          "scheme": "dmoz"
         },
         {
           "identifier": "AR24",
           "scheme": "fips"
         },
         {
-          "identifier": "3833578",
-          "scheme": "geonames"
+          "identifier": "/m/02k_9q",
+          "scheme": "freebase"
         },
         {
-          "identifier": "Regional/South_America/Argentina/Provinces/Tucumán/",
-          "scheme": "dmoz"
+          "identifier": "3833578",
+          "scheme": "geonames"
         },
         {
           "identifier": "4061144-9",

--- a/data/Australia/Senate/ep-popolo-v1.0.json
+++ b/data/Australia/Senate/ep-popolo-v1.0.json
@@ -33777,36 +33777,36 @@
       "id": "act",
       "identifiers": [
         {
-          "identifier": "2354197",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "/m/0vh3",
-          "scheme": "freebase"
+          "identifier": "12542929t",
+          "scheme": "bnf"
         },
         {
           "identifier": "AS01",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/0vh3",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "2177478",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "12542929t",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "261909586",
-          "scheme": "viaf"
         },
         {
           "identifier": "4310638-9",
           "scheme": "gnd"
         },
         {
+          "identifier": "2354197",
+          "scheme": "openstreetmap"
+        },
+        {
           "identifier": "1001989",
           "scheme": "tgn"
+        },
+        {
+          "identifier": "261909586",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q3258",
@@ -34227,40 +34227,40 @@
       "id": "nsw",
       "identifiers": [
         {
-          "identifier": "2316593",
-          "scheme": "openstreetmap"
+          "identifier": "11937155q",
+          "scheme": "bnf"
         },
         {
           "identifier": "Regional/Oceania/Australia/New_South_Wales/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/05fly",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AS02",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05fly",
+          "scheme": "freebase"
         },
         {
           "identifier": "2155400",
           "scheme": "geonames"
         },
         {
-          "identifier": "11937155q",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "138140762",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "4042010-3",
           "scheme": "gnd"
         },
         {
+          "identifier": "2316593",
+          "scheme": "openstreetmap"
+        },
+        {
           "identifier": "7001828",
           "scheme": "tgn"
+        },
+        {
+          "identifier": "138140762",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q3224",
@@ -34766,40 +34766,40 @@
       "id": "nt",
       "identifiers": [
         {
-          "identifier": "2316594",
-          "scheme": "openstreetmap"
+          "identifier": "123307653",
+          "scheme": "bnf"
         },
         {
           "identifier": "Regional/Oceania/Australia/Northern_Territory/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/05ff6",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AS03",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05ff6",
+          "scheme": "freebase"
         },
         {
           "identifier": "2064513",
           "scheme": "geonames"
         },
         {
-          "identifier": "123307653",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "153552537",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "4042588-5",
           "scheme": "gnd"
         },
         {
+          "identifier": "2316594",
+          "scheme": "openstreetmap"
+        },
+        {
           "identifier": "7001829",
           "scheme": "tgn"
+        },
+        {
+          "identifier": "153552537",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q3235",
@@ -35265,40 +35265,40 @@
       "id": "queensland",
       "identifiers": [
         {
-          "identifier": "2316595",
-          "scheme": "openstreetmap"
+          "identifier": "12101327q",
+          "scheme": "bnf"
         },
         {
           "identifier": "Regional/Oceania/Australia/Queensland/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/0g39h",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AS04",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/0g39h",
+          "scheme": "freebase"
         },
         {
           "identifier": "2152274",
           "scheme": "geonames"
         },
         {
-          "identifier": "12101327q",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "137190084",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "4103475-2",
           "scheme": "gnd"
         },
         {
+          "identifier": "2316595",
+          "scheme": "openstreetmap"
+        },
+        {
           "identifier": "7001830",
           "scheme": "tgn"
+        },
+        {
+          "identifier": "137190084",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q36074",
@@ -35589,36 +35589,36 @@
       "id": "sa",
       "identifiers": [
         {
-          "identifier": "2316596",
-          "scheme": "openstreetmap"
-        },
-        {
           "identifier": "Regional/Oceania/Australia/South_Australia/",
           "scheme": "dmoz"
-        },
-        {
-          "identifier": "/m/06mtq",
-          "scheme": "freebase"
         },
         {
           "identifier": "AS05",
           "scheme": "fips"
         },
         {
-          "identifier": "2061327",
-          "scheme": "geonames"
+          "identifier": "/m/06mtq",
+          "scheme": "freebase"
         },
         {
-          "identifier": "147693495",
-          "scheme": "viaf"
+          "identifier": "2061327",
+          "scheme": "geonames"
         },
         {
           "identifier": "4078016-8",
           "scheme": "gnd"
         },
         {
+          "identifier": "2316596",
+          "scheme": "openstreetmap"
+        },
+        {
           "identifier": "7001831",
           "scheme": "tgn"
+        },
+        {
+          "identifier": "147693495",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q35715",
@@ -36149,40 +36149,40 @@
       "id": "tasmania",
       "identifiers": [
         {
-          "identifier": "2369652",
-          "scheme": "openstreetmap"
+          "identifier": "15324128d",
+          "scheme": "bnf"
         },
         {
           "identifier": "Regional/Oceania/Australia/Tasmania/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/07cfx",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AS06",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/07cfx",
+          "scheme": "freebase"
         },
         {
           "identifier": "2147291",
           "scheme": "geonames"
         },
         {
-          "identifier": "15324128d",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "123100758",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "4059099-9",
           "scheme": "gnd"
         },
         {
+          "identifier": "2369652",
+          "scheme": "openstreetmap"
+        },
+        {
           "identifier": "7001992",
           "scheme": "tgn"
+        },
+        {
+          "identifier": "123100758",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q34366",
@@ -36638,40 +36638,40 @@
       "id": "victoria",
       "identifiers": [
         {
-          "identifier": "2316741",
-          "scheme": "openstreetmap"
+          "identifier": "12034058b",
+          "scheme": "bnf"
         },
         {
           "identifier": "Regional/Oceania/Australia/Victoria/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/0chgr2",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "AS07",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/0chgr2",
+          "scheme": "freebase"
         },
         {
           "identifier": "2145234",
           "scheme": "geonames"
         },
         {
-          "identifier": "12034058b",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "316750596",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "4063452-8",
           "scheme": "gnd"
         },
         {
+          "identifier": "2316741",
+          "scheme": "openstreetmap"
+        },
+        {
           "identifier": "7006238",
           "scheme": "tgn"
+        },
+        {
+          "identifier": "316750596",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q36687",
@@ -36977,36 +36977,36 @@
       "id": "wa",
       "identifiers": [
         {
-          "identifier": "2316598",
-          "scheme": "openstreetmap"
-        },
-        {
           "identifier": "Regional/Oceania/Australia/Western_Australia/",
           "scheme": "dmoz"
-        },
-        {
-          "identifier": "/m/0847q",
-          "scheme": "freebase"
         },
         {
           "identifier": "AS08",
           "scheme": "fips"
         },
         {
-          "identifier": "2058645",
-          "scheme": "geonames"
+          "identifier": "/m/0847q",
+          "scheme": "freebase"
         },
         {
-          "identifier": "154702212",
-          "scheme": "viaf"
+          "identifier": "2058645",
+          "scheme": "geonames"
         },
         {
           "identifier": "4079207-9",
           "scheme": "gnd"
         },
         {
+          "identifier": "2316598",
+          "scheme": "openstreetmap"
+        },
+        {
           "identifier": "7001834",
           "scheme": "tgn"
+        },
+        {
+          "identifier": "154702212",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q3206",

--- a/data/Belgium/Representatives/ep-popolo-v1.0.json
+++ b/data/Belgium/Representatives/ep-popolo-v1.0.json
@@ -16814,24 +16814,24 @@
       "id": "1241ba6f-fd42-46c7-accf-e5d48fd8a367",
       "identifiers": [
         {
-          "identifier": "3333250",
-          "scheme": "geonames"
-        },
-        {
-          "identifier": "58004",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "/m/0hz77",
-          "scheme": "freebase"
+          "identifier": "place/Flemish-Brabant",
+          "scheme": "britannica"
         },
         {
           "identifier": "BE12",
           "scheme": "fips"
         },
         {
-          "identifier": "place/Flemish-Brabant",
-          "scheme": "britannica"
+          "identifier": "/m/0hz77",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "3333250",
+          "scheme": "geonames"
+        },
+        {
+          "identifier": "58004",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Q1118",
@@ -17242,28 +17242,28 @@
       "id": "20376078-e084-487e-b1e4-1c633cb87d9d",
       "identifiers": [
         {
-          "identifier": "2792347",
-          "scheme": "geonames"
-        },
-        {
-          "identifier": "53142",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "/m/0hzmv",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "4035747-8",
-          "scheme": "gnd"
+          "identifier": "place/Limburg-province-Belgium",
+          "scheme": "britannica"
         },
         {
           "identifier": "BE05",
           "scheme": "fips"
         },
         {
-          "identifier": "place/Limburg-province-Belgium",
-          "scheme": "britannica"
+          "identifier": "/m/0hzmv",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "2792347",
+          "scheme": "geonames"
+        },
+        {
+          "identifier": "4035747-8",
+          "scheme": "gnd"
+        },
+        {
+          "identifier": "53142",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Q1095",
@@ -17569,24 +17569,24 @@
       "id": "2779c785-95c4-4b50-8bd2-fd74e435df65",
       "identifiers": [
         {
-          "identifier": "2803136",
-          "scheme": "geonames"
-        },
-        {
-          "identifier": "53114",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "/m/0fyfc",
-          "scheme": "freebase"
+          "identifier": "11943066b",
+          "scheme": "bnf"
         },
         {
           "identifier": "BE01",
           "scheme": "fips"
         },
         {
-          "identifier": "11943066b",
-          "scheme": "bnf"
+          "identifier": "/m/0fyfc",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "2803136",
+          "scheme": "geonames"
+        },
+        {
+          "identifier": "53114",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Q1116",
@@ -17987,24 +17987,8 @@
       "id": "286e7423-94a8-486a-b037-d1b00c7d7fbf",
       "identifiers": [
         {
-          "identifier": "2792411",
-          "scheme": "geonames"
-        },
-        {
-          "identifier": "1407192",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "/m/013d56",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "4036534-7",
-          "scheme": "gnd"
-        },
-        {
-          "identifier": "BE04",
-          "scheme": "fips"
+          "identifier": "11940624b",
+          "scheme": "bnf"
         },
         {
           "identifier": "place/Liege-province-Belgium",
@@ -18015,8 +17999,24 @@
           "scheme": "dmoz"
         },
         {
-          "identifier": "11940624b",
-          "scheme": "bnf"
+          "identifier": "BE04",
+          "scheme": "fips"
+        },
+        {
+          "identifier": "/m/013d56",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "2792411",
+          "scheme": "geonames"
+        },
+        {
+          "identifier": "4036534-7",
+          "scheme": "gnd"
+        },
+        {
+          "identifier": "1407192",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "143892616",
@@ -18336,20 +18336,8 @@
       "id": "41467d4b-517c-4aba-8051-02bc2582a6ce",
       "identifiers": [
         {
-          "identifier": "2790469",
-          "scheme": "geonames"
-        },
-        {
-          "identifier": "1311816",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "/m/013x2x",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "BE07",
-          "scheme": "fips"
+          "identifier": "119486081",
+          "scheme": "bnf"
         },
         {
           "identifier": "place/Namur-province-Belgium",
@@ -18360,8 +18348,20 @@
           "scheme": "dmoz"
         },
         {
-          "identifier": "119486081",
-          "scheme": "bnf"
+          "identifier": "BE07",
+          "scheme": "fips"
+        },
+        {
+          "identifier": "/m/013x2x",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "2790469",
+          "scheme": "geonames"
+        },
+        {
+          "identifier": "1311816",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Q1125",
@@ -18794,24 +18794,24 @@
       "id": "570cb1b8-d741-446f-a574-3c5a77553a16",
       "identifiers": [
         {
-          "identifier": "2796741",
-          "scheme": "geonames"
-        },
-        {
-          "identifier": "157559",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "/m/013x15",
-          "scheme": "freebase"
+          "identifier": "Regional/Europe/Belgium/Regions/Wallonia/Hainaut/",
+          "scheme": "dmoz"
         },
         {
           "identifier": "BE03",
           "scheme": "fips"
         },
         {
-          "identifier": "Regional/Europe/Belgium/Regions/Wallonia/Hainaut/",
-          "scheme": "dmoz"
+          "identifier": "/m/013x15",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "2796741",
+          "scheme": "geonames"
+        },
+        {
+          "identifier": "157559",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Q1129",
@@ -19107,28 +19107,28 @@
       "id": "8a15807b-8c67-46f4-8589-d5b59c1aa8b7",
       "identifiers": [
         {
-          "identifier": "2791993",
-          "scheme": "geonames"
-        },
-        {
-          "identifier": "1412581",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "/m/0hznq",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "BE06",
-          "scheme": "fips"
-        },
-        {
           "identifier": "place/Luxembourg-province-Belgium",
           "scheme": "britannica"
         },
         {
           "identifier": "Regional/Europe/Belgium/Regions/Wallonia/Luxembourg/",
           "scheme": "dmoz"
+        },
+        {
+          "identifier": "BE06",
+          "scheme": "fips"
+        },
+        {
+          "identifier": "/m/0hznq",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "2791993",
+          "scheme": "geonames"
+        },
+        {
+          "identifier": "1412581",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Q1126",
@@ -19484,20 +19484,8 @@
       "id": "932cbc86-a3b7-4574-bfbe-808a99a9aa1b",
       "identifiers": [
         {
-          "identifier": "2783770",
-          "scheme": "geonames"
-        },
-        {
-          "identifier": "416271",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "/m/013vsf",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "BE09",
-          "scheme": "fips"
+          "identifier": "122119899",
+          "scheme": "bnf"
         },
         {
           "identifier": "place/West-Flanders",
@@ -19508,8 +19496,20 @@
           "scheme": "dmoz"
         },
         {
-          "identifier": "122119899",
-          "scheme": "bnf"
+          "identifier": "BE09",
+          "scheme": "fips"
+        },
+        {
+          "identifier": "/m/013vsf",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "2783770",
+          "scheme": "geonames"
+        },
+        {
+          "identifier": "416271",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "West-Vlaanderen",
@@ -19954,28 +19954,28 @@
       "id": "e8e51560-6030-47ba-aa0c-75cf85e6f9cc",
       "identifiers": [
         {
-          "identifier": "2789733",
-          "scheme": "geonames"
-        },
-        {
-          "identifier": "53135",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "/m/013v_g",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "BE08",
-          "scheme": "fips"
-        },
-        {
           "identifier": "place/East-Flanders",
           "scheme": "britannica"
         },
         {
           "identifier": "Regional/Europe/Belgium/Regions/Flanders/Oost-Vlaanderen/",
           "scheme": "dmoz"
+        },
+        {
+          "identifier": "BE08",
+          "scheme": "fips"
+        },
+        {
+          "identifier": "/m/013v_g",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "2789733",
+          "scheme": "geonames"
+        },
+        {
+          "identifier": "53135",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Q1114",
@@ -20391,20 +20391,8 @@
       "id": "ff83572d-6b06-4363-a6c5-e2202b37fe72",
       "identifiers": [
         {
-          "identifier": "3333251",
-          "scheme": "geonames"
-        },
-        {
-          "identifier": "78748",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "/m/0kx8x",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "BE10",
-          "scheme": "fips"
+          "identifier": "135613958",
+          "scheme": "bnf"
         },
         {
           "identifier": "place/Walloon-Brabant",
@@ -20415,8 +20403,20 @@
           "scheme": "dmoz"
         },
         {
-          "identifier": "135613958",
-          "scheme": "bnf"
+          "identifier": "BE10",
+          "scheme": "fips"
+        },
+        {
+          "identifier": "/m/0kx8x",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "3333251",
+          "scheme": "geonames"
+        },
+        {
+          "identifier": "78748",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Brabant-Wallon",

--- a/data/Brazil/Deputies/ep-popolo-v1.0.json
+++ b/data/Brazil/Deputies/ep-popolo-v1.0.json
@@ -60219,8 +60219,8 @@
       "id": "ac",
       "identifiers": [
         {
-          "identifier": "/m/01hdgz",
-          "scheme": "freebase"
+          "identifier": "place/Acre-state-Brazil",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Acre/",
@@ -60231,20 +60231,20 @@
           "scheme": "fips"
         },
         {
-          "identifier": "3665474",
-          "scheme": "geonames"
+          "identifier": "/m/01hdgz",
+          "scheme": "freebase"
         },
         {
-          "identifier": "1001822",
-          "scheme": "tgn"
+          "identifier": "3665474",
+          "scheme": "geonames"
         },
         {
           "identifier": "326266",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Acre-state-Brazil",
-          "scheme": "britannica"
+          "identifier": "1001822",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q40780",
@@ -60480,32 +60480,32 @@
       "id": "al",
       "identifiers": [
         {
-          "identifier": "/m/015zxx",
-          "scheme": "freebase"
+          "identifier": "11969954p",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Alagoas",
+          "scheme": "britannica"
         },
         {
           "identifier": "BR02",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/015zxx",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3408096",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "11969954p",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "7016581",
-          "scheme": "tgn"
         },
         {
           "identifier": "303781",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Alagoas",
-          "scheme": "britannica"
+          "identifier": "7016581",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q40885",
@@ -60726,8 +60726,12 @@
       "id": "am",
       "identifiers": [
         {
-          "identifier": "/m/01hdky",
-          "scheme": "freebase"
+          "identifier": "11978558x",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Amazonas-state-Brazil",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Amazonas/",
@@ -60738,28 +60742,24 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01hdky",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3665361",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "11978558x",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "1001826",
-          "scheme": "tgn"
         },
         {
           "identifier": "332476",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Amazonas-state-Brazil",
-          "scheme": "britannica"
-        },
-        {
           "identifier": "AmazonES",
           "scheme": "quora"
+        },
+        {
+          "identifier": "1001826",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q40040",
@@ -60985,8 +60985,12 @@
       "id": "ap",
       "identifiers": [
         {
-          "identifier": "/m/01hdj9",
-          "scheme": "freebase"
+          "identifier": "11978557k",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Amapa",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Amapá/",
@@ -60997,24 +61001,20 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01hdj9",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3407762",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "11978557k",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "1001986",
-          "scheme": "tgn"
         },
         {
           "identifier": "331463",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Amapa",
-          "scheme": "britannica"
+          "identifier": "1001986",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q40130",
@@ -61245,12 +61245,8 @@
       "id": "ba",
       "identifiers": [
         {
-          "identifier": "/m/01c8c6",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "4004254-6",
-          "scheme": "gnd"
+          "identifier": "place/Bahia",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Bahia/",
@@ -61261,16 +61257,16 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01c8c6",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3471168",
           "scheme": "geonames"
         },
         {
-          "identifier": "1001834",
-          "scheme": "tgn"
-        },
-        {
-          "identifier": "126675199",
-          "scheme": "viaf"
+          "identifier": "4004254-6",
+          "scheme": "gnd"
         },
         {
           "identifier": "n81018677",
@@ -61281,8 +61277,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Bahia",
-          "scheme": "britannica"
+          "identifier": "1001834",
+          "scheme": "tgn"
+        },
+        {
+          "identifier": "126675199",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q40430",
@@ -61548,12 +61548,8 @@
       "id": "ce",
       "identifiers": [
         {
-          "identifier": "/m/01hdlf",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "4009641-5",
-          "scheme": "gnd"
+          "identifier": "place/Ceara",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Ceará/",
@@ -61564,8 +61560,24 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01hdlf",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3402362",
           "scheme": "geonames"
+        },
+        {
+          "identifier": "4009641-5",
+          "scheme": "gnd"
+        },
+        {
+          "identifier": "302635",
+          "scheme": "openstreetmap"
+        },
+        {
+          "identifier": "Ceará-Brazil-State",
+          "scheme": "quora"
         },
         {
           "identifier": "7006064",
@@ -61574,18 +61586,6 @@
         {
           "identifier": "128997459",
           "scheme": "viaf"
-        },
-        {
-          "identifier": "302635",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "place/Ceara",
-          "scheme": "britannica"
-        },
-        {
-          "identifier": "Ceará-Brazil-State",
-          "scheme": "quora"
         },
         {
           "identifier": "Q40123",
@@ -61821,24 +61821,20 @@
       "id": "df",
       "identifiers": [
         {
-          "identifier": "/m/012l8y",
-          "scheme": "freebase"
+          "identifier": "place/Federal-District-Brazil",
+          "scheme": "britannica"
         },
         {
           "identifier": "BR07",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/012l8y",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3463504",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "1000841",
-          "scheme": "tgn"
-        },
-        {
-          "identifier": "146568829",
-          "scheme": "viaf"
         },
         {
           "identifier": "n79072647",
@@ -61849,8 +61845,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Federal-District-Brazil",
-          "scheme": "britannica"
+          "identifier": "1000841",
+          "scheme": "tgn"
+        },
+        {
+          "identifier": "146568829",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q119158",
@@ -62276,8 +62276,8 @@
       "id": "es",
       "identifiers": [
         {
-          "identifier": "/m/021tyb",
-          "scheme": "freebase"
+          "identifier": "place/Espirito-Santo",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Espirito_Santo/",
@@ -62288,24 +62288,24 @@
           "scheme": "fips"
         },
         {
-          "identifier": "3463930",
-          "scheme": "geonames"
+          "identifier": "/m/021tyb",
+          "scheme": "freebase"
         },
         {
-          "identifier": "7006389",
-          "scheme": "tgn"
+          "identifier": "3463930",
+          "scheme": "geonames"
         },
         {
           "identifier": "54882",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Espirito-Santo",
-          "scheme": "britannica"
-        },
-        {
           "identifier": "Espirito-Santo-state-Brazil",
           "scheme": "quora"
+        },
+        {
+          "identifier": "7006389",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q43233",
@@ -62541,8 +62541,12 @@
       "id": "go",
       "identifiers": [
         {
-          "identifier": "/m/012yz_",
-          "scheme": "freebase"
+          "identifier": "11960194j",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Goias-Brazil",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Goias/",
@@ -62553,24 +62557,20 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/012yz_",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3462372",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "11960194j",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "7012827",
-          "scheme": "tgn"
         },
         {
           "identifier": "334443",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Goias-Brazil",
-          "scheme": "britannica"
+          "identifier": "7012827",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q41587",
@@ -62806,8 +62806,8 @@
       "id": "ma",
       "identifiers": [
         {
-          "identifier": "/m/01hd3y",
-          "scheme": "freebase"
+          "identifier": "place/Maranhao",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Maranhão/",
@@ -62818,20 +62818,20 @@
           "scheme": "fips"
         },
         {
-          "identifier": "3395443",
-          "scheme": "geonames"
+          "identifier": "/m/01hd3y",
+          "scheme": "freebase"
         },
         {
-          "identifier": "7006246",
-          "scheme": "tgn"
+          "identifier": "3395443",
+          "scheme": "geonames"
         },
         {
           "identifier": "332924",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Maranhao",
-          "scheme": "britannica"
+          "identifier": "7006246",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q42362",
@@ -63077,12 +63077,12 @@
       "id": "mg",
       "identifiers": [
         {
-          "identifier": "/m/01gh6z",
-          "scheme": "freebase"
+          "identifier": "11945096r",
+          "scheme": "bnf"
         },
         {
-          "identifier": "4039398-7",
-          "scheme": "gnd"
+          "identifier": "place/Minas-Gerais",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Minas_Gerais/",
@@ -63093,12 +63093,20 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01gh6z",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3457153",
           "scheme": "geonames"
         },
         {
-          "identifier": "11945096r",
-          "scheme": "bnf"
+          "identifier": "4039398-7",
+          "scheme": "gnd"
+        },
+        {
+          "identifier": "315173",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "7006237",
@@ -63107,14 +63115,6 @@
         {
           "identifier": "139547738",
           "scheme": "viaf"
-        },
-        {
-          "identifier": "315173",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "place/Minas-Gerais",
-          "scheme": "britannica"
         },
         {
           "identifier": "Q39109",
@@ -63365,8 +63365,12 @@
       "id": "ms",
       "identifiers": [
         {
-          "identifier": "/m/01hdn5",
-          "scheme": "freebase"
+          "identifier": "12089491h",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Mato-Grosso-do-Sul",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Mato_Grosso_do_Sul/",
@@ -63377,24 +63381,20 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01hdn5",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3457415",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "12089491h",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "1001898",
-          "scheme": "tgn"
         },
         {
           "identifier": "334051",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Mato-Grosso-do-Sul",
-          "scheme": "britannica"
+          "identifier": "1001898",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q43319",
@@ -63630,8 +63630,8 @@
       "id": "mt",
       "identifiers": [
         {
-          "identifier": "/m/01hdly",
-          "scheme": "freebase"
+          "identifier": "place/Mato-Grosso",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Mato_Grosso/",
@@ -63642,20 +63642,20 @@
           "scheme": "fips"
         },
         {
-          "identifier": "3457419",
-          "scheme": "geonames"
+          "identifier": "/m/01hdly",
+          "scheme": "freebase"
         },
         {
-          "identifier": "7006260",
-          "scheme": "tgn"
+          "identifier": "3457419",
+          "scheme": "geonames"
         },
         {
           "identifier": "333597",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Mato-Grosso",
-          "scheme": "britannica"
+          "identifier": "7006260",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q42824",
@@ -63891,8 +63891,12 @@
       "id": "pa",
       "identifiers": [
         {
-          "identifier": "/m/01hdnp",
-          "scheme": "freebase"
+          "identifier": "119785598",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Para-state-Brazil",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Pará/",
@@ -63903,24 +63907,20 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01hdnp",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3393129",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "119785598",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "7006247",
-          "scheme": "tgn"
         },
         {
           "identifier": "185579",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Para-state-Brazil",
-          "scheme": "britannica"
+          "identifier": "7006247",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q39517",
@@ -64166,8 +64166,12 @@
       "id": "pb",
       "identifiers": [
         {
-          "identifier": "/m/01hdp5",
-          "scheme": "freebase"
+          "identifier": "119456089",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Paraiba",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Paraíba/",
@@ -64178,24 +64182,20 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01hdp5",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3393098",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "119456089",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "7005439",
-          "scheme": "tgn"
         },
         {
           "identifier": "301464",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Paraiba",
-          "scheme": "britannica"
+          "identifier": "7005439",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q38088",
@@ -64441,12 +64441,12 @@
       "id": "pe",
       "identifiers": [
         {
-          "identifier": "/m/01hdpp",
-          "scheme": "freebase"
+          "identifier": "119981060",
+          "scheme": "bnf"
         },
         {
-          "identifier": "4045212-8",
-          "scheme": "gnd"
+          "identifier": "place/Pernambuco",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Pernambuco/",
@@ -64457,20 +64457,16 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01hdpp",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3392268",
           "scheme": "geonames"
         },
         {
-          "identifier": "119981060",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "7005437",
-          "scheme": "tgn"
-        },
-        {
-          "identifier": "127838743",
-          "scheme": "viaf"
+          "identifier": "4045212-8",
+          "scheme": "gnd"
         },
         {
           "identifier": "n80061033",
@@ -64481,8 +64477,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Pernambuco",
-          "scheme": "britannica"
+          "identifier": "7005437",
+          "scheme": "tgn"
+        },
+        {
+          "identifier": "127838743",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q40942",
@@ -64723,8 +64723,12 @@
       "id": "pi",
       "identifiers": [
         {
-          "identifier": "/m/01hdqj",
-          "scheme": "freebase"
+          "identifier": "11951530f",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Piaui",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Piaui/",
@@ -64735,24 +64739,20 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01hdqj",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3392213",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "11951530f",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "7006252",
-          "scheme": "tgn"
         },
         {
           "identifier": "302819",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Piaui",
-          "scheme": "britannica"
+          "identifier": "7006252",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q42722",
@@ -64988,8 +64988,8 @@
       "id": "pr",
       "identifiers": [
         {
-          "identifier": "/m/01hd3f",
-          "scheme": "freebase"
+          "identifier": "place/Parana-state-Brazil",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Parana/",
@@ -65000,20 +65000,20 @@
           "scheme": "fips"
         },
         {
-          "identifier": "3455077",
-          "scheme": "geonames"
+          "identifier": "/m/01hd3f",
+          "scheme": "freebase"
         },
         {
-          "identifier": "1001925",
-          "scheme": "tgn"
+          "identifier": "3455077",
+          "scheme": "geonames"
         },
         {
           "identifier": "297640",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Parana-state-Brazil",
-          "scheme": "britannica"
+          "identifier": "1001925",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q15499",
@@ -65279,12 +65279,12 @@
       "id": "rj",
       "identifiers": [
         {
-          "identifier": "/m/01hd4s",
-          "scheme": "freebase"
+          "identifier": "11941123v",
+          "scheme": "bnf"
         },
         {
-          "identifier": "4117025-8",
-          "scheme": "gnd"
+          "identifier": "place/Rio-de-Janeiro-state-Brazil",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Rio_de_Janeiro/",
@@ -65295,20 +65295,20 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01hd4s",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3451189",
           "scheme": "geonames"
         },
         {
-          "identifier": "11941123v",
-          "scheme": "bnf"
+          "identifier": "4117025-8",
+          "scheme": "gnd"
         },
         {
           "identifier": "1001942",
           "scheme": "tgn"
-        },
-        {
-          "identifier": "place/Rio-de-Janeiro-state-Brazil",
-          "scheme": "britannica"
         },
         {
           "identifier": "Q41428",
@@ -65569,8 +65569,12 @@
       "id": "rn",
       "identifiers": [
         {
-          "identifier": "/m/01hdrc",
-          "scheme": "freebase"
+          "identifier": "12182044c",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Rio-Grande-do-Norte",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Rio_Grande_do_Norte/",
@@ -65581,24 +65585,20 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01hdrc",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3390290",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "12182044c",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "7006257",
-          "scheme": "tgn"
         },
         {
           "identifier": "301079",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Rio-Grande-do-Norte",
-          "scheme": "britannica"
+          "identifier": "7006257",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q43255",
@@ -65834,8 +65834,12 @@
       "id": "ro",
       "identifiers": [
         {
-          "identifier": "/m/01hds7",
-          "scheme": "freebase"
+          "identifier": "11978560g",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Rondonia",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Rondonia/",
@@ -65846,24 +65850,20 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01hds7",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3924825",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "11978560g",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "1001944",
-          "scheme": "tgn"
         },
         {
           "identifier": "325866",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Rondonia",
-          "scheme": "britannica"
+          "identifier": "1001944",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q43235",
@@ -66104,8 +66104,12 @@
       "id": "rr",
       "identifiers": [
         {
-          "identifier": "/m/01tq_j",
-          "scheme": "freebase"
+          "identifier": "11942530g",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Roraima",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Roraima/",
@@ -66116,12 +66120,16 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01tq_j",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3662560",
           "scheme": "geonames"
         },
         {
-          "identifier": "11942530g",
-          "scheme": "bnf"
+          "identifier": "326287",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "1002001",
@@ -66130,14 +66138,6 @@
         {
           "identifier": "3150323821709972745",
           "scheme": "viaf"
-        },
-        {
-          "identifier": "326287",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "place/Roraima",
-          "scheme": "britannica"
         },
         {
           "identifier": "Q42508",
@@ -66343,32 +66343,32 @@
       "id": "rs",
       "identifiers": [
         {
-          "identifier": "/m/01l_9d",
-          "scheme": "freebase"
+          "identifier": "11951602g",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Rio-Grande-do-Sul",
+          "scheme": "britannica"
         },
         {
           "identifier": "BR23",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01l_9d",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3451133",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "11951602g",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "1001941",
-          "scheme": "tgn"
         },
         {
           "identifier": "242620",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Rio-Grande-do-Sul",
-          "scheme": "britannica"
+          "identifier": "1001941",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q40030",
@@ -66634,8 +66634,8 @@
       "id": "sc",
       "identifiers": [
         {
-          "identifier": "/m/01l_jz",
-          "scheme": "freebase"
+          "identifier": "place/Santa-Catarina",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Santa_Catarina/",
@@ -66646,20 +66646,20 @@
           "scheme": "fips"
         },
         {
-          "identifier": "3450387",
-          "scheme": "geonames"
+          "identifier": "/m/01l_jz",
+          "scheme": "freebase"
         },
         {
-          "identifier": "7006262",
-          "scheme": "tgn"
+          "identifier": "3450387",
+          "scheme": "geonames"
         },
         {
           "identifier": "296584",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Santa-Catarina",
-          "scheme": "britannica"
+          "identifier": "7006262",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q41115",
@@ -66890,8 +66890,12 @@
       "id": "se",
       "identifiers": [
         {
-          "identifier": "/m/01hdt7",
-          "scheme": "freebase"
+          "identifier": "11938655b",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Sergipe",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Sergipe/",
@@ -66902,12 +66906,16 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01hdt7",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3447799",
           "scheme": "geonames"
         },
         {
-          "identifier": "11938655b",
-          "scheme": "bnf"
+          "identifier": "303940",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "1001955",
@@ -66916,14 +66924,6 @@
         {
           "identifier": "148919553",
           "scheme": "viaf"
-        },
-        {
-          "identifier": "303940",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "place/Sergipe",
-          "scheme": "britannica"
         },
         {
           "identifier": "Q43783",
@@ -67139,12 +67139,12 @@
       "id": "sp",
       "identifiers": [
         {
-          "identifier": "/m/01hd58",
-          "scheme": "freebase"
+          "identifier": "11933588t",
+          "scheme": "bnf"
         },
         {
-          "identifier": "4051668-4",
-          "scheme": "gnd"
+          "identifier": "place/Sao-Paulo-state-Brazil",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Sao_Paulo/",
@@ -67155,24 +67155,24 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01hd58",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "3448433",
           "scheme": "geonames"
         },
         {
-          "identifier": "11933588t",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "1001945",
-          "scheme": "tgn"
+          "identifier": "4051668-4",
+          "scheme": "gnd"
         },
         {
           "identifier": "298204",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Sao-Paulo-state-Brazil",
-          "scheme": "britannica"
+          "identifier": "1001945",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q175",
@@ -67493,8 +67493,8 @@
       "id": "to",
       "identifiers": [
         {
-          "identifier": "/m/0d0k4",
-          "scheme": "freebase"
+          "identifier": "place/Tocantins",
+          "scheme": "britannica"
         },
         {
           "identifier": "Regional/South_America/Brazil/States/Tocantins/",
@@ -67505,20 +67505,20 @@
           "scheme": "fips"
         },
         {
-          "identifier": "3474575",
-          "scheme": "geonames"
+          "identifier": "/m/0d0k4",
+          "scheme": "freebase"
         },
         {
-          "identifier": "7012828",
-          "scheme": "tgn"
+          "identifier": "3474575",
+          "scheme": "geonames"
         },
         {
           "identifier": "336819",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "place/Tocantins",
-          "scheme": "britannica"
+          "identifier": "7012828",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q43695",

--- a/data/Cyprus/House_of_Representatives/ep-popolo-v1.0.json
+++ b/data/Cyprus/House_of_Representatives/ep-popolo-v1.0.json
@@ -9365,12 +9365,12 @@
       "id": "ammochostos",
       "identifiers": [
         {
-          "identifier": "/m/05wlvz",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "CY01",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05wlvz",
+          "scheme": "freebase"
         },
         {
           "identifier": "146615",
@@ -9585,12 +9585,12 @@
       "id": "keryneia",
       "identifiers": [
         {
-          "identifier": "/m/05wlwn",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "CY02",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05wlwn",
+          "scheme": "freebase"
         },
         {
           "identifier": "146411",
@@ -9860,12 +9860,12 @@
       "id": "larnaka",
       "identifiers": [
         {
-          "identifier": "/m/05wlxb",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "CY03",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05wlxb",
+          "scheme": "freebase"
         },
         {
           "identifier": "146398",
@@ -10120,12 +10120,12 @@
       "id": "lefkosia",
       "identifiers": [
         {
-          "identifier": "/m/05wlxp",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "CY04",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05wlxp",
+          "scheme": "freebase"
         },
         {
           "identifier": "146267",
@@ -10360,12 +10360,12 @@
       "id": "lemesos",
       "identifiers": [
         {
-          "identifier": "/m/05wly0",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "CY05",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05wly0",
+          "scheme": "freebase"
         },
         {
           "identifier": "146383",
@@ -10635,20 +10635,20 @@
       "id": "pafos",
       "identifiers": [
         {
-          "identifier": "/m/05wlyc",
-          "scheme": "freebase"
+          "identifier": "12002568x",
+          "scheme": "bnf"
         },
         {
           "identifier": "CY06",
           "scheme": "fips"
         },
         {
-          "identifier": "146213",
-          "scheme": "geonames"
+          "identifier": "/m/05wlyc",
+          "scheme": "freebase"
         },
         {
-          "identifier": "12002568x",
-          "scheme": "bnf"
+          "identifier": "146213",
+          "scheme": "geonames"
         },
         {
           "identifier": "Q59133",

--- a/data/Portugal/Assembly/ep-popolo-v1.0.json
+++ b/data/Portugal/Assembly/ep-popolo-v1.0.json
@@ -118895,28 +118895,28 @@
       "id": "027cc29e-8264-49b4-934b-7f18719a41db",
       "identifiers": [
         {
-          "identifier": "/m/02hdvg",
-          "scheme": "freebase"
+          "identifier": "119617724",
+          "scheme": "bnf"
         },
         {
           "identifier": "PO13",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/02hdvg",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "2267094",
           "scheme": "geonames"
         },
         {
-          "identifier": "119617724",
-          "scheme": "bnf"
+          "identifier": "7657354-0",
+          "scheme": "gnd"
         },
         {
           "identifier": "245879689",
           "scheme": "viaf"
-        },
-        {
-          "identifier": "7657354-0",
-          "scheme": "gnd"
         },
         {
           "identifier": "Q244512",
@@ -119197,24 +119197,20 @@
       "id": "1aa17852-5eb8-43bc-a146-96ca21515334",
       "identifiers": [
         {
-          "identifier": "/m/05xmcw",
-          "scheme": "freebase"
+          "identifier": "119520351",
+          "scheme": "bnf"
         },
         {
           "identifier": "PO11",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/05xmcw",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "2738782",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "119520351",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "140735453",
-          "scheme": "viaf"
         },
         {
           "identifier": "4468254-2",
@@ -119223,6 +119219,10 @@
         {
           "identifier": "n82006081",
           "scheme": "lcauth"
+        },
+        {
+          "identifier": "140735453",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q273533",
@@ -119453,28 +119453,28 @@
       "id": "392bc8f5-4e7e-4c54-9e51-f0ddcde0787b",
       "identifiers": [
         {
-          "identifier": "/m/052gr3",
-          "scheme": "freebase"
+          "identifier": "11932254f",
+          "scheme": "bnf"
         },
         {
           "identifier": "PO14",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/052gr3",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "2267056",
           "scheme": "geonames"
         },
         {
-          "identifier": "11932254f",
-          "scheme": "bnf"
+          "identifier": "4472098-1",
+          "scheme": "gnd"
         },
         {
           "identifier": "244275270",
           "scheme": "viaf"
-        },
-        {
-          "identifier": "4472098-1",
-          "scheme": "gnd"
         },
         {
           "identifier": "Q207199",
@@ -119745,24 +119745,24 @@
       "id": "423cceff-2282-4d94-9922-6b5b86e9ac3b",
       "identifiers": [
         {
-          "identifier": "/m/05xmbq",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "PO07",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05xmbq",
+          "scheme": "freebase"
         },
         {
           "identifier": "2740636",
           "scheme": "geonames"
         },
         {
-          "identifier": "155959489",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n82062599",
           "scheme": "lcauth"
+        },
+        {
+          "identifier": "155959489",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q244517",
@@ -120048,24 +120048,24 @@
       "id": "496b95a9-fc37-4b9d-a170-f2e9ea8c2220",
       "identifiers": [
         {
-          "identifier": "/m/05xmmm",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "PO21",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05xmmm",
+          "scheme": "freebase"
         },
         {
           "identifier": "2732437",
           "scheme": "geonames"
         },
         {
-          "identifier": "244298137",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "4674948-2",
           "scheme": "gnd"
+        },
+        {
+          "identifier": "244298137",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q379372",
@@ -120276,24 +120276,20 @@
       "id": "51009b54-888c-4671-991f-25fe4b74c78c",
       "identifiers": [
         {
-          "identifier": "/m/04z0mx",
-          "scheme": "freebase"
+          "identifier": "15070963p",
+          "scheme": "bnf"
         },
         {
           "identifier": "PO06",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/04z0mx",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "2269513",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "15070963p",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "147804520",
-          "scheme": "viaf"
         },
         {
           "identifier": "7657360-6",
@@ -120302,6 +120298,10 @@
         {
           "identifier": "n85003722",
           "scheme": "lcauth"
+        },
+        {
+          "identifier": "147804520",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q273529",
@@ -120592,36 +120592,36 @@
       "id": "5380183b-f0d3-4519-8f95-9823fa2ff069",
       "identifiers": [
         {
-          "identifier": "/m/05xnrj",
-          "scheme": "freebase"
+          "identifier": "15059435t",
+          "scheme": "bnf"
         },
         {
           "identifier": "PO20",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/05xnrj",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "2732772",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "15059435t",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "131423850",
-          "scheme": "viaf"
         },
         {
           "identifier": "7655772-8",
           "scheme": "gnd"
         },
         {
+          "identifier": "n85313237",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "3898131",
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "n85313237",
-          "scheme": "lcauth"
+          "identifier": "131423850",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q326214",
@@ -120907,24 +120907,20 @@
       "id": "5a4acfba-f1c6-437e-9fe9-f97ae7164e6d",
       "identifiers": [
         {
-          "identifier": "/m/04ntgq",
-          "scheme": "freebase"
+          "identifier": "12137305g",
+          "scheme": "bnf"
         },
         {
           "identifier": "PO09",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/04ntgq",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "2268337",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "12137305g",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "147814950",
-          "scheme": "viaf"
         },
         {
           "identifier": "4448197-4",
@@ -120933,6 +120929,10 @@
         {
           "identifier": "n85187871",
           "scheme": "lcauth"
+        },
+        {
+          "identifier": "147814950",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q244521",
@@ -121223,24 +121223,20 @@
       "id": "811a485c-a955-4e56-b6f2-23a72cf38a5d",
       "identifiers": [
         {
-          "identifier": "/m/05xmj5",
-          "scheme": "freebase"
+          "identifier": "12518521s",
+          "scheme": "bnf"
         },
         {
           "identifier": "PO22",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/05xmj5",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "2732264",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "12518521s",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "151292743",
-          "scheme": "viaf"
         },
         {
           "identifier": "4472444-5",
@@ -121249,6 +121245,10 @@
         {
           "identifier": "n82081242",
           "scheme": "lcauth"
+        },
+        {
+          "identifier": "151292743",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q273525",
@@ -121534,24 +121534,20 @@
       "id": "8732a79c-980c-4654-a0c9-56b7248247d3",
       "identifiers": [
         {
-          "identifier": "/m/05xmm4",
-          "scheme": "freebase"
+          "identifier": "11970334f",
+          "scheme": "bnf"
         },
         {
           "identifier": "PO05",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/05xmm4",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "2742026",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "11970334f",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "145460758",
-          "scheme": "viaf"
         },
         {
           "identifier": "4462374-4",
@@ -121560,6 +121556,10 @@
         {
           "identifier": "n83236694",
           "scheme": "lcauth"
+        },
+        {
+          "identifier": "145460758",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q373528",
@@ -121805,52 +121805,52 @@
       "id": "9f3699bc-1a85-491b-8057-de6923704d46",
       "identifiers": [
         {
-          "identifier": "/m/014l9",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "PO23",
-          "scheme": "fips"
-        },
-        {
-          "identifier": "3373385",
-          "scheme": "geonames"
-        },
-        {
           "identifier": "118621418",
           "scheme": "bnf"
-        },
-        {
-          "identifier": "155905425",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "4004066-5",
-          "scheme": "gnd"
-        },
-        {
-          "identifier": "1629146",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "World/Português/Regional/Europa/Portugal/Regiões_Autónomas/Açores/",
-          "scheme": "dmoz"
-        },
-        {
-          "identifier": "7003833",
-          "scheme": "tgn"
-        },
-        {
-          "identifier": "Azores-Islands",
-          "scheme": "quora"
         },
         {
           "identifier": "place/Azores",
           "scheme": "britannica"
         },
         {
+          "identifier": "World/Português/Regional/Europa/Portugal/Regiões_Autónomas/Açores/",
+          "scheme": "dmoz"
+        },
+        {
+          "identifier": "PO23",
+          "scheme": "fips"
+        },
+        {
+          "identifier": "/m/014l9",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "3373385",
+          "scheme": "geonames"
+        },
+        {
+          "identifier": "4004066-5",
+          "scheme": "gnd"
+        },
+        {
           "identifier": "n50000028",
           "scheme": "lcauth"
+        },
+        {
+          "identifier": "1629146",
+          "scheme": "openstreetmap"
+        },
+        {
+          "identifier": "Azores-Islands",
+          "scheme": "quora"
+        },
+        {
+          "identifier": "7003833",
+          "scheme": "tgn"
+        },
+        {
+          "identifier": "155905425",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q25263",
@@ -122346,24 +122346,20 @@
       "id": "a34fa591-b1a1-4234-ab52-4e662b6971dd",
       "identifiers": [
         {
-          "identifier": "/m/04nthy",
-          "scheme": "freebase"
+          "identifier": "12323990c",
+          "scheme": "bnf"
         },
         {
           "identifier": "PO08",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/04nthy",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "2268404",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "12323990c",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "141910924",
-          "scheme": "viaf"
         },
         {
           "identifier": "4085640-9",
@@ -122372,6 +122368,10 @@
         {
           "identifier": "n82020619",
           "scheme": "lcauth"
+        },
+        {
+          "identifier": "141910924",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q274118",
@@ -122662,24 +122662,20 @@
       "id": "a3e41172-2231-4ab1-9f47-6f767194092c",
       "identifiers": [
         {
-          "identifier": "/m/017927",
-          "scheme": "freebase"
+          "identifier": "13577496j",
+          "scheme": "bnf"
         },
         {
           "identifier": "PO19",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/017927",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "2262961",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "13577496j",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "129002836",
-          "scheme": "viaf"
         },
         {
           "identifier": "4491399-0",
@@ -122688,6 +122684,10 @@
         {
           "identifier": "n80070834",
           "scheme": "lcauth"
+        },
+        {
+          "identifier": "129002836",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q274109",
@@ -122963,20 +122963,20 @@
       "id": "a51d19f1-1d65-40d4-8b59-51ac097e53e1",
       "identifiers": [
         {
-          "identifier": "/m/04_z1",
-          "scheme": "freebase"
+          "identifier": "Regional/Europe/Portugal/Madeira/",
+          "scheme": "dmoz"
         },
         {
           "identifier": "PO10",
           "scheme": "fips"
         },
         {
-          "identifier": "2593105",
-          "scheme": "geonames"
+          "identifier": "/m/04_z1",
+          "scheme": "freebase"
         },
         {
-          "identifier": "Regional/Europe/Portugal/Madeira/",
-          "scheme": "dmoz"
+          "identifier": "2593105",
+          "scheme": "geonames"
         },
         {
           "identifier": "7003831",
@@ -123316,20 +123316,16 @@
       "id": "df7e9e75-7bed-4f38-b4e5-3ca6ae348d58",
       "identifiers": [
         {
-          "identifier": "/m/05xm7q",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "PO16",
           "scheme": "fips"
         },
         {
-          "identifier": "2264507",
-          "scheme": "geonames"
+          "identifier": "/m/05xm7q",
+          "scheme": "freebase"
         },
         {
-          "identifier": "140816811",
-          "scheme": "viaf"
+          "identifier": "2264507",
+          "scheme": "geonames"
         },
         {
           "identifier": "4116063-0",
@@ -123338,6 +123334,10 @@
         {
           "identifier": "n87875639",
           "scheme": "lcauth"
+        },
+        {
+          "identifier": "140816811",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q225189",
@@ -123508,36 +123508,36 @@
       "id": "e0099ab8-09d0-4bc5-8560-d0dabe72e941",
       "identifiers": [
         {
-          "identifier": "/m/04ntf4",
-          "scheme": "freebase"
+          "identifier": "12075549t",
+          "scheme": "bnf"
         },
         {
           "identifier": "PO03",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/04ntf4",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "2270984",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "12075549t",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "146655021",
-          "scheme": "viaf"
         },
         {
           "identifier": "7658895-6",
           "scheme": "gnd"
         },
         {
+          "identifier": "n85302954",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "1000810",
           "scheme": "tgn"
         },
         {
-          "identifier": "n85302954",
-          "scheme": "lcauth"
+          "identifier": "146655021",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q321455",
@@ -123828,20 +123828,16 @@
       "id": "e7e1c599-ab6c-4eca-bacb-e87addd2effb",
       "identifiers": [
         {
-          "identifier": "/m/04ntl8",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "PO18",
           "scheme": "fips"
         },
         {
-          "identifier": "2263478",
-          "scheme": "geonames"
+          "identifier": "/m/04ntl8",
+          "scheme": "freebase"
         },
         {
-          "identifier": "146626797",
-          "scheme": "viaf"
+          "identifier": "2263478",
+          "scheme": "geonames"
         },
         {
           "identifier": "380260-7",
@@ -123850,6 +123846,10 @@
         {
           "identifier": "n84027810",
           "scheme": "lcauth"
+        },
+        {
+          "identifier": "146626797",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q244510",
@@ -124150,24 +124150,20 @@
       "id": "eb073bce-bfd7-4bc1-a3fb-5720df172716",
       "identifiers": [
         {
-          "identifier": "/m/05xnnz",
-          "scheme": "freebase"
+          "identifier": "119492770",
+          "scheme": "bnf"
         },
         {
           "identifier": "PO04",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/05xnnz",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "2742031",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "119492770",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "124378399",
-          "scheme": "viaf"
         },
         {
           "identifier": "4471748-9",
@@ -124176,6 +124172,10 @@
         {
           "identifier": "n83228841",
           "scheme": "lcauth"
+        },
+        {
+          "identifier": "124378399",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q326203",
@@ -124461,20 +124461,16 @@
       "id": "ed5cc8b9-92ac-4c31-a50e-52cab7150da0",
       "identifiers": [
         {
-          "identifier": "/m/05xnnh",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "PO17",
           "scheme": "fips"
         },
         {
-          "identifier": "2735941",
-          "scheme": "geonames"
+          "identifier": "/m/05xnnh",
+          "scheme": "freebase"
         },
         {
-          "identifier": "137219723",
-          "scheme": "viaf"
+          "identifier": "2735941",
+          "scheme": "geonames"
         },
         {
           "identifier": "4383136-9",
@@ -124483,6 +124479,10 @@
         {
           "identifier": "n81112475",
           "scheme": "lcauth"
+        },
+        {
+          "identifier": "137219723",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q322792",
@@ -124718,24 +124718,20 @@
       "id": "fda2f770-d4ef-4338-be0b-58f6751dc048",
       "identifiers": [
         {
-          "identifier": "/m/05xkmt",
-          "scheme": "freebase"
+          "identifier": "123856861",
+          "scheme": "bnf"
         },
         {
           "identifier": "PO02",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/05xkmt",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "2742610",
           "scheme": "geonames"
-        },
-        {
-          "identifier": "123856861",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "141908085",
-          "scheme": "viaf"
         },
         {
           "identifier": "4238582-9",
@@ -124744,6 +124740,10 @@
         {
           "identifier": "n81133592",
           "scheme": "lcauth"
+        },
+        {
+          "identifier": "141908085",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q210527",

--- a/data/Romania/Deputies/ep-popolo-v1.0.json
+++ b/data/Romania/Deputies/ep-popolo-v1.0.json
@@ -25633,12 +25633,12 @@
       "id": "03050209-0f3d-463d-945c-90a2a1333518",
       "identifiers": [
         {
-          "identifier": "/m/03rmx7",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "RO43",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/03rmx7",
+          "scheme": "freebase"
         },
         {
           "identifier": "865518",
@@ -25932,20 +25932,20 @@
           "scheme": "bnf"
         },
         {
-          "identifier": "/m/01nqz6",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "10009961-0",
-          "scheme": "gnd"
-        },
-        {
           "identifier": "RO02",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01nqz6",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "686253",
           "scheme": "geonames"
+        },
+        {
+          "identifier": "10009961-0",
+          "scheme": "gnd"
         },
         {
           "identifier": "1000337",
@@ -26275,16 +26275,16 @@
       "id": "0c655992-000f-4896-9a82-97d359683f24",
       "identifiers": [
         {
-          "identifier": "/m/01nqzp",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Ialomita",
           "scheme": "britannica"
         },
         {
           "identifier": "RO22",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqzp",
+          "scheme": "freebase"
         },
         {
           "identifier": "675848",
@@ -26657,16 +26657,16 @@
           "scheme": "bnf"
         },
         {
-          "identifier": "/m/01nqmn",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Constanta-county-Romania",
           "scheme": "britannica"
         },
         {
           "identifier": "RO14",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqmn",
+          "scheme": "freebase"
         },
         {
           "identifier": "680962",
@@ -27075,12 +27075,12 @@
       "id": "102df5ec-f688-42d3-a193-2bb148c38325",
       "identifiers": [
         {
-          "identifier": "/m/01nqsj",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "RO35",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqsj",
+          "scheme": "freebase"
         },
         {
           "identifier": "665283",
@@ -27379,12 +27379,12 @@
       "id": "19e73db0-a219-4bae-bf07-eeec4ea063e0",
       "identifiers": [
         {
-          "identifier": "/m/01nqpf",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "RO42",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqpf",
+          "scheme": "freebase"
         },
         {
           "identifier": "677104",
@@ -27683,16 +27683,16 @@
           "scheme": "bnf"
         },
         {
-          "identifier": "/m/01nqh_",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Bihor",
           "scheme": "britannica"
         },
         {
           "identifier": "RO05",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqh_",
+          "scheme": "freebase"
         },
         {
           "identifier": "684878",
@@ -28001,12 +28001,12 @@
       "id": "246a7d0e-e5ad-40e7-90eb-d2658201db5a",
       "identifiers": [
         {
-          "identifier": "/m/01nqqr",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "RO38",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqqr",
+          "scheme": "freebase"
         },
         {
           "identifier": "663116",
@@ -28295,12 +28295,12 @@
       "id": "2decc748-1598-4b33-b4ea-678718c5c039",
       "identifiers": [
         {
-          "identifier": "/m/01nq_3",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "RO30",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nq_3",
+          "scheme": "freebase"
         },
         {
           "identifier": "669737",
@@ -28604,16 +28604,16 @@
           "scheme": "bnf"
         },
         {
-          "identifier": "/m/01nqvr",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Maramures",
           "scheme": "britannica"
         },
         {
           "identifier": "RO25",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqvr",
+          "scheme": "freebase"
         },
         {
           "identifier": "673887",
@@ -28927,12 +28927,12 @@
           "scheme": "bnf"
         },
         {
-          "identifier": "/m/01nqv9",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "RO29",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqv9",
+          "scheme": "freebase"
         },
         {
           "identifier": "671857",
@@ -29236,20 +29236,20 @@
           "scheme": "bnf"
         },
         {
-          "identifier": "/m/01nqtw",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "Mehedinti",
-          "scheme": "quora"
-        },
-        {
           "identifier": "RO26",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01nqtw",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "673612",
           "scheme": "geonames"
+        },
+        {
+          "identifier": "Mehedinti",
+          "scheme": "quora"
         },
         {
           "identifier": "Q191717",
@@ -29692,16 +29692,16 @@
       "id": "4b168aa3-4189-40b4-9a29-df192dd031ab",
       "identifiers": [
         {
-          "identifier": "/m/01nqjx",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Botosani-county-Romania",
           "scheme": "britannica"
         },
         {
           "identifier": "RO07",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqjx",
+          "scheme": "freebase"
         },
         {
           "identifier": "684038",
@@ -30110,16 +30110,16 @@
       "id": "50822bc4-d89a-4a9e-b786-311516c6b254",
       "identifiers": [
         {
-          "identifier": "/m/01nqlq",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Calarasi-county-Romania",
           "scheme": "britannica"
         },
         {
           "identifier": "RO41",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqlq",
+          "scheme": "freebase"
         },
         {
           "identifier": "683016",
@@ -30509,12 +30509,12 @@
       "id": "56ee1f17-3f64-4b8b-902b-e44253888baa",
       "identifiers": [
         {
-          "identifier": "/m/01nqpw",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "RO40",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqpw",
+          "scheme": "freebase"
         },
         {
           "identifier": "662447",
@@ -30813,16 +30813,16 @@
       "id": "57cd61fc-b9e6-41e0-bf3a-9674cb821a98",
       "identifiers": [
         {
-          "identifier": "/m/01nqnj",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Dolj",
           "scheme": "britannica"
         },
         {
           "identifier": "RO17",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqnj",
+          "scheme": "freebase"
         },
         {
           "identifier": "679134",
@@ -31136,44 +31136,44 @@
       "id": "628ade3a-9ea1-458f-8b6a-6d26e46d9383",
       "identifiers": [
         {
-          "identifier": "122531189",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79018848",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "/m/096gm",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "4008858-3",
-          "scheme": "gnd"
-        },
-        {
-          "identifier": "Bucharest-2",
-          "scheme": "quora"
-        },
-        {
           "identifier": "place/Bucharest",
           "scheme": "britannica"
+        },
+        {
+          "identifier": "Regional/Europe/Romania/Localities/Bucharest/",
+          "scheme": "dmoz"
         },
         {
           "identifier": "RO10",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/096gm",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "8335003",
           "scheme": "geonames"
+        },
+        {
+          "identifier": "4008858-3",
+          "scheme": "gnd"
+        },
+        {
+          "identifier": "n79018848",
+          "scheme": "lcauth"
+        },
+        {
+          "identifier": "Bucharest-2",
+          "scheme": "quora"
         },
         {
           "identifier": "1000394",
           "scheme": "tgn"
         },
         {
-          "identifier": "Regional/Europe/Romania/Localities/Bucharest/",
-          "scheme": "dmoz"
+          "identifier": "122531189",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q19660",
@@ -32064,12 +32064,12 @@
       "id": "6ea56396-458e-4717-9711-109c0f26b0a5",
       "identifiers": [
         {
-          "identifier": "/m/01nqx1",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "RO32",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqx1",
+          "scheme": "freebase"
         },
         {
           "identifier": "667869",
@@ -32428,16 +32428,16 @@
       "id": "7455ca07-c865-4eff-97df-27766f3ebfab",
       "identifiers": [
         {
-          "identifier": "/m/01nqxh",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Iasi-county-Romania",
           "scheme": "britannica"
         },
         {
           "identifier": "RO23",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqxh",
+          "scheme": "freebase"
         },
         {
           "identifier": "675809",
@@ -32831,16 +32831,16 @@
       "id": "769da163-9a57-42b9-9fcb-6f5ceb6e7d30",
       "identifiers": [
         {
-          "identifier": "/m/01bppy",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Neamt",
           "scheme": "britannica"
         },
         {
           "identifier": "RO28",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01bppy",
+          "scheme": "freebase"
         },
         {
           "identifier": "672460",
@@ -33223,22 +33223,6 @@
           "scheme": "bnf"
         },
         {
-          "identifier": "124347063",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n81102947",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "/m/01nqw5",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "4346870-6",
-          "scheme": "gnd"
-        },
-        {
           "identifier": "place/Suceava-county-Romania",
           "scheme": "britannica"
         },
@@ -33247,8 +33231,24 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01nqw5",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "665849",
           "scheme": "geonames"
+        },
+        {
+          "identifier": "4346870-6",
+          "scheme": "gnd"
+        },
+        {
+          "identifier": "n81102947",
+          "scheme": "lcauth"
+        },
+        {
+          "identifier": "124347063",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q181209",
@@ -33574,16 +33574,16 @@
       "id": "81a10167-9523-4958-ae61-5c33a903f6a0",
       "identifiers": [
         {
-          "identifier": "/m/0grf2",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Caras-Severin",
           "scheme": "britannica"
         },
         {
           "identifier": "RO12",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/0grf2",
+          "scheme": "freebase"
         },
         {
           "identifier": "682714",
@@ -33973,16 +33973,16 @@
       "id": "848e8048-965b-4e90-bc8f-4eac415b4e5b",
       "identifiers": [
         {
-          "identifier": "/m/01nr18",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Covasna",
           "scheme": "britannica"
         },
         {
           "identifier": "RO15",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nr18",
+          "scheme": "freebase"
         },
         {
           "identifier": "680428",
@@ -34276,12 +34276,12 @@
       "id": "8857d530-ef54-43c2-9bc1-25a531913dd1",
       "identifiers": [
         {
-          "identifier": "/m/01nqr5",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "RO37",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqr5",
+          "scheme": "freebase"
         },
         {
           "identifier": "664517",
@@ -34604,12 +34604,12 @@
           "scheme": "bnf"
         },
         {
-          "identifier": "/m/01nw_0",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "RO03",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nw_0",
+          "scheme": "freebase"
         },
         {
           "identifier": "686192",
@@ -34999,16 +34999,16 @@
       "id": "911a6bc7-684b-4b1f-919d-92a7cf149f27",
       "identifiers": [
         {
-          "identifier": "/m/01nqxy",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Gorj",
           "scheme": "britannica"
         },
         {
           "identifier": "RO19",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqxy",
+          "scheme": "freebase"
         },
         {
           "identifier": "676898",
@@ -35313,16 +35313,16 @@
       "id": "97c9e9d7-1997-4408-8aca-3f540eb3bd95",
       "identifiers": [
         {
-          "identifier": "/m/01nqn_",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Galati-county-Romania",
           "scheme": "britannica"
         },
         {
           "identifier": "RO18",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqn_",
+          "scheme": "freebase"
         },
         {
           "identifier": "677692",
@@ -35696,16 +35696,16 @@
       "id": "9c19267b-f835-4bde-93e8-324dd106933d",
       "identifiers": [
         {
-          "identifier": "/m/01nqsz",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Salaj",
           "scheme": "britannica"
         },
         {
           "identifier": "RO31",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqsz",
+          "scheme": "freebase"
         },
         {
           "identifier": "668248",
@@ -36099,12 +36099,12 @@
       "id": "aac24131-836a-4056-85b0-530287b1f9bb",
       "identifiers": [
         {
-          "identifier": "/m/01nr0d",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "RO20",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nr0d",
+          "scheme": "freebase"
         },
         {
           "identifier": "676309",
@@ -36393,12 +36393,12 @@
       "id": "af669b01-9558-4d0e-8c44-31cedb985615",
       "identifiers": [
         {
-          "identifier": "/m/04s2ts",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "RO01",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/04s2ts",
+          "scheme": "freebase"
         },
         {
           "identifier": "686581",
@@ -36726,16 +36726,16 @@
           "scheme": "bnf"
         },
         {
-          "identifier": "/m/01nqjf",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Bistrita-Nasaud",
           "scheme": "britannica"
         },
         {
           "identifier": "RO06",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqjf",
+          "scheme": "freebase"
         },
         {
           "identifier": "684647",
@@ -37129,20 +37129,20 @@
       "id": "bb34e907-88c0-4cab-8322-2e25de581176",
       "identifiers": [
         {
-          "identifier": "/m/01nqrm",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "Timiș-County",
-          "scheme": "quora"
-        },
-        {
           "identifier": "RO36",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01nqrm",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "665091",
           "scheme": "geonames"
+        },
+        {
+          "identifier": "Timiș-County",
+          "scheme": "quora"
         },
         {
           "identifier": "Q185586",
@@ -37538,16 +37538,16 @@
       "id": "c58f8c5b-e7d5-4bf0-9cbc-63ab9919134d",
       "identifiers": [
         {
-          "identifier": "/m/01nr0v",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Mures",
           "scheme": "britannica"
         },
         {
           "identifier": "RO27",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nr0v",
+          "scheme": "freebase"
         },
         {
           "identifier": "672628",
@@ -37926,10 +37926,6 @@
       "id": "c7c9cac4-1186-483f-b3cc-22b6da8a1631",
       "identifiers": [
         {
-          "identifier": "/m/01nqkt",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Buzau-county-Romania",
           "scheme": "britannica"
         },
@@ -37938,16 +37934,20 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01nqkt",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "683121",
           "scheme": "geonames"
         },
         {
-          "identifier": "1000353",
-          "scheme": "tgn"
-        },
-        {
           "identifier": "2355511",
           "scheme": "openstreetmap"
+        },
+        {
+          "identifier": "1000353",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q185309",
@@ -38337,12 +38337,12 @@
           "scheme": "bnf"
         },
         {
-          "identifier": "/m/01nqwm",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "RO33",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqwm",
+          "scheme": "freebase"
         },
         {
           "identifier": "667267",
@@ -38676,22 +38676,6 @@
       "id": "ce71010c-ffe2-439f-b69c-54372ffa1d99",
       "identifiers": [
         {
-          "identifier": "124344030",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n81058778",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "/m/01nqyr",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "7574140-4",
-          "scheme": "gnd"
-        },
-        {
           "identifier": "place/Hunedoara-county-Romania",
           "scheme": "britannica"
         },
@@ -38700,8 +38684,24 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01nqyr",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "675917",
           "scheme": "geonames"
+        },
+        {
+          "identifier": "7574140-4",
+          "scheme": "gnd"
+        },
+        {
+          "identifier": "n81058778",
+          "scheme": "lcauth"
+        },
+        {
+          "identifier": "124344030",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q191071",
@@ -39002,12 +39002,12 @@
       "id": "dbe3b321-dcdf-4299-af0d-d2cd91ae5576",
       "identifiers": [
         {
-          "identifier": "/m/01nqm4",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "RO13",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqm4",
+          "scheme": "freebase"
         },
         {
           "identifier": "681291",
@@ -39337,16 +39337,16 @@
       "id": "e0909378-9193-470f-b19d-8ce4c866664c",
       "identifiers": [
         {
-          "identifier": "/m/01nqq9",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Valcea",
           "scheme": "britannica"
         },
         {
           "identifier": "RO39",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqq9",
+          "scheme": "freebase"
         },
         {
           "identifier": "662892",
@@ -39740,10 +39740,6 @@
       "id": "e1177483-8737-43f8-90b1-6a52f3dd17b3",
       "identifiers": [
         {
-          "identifier": "/m/01nql7",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Braila-county-Romania",
           "scheme": "britannica"
         },
@@ -39752,16 +39748,20 @@
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01nql7",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "683901",
           "scheme": "geonames"
         },
         {
-          "identifier": "1000350",
-          "scheme": "tgn"
-        },
-        {
           "identifier": "2355512",
           "scheme": "openstreetmap"
+        },
+        {
+          "identifier": "1000350",
+          "scheme": "tgn"
         },
         {
           "identifier": "Q188503",
@@ -40137,12 +40137,12 @@
       "id": "e564bb6f-10e2-4fb2-804a-a51a5be448a1",
       "identifiers": [
         {
-          "identifier": "/m/01nr21",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "RO04",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nr21",
+          "scheme": "freebase"
         },
         {
           "identifier": "685947",
@@ -40506,16 +40506,16 @@
       "id": "f2979b94-0c26-4313-a132-6f4487a6cb9e",
       "identifiers": [
         {
-          "identifier": "/m/01nqkc",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "place/Brasov-county-Romania",
           "scheme": "britannica"
         },
         {
           "identifier": "RO09",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01nqkc",
+          "scheme": "freebase"
         },
         {
           "identifier": "683843",
@@ -40914,20 +40914,20 @@
       "id": "f5e8bcce-91a5-465a-8b08-1d9acdbc5938",
       "identifiers": [
         {
-          "identifier": "/m/01nqn2",
-          "scheme": "freebase"
-        },
-        {
-          "identifier": "4445766-2",
-          "scheme": "gnd"
-        },
-        {
           "identifier": "RO16",
           "scheme": "fips"
         },
         {
+          "identifier": "/m/01nqn2",
+          "scheme": "freebase"
+        },
+        {
           "identifier": "679385",
           "scheme": "geonames"
+        },
+        {
+          "identifier": "4445766-2",
+          "scheme": "gnd"
         },
         {
           "identifier": "1000363",

--- a/data/United_States_of_America/Senate/ep-popolo-v1.0.json
+++ b/data/United_States_of_America/Senate/ep-popolo-v1.0.json
@@ -109891,16 +109891,24 @@
       "id": "ocd-division/country:us/state:ak",
       "identifiers": [
         {
+          "identifier": "01490999-8dec-4129-8254-eef6e80fadc3",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "place/Alaska",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Alaska/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/0hjy",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US02",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/0hjy",
+          "scheme": "freebase"
         },
         {
           "identifier": "5879092",
@@ -109911,6 +109919,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79018447",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/alaska",
           "scheme": "newyorktimes"
         },
@@ -109919,24 +109931,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "139487266",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79018447",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "01490999-8dec-4129-8254-eef6e80fadc3",
-          "scheme": "bbc_things"
-        },
-        {
           "identifier": "Alaska-state",
           "scheme": "quora"
         },
         {
-          "identifier": "place/Alaska",
-          "scheme": "britannica"
+          "identifier": "139487266",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q797",
@@ -110472,16 +110472,28 @@
       "id": "ocd-division/country:us/state:al",
       "identifiers": [
         {
+          "identifier": "b6883c2b-57e4-4236-aafc-f4f8dd6b43dc",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "12065837f",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Alabama-state",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Alabama/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/0gyh",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US01",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/0gyh",
+          "scheme": "freebase"
         },
         {
           "identifier": "4829764",
@@ -110492,32 +110504,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "161950",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "131885589",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79027034",
           "scheme": "lcauth"
         },
         {
-          "identifier": "b6883c2b-57e4-4236-aafc-f4f8dd6b43dc",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "12065837f",
-          "scheme": "bnf"
+          "identifier": "161950",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Alabama-state",
           "scheme": "quora"
         },
         {
-          "identifier": "place/Alabama-state",
-          "scheme": "britannica"
+          "identifier": "131885589",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q173",
@@ -110918,16 +110918,24 @@
       "id": "ocd-division/country:us/state:ar",
       "identifiers": [
         {
+          "identifier": "38a19ea5-e082-4ed3-8f71-29ad1777a430",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "11997202n",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Arkansas/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/0vbk",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US05",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/0vbk",
+          "scheme": "freebase"
         },
         {
           "identifier": "4099753",
@@ -110938,6 +110946,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79034503",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/arkansas",
           "scheme": "newyorktimes"
         },
@@ -110946,24 +110958,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "150033129",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79034503",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "38a19ea5-e082-4ed3-8f71-29ad1777a430",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "11997202n",
-          "scheme": "bnf"
-        },
-        {
           "identifier": "Arkansas-state",
           "scheme": "quora"
+        },
+        {
+          "identifier": "150033129",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1612",
@@ -111399,16 +111399,24 @@
       "id": "ocd-division/country:us/state:az",
       "identifiers": [
         {
+          "identifier": "c9805c67-ff2b-4829-aaac-21784fb85d23",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "119773584",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Arizona/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/0vmt",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US04",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/0vmt",
+          "scheme": "freebase"
         },
         {
           "identifier": "5551752",
@@ -111419,28 +111427,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "162018",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "125475793",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79034873",
           "scheme": "lcauth"
         },
         {
-          "identifier": "c9805c67-ff2b-4829-aaac-21784fb85d23",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "119773584",
-          "scheme": "bnf"
+          "identifier": "162018",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Arizona-state-1",
           "scheme": "quora"
+        },
+        {
+          "identifier": "125475793",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q816",
@@ -111871,16 +111871,28 @@
       "id": "ocd-division/country:us/state:ca",
       "identifiers": [
         {
+          "identifier": "c404c0a9-608c-4cc1-b172-ee027e024f76",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "118625808",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/California-state",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/California/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/01n7q",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US06",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01n7q",
+          "scheme": "freebase"
         },
         {
           "identifier": "5332921",
@@ -111891,36 +111903,24 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "165475",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "147680367",
-          "scheme": "viaf"
+          "identifier": "us-news/california",
+          "scheme": "guardian"
         },
         {
           "identifier": "n79041717",
           "scheme": "lcauth"
         },
         {
-          "identifier": "c404c0a9-608c-4cc1-b172-ee027e024f76",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "118625808",
-          "scheme": "bnf"
+          "identifier": "165475",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "California-state-1",
           "scheme": "quora"
         },
         {
-          "identifier": "place/California-state",
-          "scheme": "britannica"
-        },
-        {
-          "identifier": "us-news/california",
-          "scheme": "guardian"
+          "identifier": "147680367",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q99",
@@ -112686,16 +112686,24 @@
       "id": "ocd-division/country:us/state:co",
       "identifiers": [
         {
+          "identifier": "dc027000-a334-4de1-be7e-205cba8cec88",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "12065838s",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Colorado/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/01n4w",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US08",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01n4w",
+          "scheme": "freebase"
         },
         {
           "identifier": "5417618",
@@ -112706,28 +112714,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "161961",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "145998913",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n80125532",
           "scheme": "lcauth"
         },
         {
-          "identifier": "dc027000-a334-4de1-be7e-205cba8cec88",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "12065838s",
-          "scheme": "bnf"
+          "identifier": "161961",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Colorado-state-1",
           "scheme": "quora"
+        },
+        {
+          "identifier": "145998913",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1261",
@@ -113198,16 +113198,24 @@
       "id": "ocd-division/country:us/state:ct",
       "identifiers": [
         {
+          "identifier": "9bd653fc-14d6-42ac-8267-c787ee58c000",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "11986225v",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Connecticut/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/01x73",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US09",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/01x73",
+          "scheme": "freebase"
         },
         {
           "identifier": "4831725",
@@ -113218,6 +113226,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79074102",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/connecticut",
           "scheme": "newyorktimes"
         },
@@ -113226,28 +113238,16 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "141881815",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79074102",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "9bd653fc-14d6-42ac-8267-c787ee58c000",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "11986225v",
-          "scheme": "bnf"
+          "identifier": "Connecticut-state",
+          "scheme": "quora"
         },
         {
           "identifier": "7007159",
           "scheme": "tgn"
         },
         {
-          "identifier": "Connecticut-state",
-          "scheme": "quora"
+          "identifier": "141881815",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q779",
@@ -113663,16 +113663,28 @@
       "id": "ocd-division/country:us/state:de",
       "identifiers": [
         {
+          "identifier": "f2244ef4-11cc-497f-8323-e4815af47d8d",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "11995405r",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Delaware-state",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Delaware/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/026mj",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US10",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/026mj",
+          "scheme": "freebase"
         },
         {
           "identifier": "4142224",
@@ -113683,6 +113695,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79041720",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/delaware",
           "scheme": "newyorktimes"
         },
@@ -113691,28 +113707,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "235924579",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79041720",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "f2244ef4-11cc-497f-8323-e4815af47d8d",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "11995405r",
-          "scheme": "bnf"
-        },
-        {
           "identifier": "Delaware-state",
           "scheme": "quora"
         },
         {
-          "identifier": "place/Delaware-state",
-          "scheme": "britannica"
+          "identifier": "235924579",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1393",
@@ -114113,16 +114113,20 @@
       "id": "ocd-division/country:us/state:fl",
       "identifiers": [
         {
+          "identifier": "253f489d-3136-4c2c-8b76-81edccf0d459",
+          "scheme": "bbc_things"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Florida/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/02xry",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US12",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/02xry",
+          "scheme": "freebase"
         },
         {
           "identifier": "4155751",
@@ -114133,6 +114137,14 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "us-news/florida",
+          "scheme": "guardian"
+        },
+        {
+          "identifier": "n79053995",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/west-florida",
           "scheme": "newyorktimes"
         },
@@ -114141,24 +114153,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "135974315",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79053995",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "253f489d-3136-4c2c-8b76-81edccf0d459",
-          "scheme": "bbc_things"
-        },
-        {
           "identifier": "Florida-United-States",
           "scheme": "quora"
         },
         {
-          "identifier": "us-news/florida",
-          "scheme": "guardian"
+          "identifier": "135974315",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q812",
@@ -114604,16 +114604,20 @@
       "id": "ocd-division/country:us/state:ga",
       "identifiers": [
         {
+          "identifier": "654d954e-7bf8-4da5-804a-852cf6e4be04",
+          "scheme": "bbc_things"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Georgia/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/0d0x8",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US13",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/0d0x8",
+          "scheme": "freebase"
         },
         {
           "identifier": "4197000",
@@ -114624,24 +114628,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "161957",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "144230826",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79023113",
           "scheme": "lcauth"
         },
         {
-          "identifier": "654d954e-7bf8-4da5-804a-852cf6e4be04",
-          "scheme": "bbc_things"
+          "identifier": "161957",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Georgia-state",
           "scheme": "quora"
+        },
+        {
+          "identifier": "144230826",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1428",
@@ -115137,16 +115137,28 @@
       "id": "ocd-division/country:us/state:hi",
       "identifiers": [
         {
+          "identifier": "ab0eb187-64fa-4863-94c3-daaa1844b024",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "13903909f",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Hawaii-state",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Hawaii/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/03gh4",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US15",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/03gh4",
+          "scheme": "freebase"
         },
         {
           "identifier": "5855797",
@@ -115157,32 +115169,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "166563",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "143064067",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n80061028",
           "scheme": "lcauth"
         },
         {
-          "identifier": "ab0eb187-64fa-4863-94c3-daaa1844b024",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "13903909f",
-          "scheme": "bnf"
+          "identifier": "166563",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Hawaii",
           "scheme": "quora"
         },
         {
-          "identifier": "place/Hawaii-state",
-          "scheme": "britannica"
+          "identifier": "143064067",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q782",
@@ -115768,16 +115768,24 @@
       "id": "ocd-division/country:us/state:ia",
       "identifiers": [
         {
+          "identifier": "fd17f7b4-a7da-4f8b-a43c-0d19cfdca655",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "123174975",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Iowa/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/03s0w",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US19",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/03s0w",
+          "scheme": "freebase"
         },
         {
           "identifier": "4862182",
@@ -115788,28 +115796,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "161650",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "153594323",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79081387",
           "scheme": "lcauth"
         },
         {
-          "identifier": "fd17f7b4-a7da-4f8b-a43c-0d19cfdca655",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "123174975",
-          "scheme": "bnf"
+          "identifier": "161650",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Iowa-state-2",
           "scheme": "quora"
+        },
+        {
+          "identifier": "153594323",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1546",
@@ -116275,16 +116275,20 @@
       "id": "ocd-division/country:us/state:id",
       "identifiers": [
         {
+          "identifier": "1c09b733-1899-4e82-8a73-b6d57593c51f",
+          "scheme": "bbc_things"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Idaho/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/03s5t",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US16",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/03s5t",
+          "scheme": "freebase"
         },
         {
           "identifier": "5596512",
@@ -116295,24 +116299,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "162116",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "148929220",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n81014565",
           "scheme": "lcauth"
         },
         {
-          "identifier": "1c09b733-1899-4e82-8a73-b6d57593c51f",
-          "scheme": "bbc_things"
+          "identifier": "162116",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Idaho-state-1",
           "scheme": "quora"
+        },
+        {
+          "identifier": "148929220",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1221",
@@ -116718,16 +116718,24 @@
       "id": "ocd-division/country:us/state:il",
       "identifiers": [
         {
+          "identifier": "f88cd74b-66c0-456d-ac68-fc39dfa40dd3",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "12038894c",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Illinois/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/03v0t",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US17",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/03v0t",
+          "scheme": "freebase"
         },
         {
           "identifier": "4896861",
@@ -116738,6 +116746,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79053746",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/illinois",
           "scheme": "newyorktimes"
         },
@@ -116746,24 +116758,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "138972861",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79053746",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "f88cd74b-66c0-456d-ac68-fc39dfa40dd3",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "12038894c",
-          "scheme": "bnf"
-        },
-        {
           "identifier": "Illinois-state-2",
           "scheme": "quora"
+        },
+        {
+          "identifier": "138972861",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1204",
@@ -117189,16 +117189,24 @@
       "id": "ocd-division/country:us/state:in",
       "identifiers": [
         {
+          "identifier": "1d359de4-42da-4126-8395-adc162dac1fb",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "11945453k",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Indiana/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/03v1s",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US18",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/03v1s",
+          "scheme": "freebase"
         },
         {
           "identifier": "4921868",
@@ -117209,6 +117217,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79022925",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/indiana",
           "scheme": "newyorktimes"
         },
@@ -117217,24 +117229,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "129599983",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79022925",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "1d359de4-42da-4126-8395-adc162dac1fb",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "11945453k",
-          "scheme": "bnf"
-        },
-        {
           "identifier": "Indiana-state",
           "scheme": "quora"
+        },
+        {
+          "identifier": "129599983",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1415",
@@ -117665,16 +117665,28 @@
       "id": "ocd-division/country:us/state:ks",
       "identifiers": [
         {
+          "identifier": "3e78f062-d409-4515-b637-cda34d16982d",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "13934270f",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Kansas",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Kansas/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/0488g",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US20",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/0488g",
+          "scheme": "freebase"
         },
         {
           "identifier": "4273857",
@@ -117685,6 +117697,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79007369",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/kansas",
           "scheme": "newyorktimes"
         },
@@ -117693,28 +117709,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "152389568",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79007369",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "3e78f062-d409-4515-b637-cda34d16982d",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "13934270f",
-          "scheme": "bnf"
-        },
-        {
           "identifier": "Kansas-state-1",
           "scheme": "quora"
         },
         {
-          "identifier": "place/Kansas",
-          "scheme": "britannica"
+          "identifier": "152389568",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1558",
@@ -118125,16 +118125,28 @@
       "id": "ocd-division/country:us/state:ky",
       "identifiers": [
         {
+          "identifier": "a69ae27b-885e-4105-8e89-65a8a301638a",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "119617050",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Kentucky",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Kentucky/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/0498y",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US21",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/0498y",
+          "scheme": "freebase"
         },
         {
           "identifier": "6254925",
@@ -118145,6 +118157,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79018583",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/kentucky",
           "scheme": "newyorktimes"
         },
@@ -118153,28 +118169,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "144869566",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79018583",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "a69ae27b-885e-4105-8e89-65a8a301638a",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "119617050",
-          "scheme": "bnf"
-        },
-        {
           "identifier": "Kentucky-state-1",
           "scheme": "quora"
         },
         {
-          "identifier": "place/Kentucky",
-          "scheme": "britannica"
+          "identifier": "144869566",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1603",
@@ -118550,16 +118550,24 @@
       "id": "ocd-division/country:us/state:la",
       "identifiers": [
         {
+          "identifier": "946f5b35-ee30-45b9-ab0b-f167e35701be",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "place/Louisiana-state",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Louisiana/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/04ly1",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US22",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/04ly1",
+          "scheme": "freebase"
         },
         {
           "identifier": "4331987",
@@ -118570,6 +118578,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79138970",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/louisiana",
           "scheme": "newyorktimes"
         },
@@ -118578,28 +118590,16 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "316750576",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79138970",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "946f5b35-ee30-45b9-ab0b-f167e35701be",
-          "scheme": "bbc_things"
+          "identifier": "Louisiana-state-1",
+          "scheme": "quora"
         },
         {
           "identifier": "7007256",
           "scheme": "tgn"
         },
         {
-          "identifier": "Louisiana-state-1",
-          "scheme": "quora"
-        },
-        {
-          "identifier": "place/Louisiana-state",
-          "scheme": "britannica"
+          "identifier": "316750576",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1588",
@@ -119080,16 +119080,24 @@
       "id": "ocd-division/country:us/state:ma",
       "identifiers": [
         {
+          "identifier": "b44ff572-fe2d-4515-a728-62e312fbfad6",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "11941588j",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Massachusetts/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/05k7sb",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US25",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05k7sb",
+          "scheme": "freebase"
         },
         {
           "identifier": "6254926",
@@ -119100,28 +119108,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "61315",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "130169058",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79007084",
           "scheme": "lcauth"
         },
         {
-          "identifier": "b44ff572-fe2d-4515-a728-62e312fbfad6",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "11941588j",
-          "scheme": "bnf"
+          "identifier": "61315",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Massachusetts-state",
           "scheme": "quora"
+        },
+        {
+          "identifier": "130169058",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q771",
@@ -119552,16 +119552,24 @@
       "id": "ocd-division/country:us/state:md",
       "identifiers": [
         {
+          "identifier": "2cec13cf-44ec-456f-8971-057d2556860f",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "11945072r",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Maryland/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/04rrd",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US24",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/04rrd",
+          "scheme": "freebase"
         },
         {
           "identifier": "4361885",
@@ -119572,6 +119580,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79029831",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/maryland",
           "scheme": "newyorktimes"
         },
@@ -119580,24 +119592,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "151255387",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79029831",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "2cec13cf-44ec-456f-8971-057d2556860f",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "11945072r",
-          "scheme": "bnf"
-        },
-        {
           "identifier": "Maryland-state",
           "scheme": "quora"
+        },
+        {
+          "identifier": "151255387",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1391",
@@ -120033,16 +120033,20 @@
       "id": "ocd-division/country:us/state:me",
       "identifiers": [
         {
+          "identifier": "4a2b8673-ebf7-40cd-970b-3fe1a1dd99fc",
+          "scheme": "bbc_things"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Maine/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/050ks",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US23",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/050ks",
+          "scheme": "freebase"
         },
         {
           "identifier": "4971068",
@@ -120053,6 +120057,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79005604",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/maine",
           "scheme": "newyorktimes"
         },
@@ -120061,20 +120069,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "151253777",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79005604",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "4a2b8673-ebf7-40cd-970b-3fe1a1dd99fc",
-          "scheme": "bbc_things"
-        },
-        {
           "identifier": "Maine-state-1",
           "scheme": "quora"
+        },
+        {
+          "identifier": "151253777",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q724",
@@ -120480,16 +120480,24 @@
       "id": "ocd-division/country:us/state:mi",
       "identifiers": [
         {
+          "identifier": "14533be6-4e27-40d7-8883-b74bfd84ef88",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "119884476",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Michigan/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/04rrx",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US26",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/04rrx",
+          "scheme": "freebase"
         },
         {
           "identifier": "5001836",
@@ -120500,28 +120508,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "165789",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "267241450",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n80046126",
           "scheme": "lcauth"
         },
         {
-          "identifier": "14533be6-4e27-40d7-8883-b74bfd84ef88",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "119884476",
-          "scheme": "bnf"
+          "identifier": "165789",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Michigan-state-1",
           "scheme": "quora"
+        },
+        {
+          "identifier": "267241450",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1166",
@@ -120932,16 +120932,28 @@
       "id": "ocd-division/country:us/state:mn",
       "identifiers": [
         {
+          "identifier": "17be21a7-c94f-4dca-a8ea-ff6db74d60c5",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "12065846d",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Minnesota",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Minnesota/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/04ykg",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US27",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/04ykg",
+          "scheme": "freebase"
         },
         {
           "identifier": "5037779",
@@ -120952,6 +120964,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79021675",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/minnesota",
           "scheme": "newyorktimes"
         },
@@ -120960,28 +120976,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "146514191",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79021675",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "17be21a7-c94f-4dca-a8ea-ff6db74d60c5",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "12065846d",
-          "scheme": "bnf"
-        },
-        {
           "identifier": "Minnesota-state",
           "scheme": "quora"
         },
         {
-          "identifier": "place/Minnesota",
-          "scheme": "britannica"
+          "identifier": "146514191",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1527",
@@ -121372,16 +121372,28 @@
       "id": "ocd-division/country:us/state:mo",
       "identifiers": [
         {
+          "identifier": "59e734c8-46db-4d0b-9fbf-a3de9ef3fcb6",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "119374724",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Missouri-state",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Missouri/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/04ych",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US29",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/04ych",
+          "scheme": "freebase"
         },
         {
           "identifier": "4398678",
@@ -121392,6 +121404,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79029210",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/missouri",
           "scheme": "newyorktimes"
         },
@@ -121400,28 +121416,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "146566329",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79029210",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "59e734c8-46db-4d0b-9fbf-a3de9ef3fcb6",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "119374724",
-          "scheme": "bnf"
-        },
-        {
           "identifier": "Missouri-state-1",
           "scheme": "quora"
         },
         {
-          "identifier": "place/Missouri-state",
-          "scheme": "britannica"
+          "identifier": "146566329",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1581",
@@ -121872,16 +121872,24 @@
       "id": "ocd-division/country:us/state:ms",
       "identifiers": [
         {
+          "identifier": "62a31a5b-e8db-41f6-b612-94b59e34a35b",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "120326006",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Mississippi/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/04tgp",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US28",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/04tgp",
+          "scheme": "freebase"
         },
         {
           "identifier": "4436296",
@@ -121892,6 +121900,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79138969",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/mississippi",
           "scheme": "newyorktimes"
         },
@@ -121900,24 +121912,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "140657496",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79138969",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "62a31a5b-e8db-41f6-b612-94b59e34a35b",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "120326006",
-          "scheme": "bnf"
-        },
-        {
           "identifier": "Mississippi-state-1",
           "scheme": "quora"
+        },
+        {
+          "identifier": "140657496",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1494",
@@ -122363,16 +122363,24 @@
       "id": "ocd-division/country:us/state:mt",
       "identifiers": [
         {
+          "identifier": "8a82cf5e-0bc6-4ac9-a235-0d23e27d3932",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "120658483",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Montana/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/050l8",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US30",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/050l8",
+          "scheme": "freebase"
         },
         {
           "identifier": "5667009",
@@ -122383,28 +122391,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "162115",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "133316844",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n80010207",
           "scheme": "lcauth"
         },
         {
-          "identifier": "8a82cf5e-0bc6-4ac9-a235-0d23e27d3932",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "120658483",
-          "scheme": "bnf"
+          "identifier": "162115",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Montana-state",
           "scheme": "quora"
+        },
+        {
+          "identifier": "133316844",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1212",
@@ -122830,16 +122830,28 @@
       "id": "ocd-division/country:us/state:nc",
       "identifiers": [
         {
+          "identifier": "ff1be8bf-64d9-4373-8aa4-bf7ec1a8cf7c",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "12002278d",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/North-Carolina-state",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/North_Carolina/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/05fkf",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US37",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05fkf",
+          "scheme": "freebase"
         },
         {
           "identifier": "4482348",
@@ -122850,36 +122862,24 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "224045",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "127824921",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79007042",
           "scheme": "lcauth"
         },
         {
-          "identifier": "ff1be8bf-64d9-4373-8aa4-bf7ec1a8cf7c",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "12002278d",
-          "scheme": "bnf"
-        },
-        {
-          "identifier": "7007709",
-          "scheme": "tgn"
+          "identifier": "224045",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "North-Carolina-state-1",
           "scheme": "quora"
         },
         {
-          "identifier": "place/North-Carolina-state",
-          "scheme": "britannica"
+          "identifier": "7007709",
+          "scheme": "tgn"
+        },
+        {
+          "identifier": "127824921",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1454",
@@ -123555,16 +123555,24 @@
       "id": "ocd-division/country:us/state:nd",
       "identifiers": [
         {
+          "identifier": "c061e955-277c-4d5a-8350-4887e8b8445b",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "place/North-Dakota",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/North_Dakota/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/05fky",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US38",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05fky",
+          "scheme": "freebase"
         },
         {
           "identifier": "5690763",
@@ -123575,6 +123583,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79068662",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/north-dakota",
           "scheme": "newyorktimes"
         },
@@ -123583,28 +123595,16 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "180769387",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79068662",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "c061e955-277c-4d5a-8350-4887e8b8445b",
-          "scheme": "bbc_things"
+          "identifier": "North-Dakota-state-1",
+          "scheme": "quora"
         },
         {
           "identifier": "7007705",
           "scheme": "tgn"
         },
         {
-          "identifier": "North-Dakota-state-1",
-          "scheme": "quora"
-        },
-        {
-          "identifier": "place/North-Dakota",
-          "scheme": "britannica"
+          "identifier": "180769387",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1207",
@@ -124280,16 +124280,24 @@
       "id": "ocd-division/country:us/state:ne",
       "identifiers": [
         {
+          "identifier": "43bcb5c4-e856-47f3-979a-14179b5a72e3",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "12021261v",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Nebraska/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/05fhy",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US31",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05fhy",
+          "scheme": "freebase"
         },
         {
           "identifier": "5073708",
@@ -124300,6 +124308,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n80072484",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/nebraska",
           "scheme": "newyorktimes"
         },
@@ -124308,24 +124320,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "131284407",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n80072484",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "43bcb5c4-e856-47f3-979a-14179b5a72e3",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "12021261v",
-          "scheme": "bnf"
-        },
-        {
           "identifier": "Nebraska-state",
           "scheme": "quora"
+        },
+        {
+          "identifier": "131284407",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1553",
@@ -124716,16 +124716,24 @@
       "id": "ocd-division/country:us/state:nh",
       "identifiers": [
         {
+          "identifier": "f35b55f3-2d05-43cb-bab3-5cb1aa4dc2c0",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "11951492q",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/New_Hampshire/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/059f4",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US33",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/059f4",
+          "scheme": "freebase"
         },
         {
           "identifier": "5090174",
@@ -124736,28 +124744,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "67213",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "155922170",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79007325",
           "scheme": "lcauth"
         },
         {
-          "identifier": "f35b55f3-2d05-43cb-bab3-5cb1aa4dc2c0",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "11951492q",
-          "scheme": "bnf"
+          "identifier": "67213",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "New-Hampshire-state",
           "scheme": "quora"
+        },
+        {
+          "identifier": "155922170",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q759",
@@ -125268,16 +125268,24 @@
       "id": "ocd-division/country:us/state:nj",
       "identifiers": [
         {
+          "identifier": "676488c9-3b71-4719-b9f0-2e57bcdc971c",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "11941594g",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/New_Jersey/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/05fjf",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US34",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05fjf",
+          "scheme": "freebase"
         },
         {
           "identifier": "5101760",
@@ -125288,6 +125296,14 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "uk-news/new-jersey",
+          "scheme": "guardian"
+        },
+        {
+          "identifier": "n80046086",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/new-jersey-shore",
           "scheme": "newyorktimes"
         },
@@ -125296,28 +125312,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "157102040",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n80046086",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "676488c9-3b71-4719-b9f0-2e57bcdc971c",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "11941594g",
-          "scheme": "bnf"
-        },
-        {
           "identifier": "New-Jersey-state",
           "scheme": "quora"
         },
         {
-          "identifier": "uk-news/new-jersey",
-          "scheme": "guardian"
+          "identifier": "157102040",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1408",
@@ -125828,16 +125828,20 @@
       "id": "ocd-division/country:us/state:nm",
       "identifiers": [
         {
+          "identifier": "9ecded3d-9681-4db3-92e0-7764379433e9",
+          "scheme": "bbc_things"
+        },
+        {
           "identifier": "Regional/North_America/United_States/New_Mexico/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/05fjy",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US35",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05fjy",
+          "scheme": "freebase"
         },
         {
           "identifier": "5481136",
@@ -125848,24 +125852,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "162014",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "131332136",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79005595",
           "scheme": "lcauth"
         },
         {
-          "identifier": "9ecded3d-9681-4db3-92e0-7764379433e9",
-          "scheme": "bbc_things"
+          "identifier": "162014",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "New-Mexico-state",
           "scheme": "quora"
+        },
+        {
+          "identifier": "131332136",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1522",
@@ -126476,16 +126476,20 @@
       "id": "ocd-division/country:us/state:nv",
       "identifiers": [
         {
+          "identifier": "3b201abb-b8e9-4a43-8bc9-0c38bcae2982",
+          "scheme": "bbc_things"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Nevada/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/059_c",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US32",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/059_c",
+          "scheme": "freebase"
         },
         {
           "identifier": "5509151",
@@ -126496,6 +126500,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79072716",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/nevada",
           "scheme": "newyorktimes"
         },
@@ -126504,20 +126512,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "130694101",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79072716",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "3b201abb-b8e9-4a43-8bc9-0c38bcae2982",
-          "scheme": "bbc_things"
-        },
-        {
           "identifier": "Nevada-state-1",
           "scheme": "quora"
+        },
+        {
+          "identifier": "130694101",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1227",
@@ -126898,16 +126898,24 @@
       "id": "ocd-division/country:us/state:ny",
       "identifiers": [
         {
+          "identifier": "1c5a316a-fb99-4b1a-a9e6-474f2eda6c12",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "118801040",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/New_York/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/059rby",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US36",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/059rby",
+          "scheme": "freebase"
         },
         {
           "identifier": "5128638",
@@ -126918,32 +126926,24 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "61320",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "146785329",
-          "scheme": "viaf"
+          "identifier": "us-news/new-york",
+          "scheme": "guardian"
         },
         {
           "identifier": "n80126293",
           "scheme": "lcauth"
         },
         {
-          "identifier": "1c5a316a-fb99-4b1a-a9e6-474f2eda6c12",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "118801040",
-          "scheme": "bnf"
+          "identifier": "61320",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "New-York-state",
           "scheme": "quora"
         },
         {
-          "identifier": "us-news/new-york",
-          "scheme": "guardian"
+          "identifier": "146785329",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1384",
@@ -127594,16 +127594,20 @@
       "id": "ocd-division/country:us/state:oh",
       "identifiers": [
         {
+          "identifier": "78f1cc31-87b9-4d77-a679-2df4fd483fa3",
+          "scheme": "bbc_things"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Ohio/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/05kkh",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US39",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05kkh",
+          "scheme": "freebase"
         },
         {
           "identifier": "5165418",
@@ -127614,6 +127618,14 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "us-news/ohio",
+          "scheme": "guardian"
+        },
+        {
+          "identifier": "n79049197",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/ohio",
           "scheme": "newyorktimes"
         },
@@ -127622,24 +127634,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "144232296",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79049197",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "78f1cc31-87b9-4d77-a679-2df4fd483fa3",
-          "scheme": "bbc_things"
-        },
-        {
           "identifier": "Ohio-state-1",
           "scheme": "quora"
         },
         {
-          "identifier": "us-news/ohio",
-          "scheme": "guardian"
+          "identifier": "144232296",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1397",
@@ -128080,16 +128080,28 @@
       "id": "ocd-division/country:us/state:ok",
       "identifiers": [
         {
+          "identifier": "35e36830-f0d2-4d49-b4e5-beb83f102954",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "12338977k",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Oklahoma-state",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Oklahoma/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/05mph",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US40",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05mph",
+          "scheme": "freebase"
         },
         {
           "identifier": "4544379",
@@ -128100,32 +128112,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "161645",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "137038395",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79046257",
           "scheme": "lcauth"
         },
         {
-          "identifier": "35e36830-f0d2-4d49-b4e5-beb83f102954",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "12338977k",
-          "scheme": "bnf"
+          "identifier": "161645",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Oklahoma-state-1",
           "scheme": "quora"
         },
         {
-          "identifier": "place/Oklahoma-state",
-          "scheme": "britannica"
+          "identifier": "137038395",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1649",
@@ -128511,16 +128511,24 @@
       "id": "ocd-division/country:us/state:or",
       "identifiers": [
         {
+          "identifier": "04e7c4fd-f3c2-4324-a7cb-4c450194259a",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "139055461",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Oregon/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/05kj_",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US41",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05kj_",
+          "scheme": "freebase"
         },
         {
           "identifier": "5744337",
@@ -128531,6 +128539,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79021953",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/oregon",
           "scheme": "newyorktimes"
         },
@@ -128539,24 +128551,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "129543877",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79021953",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "04e7c4fd-f3c2-4324-a7cb-4c450194259a",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "139055461",
-          "scheme": "bnf"
-        },
-        {
           "identifier": "Oregon-state-1",
           "scheme": "quora"
+        },
+        {
+          "identifier": "129543877",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q824",
@@ -128962,16 +128962,24 @@
       "id": "ocd-division/country:us/state:pa",
       "identifiers": [
         {
+          "identifier": "47742f73-b93b-4f8f-9fda-cc1dfdf58e88",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "place/Pennsylvania-state",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Pennsylvania/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/05tbn",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US42",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/05tbn",
+          "scheme": "freebase"
         },
         {
           "identifier": "6254927",
@@ -128982,6 +128990,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79022911",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/pennsylvania",
           "scheme": "newyorktimes"
         },
@@ -128990,24 +129002,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "150023893",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79022911",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "47742f73-b93b-4f8f-9fda-cc1dfdf58e88",
-          "scheme": "bbc_things"
-        },
-        {
           "identifier": "Pennsylvania-state",
           "scheme": "quora"
         },
         {
-          "identifier": "place/Pennsylvania-state",
-          "scheme": "britannica"
+          "identifier": "150023893",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1400",
@@ -129588,16 +129588,20 @@
       "id": "ocd-division/country:us/state:ri",
       "identifiers": [
         {
+          "identifier": "408b0fb3-ba89-4fc9-a5df-790ccf45d7a9",
+          "scheme": "bbc_things"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Rhode_Island/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/06btq",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US44",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/06btq",
+          "scheme": "freebase"
         },
         {
           "identifier": "5224323",
@@ -129608,24 +129612,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "165795",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "157090640",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79022912",
           "scheme": "lcauth"
         },
         {
-          "identifier": "408b0fb3-ba89-4fc9-a5df-790ccf45d7a9",
-          "scheme": "bbc_things"
+          "identifier": "165795",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Rhode-Island-state",
           "scheme": "quora"
+        },
+        {
+          "identifier": "157090640",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1387",
@@ -130061,16 +130061,24 @@
       "id": "ocd-division/country:us/state:sc",
       "identifiers": [
         {
+          "identifier": "41ff94f6-d0b7-4d5f-a56a-74685441822e",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "place/South-Carolina",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/South_Carolina/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/06yxd",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US45",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/06yxd",
+          "scheme": "freebase"
         },
         {
           "identifier": "4597040",
@@ -130081,28 +130089,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "224040",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "126093597",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79022914",
           "scheme": "lcauth"
         },
         {
-          "identifier": "41ff94f6-d0b7-4d5f-a56a-74685441822e",
-          "scheme": "bbc_things"
+          "identifier": "224040",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "South-Carolina-state-1",
           "scheme": "quora"
         },
         {
-          "identifier": "place/South-Carolina",
-          "scheme": "britannica"
+          "identifier": "126093597",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1456",
@@ -130773,16 +130773,24 @@
       "id": "ocd-division/country:us/state:sd",
       "identifiers": [
         {
+          "identifier": "863c53a2-c228-4f13-980e-80d6c94285f7",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "11973495n",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/South_Dakota/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/06mz5",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US46",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/06mz5",
+          "scheme": "freebase"
         },
         {
           "identifier": "5769223",
@@ -130793,6 +130801,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79007333",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/south-dakota",
           "scheme": "newyorktimes"
         },
@@ -130801,28 +130813,16 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "145354047",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79007333",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "863c53a2-c228-4f13-980e-80d6c94285f7",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "11973495n",
-          "scheme": "bnf"
+          "identifier": "South-Dakota-state",
+          "scheme": "quora"
         },
         {
           "identifier": "7007713",
           "scheme": "tgn"
         },
         {
-          "identifier": "South-Dakota-state",
-          "scheme": "quora"
+          "identifier": "145354047",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1211",
@@ -131538,16 +131538,28 @@
       "id": "ocd-division/country:us/state:tn",
       "identifiers": [
         {
+          "identifier": "9489a98e-faca-40fb-950f-9d46e91ea9f3",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "11952980b",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Tennessee",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Tennessee/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/07h34",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US47",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/07h34",
+          "scheme": "freebase"
         },
         {
           "identifier": "4662168",
@@ -131558,6 +131570,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n79060965",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/tennessee",
           "scheme": "newyorktimes"
         },
@@ -131566,28 +131582,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "312794257",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n79060965",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "9489a98e-faca-40fb-950f-9d46e91ea9f3",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "11952980b",
-          "scheme": "bnf"
-        },
-        {
           "identifier": "Tennessee-state-1",
           "scheme": "quora"
         },
         {
-          "identifier": "place/Tennessee",
-          "scheme": "britannica"
+          "identifier": "312794257",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1509",
@@ -132023,16 +132023,28 @@
       "id": "ocd-division/country:us/state:tx",
       "identifiers": [
         {
+          "identifier": "afc26326-134e-42c9-a6d6-ace9062bbb2b",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "139217717",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "place/Texas-state",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Texas/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/07b_l",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US48",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/07b_l",
+          "scheme": "freebase"
         },
         {
           "identifier": "4736286",
@@ -132043,6 +132055,10 @@
           "scheme": "gnd"
         },
         {
+          "identifier": "n80129616",
+          "scheme": "lcauth"
+        },
+        {
           "identifier": "destination/texas",
           "scheme": "newyorktimes"
         },
@@ -132051,28 +132067,12 @@
           "scheme": "openstreetmap"
         },
         {
-          "identifier": "152620751",
-          "scheme": "viaf"
-        },
-        {
-          "identifier": "n80129616",
-          "scheme": "lcauth"
-        },
-        {
-          "identifier": "afc26326-134e-42c9-a6d6-ace9062bbb2b",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "139217717",
-          "scheme": "bnf"
-        },
-        {
           "identifier": "Texas-state-1",
           "scheme": "quora"
         },
         {
-          "identifier": "place/Texas-state",
-          "scheme": "britannica"
+          "identifier": "152620751",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1439",
@@ -132573,16 +132573,20 @@
       "id": "ocd-division/country:us/state:ut",
       "identifiers": [
         {
+          "identifier": "3d8f61d1-467d-432c-9b4a-4a51d396e260",
+          "scheme": "bbc_things"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Utah/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/07srw",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US49",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/07srw",
+          "scheme": "freebase"
         },
         {
           "identifier": "5549030",
@@ -132593,24 +132597,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "161993",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "131333076",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79021759",
           "scheme": "lcauth"
         },
         {
-          "identifier": "3d8f61d1-467d-432c-9b4a-4a51d396e260",
-          "scheme": "bbc_things"
+          "identifier": "161993",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Utah-state-1",
           "scheme": "quora"
+        },
+        {
+          "identifier": "131333076",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q829",
@@ -133026,16 +133026,20 @@
       "id": "ocd-division/country:us/state:va",
       "identifiers": [
         {
+          "identifier": "db2fa126-50ea-4e2e-81fa-6f7957acdafe",
+          "scheme": "bbc_things"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Virginia/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/07z1m",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US51",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/07z1m",
+          "scheme": "freebase"
         },
         {
           "identifier": "6254928",
@@ -133046,24 +133050,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "224042",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "128935789",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79022909",
           "scheme": "lcauth"
         },
         {
-          "identifier": "db2fa126-50ea-4e2e-81fa-6f7957acdafe",
-          "scheme": "bbc_things"
+          "identifier": "224042",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Virginia-state",
           "scheme": "quora"
+        },
+        {
+          "identifier": "128935789",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1370",
@@ -133589,16 +133589,20 @@
       "id": "ocd-division/country:us/state:vt",
       "identifiers": [
         {
+          "identifier": "650ddbef-6b8f-4ae9-8f90-22069bb51ee2",
+          "scheme": "bbc_things"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Vermont/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/07_f2",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US50",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/07_f2",
+          "scheme": "freebase"
         },
         {
           "identifier": "5242283",
@@ -133609,24 +133613,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "60759",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "128936020",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79007067",
           "scheme": "lcauth"
         },
         {
-          "identifier": "650ddbef-6b8f-4ae9-8f90-22069bb51ee2",
-          "scheme": "bbc_things"
+          "identifier": "60759",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Vermont-state",
           "scheme": "quora"
+        },
+        {
+          "identifier": "128936020",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q16551",
@@ -134037,16 +134037,20 @@
       "id": "ocd-division/country:us/state:wa",
       "identifiers": [
         {
+          "identifier": "26999283-b557-4514-b97d-e787c6bc6e15",
+          "scheme": "bbc_things"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Washington/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/081yw",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US53",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/081yw",
+          "scheme": "freebase"
         },
         {
           "identifier": "5815135",
@@ -134057,24 +134061,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "165479",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "155860715",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79027224",
           "scheme": "lcauth"
         },
         {
-          "identifier": "26999283-b557-4514-b97d-e787c6bc6e15",
-          "scheme": "bbc_things"
+          "identifier": "165479",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Washington-state-1",
           "scheme": "quora"
+        },
+        {
+          "identifier": "155860715",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1223",
@@ -134535,16 +134535,24 @@
       "id": "ocd-division/country:us/state:wi",
       "identifiers": [
         {
+          "identifier": "e760c493-c769-4065-bb88-cbabc008a2e7",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "11957757g",
+          "scheme": "bnf"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Wisconsin/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/0824r",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US55",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/0824r",
+          "scheme": "freebase"
         },
         {
           "identifier": "5279468",
@@ -134555,28 +134563,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "165466",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "152370817",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79022855",
           "scheme": "lcauth"
         },
         {
-          "identifier": "e760c493-c769-4065-bb88-cbabc008a2e7",
-          "scheme": "bbc_things"
-        },
-        {
-          "identifier": "11957757g",
-          "scheme": "bnf"
+          "identifier": "165466",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Wisconsin-state",
           "scheme": "quora"
+        },
+        {
+          "identifier": "152370817",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1537",
@@ -135007,16 +135007,24 @@
       "id": "ocd-division/country:us/state:wv",
       "identifiers": [
         {
+          "identifier": "126d52c5-1c8e-4e75-9a92-0c606f992436",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "place/West-Virginia",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/West_Virginia/",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/081mh",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US54",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/081mh",
+          "scheme": "freebase"
         },
         {
           "identifier": "4826850",
@@ -135027,28 +135035,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "162068",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "155293408",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79059831",
           "scheme": "lcauth"
         },
         {
-          "identifier": "126d52c5-1c8e-4e75-9a92-0c606f992436",
-          "scheme": "bbc_things"
+          "identifier": "162068",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "West-Virginia-state",
           "scheme": "quora"
         },
         {
-          "identifier": "place/West-Virginia",
-          "scheme": "britannica"
+          "identifier": "155293408",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1371",
@@ -135744,16 +135744,24 @@
       "id": "ocd-division/country:us/state:wy",
       "identifiers": [
         {
+          "identifier": "cff26426-a05d-4eca-a698-c530ee8e5712",
+          "scheme": "bbc_things"
+        },
+        {
+          "identifier": "place/Wyoming-state",
+          "scheme": "britannica"
+        },
+        {
           "identifier": "Regional/North_America/United_States/Wyoming",
           "scheme": "dmoz"
         },
         {
-          "identifier": "/m/0846v",
-          "scheme": "freebase"
-        },
-        {
           "identifier": "US56",
           "scheme": "fips"
+        },
+        {
+          "identifier": "/m/0846v",
+          "scheme": "freebase"
         },
         {
           "identifier": "5843591",
@@ -135764,28 +135772,20 @@
           "scheme": "gnd"
         },
         {
-          "identifier": "161991",
-          "scheme": "openstreetmap"
-        },
-        {
-          "identifier": "155923263",
-          "scheme": "viaf"
-        },
-        {
           "identifier": "n79022108",
           "scheme": "lcauth"
         },
         {
-          "identifier": "cff26426-a05d-4eca-a698-c530ee8e5712",
-          "scheme": "bbc_things"
+          "identifier": "161991",
+          "scheme": "openstreetmap"
         },
         {
           "identifier": "Wyoming-state",
           "scheme": "quora"
         },
         {
-          "identifier": "place/Wyoming-state",
-          "scheme": "britannica"
+          "identifier": "155923263",
+          "scheme": "viaf"
         },
         {
           "identifier": "Q1214",

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -117,6 +117,7 @@ def popolo_write(pathname, json)
   json[:events] &&= json[:events].portable_sort_by { |e| [e[:start_date].to_s || '', e[:id].to_s] }
   json[:areas]  &&= json[:areas].portable_sort_by  { |a| [a[:id]] }
   json[:areas].each do |area|
+    area[:identifiers] &&= area[:identifiers].portable_sort_by { |i| [i[:scheme], i[:identifier]] }
     area[:other_names] &&= area[:other_names].portable_sort_by { |name| [name[:lang].to_s, name[:name]] }
   end
 


### PR DESCRIPTION
Within an Area, make the sort order of the identifiers stable, to avoid
needless diffs.