### PR TITLE
Ensure all instucitons files parse as pure JSON

### DIFF
--- a/data/Aruba/Estates/sources/instructions.json
+++ b/data/Aruba/Estates/sources/instructions.json
@@ -12,7 +12,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "gender-balance/results.csv",

--- a/data/Benin/National_Assembly/sources/instructions.json
+++ b/data/Benin/National_Assembly/sources/instructions.json
@@ -12,7 +12,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "gender-balance/results.csv",

--- a/data/Bermuda/Assembly/sources/instructions.json
+++ b/data/Bermuda/Assembly/sources/instructions.json
@@ -52,7 +52,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "morph/genderbalance.csv",

--- a/data/Brunei/Legislative_Council/sources/instructions.json
+++ b/data/Brunei/Legislative_Council/sources/instructions.json
@@ -12,7 +12,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "gender-balance/results.csv",

--- a/data/Curacao/Estates/sources/instructions.json
+++ b/data/Curacao/Estates/sources/instructions.json
@@ -26,7 +26,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "wikidata/groups.json",

--- a/data/French_Polynesia/Assembly/sources/instructions.json
+++ b/data/French_Polynesia/Assembly/sources/instructions.json
@@ -27,7 +27,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "morph/genderbalance.csv",

--- a/data/India/Lok_Sabha/sources/instructions.json
+++ b/data/India/Lok_Sabha/sources/instructions.json
@@ -27,7 +27,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "morph/genderbalance.csv",

--- a/data/Indonesia/Council/sources/instructions.json
+++ b/data/Indonesia/Council/sources/instructions.json
@@ -27,7 +27,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "morph/genderbalance.csv",

--- a/data/Ivory_Coast/Assembly/sources/instructions.json
+++ b/data/Ivory_Coast/Assembly/sources/instructions.json
@@ -12,7 +12,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "gender-balance/results.csv",

--- a/data/Kenya/Assembly/sources/instructions.json
+++ b/data/Kenya/Assembly/sources/instructions.json
@@ -42,7 +42,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "morph/genderbalance.csv",

--- a/data/Kosovo/Assembly/sources/instructions.json
+++ b/data/Kosovo/Assembly/sources/instructions.json
@@ -27,7 +27,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "gender-balance/results.csv",

--- a/data/Libya/House_of_Representatives/sources/instructions.json
+++ b/data/Libya/House_of_Representatives/sources/instructions.json
@@ -12,7 +12,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "gender-balance/results.csv",

--- a/data/Mauritania/National_Assembly/sources/instructions.json
+++ b/data/Mauritania/National_Assembly/sources/instructions.json
@@ -12,7 +12,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "gender-balance/results.csv",

--- a/data/Montserrat/Assembly/sources/instructions.json
+++ b/data/Montserrat/Assembly/sources/instructions.json
@@ -12,7 +12,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "gender-balance/results.csv",

--- a/data/Mozambique/Assembly/sources/instructions.json
+++ b/data/Mozambique/Assembly/sources/instructions.json
@@ -12,7 +12,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "gender-balance/results.csv",

--- a/data/Pakistan/Assembly/sources/instructions.json
+++ b/data/Pakistan/Assembly/sources/instructions.json
@@ -32,7 +32,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "wikidata/groups.json",

--- a/data/Saint_Vincent_and_the_Grenadines/Assembly/sources/instructions.json
+++ b/data/Saint_Vincent_and_the_Grenadines/Assembly/sources/instructions.json
@@ -17,7 +17,7 @@
       "merge": {
         "incoming_field": "name",
         "existing_field": "name",
-        "reconciliation_file": "reconciliation/elections-2015.csv",
+        "reconciliation_file": "reconciliation/elections-2015.csv"
       }
     },
     {

--- a/data/Sark/Chief_Pleas/sources/instructions.json
+++ b/data/Sark/Chief_Pleas/sources/instructions.json
@@ -12,7 +12,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "gender-balance/results.csv",

--- a/data/South_Sudan/Assembly/sources/instructions.json
+++ b/data/South_Sudan/Assembly/sources/instructions.json
@@ -12,7 +12,7 @@
     },
     {
       "file": "manual/terms.csv",
-      "type": "term",
+      "type": "term"
     },
     {
       "file": "gender-balance/results.csv",

--- a/data/Turks_and_Caicos_Islands/Assembly/sources/instructions.json
+++ b/data/Turks_and_Caicos_Islands/Assembly/sources/instructions.json
@@ -13,7 +13,7 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official-2012-elected-members.csv"
-      },
+      }
     },
     {
       "file": "morph/wikipedia.csv",

--- a/data/UK/Commons/sources/instructions.json
+++ b/data/UK/Commons/sources/instructions.json
@@ -147,7 +147,7 @@
       "type": "person",
       "merge": {
         "incoming_field": "parlparse_id",
-        "existing_field": "identifier__parlparse",
+        "existing_field": "identifier__parlparse"
       }
     }
   ]

--- a/lib/instructions.rb
+++ b/lib/instructions.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'source'
-require 'json5'
 
 class Instructions
   def initialize(path)
@@ -25,7 +24,7 @@ class Instructions
   attr_reader :path
 
   def data
-    @data ||= JSON.parse(JSON5.parse(path.read).to_json, symbolize_names: true)
+    @data ||= JSON.parse(path.read, symbolize_names: true)
   end
 
   def raw_sources


### PR DESCRIPTION
We previously decided to treat them as JSON5, to be more flexible, but
this has generally caused more problems than it has fixed. Instead we
should bail out early if the file isn't true JSON.