### PR TITLE
Australia (Representatives): add Wikidata ID for terms

### DIFF
--- a/data/Australia/Representatives/ep-popolo-v1.0.json
+++ b/data/Australia/Representatives/ep-popolo-v1.0.json
@@ -59874,6 +59874,12 @@
       "classification": "legislative period",
       "end_date": "2016-05-09",
       "id": "term/44",
+      "identifiers": [
+        {
+          "identifier": "Q24891029",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "44th Parliament",
       "organization_id": "2ab5a3aa-ef1e-46c0-abc9-dad161aa0390",
       "start_date": "2013-09-07"
@@ -59894,6 +59900,12 @@
     {
       "classification": "legislative period",
       "id": "term/45",
+      "identifiers": [
+        {
+          "identifier": "Q39057922",
+          "scheme": "wikidata"
+        }
+      ],
       "name": "45th Parliament",
       "organization_id": "2ab5a3aa-ef1e-46c0-abc9-dad161aa0390",
       "start_date": "2016-07-02"

--- a/data/Australia/Representatives/sources/manual/terms.csv
+++ b/data/Australia/Representatives/sources/manual/terms.csv
@@ -1,12 +1,12 @@
-id,name,start_date,end_date
-35,35th Parliament,1987-07-11,1990-03-24
-36,36th Parliament,1990-03-24,1993-03-13
-37,37th Parliament,1993-03-13,1996-03-02
-38,38th Parliament,1996-03-02,1998-10-03
-39,39th Parliament,1998-10-03,2001-11-10
-40,40th Parliament,2001-11-10,2004-10-09
-41,41st Parliament,2004-10-09,2007-11-24
-42,42nd Parliament,2007-11-24,2010-08-21
-43,43rd Parliament,2010-08-21,2013-09-07
-44,44th Parliament,2013-09-07,2016-05-09
-45,45th Parliament,2016-07-02,
+id,name,start_date,end_date,wikidata
+35,35th Parliament,1987-07-11,1990-03-24,
+36,36th Parliament,1990-03-24,1993-03-13,
+37,37th Parliament,1993-03-13,1996-03-02,
+38,38th Parliament,1996-03-02,1998-10-03,
+39,39th Parliament,1998-10-03,2001-11-10,
+40,40th Parliament,2001-11-10,2004-10-09,
+41,41st Parliament,2004-10-09,2007-11-24,
+42,42nd Parliament,2007-11-24,2010-08-21,
+43,43rd Parliament,2010-08-21,2013-09-07,
+44,44th Parliament,2013-09-07,2016-05-09,Q24891029
+45,45th Parliament,2016-07-02,,Q39057922

--- a/data/Australia/Representatives/unstable/stats.json
+++ b/data/Australia/Representatives/unstable/stats.json
@@ -20,7 +20,7 @@
   "terms": {
     "count": 11,
     "latest": "2016-07-02",
-    "wikidata": 0
+    "wikidata": 2
   },
   "areas": {
     "count": 169,


### PR DESCRIPTION
```
Add memberships from sources/morph/openaustralia.csv
Merging with sources/morph/openaustralia-contact-details.csv
Merging with sources/morph/wikidata.csv
Data Mismatches
* 2 of 514 unmatched
	{:id=>"Q55807656", :name=>"Patrick Gorman"}
	{:id=>"Q14954679", :name=>"Ged Kearney"}
Merging with sources/manual/emails.csv
Merging with sources/manual/guessed-emails.csv
Merging with sources/morph/genderbalance.csv
Data Mismatches
  ☁ Mismatch in gender for 0448f62d-f3ab-4aa1-86da-70c3fe73912d (male) vs female (for )
  ☁ Mismatch in gender for 56477745-9d1a-437d-944a-95f0d8ba164a (male) vs female (for )
  ☁ Mismatch in gender for f24b325e-6885-4028-b414-3b98d8b287ff (female) vs male (for )
Applying local corrections from sources/manual/corrections.csv

Top identifiers:
  512 x openaustralia
  512 x wikidata
  195 x aph
  161 x viaf
  116 x freebase

Creating names.csv
  ☇ No dates for Greg Combet (Q11701393) as Minister for Defence Materiel
  ☇ No dates for Tony Burke (Q1449483) as Minister for Immigration and Border Protection of Australia
  ☇ No dates for John Dawkins (Q1466753) as Minister for School Education, Early Childhood and Youth
  ☇ No dates for John Dawkins (Q1466753) as Minister for Trade
  ☇ No dates for Duncan Kerr (Q15525005) as Minister for Justice
  ☇ No dates for David Cowan (Q2313174) as Minister for Primary Industries
  ☇ No dates for Kate Ellis (Q4354268) as Minister for Sport
  ☇ No dates for Kate Ellis (Q4354268) as Minister for Employment and Workplace Relations
  ☇ No dates for Kate Ellis (Q4354268) as Minister for the Status of Women
  ☇ No dates for Andrew Robb (Q4758396) as Minister for Trade
  ☇ No dates for Bill Shorten (Q4910865) as Minister for School Education, Early Childhood and Youth
  ☇ No dates for Bob Debus (Q4932251) as Minister for Finance, Services and Property
  ☇ No dates for Bob Debus (Q4932251) as Minister for Industry, Resources and Energy
  ☇ No dates for Bob Debus (Q4932251) as Minister for Home Affairs
  ☇ No dates for Bob Debus (Q4932251) as Minister for Police and Emergency Services
  ☇ No dates for Bob Debus (Q4932251) as Minister for Tourism, Major Events, Hospitality and Racing
  ☇ No dates for Brian Howe (Q4964109) as Minister for Infrastructure and Transport
  ☇ No dates for Jason Clare (Q6162219) as Minister for Defence Materiel
  ☇ No dates for Jason Clare (Q6162219) as Minister for Home Affairs
  ☇ No dates for Michael Ronaldson (Q6833958) as Minister for Veterans' Affairs
  ☇ No dates for Michael Ronaldson (Q6833958) as Special Minister of State
  ☇ No dates for Richard Marles (Q7327642) as Minister for Trade
Persons matched to Wikidata: 512 ✓ 
Parties matched to Wikidata: 12 ✓ | 1 ✘
  No wikidata: CWM (cwm)
Areas matched to Wikidata: 169 ✓ 
```