### PR TITLE
Don’t display unmatched reconciliation if 'report_missing' set

### DIFF
--- a/data/Ireland/Dail/sources/instructions.json
+++ b/data/Ireland/Dail/sources/instructions.json
@@ -62,7 +62,8 @@
       "merge": {
         "incoming_field": "name",
         "existing_field": "name",
-        "reconciliation_file": "idmap/p39s.csv"
+        "reconciliation_file": "idmap/p39s.csv",
+        "report_missing": false
       }
     },
     {

--- a/lib/source/person.rb
+++ b/lib/source/person.rb
@@ -50,10 +50,14 @@ module Source
           unmatched << incoming_row
         end
       end
-      add_warning '* %d of %d unmatched'.magenta % [unmatched.count, as_table.count] if unmatched.any?
-      unmatched.sample(10).each do |r|
-        add_warning "\t#{r.to_hash.reject { |_, v| v.to_s.empty? }.select { |k, _| %i[id name].include? k }}"
+
+      if unmatched.any? && merge_instructions.dig(:report_missing) != false
+        add_warning '* %d of %d unmatched'.magenta % [unmatched.count, as_table.count]
+        unmatched.sample(10).each do |r|
+          add_warning "\t#{r.to_hash.reject { |_, v| v.to_s.empty? }.select { |k, _| %i[id name].include? k }}"
+        end
       end
+
       csv
     end
   end


### PR DESCRIPTION
This presumably existed at some point in the past, as we have a flag for
this set in a variety of instructions files, but it has disappeared. Bring
it back.

This is usually for the case where a Wikidata source includes lots of
details for former members who we don’t know anything about, and we don’t
need to clutter up the build output with lots of "unmatched" warnings,
especially if we’ve actually matched every member.