### PR TITLE
Warn on positions being skipped when building Cabinet

### DIFF
--- a/lib/source/cabinet.rb
+++ b/lib/source/cabinet.rb
@@ -4,10 +4,10 @@ require_relative 'plain_csv'
 
 module Source
   class Cabinet < PlainCSV
-    def filtered(position_map:)
+    def partitioned(position_map:)
       map = ::CSV.table(position_map)
       wanted = map.select { |r| r[:type] == 'cabinet' }.map { |r| r[:id] }
-      as_table.select { |r| wanted.include? r[:position] }
+      as_table.partition { |r| wanted.include? r[:position] }
     end
   end
 end

--- a/rake_build/generate_final_csvs.rb
+++ b/rake_build/generate_final_csvs.rb
@@ -69,11 +69,11 @@ namespace :term_csvs do
     src = @INSTRUCTIONS.sources_of_type('wikidata-cabinet').first or next
     source_warn "Creating #{POSITION_CSV}"
 
-    data = src.filtered(position_map: POSITION_FILTER_CSV)
+    wanted, unwanted = src.partitioned(position_map: POSITION_FILTER_CSV)
     members = @popolo.persons.select(&:wikidata).group_by(&:wikidata)
 
     csv_headers = %w[id name position start_date end_date type].to_csv
-    csv_data = data.select { |r| members.key? r[:id] }.map do |r|
+    csv_data = wanted.select { |r| members.key? r[:id] }.map do |r|
       member = members[r[:id]].first
       warn "  ☇ No dates for #{member.name} (#{member.wikidata}) as #{r[:label]}" if r[:start_date].to_s.empty? && r[:end_date].to_s.empty?
       [member.id, member.name, r[:label], r[:start_date], r[:end_date], 'cabinet'].to_csv

--- a/rake_build/generate_final_csvs.rb
+++ b/rake_build/generate_final_csvs.rb
@@ -82,7 +82,11 @@ namespace :term_csvs do
     POSITION_CSV.dirname.mkpath
     POSITION_CSV.write(csv_headers + csv_data.join)
 
-    # TODO: Warn about uncategorised positions
+    # Warn about uncategorised positions
+    skipped = unwanted.group_by { |r| r[:position] }.sort_by { |_r, rs| rs.count }.reverse
+    skipped.take(3).each do |posn, posns|
+      warn "  ⁕ skipped #{posns.count} x #{posn} (#{posns.first[:label]})"
+    end
   end
 end
 


### PR DESCRIPTION
This will be a sign that either the query to find the list of positions
held by members is too broad (finding non-Cabinet positions), or that the
position filter is too narrow (not including a position that _is_ actually
part of the Cabinet)