### PR TITLE
rename 'report_missing' as 'report_extras'

### DIFF
--- a/data/Argentina/Senado/sources/instructions.json
+++ b/data/Argentina/Senado/sources/instructions.json
@@ -28,7 +28,7 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/wikidata.csv",
-        "report_missing": false
+        "report_extras": false
       }
     },
     {

--- a/data/Canada/Senate/sources/instructions.json
+++ b/data/Canada/Senate/sources/instructions.json
@@ -27,7 +27,7 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/wikidata.csv",
-        "report_missing": false
+        "report_extras": false
       }
     },
     {

--- a/data/Finland/Eduskunta/sources/instructions.json
+++ b/data/Finland/Eduskunta/sources/instructions.json
@@ -33,7 +33,7 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "idmap/p39s.csv",
-        "report_missing": false
+        "report_extras": false
       }
     },
     {

--- a/data/Ireland/Dail/sources/instructions.json
+++ b/data/Ireland/Dail/sources/instructions.json
@@ -63,7 +63,7 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "idmap/p39s.csv",
-        "report_missing": false
+        "report_extras": false
       }
     },
     {

--- a/data/Italy/Senate/sources/instructions.json
+++ b/data/Italy/Senate/sources/instructions.json
@@ -23,7 +23,7 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/wikidata.csv",
-        "report_missing": false
+        "report_extras": false
       }
     },
     {

--- a/data/United_States_of_America/House/sources/instructions.json
+++ b/data/United_States_of_America/House/sources/instructions.json
@@ -20,7 +20,7 @@
       "merge": {
         "incoming_field": "id",
         "existing_field": "id",
-        "report_missing": false
+        "report_extras": false
       },
       "source": "https://github.com/unitedstates/congress-legislators",
       "type": "person"

--- a/data/United_States_of_America/Senate/sources/instructions.json
+++ b/data/United_States_of_America/Senate/sources/instructions.json
@@ -20,7 +20,7 @@
       "merge": {
         "incoming_field": "id",
         "existing_field": "id",
-        "report_missing": false
+        "report_extras": false
       },
       "source": "https://github.com/unitedstates/congress-legislators",
       "type": "person"

--- a/data/Zimbabwe/Assembly/sources/instructions.json
+++ b/data/Zimbabwe/Assembly/sources/instructions.json
@@ -22,7 +22,7 @@
       "merge": {
         "incoming_field": "id",
         "existing_field": "identifier__kuvakazim",
-        "report_missing": false
+        "report_extras": false
       }
     },
     {

--- a/data/Zimbabwe/Senate/sources/instructions.json
+++ b/data/Zimbabwe/Senate/sources/instructions.json
@@ -22,7 +22,7 @@
       "merge": {
         "incoming_field": "id",
         "existing_field": "identifier__kuvakazim",
-        "report_missing": false
+        "report_extras": false
       }
     },
     {

--- a/lib/source/person.rb
+++ b/lib/source/person.rb
@@ -51,7 +51,7 @@ module Source
         end
       end
 
-      if unmatched.any? && merge_instructions.dig(:report_missing) != false
+      if unmatched.any? && merge_instructions.dig(:report_extras) != false
         add_warning "\t* %d of %d unmatched".magenta % [unmatched.count, as_table.count]
         unmatched.sample(10).each do |row|
           info = row.to_hash.compact.slice(:id, :name)


### PR DESCRIPTION
`report_missing` is slightly misleading, as this isn't about anything
that's *missing* from the source, it's about *extra* rows coming from
the source that we don't know how to handle. As this is almost always
about having Wikidata bio info for people who aren't actually members
we care about, rename this to `report_extras` instead.

Closes https://github.com/everypolitician/everypolitician/issues/639