### PR TITLE
Cache grouped match rows

### DIFF
--- a/lib/matcher.rb
+++ b/lib/matcher.rb
@@ -11,11 +11,11 @@ class Matcher
   end
 
   def existing
-    @_existing_rows.group_by { |r| r[@_existing_field].to_s.downcase }
+    @existing ||= @_existing_rows.group_by { |r| r[@_existing_field].to_s.downcase }
   end
 
   def existing_by_uuid
-    @_existing_rows.group_by { |r| r[:uuid].to_s }
+    @existing_by_uuid ||= @_existing_rows.group_by { |r| r[:uuid].to_s }
   end
 end
 


### PR DESCRIPTION
If we're going to group by a field in order to make lookups on it
quicker, we should really also cache the grouping.

This speeds up the Wikidata merge of the German Bundestag, for example,
from just under 2 minutes on my laptop, to about 40 seconds.