### PR TITLE
Look up file change times via Octokit if no local history

### DIFF
--- a/rake_build/generate_stats.rb
+++ b/rake_build/generate_stats.rb
@@ -5,15 +5,34 @@
 #-----------------------------------------------------------------------
 
 require 'date' # To give us DateTime.now
+require 'octokit'
 
 STATSFILE = Pathname.new('unstable/stats.json')
 
 namespace :stats do
+  def local_git_lastmod(file)
+    Date.parse `git log -1 --format="%ai" -- #{file}`.split.first
+  end
+
+  def octokit
+    @octokit ||= Octokit::Client.new
+  end
+
+  def datapath
+    @datapath ||= Pathname.pwd.relative_path_from(PROJECT.realpath)
+  end
+
+  def github_lastmod(file)
+    lc = octokit.commits('everypolitician/everypolitician-data', path: datapath + file).first
+    lc.commit.author.date.to_date
+  end
+
   def lastmod(source)
     path = Pathname('sources') + source[:file]
-    lm = `git log -1 --format="%ai" -- #{path}`.split.first
+    lm = ENV['EP_FULL_GIT'] ? local_git_lastmod(path) : github_lastmod(path)
+
     if source.key? :create
-      elapsed = (DateTime.now - Date.parse(lm)).to_i
+      elapsed = (DateTime.now - lm).to_i
       warn "  ☢  #{source[:file]} has not been updated for #{elapsed} days" if elapsed > 90
     end
     lm

--- a/rakefile_common.rb
+++ b/rakefile_common.rb
@@ -61,7 +61,8 @@ COUNTRY_META = Pathname.new('../meta.json')
 CLEAN.include(MERGED_CSV, MERGED_JSON, NAMES_CSV)
 
 # Files at project level
-POSITION_LEARNER = Pathname.new('../../../bin/learn_position.rb')
+PROJECT = Pathname.new('../../..')
+POSITION_LEARNER = PROJECT + 'bin/learn_position.rb'
 
 if RUBY_VERSION < '2.4'
   Hash.class_eval do


### PR DESCRIPTION
The everypolitician-bot works with a shallow clone of the repo, with no
history, so if it asks `git` for the last change time of a file, it will be
seconds ago. So make it so that we look up the date via the Github API
instead, unless EP_FULL_GIT is set in the environment.