### PR TITLE
Gracefully handle Octokit errors

### DIFF
--- a/rake_build/generate_stats.rb
+++ b/rake_build/generate_stats.rb
@@ -25,13 +25,18 @@ namespace :stats do
   def github_lastmod(file)
     lc = octokit.commits('everypolitician/everypolitician-data', path: datapath + file).first
     lc.commit.author.date.to_date
+  rescue Octokit::TooManyRequests
+    nil
+  rescue => e
+    warn e
+    nil
   end
 
   def lastmod(source)
     path = Pathname('sources') + source[:file]
     lm = ENV['EP_FULL_GIT'] ? local_git_lastmod(path) : github_lastmod(path)
 
-    if source.key? :create
+    if lm && source.key?(:create)
       elapsed = (DateTime.now - lm).to_i
       warn "  ☢  #{source[:file]} has not been updated for #{elapsed} days" if elapsed > 90
     end


### PR DESCRIPTION
The GitHub API is rate-limited, so if we hit too many requests, we should fail graceully.

Ideally we'll be able to authenticate, and get a much higher limit, but we should handle errors better anyway.