### PR TITLE
Use GITHUB_ACCESS_TOKEN when making API calls

### DIFF
--- a/rake_build/generate_stats.rb
+++ b/rake_build/generate_stats.rb
@@ -18,7 +18,13 @@ namespace :stats do
   end
 
   def octokit
-    @octokit ||= Octokit::Client.new
+    @octokit ||= Octokit::Client.new(access_token: github_access_token)
+  end
+
+  def github_access_token
+    @github_access_token ||= ENV.fetch('GITHUB_ACCESS_TOKEN')
+  rescue KeyError
+    abort 'Please set GITHUB_ACCESS_TOKEN in the environment before running'
   end
 
   def datapath


### PR DESCRIPTION
This lets us have 5000 requests per hour, compared to 60 per hour
if unathenticated:
  https://developer.github.com/v3/#rate-limiting

Heroku is already configured to have access to this, since 2016:
  https://github.com/everypolitician/rebuilder/pull/34