### PR TITLE
add the Wikidata Membership item id to meta.json

### DIFF
--- a/data/Afghanistan/Wolesi_Jirga/meta.json
+++ b/data/Afghanistan/Wolesi_Jirga/meta.json
@@ -3,5 +3,6 @@
   "seats": 249,
   "wikidata": "Q2108181",
   "uuid": "95d7cf9c-1250-45fa-975f-cf175d11dd5a",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q19853383"
 }

--- a/data/Albania/Assembly/meta.json
+++ b/data/Albania/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 140,
   "wikidata": "Q1135960",
   "uuid": "f328d977-3f59-4891-9a07-a5a7ace80e0c",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q20177772"
 }

--- a/data/Algeria/Majlis/meta.json
+++ b/data/Algeria/Majlis/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q633590",
   "seats": 462,
   "uuid": "3ce52a04-f9ee-4906-a800-0ddf71ce7b5a",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21290886"
 }

--- a/data/Andorra/General_Council/meta.json
+++ b/data/Andorra/General_Council/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q24824",
   "seats": 28,
   "uuid": "2cbf8397-a80d-40ef-8b64-b633a56468d7",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q20177831"
 }

--- a/data/Angola/National_Assembly/meta.json
+++ b/data/Angola/National_Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1969479",
   "seats": 220,
   "uuid": "5a0ab6f8-f39d-41e0-9892-ee0ba49c5d03",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q20179557"
 }

--- a/data/Angola/meta.json
+++ b/data/Angola/meta.json
@@ -2,5 +2,6 @@
   "id": "abd91e69-adf1-4489-b343-bd73406a2abe",
   "name": "Angola",
   "iso_code": "AO",
-  "wikidata": "Q916"
+  "wikidata": "Q916",
+  "cabinet": "Q5015488"
 }

--- a/data/Antigua_and_Barbuda/Representatives/meta.json
+++ b/data/Antigua_and_Barbuda/Representatives/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1266832",
   "seats": 19,
   "uuid": "02f06e68-acfc-4e2e-8e71-b6dc70e105fa",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21290853"
 }

--- a/data/Argentina/Diputados/meta.json
+++ b/data/Argentina/Diputados/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q629133",
   "seats": 257,
   "uuid": "5b5e0f3d-0f45-41ea-a8a9-8e5de20c3d11",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q18229570"
 }

--- a/data/Argentina/Senado/meta.json
+++ b/data/Argentina/Senado/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q2118303",
   "seats": 72,
   "uuid": "41634900-1289-4552-abfc-a4e347395b0e",
-  "type": "upper house"
+  "type": "upper house",
+  "member": "Q18711738"
 }

--- a/data/Armenia/Assembly/meta.json
+++ b/data/Armenia/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 131,
   "wikidata": "Q1337463",
   "uuid": "732f3cfe-3740-49df-bfb1-13c67424f3ac",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q17277248"
 }

--- a/data/Aruba/Estates/meta.json
+++ b/data/Aruba/Estates/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1283189",
   "seats": 21,
   "uuid": "415d6b70-98b1-49cb-98ad-17fedc97a816",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q52802973"
 }

--- a/data/Australia/Representatives/meta.json
+++ b/data/Australia/Representatives/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q783401",
   "seats": 150,
   "uuid": "2ab5a3aa-ef1e-46c0-abc9-dad161aa0390",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q18912794"
 }

--- a/data/Australia/Senate/meta.json
+++ b/data/Australia/Senate/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q783330",
   "seats": 76,
   "uuid": "e84f0da7-38e2-4ad3-b02a-6d5796ba90ad",
-  "type": "upper house"
+  "type": "upper house",
+  "member": "Q6814428"
 }

--- a/data/Austria/Nationalrat/meta.json
+++ b/data/Austria/Nationalrat/meta.json
@@ -3,5 +3,6 @@
   "seats": 183,
   "wikidata": "Q871363",
   "uuid": "332feca5-e411-4ea6-9c9f-e162170da8b7",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q17535155"
 }

--- a/data/Austria/meta.json
+++ b/data/Austria/meta.json
@@ -2,5 +2,6 @@
   "id": "215d697b-5e56-4e99-8ddb-b7b7078e8d8e",
   "name": "Austria",
   "iso_code": "AT",
-  "wikidata": "Q40"
+  "wikidata": "Q40",
+  "cabinet": "Q695599"
 }

--- a/data/Azerbaijan/National_Assembly/meta.json
+++ b/data/Azerbaijan/National_Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q330600",
   "seats": 125,
   "uuid": "a43e94bf-8bd4-4751-918e-26f746e4f562",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21269547"
 }

--- a/data/Bahamas/House_of_Assembly/meta.json
+++ b/data/Bahamas/House_of_Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 38,
   "wikidata": "Q2948139",
   "uuid": "e7203fe5-740b-44fc-9f5e-feee9f1dd5e3",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q17601986"
 }

--- a/data/Bahrain/Council_of_Representatives/meta.json
+++ b/data/Bahrain/Council_of_Representatives/meta.json
@@ -3,5 +3,6 @@
   "seats": 40,
   "wikidata": "Q4118178",
   "uuid": "68e8bbe5-0b13-4963-ab6f-0ea3b8d8d930",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21328582"
 }

--- a/data/Bangladesh/House/meta.json
+++ b/data/Bangladesh/House/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1684080",
   "seats": 350,
   "uuid": "a8da8135-339c-411f-95b8-bc2872597fc8",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q13058882"
 }

--- a/data/Barbados/House_of_Assembly/meta.json
+++ b/data/Barbados/House_of_Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q570619",
   "seats": 30,
   "uuid": "0b3ce1ea-3486-4435-bf38-248e4157bba6",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21296440"
 }

--- a/data/Belarus/Chamber/meta.json
+++ b/data/Belarus/Chamber/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1649622",
   "seats": 110,
   "uuid": "2be7ca8f-4489-4098-9493-e5c8a62e91fc",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q14335901"
 }

--- a/data/Belgium/Representatives/meta.json
+++ b/data/Belgium/Representatives/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1347545",
   "seats": 150,
   "uuid": "a013af0f-352e-4ca9-b17a-efa71edcc695",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q15705021"
 }

--- a/data/Belize/Representatives/meta.json
+++ b/data/Belize/Representatives/meta.json
@@ -3,5 +3,6 @@
   "seats": 31,
   "wikidata": "Q827805",
   "uuid": "60da1355-8aef-4599-9292-5f796f99eb2a",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21290854"
 }

--- a/data/Benin/National_Assembly/meta.json
+++ b/data/Benin/National_Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1969527",
   "seats": 83,
   "uuid": "77c18b7e-2b64-4402-a19d-26a71a7da48e",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21290849"
 }

--- a/data/Bermuda/Assembly/meta.json
+++ b/data/Bermuda/Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q5914694",
   "seats": 36,
   "uuid": "898e60f2-fb36-4c15-946d-d3c026e6316e",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q33487629"
 }

--- a/data/Bhutan/Assembly/meta.json
+++ b/data/Bhutan/Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q2579023",
   "seats": 47,
   "uuid": "e2932442-90a3-4bfe-a479-9855e3deb001",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21295972"
 }

--- a/data/Bolivia/Deputies/meta.json
+++ b/data/Bolivia/Deputies/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q20081431",
   "seats": 130,
   "uuid": "22b091f6-4031-4527-b7ea-b53e6f50b524",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q20081432"
 }

--- a/data/Bosnia_and_Herzegovina/House_of_Representatives/meta.json
+++ b/data/Bosnia_and_Herzegovina/House_of_Representatives/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q320268",
   "seats": 42,
   "uuid": "72d48234-3144-456e-89fd-5ec0b33513ac",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21290855"
 }

--- a/data/Botswana/Assembly/meta.json
+++ b/data/Botswana/Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q859658",
   "seats": 63,
   "uuid": "93d742c6-207c-44e3-80b8-4f04845cced3",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21290847"
 }

--- a/data/Brazil/Deputies/meta.json
+++ b/data/Brazil/Deputies/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1834804",
   "seats": 513,
   "uuid": "c5d9ea98-074a-4a11-9016-a5157e4aa51e",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q20058725"
 }

--- a/data/Brunei/Legislative_Council/meta.json
+++ b/data/Brunei/Legislative_Council/meta.json
@@ -3,5 +3,6 @@
   "seats": 36,
   "wikidata": "Q2396996",
   "uuid": "bb48685a-28e6-4215-95cd-6ac7f309fcb6",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328623"
 }

--- a/data/Bulgaria/National_Assembly/meta.json
+++ b/data/Bulgaria/National_Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 240,
   "wikidata": "Q639704",
   "uuid": "51d87586-83a3-4f2c-98ef-239a1556c01e",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q18924508"
 }

--- a/data/Burkina_Faso/Assembly/meta.json
+++ b/data/Burkina_Faso/Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q619238",
   "seats": 127,
   "uuid": "41a56fd3-f740-43a8-9464-b9bc6e45a17e",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q18339650"
 }

--- a/data/Burundi/Assembly/meta.json
+++ b/data/Burundi/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 118,
   "wikidata": "Q720003",
   "uuid": "c44a21e2-9af5-4da2-8696-f153906fad4d",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21295973"
 }

--- a/data/Cabo_Verde/Assembly/meta.json
+++ b/data/Cabo_Verde/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 72,
   "wikidata": "Q1718790",
   "uuid": "33b73eeb-ccb7-480a-87fa-d0728966d2b9",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21295976"
 }

--- a/data/Cambodia/National_Assembly/meta.json
+++ b/data/Cambodia/National_Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 123,
   "wikidata": "Q1234896",
   "uuid": "bf904834-04de-4b67-917a-325d5b202e48",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21295974"
 }

--- a/data/Cameroon/Assembly/meta.json
+++ b/data/Cameroon/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 180,
   "wikidata": "Q1634099",
   "uuid": "3dafd5fb-cc08-4ed1-9633-5e35053948fd",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21295975"
 }

--- a/data/Cameroon/Senate/meta.json
+++ b/data/Cameroon/Senate/meta.json
@@ -3,5 +3,6 @@
   "seats": 100,
   "wikidata": "Q3510836",
   "uuid": "eed761a0-3d01-4631-8141-e2a2edde2fb8",
-  "type": "upper house"
+  "type": "upper house",
+  "member": "Q21295128"
 }

--- a/data/Canada/Commons/meta.json
+++ b/data/Canada/Commons/meta.json
@@ -3,5 +3,6 @@
   "seats": 308,
   "wikidata": "Q383590",
   "uuid": "66326899-6dd4-432c-ae60-ca6375072785",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q15964890"
 }

--- a/data/Canada/Senate/meta.json
+++ b/data/Canada/Senate/meta.json
@@ -3,5 +3,6 @@
   "seats": 105,
   "wikidata": "Q841180",
   "uuid": "aa0787d3-5383-4638-a107-b5d0b2aac937",
-  "type": "upper house"
+  "type": "upper house",
+  "member": "Q18524027"
 }

--- a/data/Chad/Assembly/meta.json
+++ b/data/Chad/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 188,
   "wikidata": "Q1599346",
   "uuid": "6a08b966-6561-4115-a43e-3a5d0fa06b0a",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21295978"
 }

--- a/data/China/Congress/meta.json
+++ b/data/China/Congress/meta.json
@@ -3,5 +3,6 @@
   "seats": 2987,
   "wikidata": "Q19211",
   "uuid": "98f70a4e-ed84-4fa5-b6ee-a20a4b8538bc",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q10891456"
 }

--- a/data/Colombia/Representatives/meta.json
+++ b/data/Colombia/Representatives/meta.json
@@ -3,5 +3,6 @@
   "seats": 166,
   "wikidata": "Q1571756",
   "uuid": "b11bc579-09d0-49d9-b80c-7d64eaf36bf2",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q18960607"
 }

--- a/data/Colombia/Senate/meta.json
+++ b/data/Colombia/Senate/meta.json
@@ -3,5 +3,6 @@
   "seats": 102,
   "wikidata": "Q2398781",
   "uuid": "28acf131-c784-49b9-8e62-18fd5eaa93a0",
-  "type": "upper house"
+  "type": "upper house",
+  "member": "Q19254253"
 }

--- a/data/Comoros/Assembly/meta.json
+++ b/data/Comoros/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 33,
   "wikidata": "Q1573424",
   "uuid": "210ee61e-e9c8-448a-9d6e-6f139c158ff1",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328589"
 }

--- a/data/Congo-Brazzaville/Assembly/meta.json
+++ b/data/Congo-Brazzaville/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 153,
   "wikidata": "Q1969587",
   "uuid": "b0914a86-73e1-4120-bb5c-9008d635bc02",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21295980"
 }

--- a/data/Congo-Kinshasa/Assembly/meta.json
+++ b/data/Congo-Kinshasa/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 500,
   "wikidata": "Q1574334",
   "uuid": "627e8bc6-dc2e-4599-b795-05475769bf85",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21295979"
 }

--- a/data/Cook_Islands/Parliament/meta.json
+++ b/data/Cook_Islands/Parliament/meta.json
@@ -3,5 +3,6 @@
   "seats": 24,
   "wikidata": "Q7138950",
   "uuid": "a1a85685-7d9a-4b03-a581-720f77e13a38",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q19247218"
 }

--- a/data/Costa_Rica/Assembly/meta.json
+++ b/data/Costa_Rica/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 57,
   "wikidata": "Q1386962",
   "uuid": "b1b06472-29ef-4eb1-bed1-407f9e11e731",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328617"
 }

--- a/data/Croatia/Sabor/meta.json
+++ b/data/Croatia/Sabor/meta.json
@@ -3,5 +3,6 @@
   "seats": 151,
   "wikidata": "Q371576",
   "uuid": "ecec7a71-01ce-46db-af3b-f8ec9b956ca5",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q18643511"
 }

--- a/data/Curacao/Estates/meta.json
+++ b/data/Curacao/Estates/meta.json
@@ -3,5 +3,6 @@
   "seats": 21,
   "wikidata": "Q2326816",
   "uuid": "675643a3-f32d-4079-aa62-8f1994875445",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q28479658"
 }

--- a/data/Cyprus/House_of_Representatives/meta.json
+++ b/data/Cyprus/House_of_Representatives/meta.json
@@ -3,5 +3,6 @@
   "seats": 80,
   "wikidata": "Q1112381",
   "uuid": "94d3bc35-8e9a-434b-9062-416ec38582d3",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q19801674"
 }

--- a/data/Czech_Republic/Deputies/meta.json
+++ b/data/Czech_Republic/Deputies/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q320265",
   "seats": 200,
   "uuid": "8b61aee3-0001-4cec-91c1-946ef545ceb1",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q19803234"
 }

--- a/data/Denmark/Folketing/meta.json
+++ b/data/Denmark/Folketing/meta.json
@@ -3,5 +3,6 @@
   "seats": 179,
   "wikidata": "Q209151",
   "uuid": "4cacca66-8d6f-47f2-a5c4-eaf74fa80999",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q12311817"
 }

--- a/data/Djibouti/Assembly/meta.json
+++ b/data/Djibouti/Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1139363",
   "seats": 65,
   "uuid": "ea765c61-894e-47c3-ba02-148ba28a5386",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q19252823"
 }

--- a/data/Dominica/House_of_Assembly/meta.json
+++ b/data/Dominica/House_of_Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1297237",
   "seats": 31,
   "uuid": "1f67ca1f-eb15-4634-94cf-db63f34865be",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21296441"
 }

--- a/data/Dominican_Republic/Diputados/meta.json
+++ b/data/Dominican_Republic/Diputados/meta.json
@@ -3,5 +3,6 @@
   "seats": 190,
   "wikidata": "Q320280",
   "uuid": "b7c27877-0b17-4145-a87d-3bec5711864c",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21328590"
 }

--- a/data/Ecuador/Asamblea/meta.json
+++ b/data/Ecuador/Asamblea/meta.json
@@ -3,5 +3,6 @@
   "seats": 137,
   "wikidata": "Q1319595",
   "uuid": "9e0caec8-ba6c-4c1f-aa1f-fedb1ede6535",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21295982"
 }

--- a/data/El_Salvador/Legislative_Assembly/meta.json
+++ b/data/El_Salvador/Legislative_Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 84,
   "wikidata": "Q1812873",
   "uuid": "a8ab9a09-42fe-4444-a43f-e6c5ecc92365",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328618"
 }

--- a/data/Estonia/Riigikogu/meta.json
+++ b/data/Estonia/Riigikogu/meta.json
@@ -3,5 +3,6 @@
   "seats": 101,
   "wikidata": "Q217799",
   "uuid": "1ba661a9-22ad-4d0f-8a60-fe8e28f2488c",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21100241"
 }

--- a/data/Falkland_Islands/Assembly/meta.json
+++ b/data/Falkland_Islands/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 11,
   "wikidata": "Q3365321",
   "uuid": "07436402-48a2-42ba-93f2-b68fd1b8bbff",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q24232020"
 }

--- a/data/Fiji/Parliament/meta.json
+++ b/data/Fiji/Parliament/meta.json
@@ -3,5 +3,6 @@
   "seats": 50,
   "wikidata": "Q4345425",
   "uuid": "0185d125-915d-45bf-92f6-a8bd2b038853",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q18145348"
 }

--- a/data/Finland/Eduskunta/meta.json
+++ b/data/Finland/Eduskunta/meta.json
@@ -3,5 +3,6 @@
   "seats": 200,
   "wikidata": "Q643412",
   "uuid": "88d9bfa8-a8f8-4312-bfb9-a851657d3780",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q17592486"
 }

--- a/data/Gabon/Assembly/meta.json
+++ b/data/Gabon/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 121,
   "wikidata": "Q1969545",
   "uuid": "fa7595d4-6129-4bbd-95c7-51dc37ae8171",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q19798976"
 }

--- a/data/Gambia/National_Assembly/meta.json
+++ b/data/Gambia/National_Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1427127",
   "seats": 53,
   "uuid": "19871de8-5cf3-4011-8c60-5a8761c3e09e",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21295984"
 }

--- a/data/Georgia/Parliament/meta.json
+++ b/data/Georgia/Parliament/meta.json
@@ -3,5 +3,6 @@
   "seats": 150,
   "wikidata": "Q1417210",
   "uuid": "a2f5a173-89e1-4eae-99f1-b1626a6f272f",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21290878"
 }

--- a/data/Germany/Bundestag/meta.json
+++ b/data/Germany/Bundestag/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q154797",
   "seats": 620,
   "uuid": "4d0242b9-fc34-4341-b9b1-58f5d0cc523a",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q1939555"
 }

--- a/data/Ghana/Parliament/meta.json
+++ b/data/Ghana/Parliament/meta.json
@@ -3,5 +3,6 @@
   "seats": 228,
   "wikidata": "Q1807513",
   "uuid": "f971230c-76ef-4828-8889-0aba2f8f525e",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21290881"
 }

--- a/data/Greece/Parliament/meta.json
+++ b/data/Greece/Parliament/meta.json
@@ -3,5 +3,6 @@
   "seats": 300,
   "wikidata": "Q477089",
   "uuid": "022607c0-5226-487d-8057-862ae73442e6",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q18915989"
 }

--- a/data/Greece/meta.json
+++ b/data/Greece/meta.json
@@ -2,5 +2,6 @@
   "id": "ed3f913b-ba7b-4a39-9654-b8fdccb59b6b",
   "name": "Greece",
   "iso_code": "GR",
-  "wikidata": "Q41"
+  "wikidata": "Q41",
+  "cabinet": "Q16331915"
 }

--- a/data/Grenada/House_of_Representatives/meta.json
+++ b/data/Grenada/House_of_Representatives/meta.json
@@ -3,5 +3,6 @@
   "seats": 15,
   "wikidata": "Q1138354",
   "uuid": "9338f736-550a-4e3c-92ef-78ee1520c827",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21290858"
 }

--- a/data/Guatemala/Congress/meta.json
+++ b/data/Guatemala/Congress/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1136026",
   "seats": 158,
   "uuid": "d719b911-f7d9-4588-8889-1e208ed3e66b",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q18277108"
 }

--- a/data/Guernsey/States/meta.json
+++ b/data/Guernsey/States/meta.json
@@ -3,5 +3,6 @@
   "seats": 47,
   "wikidata": "Q1368324",
   "uuid": "b6f68cdb-75cb-44dd-8241-f388f630efde",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q34926331"
 }

--- a/data/Guinea-Bissau/Assembly/meta.json
+++ b/data/Guinea-Bissau/Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q740533",
   "seats": 102,
   "uuid": "da6d3e09-ae79-41a2-8ef1-0e3d73ba351a",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328631"
 }

--- a/data/Guyana/National_Assembly/meta.json
+++ b/data/Guyana/National_Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 65,
   "wikidata": "Q1512579",
   "uuid": "68aa4bab-2857-4923-8b30-2edb03513c9c",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q18654760"
 }

--- a/data/Haiti/Deputies/meta.json
+++ b/data/Haiti/Deputies/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q320287",
   "seats": 99,
   "uuid": "18bdd20a-4fbc-4238-bf27-d58ca1ec5ac5",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21328591"
 }

--- a/data/Honduras/Congreso_Nacional/meta.json
+++ b/data/Honduras/Congreso_Nacional/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1415847",
   "seats": 129,
   "uuid": "0795c876-b553-40eb-8036-f8371093e15a",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q19300340"
 }

--- a/data/Hong_Kong/Legislative_Council/meta.json
+++ b/data/Hong_Kong/Legislative_Council/meta.json
@@ -3,5 +3,6 @@
   "seats": 70,
   "wikidata": "Q19208",
   "uuid": "c974194b-cbc8-44ce-975b-16517fae33bf",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q27908372"
 }

--- a/data/Hungary/Assembly/meta.json
+++ b/data/Hungary/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 386,
   "wikidata": "Q648716",
   "uuid": "777902f1-4b1f-42ea-b15a-9f12cc4bb773",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q17590876"
 }

--- a/data/Iceland/Assembly/meta.json
+++ b/data/Iceland/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 63,
   "wikidata": "Q131279",
   "uuid": "9be7d6f7-8420-4a3a-a804-fb1a68e8f9ff",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21272959"
 }

--- a/data/India/Lok_Sabha/meta.json
+++ b/data/India/Lok_Sabha/meta.json
@@ -3,5 +3,6 @@
   "seats": 545,
   "wikidata": "Q230003",
   "uuid": "12bb4025-69d6-4fba-890a-98cbc398eba9",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q16556694"
 }

--- a/data/Indonesia/Council/meta.json
+++ b/data/Indonesia/Council/meta.json
@@ -3,5 +3,6 @@
   "seats": 560,
   "wikidata": "Q2670027",
   "uuid": "5be5da16-632e-432b-a328-c7eb83b57ac5",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21328632"
 }

--- a/data/Iran/Assembly/meta.json
+++ b/data/Iran/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 290,
   "wikidata": "Q378605",
   "uuid": "82453a9d-2cd3-4163-851c-77ef28ec79df",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q17525449"
 }

--- a/data/Iraq/Majlis/meta.json
+++ b/data/Iraq/Majlis/meta.json
@@ -3,5 +3,6 @@
   "seats": 328,
   "wikidata": "Q1973075",
   "uuid": "5f11b0cb-bd29-4037-b66a-414886c10bba",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328603"
 }

--- a/data/Ireland/Dail/meta.json
+++ b/data/Ireland/Dail/meta.json
@@ -3,5 +3,6 @@
   "seats": 166,
   "wikidata": "Q651981",
   "uuid": "7556a33d-0e3c-4da7-a96e-65bc11ff47af",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q654291"
 }

--- a/data/Isle_of_Man/House_of_Keys/meta.json
+++ b/data/Isle_of_Man/House_of_Keys/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1516957",
   "seats": 24,
   "uuid": "304628d1-197d-4ef3-9d04-13d331d6eab0",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q2734582"
 }

--- a/data/Israel/Knesset/meta.json
+++ b/data/Israel/Knesset/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q133396",
   "seats": 120,
   "uuid": "09a71976-8df2-446a-b020-288af06116d7",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q4047513"
 }

--- a/data/Italy/House/meta.json
+++ b/data/Italy/House/meta.json
@@ -3,5 +3,6 @@
   "seats": 630,
   "wikidata": "Q841424",
   "uuid": "d53eb3fc-834c-4ed3-a73c-c2056685e108",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q18558478"
 }

--- a/data/Ivory_Coast/Assembly/meta.json
+++ b/data/Ivory_Coast/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 255,
   "wikidata": "Q1573929",
   "uuid": "dee525cf-054c-479b-af13-54fafbd1ea1e",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21295981"
 }

--- a/data/Jamaica/House_of_Representatives/meta.json
+++ b/data/Jamaica/House_of_Representatives/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q20080342",
   "seats": 84,
   "uuid": "5a6d8ba9-87d5-4b06-b48f-11e336432261",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21290859"
 }

--- a/data/Japan/House_of_Representatives/meta.json
+++ b/data/Japan/House_of_Representatives/meta.json
@@ -3,5 +3,6 @@
   "seats": 475,
   "wikidata": "Q659587",
   "uuid": "a1be0473-97fb-4374-8ec1-5979e28df539",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q17506823"
 }

--- a/data/Jordan/House_of_Representatives/meta.json
+++ b/data/Jordan/House_of_Representatives/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q320304",
   "seats": 150,
   "uuid": "4f7d17ea-e78a-4220-9762-eb427dcf4ded",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q17524418"
 }

--- a/data/Jordan/meta.json
+++ b/data/Jordan/meta.json
@@ -2,5 +2,6 @@
   "id": "0d4da61a-aa6d-4755-a61a-3ecff8d81be1",
   "name": "Jordan",
   "iso_code": "JO",
-  "wikidata": "Q810"
+  "wikidata": "Q810",
+  "cabinet": "Q5015522"
 }

--- a/data/Kazakhstan/Assembly/meta.json
+++ b/data/Kazakhstan/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 77,
   "wikidata": "Q1247199",
   "uuid": "fbc80d9c-86e7-4711-b4fe-f68de28af710",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21328574"
 }

--- a/data/Kenya/Assembly/meta.json
+++ b/data/Kenya/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 349,
   "wikidata": "Q1701225",
   "uuid": "574eff8e-8171-4f2b-8279-60ed8dec1a2a",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q17510786"
 }

--- a/data/Kiribati/Parliament/meta.json
+++ b/data/Kiribati/Parliament/meta.json
@@ -3,5 +3,6 @@
   "seats": 46,
   "wikidata": "Q1281107",
   "uuid": "78e913e8-5a95-44c6-a401-bf6ab80c4369",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21296447"
 }

--- a/data/Kosovo/Assembly/meta.json
+++ b/data/Kosovo/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 120,
   "wikidata": "Q1246562",
   "uuid": "c70b06ce-c00d-4e28-adf5-a00c1a1434a5",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q22262242"
 }

--- a/data/Kuwait/National_Assembly/meta.json
+++ b/data/Kuwait/National_Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 50,
   "wikidata": "Q1139228",
   "uuid": "31e69039-2f8d-4b9b-9748-f707e0e26e13",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21295986"
 }

--- a/data/Kyrgyzstan/Council/meta.json
+++ b/data/Kyrgyzstan/Council/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q578193",
   "seats": 120,
   "uuid": "b1f61e15-4b07-45e8-9d90-a3200b597751",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21091853"
 }

--- a/data/Laos/Assembly/meta.json
+++ b/data/Laos/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 132,
   "wikidata": "Q1188525",
   "uuid": "96ce70d2-b013-44ca-b5ed-b32cc62b8d9a",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21295987"
 }

--- a/data/Latvia/Saeima/meta.json
+++ b/data/Latvia/Saeima/meta.json
@@ -3,5 +3,6 @@
   "seats": 100,
   "wikidata": "Q822919",
   "uuid": "6643a93b-016c-4b1b-a2fc-35a9eea3c857",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21191589"
 }

--- a/data/Lebanon/Parliament/meta.json
+++ b/data/Lebanon/Parliament/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1422275",
   "seats": 128,
   "uuid": "a040172c-f708-4c42-a421-1e569bd158f3",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328581"
 }

--- a/data/Lesotho/Assembly/meta.json
+++ b/data/Lesotho/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 120,
   "wikidata": "Q1138713",
   "uuid": "fec02388-0c3d-4df8-802f-738125cdcccc",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21295988"
 }

--- a/data/Liberia/House/meta.json
+++ b/data/Liberia/House/meta.json
@@ -3,5 +3,6 @@
   "seats": 73,
   "wikidata": "Q1137584",
   "uuid": "5803ba28-bbd2-4e28-8566-171533b27b44",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21290860"
 }

--- a/data/Libya/House_of_Representatives/meta.json
+++ b/data/Libya/House_of_Representatives/meta.json
@@ -3,5 +3,6 @@
   "seats": 200,
   "wikidata": "Q17443556",
   "uuid": "e2ada220-cc45-40cf-b4ca-f5b9612e5adc",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328602"
 }

--- a/data/Liechtenstein/Landtag/meta.json
+++ b/data/Liechtenstein/Landtag/meta.json
@@ -3,5 +3,6 @@
   "seats": 25,
   "wikidata": "Q1149644",
   "uuid": "841153dd-50d7-4c7c-a2ca-46d1219a1b6a",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328607"
 }

--- a/data/Lithuania/Seimas/meta.json
+++ b/data/Lithuania/Seimas/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q374152",
   "seats": 141,
   "uuid": "6bbde962-f014-4c7d-b988-10a442342a7c",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q18507240"
 }

--- a/data/Luxembourg/Chamber/meta.json
+++ b/data/Luxembourg/Chamber/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q517449",
   "seats": 60,
   "uuid": "4bfa781e-4011-44f9-bee1-f6dcc6c8047d",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328592"
 }

--- a/data/Macao/Assembly/meta.json
+++ b/data/Macao/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 33,
   "wikidata": "Q550133",
   "uuid": "b5728318-17c2-47f7-ad09-feb871e408c6",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q28941940"
 }

--- a/data/Macedonia/Sobranie/meta.json
+++ b/data/Macedonia/Sobranie/meta.json
@@ -3,5 +3,6 @@
   "seats": 123,
   "wikidata": "Q1258164",
   "uuid": "ee8b4345-b39d-46e3-accc-af93caae2abd",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q20015949"
 }

--- a/data/Madagascar/Assembly/meta.json
+++ b/data/Madagascar/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 160,
   "wikidata": "Q1141206",
   "uuid": "c760e66c-88d9-42e1-a750-7b559882d49a",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21295989"
 }

--- a/data/Malawi/Assembly/meta.json
+++ b/data/Malawi/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 194,
   "wikidata": "Q1577811",
   "uuid": "806f3bee-5b26-4afd-b6ab-b5ca21e68477",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21295990"
 }

--- a/data/Malaysia/Dewan_Rakyat/meta.json
+++ b/data/Malaysia/Dewan_Rakyat/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1207092",
   "seats": 222,
   "uuid": "c13fc044-0bd4-4fb2-8f45-685f331e621a",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21290861"
 }

--- a/data/Maldives/Majlis/meta.json
+++ b/data/Maldives/Majlis/meta.json
@@ -3,5 +3,6 @@
   "seats": 85,
   "wikidata": "Q650066",
   "uuid": "55a3d4c2-12ef-49b2-a086-0e6b7c09b3d1",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328575"
 }

--- a/data/Mali/Assembly/meta.json
+++ b/data/Mali/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 160,
   "wikidata": "Q1138071",
   "uuid": "9b081a0d-e662-4f7c-b58b-0f20f0bb0700",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21295991"
 }

--- a/data/Malta/Assembly/meta.json
+++ b/data/Malta/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 69,
   "wikidata": "Q1817866",
   "uuid": "88a5ca33-f857-4634-81d7-38f97d81826e",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q19367406"
 }

--- a/data/Marshall_Islands/Nitijela/meta.json
+++ b/data/Marshall_Islands/Nitijela/meta.json
@@ -3,5 +3,6 @@
   "seats": 33,
   "wikidata": "Q1280186",
   "uuid": "ade1dce6-24c1-43e8-8e00-780367ddcdee",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328624"
 }

--- a/data/Mauritania/National_Assembly/meta.json
+++ b/data/Mauritania/National_Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 81,
   "wikidata": "Q1138935",
   "uuid": "beee2f1c-4697-4c8c-a0cd-782ad524ef42",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21295992"
 }

--- a/data/Mauritius/National_Assembly/meta.json
+++ b/data/Mauritius/National_Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1854129",
   "seats": 62,
   "uuid": "948ad600-51a8-4da3-9039-4b8883581b20",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21295993"
 }

--- a/data/Mexico/Deputies/meta.json
+++ b/data/Mexico/Deputies/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q3014316",
   "seats": 500,
   "uuid": "4ed355ff-3f76-43ce-aa10-8b6e82a16068",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q18534310"
 }

--- a/data/Micronesia/Congress/meta.json
+++ b/data/Micronesia/Congress/meta.json
@@ -3,5 +3,6 @@
   "seats": 14,
   "wikidata": "Q1287548",
   "uuid": "d4d958ee-62fa-442b-be37-6adefd8d59a2",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328596"
 }

--- a/data/Moldova/Parlamentul/meta.json
+++ b/data/Moldova/Parlamentul/meta.json
@@ -3,5 +3,6 @@
   "seats": 101,
   "wikidata": "Q555809",
   "uuid": "cb459823-f905-4d88-a0cb-c420eb796e33",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q18390049"
 }

--- a/data/Monaco/Council/meta.json
+++ b/data/Monaco/Council/meta.json
@@ -3,5 +3,6 @@
   "seats": 24,
   "wikidata": "Q1127198",
   "uuid": "0fc887d9-c8ef-49ef-80d0-81fef3dbbc85",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328626"
 }

--- a/data/Mongolia/Assembly/meta.json
+++ b/data/Mongolia/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 76,
   "wikidata": "Q1544714",
   "uuid": "8f116a9e-8a59-4f88-9a0f-395c53a87a23",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328637"
 }

--- a/data/Montenegro/Assembly/meta.json
+++ b/data/Montenegro/Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1579497",
   "seats": 81,
   "uuid": "3314d9ac-a9c0-4c6b-a715-4a972ccdd703",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328576"
 }

--- a/data/Morocco/House/meta.json
+++ b/data/Morocco/House/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1572773",
   "seats": 395,
   "uuid": "f3847dfb-5f61-47e0-8ba8-feb3f505a23e",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21328583"
 }

--- a/data/Mozambique/Assembly/meta.json
+++ b/data/Mozambique/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 250,
   "wikidata": "Q1848595",
   "uuid": "fe0c8100-e250-4d7f-a79f-06c832daba21",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q19953712"
 }

--- a/data/Myanmar/House_of_Representatives/meta.json
+++ b/data/Myanmar/House_of_Representatives/meta.json
@@ -3,5 +3,6 @@
   "seats": 440,
   "wikidata": "Q3379823",
   "uuid": "a467f432-1bb0-4dbf-a5e3-fa4024b74cbc",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21290856"
 }

--- a/data/Namibia/Assembly/meta.json
+++ b/data/Namibia/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 78,
   "wikidata": "Q1769673",
   "uuid": "2262ff14-5cd0-460b-9010-edc5ad3cc246",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21295994"
 }

--- a/data/Namibia/Council/meta.json
+++ b/data/Namibia/Council/meta.json
@@ -3,5 +3,6 @@
   "seats": 26,
   "wikidata": "Q1969272",
   "uuid": "bbb157b0-f8cc-40ee-b789-ea563a98c39f",
-  "type": "upper house"
+  "type": "upper house",
+  "member": "Q21328627"
 }

--- a/data/Nauru/Parliament/meta.json
+++ b/data/Nauru/Parliament/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1972029",
   "seats": 19,
   "uuid": "ac665e38-1444-4a44-93d1-744914968c5f",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21290882"
 }

--- a/data/Nepal/Assembly/meta.json
+++ b/data/Nepal/Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q16057514",
   "seats": 601,
   "uuid": "e77bf6a4-863e-4c3e-ba95-61ae2ca158fa",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328597"
 }

--- a/data/Netherlands/House_of_Representatives/meta.json
+++ b/data/Netherlands/House_of_Representatives/meta.json
@@ -3,5 +3,6 @@
   "seats": 150,
   "wikidata": "Q233262",
   "uuid": "4056556b-bc6a-498c-8410-0757553b5f52",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q18887908"
 }

--- a/data/Netherlands/meta.json
+++ b/data/Netherlands/meta.json
@@ -2,5 +2,6 @@
   "id": "cc721f93-7d08-44f7-bf2a-ae66b18d249f",
   "name": "Netherlands",
   "iso_code": "NL",
-  "wikidata": "Q55"
+  "wikidata": "Q29999",
+  "cabinet": "Q245709"
 }

--- a/data/Nicaragua/Asamblea/meta.json
+++ b/data/Nicaragua/Asamblea/meta.json
@@ -3,5 +3,6 @@
   "seats": 92,
   "wikidata": "Q1969591",
   "uuid": "18f800ca-400a-4ca8-bc8c-68c877eadbe7",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q18616113"
 }

--- a/data/Niger/Assembly/meta.json
+++ b/data/Niger/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 113,
   "wikidata": "Q1969585",
   "uuid": "b47530ab-a4cb-441e-8452-408015864eb5",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21295995"
 }

--- a/data/Nigeria/Representatives/meta.json
+++ b/data/Nigeria/Representatives/meta.json
@@ -3,5 +3,6 @@
   "seats": 360,
   "wikidata": "Q665693",
   "uuid": "7cbd22c6-4df6-42f8-b7c0-44b715b88153",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21290864"
 }

--- a/data/Nigeria/Senate/meta.json
+++ b/data/Nigeria/Senate/meta.json
@@ -3,5 +3,6 @@
   "seats": 109,
   "uuid": "10da9af5-426a-4857-9ae5-54c594e5f877",
   "wikidata": "Q2993611",
-  "type": "upper house"
+  "type": "upper house",
+  "member": "Q19822359"
 }

--- a/data/Niue/Assembly/meta.json
+++ b/data/Niue/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 20,
   "wikidata": "Q1643140",
   "uuid": "93dd3ef7-1c31-4baf-a273-340214ddd651",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q40011889"
 }

--- a/data/North_Korea/National_Assembly/meta.json
+++ b/data/North_Korea/National_Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 687,
   "wikidata": "Q714698",
   "uuid": "ba8804a8-1c70-4245-9534-409151b88474",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328639"
 }

--- a/data/Northern_Cyprus/Assembly/meta.json
+++ b/data/Northern_Cyprus/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 50,
   "wikidata": "Q1515950",
   "uuid": "fdd61ead-e65e-43e0-b9db-2b01ffd37b58",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q34927065"
 }

--- a/data/Northern_Ireland/Assembly/meta.json
+++ b/data/Northern_Ireland/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 108,
   "wikidata": "Q285714",
   "uuid": "f38cd15e-d461-47a1-8370-c294d1e233b5",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q3272410"
 }

--- a/data/Norway/Storting/meta.json
+++ b/data/Norway/Storting/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q109016",
   "seats": 169,
   "uuid": "b383457f-4845-4cfe-82ef-1746ae994ce0",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q9045502"
 }

--- a/data/Oman/Majlis/meta.json
+++ b/data/Oman/Majlis/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q818704",
   "seats": 84,
   "uuid": "d92c9805-900c-4270-8dd2-17ef1b866754",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21328587"
 }

--- a/data/Pakistan/Assembly/meta.json
+++ b/data/Pakistan/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 336,
   "wikidata": "Q1518223",
   "uuid": "65caa270-16bc-435c-ac92-e04751e26884",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q20760546"
 }

--- a/data/Palau/House_of_Delegates/meta.json
+++ b/data/Palau/House_of_Delegates/meta.json
@@ -3,5 +3,6 @@
   "seats": 16,
   "wikidata": "Q2118228",
   "uuid": "f341a566-ce17-4a76-b3d0-3e708ef9fc4d",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21328610"
 }

--- a/data/Panama/Assembly/meta.json
+++ b/data/Panama/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 71,
   "wikidata": "Q1368588",
   "uuid": "8946fbd5-f635-42d0-b43a-47b426fe0135",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21295996"
 }

--- a/data/Papua_New_Guinea/Parliament/meta.json
+++ b/data/Papua_New_Guinea/Parliament/meta.json
@@ -3,5 +3,6 @@
   "seats": 109,
   "wikidata": "Q24563",
   "uuid": "577fcc83-d248-4f1c-bac9-41ddb90293ff",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21294916"
 }

--- a/data/Paraguay/Deputies/meta.json
+++ b/data/Paraguay/Deputies/meta.json
@@ -3,5 +3,6 @@
   "seats": 80,
   "wikidata": "Q320290",
   "uuid": "56faf65e-f6cd-43cc-8d6d-299c1f5aa7ac",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q20058561"
 }

--- a/data/Peru/Congreso/meta.json
+++ b/data/Peru/Congreso/meta.json
@@ -3,5 +3,6 @@
   "seats": 130,
   "wikidata": "Q1357543",
   "uuid": "31b88399-5b9e-4b50-9518-43ecfe65be2f",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q18812470"
 }

--- a/data/Philippines/House/meta.json
+++ b/data/Philippines/House/meta.json
@@ -3,5 +3,6 @@
   "seats": 292,
   "wikidata": "Q678545",
   "uuid": "02e84be8-6151-4224-90bf-94d1317da396",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q18002923"
 }

--- a/data/Poland/Sejm/meta.json
+++ b/data/Poland/Sejm/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q98964",
   "seats": 460,
   "uuid": "c04d7640-3d85-4845-ad97-54929aa1908b",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q19269361"
 }

--- a/data/Portugal/Assembly/meta.json
+++ b/data/Portugal/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 230,
   "wikidata": "Q740564",
   "uuid": "a1b77ad6-aa9a-4f60-b722-ec544ecf4cea",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q19953703"
 }

--- a/data/Romania/Deputies/meta.json
+++ b/data/Romania/Deputies/meta.json
@@ -3,5 +3,6 @@
   "seats": 412,
   "wikidata": "Q320306",
   "uuid": "e9f403b8-1aa9-47c7-94d7-f0a5f6edb74b",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q17556530"
 }

--- a/data/Russia/Duma/meta.json
+++ b/data/Russia/Duma/meta.json
@@ -3,5 +3,6 @@
   "seats": 450,
   "wikidata": "Q715641",
   "uuid": "2b944f3a-ffc1-4cd0-a96b-9699b20bb38e",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q17276321"
 }

--- a/data/Rwanda/Deputies/meta.json
+++ b/data/Rwanda/Deputies/meta.json
@@ -3,5 +3,6 @@
   "seats": 80,
   "wikidata": "Q320292",
   "uuid": "3a6ab8b0-634f-4721-b8e0-0d6e521ea855",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21328594"
 }

--- a/data/Saint_Kitts_and_Nevis/Assembly/meta.json
+++ b/data/Saint_Kitts_and_Nevis/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 15,
   "wikidata": "Q654504",
   "uuid": "7a139477-56c2-4826-8fac-aaddb3c863e4",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21295997"
 }

--- a/data/Saint_Lucia/Assembly/meta.json
+++ b/data/Saint_Lucia/Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1282775",
   "seats": 18,
   "uuid": "71f00d4b-5a10-4759-b679-57a45609bac5",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21296449"
 }

--- a/data/Saint_Pierre_and_Miquelon/Territorial_Council/meta.json
+++ b/data/Saint_Pierre_and_Miquelon/Territorial_Council/meta.json
@@ -3,5 +3,6 @@
   "seats": 19,
   "wikidata": "Q2994335",
   "uuid": "5883e5b5-f5e8-4f76-a6eb-ac01aa3daefc",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q29110604"
 }

--- a/data/Saint_Vincent_and_the_Grenadines/Assembly/meta.json
+++ b/data/Saint_Vincent_and_the_Grenadines/Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1138357",
   "seats": 21,
   "uuid": "93d8c111-f7c6-4415-836c-1c4bcd795a1e",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21296452"
 }

--- a/data/Samoa/Parliament/meta.json
+++ b/data/Samoa/Parliament/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1269555",
   "seats": 49,
   "uuid": "61144f35-c484-46e3-8630-6c9e512923ff",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328619"
 }

--- a/data/San_Marino/Council/meta.json
+++ b/data/San_Marino/Council/meta.json
@@ -3,5 +3,6 @@
   "seats": 60,
   "wikidata": "Q817979",
   "uuid": "d2b74f02-b177-4f20-aa57-e3e44e0c4d92",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q20968670"
 }

--- a/data/Saudi_Arabia/Shura/meta.json
+++ b/data/Saudi_Arabia/Shura/meta.json
@@ -3,5 +3,6 @@
   "seats": 150,
   "wikidata": "Q818708",
   "uuid": "562b3352-9ab8-496b-b57c-f85f48b9c21a",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328601"
 }

--- a/data/Scotland/Parliament/meta.json
+++ b/data/Scotland/Parliament/meta.json
@@ -3,5 +3,6 @@
   "seats": 129,
   "wikidata": "Q206171",
   "uuid": "adbf5a88-3c23-4fa5-9d4c-377ab8f1fa81",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q1711695"
 }

--- a/data/Senegal/Assembly/meta.json
+++ b/data/Senegal/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 150,
   "wikidata": "Q1853640",
   "uuid": "3a434982-3a0c-4fc2-8826-c8335892885b",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q20757571"
 }

--- a/data/Serbia/National_Assembly/meta.json
+++ b/data/Serbia/National_Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 250,
   "wikidata": "Q920222",
   "uuid": "bcabb5c4-6ac3-4704-b57e-cdc33c1ddc05",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21295999"
 }

--- a/data/Seychelles/Assembly/meta.json
+++ b/data/Seychelles/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 31,
   "wikidata": "Q676484",
   "uuid": "b4e819b9-ec55-43bc-8d79-61fa3ff6bfc4",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21296000"
 }

--- a/data/Sierra_Leone/Parliament/meta.json
+++ b/data/Sierra_Leone/Parliament/meta.json
@@ -3,5 +3,6 @@
   "seats": 124,
   "wikidata": "Q1138130",
   "uuid": "8fe9a7c5-b90f-473a-bcfd-e7590b6dcda5",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q19694740"
 }

--- a/data/Singapore/Parliament/meta.json
+++ b/data/Singapore/Parliament/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1517231",
   "seats": 99,
   "uuid": "5f27a768-1cb5-410b-8f3e-abf76b7ee07e",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21294917"
 }

--- a/data/Slovakia/National_Council/meta.json
+++ b/data/Slovakia/National_Council/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1139204",
   "seats": 150,
   "uuid": "31622b07-7f1b-4639-8cb7-adc8dc6faa49",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q19967563"
 }

--- a/data/Slovenia/National_Assembly/meta.json
+++ b/data/Slovenia/National_Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 90,
   "wikidata": "Q1568676",
   "uuid": "318b4a81-c7a3-4d6c-a3ce-80e08345d86e",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21296001"
 }

--- a/data/Solomon_Islands/Parliament/meta.json
+++ b/data/Solomon_Islands/Parliament/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q727851",
   "seats": 50,
   "uuid": "95ee1a0f-d480-498d-9de5-a4d03108d83c",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q17633943"
 }

--- a/data/Somalia/Lower/meta.json
+++ b/data/Somalia/Lower/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q21078126",
   "seats": 275,
   "uuid": "89f7566b-a147-42b5-bcad-d8642da1a675",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21328615"
 }

--- a/data/Somaliland/Representatives/meta.json
+++ b/data/Somaliland/Representatives/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q16965447",
   "seats": 82,
   "uuid": "f2622e80-b9c6-48e7-8efb-0e278e6c6444",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q28941952"
 }

--- a/data/South_Africa/Assembly/meta.json
+++ b/data/South_Africa/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 400,
   "wikidata": "Q240823",
   "uuid": "a36b27d7-5cb0-49f9-bba3-8e0b68bfdcbd",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q16744266"
 }

--- a/data/South_Korea/National_Assembly/meta.json
+++ b/data/South_Korea/National_Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 300,
   "wikidata": "Q494162",
   "uuid": "eb645257-3387-42ac-9cc1-d6379eff8ca2",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q14850694"
 }

--- a/data/South_Sudan/Assembly/meta.json
+++ b/data/South_Sudan/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 170,
   "wikidata": "Q1968103",
   "uuid": "50d0c1f9-7153-41d8-be8c-a646f4b66764",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21328629"
 }

--- a/data/Spain/Congress/meta.json
+++ b/data/Spain/Congress/meta.json
@@ -3,5 +3,6 @@
   "seats": 350,
   "wikidata": "Q539149",
   "uuid": "a0ade8ef-8127-47eb-8cb5-9403d5dbeb4c",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q18171345"
 }

--- a/data/Sri_Lanka/Parliament/meta.json
+++ b/data/Sri_Lanka/Parliament/meta.json
@@ -3,5 +3,6 @@
   "seats": 225,
   "wikidata": "Q1450753",
   "uuid": "ca251504-0fe1-46f5-b838-d5ec76359a47",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q18964938"
 }

--- a/data/Suriname/Assembly/meta.json
+++ b/data/Suriname/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 51,
   "wikidata": "Q1760847",
   "uuid": "2f191010-34fe-4273-95f4-9d5b300feb28",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q17268790"
 }

--- a/data/Swaziland/Assembly/meta.json
+++ b/data/Swaziland/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 55,
   "wikidata": "Q5914707",
   "uuid": "33273a3e-36c6-4ced-8e58-862913a4335e",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21296436"
 }

--- a/data/Sweden/Riksdag/meta.json
+++ b/data/Sweden/Riksdag/meta.json
@@ -3,5 +3,6 @@
   "seats": 349,
   "wikidata": "Q272930",
   "uuid": "984f0a80-7942-4438-948e-6094b55f65ce",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q10655178"
 }

--- a/data/Switzerland/National_Council/meta.json
+++ b/data/Switzerland/National_Council/meta.json
@@ -3,5 +3,6 @@
   "seats": 200,
   "wikidata": "Q676078",
   "uuid": "8f4f13a5-bf1b-4999-a86a-9318f3ca7606",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q18510612"
 }

--- a/data/Syria/Majlis/meta.json
+++ b/data/Syria/Majlis/meta.json
@@ -3,5 +3,6 @@
   "seats": 250,
   "wikidata": "Q1372196",
   "uuid": "38d3ebeb-ed76-41c6-8b30-5ad9900f8f21",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q20489786"
 }

--- a/data/Taiwan/Legislative_Yuan/meta.json
+++ b/data/Taiwan/Legislative_Yuan/meta.json
@@ -3,5 +3,6 @@
   "seats": 113,
   "wikidata": "Q715869",
   "uuid": "e1fef832-4c78-497c-ad3a-6a8df1fef861",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q6310593"
 }

--- a/data/Tajikistan/Representatives/meta.json
+++ b/data/Tajikistan/Representatives/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q9390763",
   "seats": 63,
   "uuid": "690a9c82-c02e-477d-9128-a9c67cbca09b",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21328584"
 }

--- a/data/Tanzania/Assembly/meta.json
+++ b/data/Tanzania/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 357,
   "wikidata": "Q1138299",
   "uuid": "0a742811-0f27-4d3c-b69e-099c4f821b7b",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q17599130"
 }

--- a/data/Timor_Leste/Parlamento/meta.json
+++ b/data/Timor_Leste/Parlamento/meta.json
@@ -3,5 +3,6 @@
   "seats": 65,
   "wikidata": "Q680806",
   "uuid": "0f00ed19-6f37-4fd6-ad8f-289326d77663",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q19966812"
 }

--- a/data/Togo/Assembly/meta.json
+++ b/data/Togo/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 91,
   "wikidata": "Q1969578",
   "uuid": "988ba314-0b40-461b-bbd8-8f23acd27099",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21296004"
 }

--- a/data/Tonga/Assembly/meta.json
+++ b/data/Tonga/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 26,
   "wikidata": "Q1287831",
   "uuid": "b8ba010c-a6c6-4b93-b97f-df2c7f4112ba",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328621"
 }

--- a/data/Transnistria/Supreme_Council/meta.json
+++ b/data/Transnistria/Supreme_Council/meta.json
@@ -3,5 +3,6 @@
   "seats": 43,
   "wikidata": "Q2656777",
   "uuid": "85818632-502f-4e63-ad5e-74073936b289",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q34925040"
 }

--- a/data/Trinidad_and_Tobago/Representatives/meta.json
+++ b/data/Trinidad_and_Tobago/Representatives/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q2145199",
   "seats": 41,
   "uuid": "fe0aaad9-a550-467f-9315-f556a393f4fa",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q18719159"
 }

--- a/data/Trinidad_and_Tobago/Senate/meta.json
+++ b/data/Trinidad_and_Tobago/Senate/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q3510869",
   "seats": 31,
   "uuid": "537f7464-0bf8-458d-8282-f087f73f6d79",
-  "type": "upper house"
+  "type": "upper house",
+  "member": "Q19319420"
 }

--- a/data/Tunisia/Majlis/meta.json
+++ b/data/Tunisia/Majlis/meta.json
@@ -3,5 +3,6 @@
   "seats": 217,
   "wikidata": "Q18342090",
   "uuid": "2248fcda-00c5-4c70-a4c3-5c7927bf1c8e",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q29169698"
 }

--- a/data/Turkey/Assembly/meta.json
+++ b/data/Turkey/Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q274918",
   "seats": 550,
   "uuid": "83911419-04ab-4add-a687-93a4e8845296",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21030356"
 }

--- a/data/Turkmenistan/Mejlis/meta.json
+++ b/data/Turkmenistan/Mejlis/meta.json
@@ -3,5 +3,6 @@
   "seats": 125,
   "wikidata": "Q630145",
   "uuid": "2836b8cd-4775-40fb-bb79-1363c8f23254",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328577"
 }

--- a/data/Tuvalu/Parliament/meta.json
+++ b/data/Tuvalu/Parliament/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q897278",
   "seats": 15,
   "uuid": "153fea0b-2fd9-4947-8cde-0ed2db820827",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21294919"
 }

--- a/data/UK/Commons/meta.json
+++ b/data/UK/Commons/meta.json
@@ -3,5 +3,6 @@
   "seats": 650,
   "wikidata": "Q11005",
   "uuid": "8bbf6031-aa59-4b0a-80b2-1cdc81e4047d",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q16707842"
 }

--- a/data/US_Virgin_Islands/Legislature/meta.json
+++ b/data/US_Virgin_Islands/Legislature/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q6518465",
   "seats": 15,
   "uuid": "ea67f9ea-68f6-4afd-95db-a9aef56efc0c",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q20846080"
 }

--- a/data/Uganda/Parliament/meta.json
+++ b/data/Uganda/Parliament/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q2052850",
   "seats": 385,
   "uuid": "c0450875-2933-4737-b774-d03e0ffa61ec",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21296005"
 }

--- a/data/Ukraine/Verkhovna_Rada/meta.json
+++ b/data/Ukraine/Verkhovna_Rada/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q176296",
   "seats": 450,
   "uuid": "b5c89217-0658-4ede-9968-852d36d31866",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q12132454"
 }

--- a/data/United_Arab_Emirates/Federal_National_Council/meta.json
+++ b/data/United_Arab_Emirates/Federal_National_Council/meta.json
@@ -3,5 +3,6 @@
   "seats": 40,
   "wikidata": "Q1479761",
   "uuid": "8dcd2391-4d51-4d21-a348-37b45f8a223a",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328608"
 }

--- a/data/United_States_of_America/Senate/meta.json
+++ b/data/United_States_of_America/Senate/meta.json
@@ -3,5 +3,6 @@
   "seats": 100,
   "wikidata": "Q66096",
   "uuid": "8fa6c3d2-71dc-4788-b9f8-4ca70d5a7d85",
-  "type": "upper house"
+  "type": "upper house",
+  "member": "Q13217683"
 }

--- a/data/Uruguay/Deputies/meta.json
+++ b/data/Uruguay/Deputies/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q320303",
   "seats": 99,
   "uuid": "1f8d1d06-4b31-4afd-86c5-80de2638b93c",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q19930720"
 }

--- a/data/Uzbekistan/Legislative_Chamber/meta.json
+++ b/data/Uzbekistan/Legislative_Chamber/meta.json
@@ -3,5 +3,6 @@
   "seats": 150,
   "wikidata": "Q6518225",
   "uuid": "f5d9e203-2917-4120-88a6-938a9b2c4b46",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21328622"
 }

--- a/data/Vanuatu/Parliament/meta.json
+++ b/data/Vanuatu/Parliament/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q764201",
   "seats": 33,
   "uuid": "76b3861e-919b-4110-bd8b-b178b350b0d7",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21294920"
 }

--- a/data/Vatican_City/Pontifical_Commission/meta.json
+++ b/data/Vatican_City/Pontifical_Commission/meta.json
@@ -3,5 +3,6 @@
   "seats": 7,
   "wikidata": "Q7478146",
   "uuid": "3d569fe9-6f9f-454d-b799-eec3d1a95d1f",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21328634"
 }

--- a/data/Venezuela/Assembly/meta.json
+++ b/data/Venezuela/Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1585014",
   "seats": 163,
   "uuid": "1ece6348-141e-4df5-a7f2-1b24fccaf41d",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q20011182"
 }

--- a/data/Vietnam/National_Assembly/meta.json
+++ b/data/Vietnam/National_Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 500,
   "wikidata": "Q1765001",
   "uuid": "d201cd06-340c-4f72-a23f-8eca816bff46",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q17593571"
 }

--- a/data/Wales/Assembly/meta.json
+++ b/data/Wales/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 60,
   "wikidata": "Q493517",
   "uuid": "6d1dfea8-f6a3-4873-a8e1-d906ca8ab578",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q3406079"
 }

--- a/data/Yemen/Majlis/meta.json
+++ b/data/Yemen/Majlis/meta.json
@@ -3,5 +3,6 @@
   "seats": 301,
   "wikidata": "Q1484102",
   "uuid": "3f8ae19c-17ba-4e30-ba61-b29608d0760c",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q24810806"
 }

--- a/data/Zambia/Assembly/meta.json
+++ b/data/Zambia/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 150,
   "wikidata": "Q1784088",
   "uuid": "9b4913bc-bbad-4646-bc73-a510b11a921f",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q18607856"
 }

--- a/data/Zimbabwe/Assembly/meta.json
+++ b/data/Zimbabwe/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 210,
   "wikidata": "Q1631396",
   "uuid": "ef03883e-e4c9-490a-bd50-d3b05bcb9562",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q21296472"
 }

--- a/data/Zimbabwe/Senate/meta.json
+++ b/data/Zimbabwe/Senate/meta.json
@@ -3,5 +3,6 @@
   "seats": 80,
   "wikidata": "Q659211",
   "uuid": "713672e7-18c5-4d1d-abd1-8d597b143847",
-  "type": "upper house"
+  "type": "upper house",
+  "member": "Q21295155"
 }


### PR DESCRIPTION
For each legislature, also add the "Member of X" wikidata item id to the
meta.json file.

Not all of these updated automatically, either because they're not
detectable, or because the query returned more than one result, but we can
add those individually as we come across them.