### PR TITLE
South Africa (Assembly): regenerate Cabinet position list

### DIFF
--- a/data/South_Africa/Assembly/sources/manual/position-filter.csv
+++ b/data/South_Africa/Assembly/sources/manual/position-filter.csv
@@ -1,18 +1,13 @@
-d,label,description,type
-Q273884,President of South Africa,South Africa's head of state and head of government,cabinet
-Q2363110,Deputy President of South Africa,Wikimedia list article,cabinet
-Q20981731,Minister in the Presidency,,cabinet
-Q20981752,Minister of Women in the Presidency,,cabinet
-Q6866029,"Minister of Agriculture, Forestry and Fisheries",Minister of the Cabinet of South Africa,cabinet
-Q11794965,Minister of Arts and Culture,,cabinet
-Q6866045,Minister of Basic Education,,cabinet
-Q6866063,Minister of Communications,,cabinet
-Q20981732,Minister of Cooperative Governance and Traditional Affairs,,cabinet
-Q3251789,Minister of Education,"",cabinet
-Q2128581,Minister of Finance,in South Africa,cabinet
-Q2640095,Minister of Home Affairs,minister in the government of South Africa,cabinet
-Q20981742,Minister of Science and Technology,South African cabinet minister,cabinet
-Q20981745,Minister of Sport and Recreation,political office in South Africa,cabinet
-Q20981735,Minister of Energy,"",cabinet
-Q16744266,member of the National Assembly of South Africa,member of the National Assembly of South Africa,self
-Q3643395,Speaker of the National Assembly of South Africa,presiding officer of the lower house of the Parliament of South Africa,self
+id,label,type
+Q11794965,Minister of Arts and Culture,cabinet
+Q20981731,Minister in the Presidency,cabinet
+Q20981732,Minister of Cooperative Governance and Traditional Affairs,cabinet
+Q20981735,Minister of Energy,cabinet
+Q20981745,Minister of Sport and Recreation,cabinet
+Q20981752,Minister of Women in the Presidency,cabinet
+Q2128581,Minister of Finance,cabinet
+Q2640095,Minister of Home Affairs,cabinet
+Q3251789,Minister of Education,cabinet
+Q6866029,"Minister of Agriculture, Forestry and Fisheries",cabinet
+Q6866045,Minister of Basic Education,cabinet
+Q6866063,Minister of Communications,cabinet

--- a/data/South_Africa/Assembly/unstable/positions.csv
+++ b/data/South_Africa/Assembly/unstable/positions.csv
@@ -1,1 +1,8 @@
 id,name,position,start_date,end_date,type
+7484bc57-9640-4192-b917-4223f9c39949,Naledi Pandor,Minister of Education,"",,cabinet
+7646484a-7447-4479-9803-051eaad724f3,Fikile Mbalula,Minister of Sport and Recreation,2010-11-01,,cabinet
+4650103d-65aa-4566-95ab-3b6864f52d26,Tina Joemat-Petterssen,Minister of Energy,2014-05-25,,cabinet
+4650103d-65aa-4566-95ab-3b6864f52d26,Tina Joemat-Petterssen,"Minister of Agriculture, Forestry and Fisheries",2009-05-09,2014-05-24,cabinet
+a7c7ba60-7482-4294-82d2-854953fdf522,Mangosuthu Gatsha Buthelezi,Minister of Home Affairs,"",,cabinet
+67915719-6091-4ccf-a44b-9de7fe265613,Pravin Gordhan,Minister of Finance,2015-12-13,,cabinet
+e0dd1766-033c-4137-80d5-4aaa91f13eca,Nhlanhla Nene,Minister of Finance,2014-05-26,2015-12-09,cabinet

--- a/data/South_Africa/Assembly/unstable/stats.json
+++ b/data/South_Africa/Assembly/unstable/stats.json
@@ -31,6 +31,56 @@
     "latest": "2014-05-07"
   },
   "positions": {
-    "cabinet": 0
-  }
+    "cabinet": 7
+  },
+  "sources": [
+    {
+      "file": "morph/wikidata-memberships.csv",
+      "type": "membership",
+      "scraper": "everypolitician-scrapers/south-africa-national-assembly-wikidata",
+      "lastmod": "2018-09-25"
+    },
+    {
+      "file": "morph/peoplesassembly.csv",
+      "type": "person",
+      "scraper": "everypolitician-scrapers/south-africa-national-assembly",
+      "lastmod": "2018-09-26"
+    },
+    {
+      "file": "morph/wikidata.csv",
+      "type": "wikidata",
+      "scraper": "everypolitician-scrapers/south-african-national-assembly-members-wikidata",
+      "lastmod": "2018-09-25"
+    },
+    {
+      "file": "wikidata/parties.json",
+      "type": "group",
+      "scraper": null,
+      "lastmod": "2018-09-25"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "scraper": null,
+      "lastmod": "2017-02-23"
+    },
+    {
+      "file": "morph/genderbalance.csv",
+      "type": "person",
+      "scraper": "everypolitician-scrapers/south-africa-assembly-gender-balance",
+      "lastmod": "2018-02-19"
+    },
+    {
+      "file": "morph/cabinet.csv",
+      "type": "wikidata-cabinet",
+      "scraper": "everypolitician-scrapers/south-africa-positions",
+      "lastmod": "2017-04-02"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "scraper": null,
+      "lastmod": "2018-09-25"
+    }
+  ]
 }


### PR DESCRIPTION
```
10:52:14 Validating CSVs
10:52:15 Add memberships from sources/morph/wikidata-memberships.csv
10:52:15 Merging with sources/morph/peoplesassembly.csv
10:52:15 Merging with sources/morph/wikidata.csv
  ☁ Mismatch in honorific_prefix for c4e3374e-12ba-477b-b654-abd17a9b343c (Prof) vs professor (for Q47536761)
	* 1 of 495 unmatched
	{:id=>"Q936528", :name=>"Dov Yosef"}
10:52:16 Merging with sources/morph/genderbalance.csv
  ☁ Mismatch in gender for 161d4dff-6a3a-4740-9db8-71b417717384 (female) vs male (for )
	* 3 of 400 unmatched
10:52:16 Generating legacy_id file
10:52:16 Verifying sources/merged.csv
10:52:16 Converting to Popolo
10:52:17 Creating termfiles
10:52:17 Creating names.csv
10:52:17 Creating unstable/positions.csv
  ☇ No dates for Naledi Pandor (Q11043304) as Minister of Education
  ☇ No dates for Mangosuthu Gatsha Buthelezi (Q554131) as Minister of Home Affairs
  ⁕ skipped 69 x Q16744266 (member of the National Assembly of South Africa) — e.g. Q11043304
  ⁕ skipped 1 x Q2363110 (Deputy President of South Africa) — e.g. Q804894
  ⁕ skipped 1 x Q6566914 (List of Chief Ministers of KwaZulu) — e.g. Q554131
------------------------------------------------------------------------
Persons matched to Wikidata: 494 ✓ 
Areas matched to Wikidata: 0 ✓ | 9 ✘
Parties matched to Wikidata: 13 ✓ 
Terms matched to Wikidata: 1 ✓ 
  ☢  morph/genderbalance.csv has not been updated for 234 days
  ☢  morph/cabinet.csv has not been updated for 557 days
```