### PR TITLE
South Africa (Assembly): get terms from Wikidata

### DIFF
--- a/data/South_Africa/Assembly/ep-popolo-v1.0.json
+++ b/data/South_Africa/Assembly/ep-popolo-v1.0.json
@@ -29271,11 +29271,11 @@
       "id": "term/26",
       "identifiers": [
         {
-          "identifier": "Q4632317",
+          "identifier": "Q18109299",
           "scheme": "wikidata"
         }
       ],
-      "name": "26th Parliament",
+      "name": "26th South African Parliament",
       "organization_id": "a36b27d7-5cb0-49f9-bba3-8e0b68bfdcbd",
       "start_date": "2014-05-21"
     },

--- a/data/South_Africa/Assembly/sources/instructions.json
+++ b/data/South_Africa/Assembly/sources/instructions.json
@@ -49,7 +49,12 @@
       }
     },
     {
-      "file": "manual/terms.csv",
+      "file": "morph/terms.csv",
+      "create": {
+        "from": "morph",
+        "scraper": "everypolitician-scrapers/south-africa-parliament-terms-wikidata",
+        "query": "SELECT * FROM data ORDER BY id"
+      },
       "type": "term"
     },
     {

--- a/data/South_Africa/Assembly/sources/manual/terms.csv
+++ b/data/South_Africa/Assembly/sources/manual/terms.csv
@@ -1,2 +1,0 @@
-id,name,start_date,wikidata
-26,26th Parliament,2014-05-21,Q4632317

--- a/data/South_Africa/Assembly/sources/morph/terms.csv
+++ b/data/South_Africa/Assembly/sources/morph/terms.csv
@@ -1,0 +1,6 @@
+statement,id,name,start_date,end_date,wikidata
+Q4557664-14d1bad3-4753-8ccd-81ee-e1f1b823b358,18,18th South African Parliament,1981-04-29,1987-01-01,Q4557664
+Q4631429-3a0a6ef5-4eb0-a94b-21a0-3d4ab4b673bc,22,22nd South African Parliament,1994-01-01,1997-01-01,Q4631429
+Q4632022-c6d94862-483f-4b6e-8640-86dc39ea86b0,24,24th South African Parliament,2004-05-21,2009-02-01,Q4632022
+Q4632317-c9f55b7b-4460-9338-2e1a-b6131eb51fab,25,25th South African Parliament,2009-05-06,2014-01-01,Q4632317
+Q18109299-9ff1d572-4f1d-ce60-fcba-58e17dd46c2d,26,26th South African Parliament,2014-05-21,"",Q18109299

--- a/data/South_Africa/Assembly/unstable/stats.json
+++ b/data/South_Africa/Assembly/unstable/stats.json
@@ -59,10 +59,10 @@
       "lastmod": "2018-09-25"
     },
     {
-      "file": "manual/terms.csv",
+      "file": "morph/terms.csv",
       "type": "term",
-      "scraper": null,
-      "lastmod": "2017-02-23"
+      "scraper": "everypolitician-scrapers/south-africa-parliament-terms-wikidata",
+      "lastmod": "2016-06-13"
     },
     {
       "file": "morph/genderbalance.csv",


### PR DESCRIPTION
Part of https://github.com/everypolitician/everypolitician/issues/626

```
11:02:44 Validating CSVs
11:02:45 Refetching sources/morph/terms.csv
11:02:46 Add memberships from sources/morph/wikidata-memberships.csv
11:02:46 Merging with sources/morph/peoplesassembly.csv
11:02:46 Merging with sources/morph/wikidata.csv
  ☁ Mismatch in honorific_prefix for c4e3374e-12ba-477b-b654-abd17a9b343c (Prof) vs professor (for Q47536761)
	* 1 of 495 unmatched
	{:id=>"Q936528", :name=>"Dov Yosef"}
11:02:47 Merging with sources/morph/genderbalance.csv
  ☁ Mismatch in gender for 161d4dff-6a3a-4740-9db8-71b417717384 (female) vs male (for )
	* 3 of 400 unmatched
11:02:47 Generating legacy_id file
11:02:47 Verifying sources/merged.csv
11:02:47 Converting to Popolo
11:02:48 Creating termfiles
11:02:48 Creating names.csv
11:02:48 Creating unstable/positions.csv
  ☇ No dates for Naledi Pandor (Q11043304) as Minister of Education
  ☇ No dates for Mangosuthu Gatsha Buthelezi (Q554131) as Minister of Home Affairs
  ⁕ skipped 69 x Q16744266 (member of the National Assembly of South Africa) — e.g. Q11043304
  ⁕ skipped 1 x Q2363110 (Deputy President of South Africa) — e.g. Q804894
  ⁕ skipped 1 x Q6566914 (List of Chief Ministers of KwaZulu) — e.g. Q554131
------------------------------------------------------------------------
Persons matched to Wikidata: 494 ✓ 
Areas matched to Wikidata: 0 ✓ | 9 ✘
Parties matched to Wikidata: 13 ✓ 
Terms matched to Wikidata: 1 ✓ 
  ☢  morph/terms.csv has not been updated for 850 days
  ☢  morph/genderbalance.csv has not been updated for 234 days
  ☢  morph/cabinet.csv has not been updated for 557 days
```