### PR TITLE
Switch from RawGit to jsDelivr

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -10,7 +10,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Abkhazia/Assembly/sources",
         "popolo": "data/Abkhazia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b0784dbd4cd89bbf1099e657f8424475a5887d41/data/Abkhazia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b0784dbd4cd89bbf1099e657f8424475a5887d41/data/Abkhazia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Abkhazia/Assembly/names.csv",
         "lastmod": "1538709173",
         "person_count": 35,
@@ -22,7 +22,7 @@
             "start_date": "2012-04-03",
             "slug": "5",
             "csv": "data/Abkhazia/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Abkhazia/Assembly/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Abkhazia/Assembly/term-5.csv"
           }
         ],
         "statement_count": 771,
@@ -41,7 +41,7 @@
         "slug": "Wolesi-Jirga",
         "sources_directory": "data/Afghanistan/Wolesi_Jirga/sources",
         "popolo": "data/Afghanistan/Wolesi_Jirga/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4c7ae35a24f6155ac122a13cda7832c1cb48f0e1/data/Afghanistan/Wolesi_Jirga/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4c7ae35a24f6155ac122a13cda7832c1cb48f0e1/data/Afghanistan/Wolesi_Jirga/ep-popolo-v1.0.json",
         "names": "data/Afghanistan/Wolesi_Jirga/names.csv",
         "lastmod": "1538635767",
         "person_count": 258,
@@ -54,7 +54,7 @@
             "start_date": "2011-01-26",
             "slug": "2010",
             "csv": "data/Afghanistan/Wolesi_Jirga/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3f6e354191b477190dca4272511ddbe4bfc7bead/data/Afghanistan/Wolesi_Jirga/term-2010.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@3f6e354191b477190dca4272511ddbe4bfc7bead/data/Afghanistan/Wolesi_Jirga/term-2010.csv"
           }
         ],
         "statement_count": 3902,
@@ -73,11 +73,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Albania/Assembly/sources",
         "popolo": "data/Albania/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c8c980b21fad8cac152404ab06b1644f8a3ff819/data/Albania/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9c0d4f9ae0da2e8fae06ca2b62f98bb4bfb1d0e8/data/Albania/Assembly/ep-popolo-v1.0.json",
         "names": "data/Albania/Assembly/names.csv",
-        "lastmod": "1537800550",
+        "lastmod": "1539665886",
         "person_count": 213,
-        "sha": "c8c980b21fad8cac152404ab06b1644f8a3ff819",
+        "sha": "9c0d4f9ae0da2e8fae06ca2b62f98bb4bfb1d0e8",
         "legislative_periods": [
           {
             "id": "term/8",
@@ -85,7 +85,7 @@
             "start_date": "2013-09-09",
             "slug": "8",
             "csv": "data/Albania/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Albania/Assembly/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Albania/Assembly/term-8.csv"
           },
           {
             "end_date": "2013",
@@ -94,10 +94,10 @@
             "start_date": "2009",
             "slug": "7",
             "csv": "data/Albania/Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c8c980b21fad8cac152404ab06b1644f8a3ff819/data/Albania/Assembly/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c8c980b21fad8cac152404ab06b1644f8a3ff819/data/Albania/Assembly/term-7.csv"
           }
         ],
-        "statement_count": 9304,
+        "statement_count": 9310,
         "type": "unicameral legislature"
       }
     ]
@@ -113,7 +113,7 @@
         "slug": "States",
         "sources_directory": "data/Alderney/States/sources",
         "popolo": "data/Alderney/States/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66230cb8d6458206672b79b149bd8f70699d36ca/data/Alderney/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@66230cb8d6458206672b79b149bd8f70699d36ca/data/Alderney/States/ep-popolo-v1.0.json",
         "names": "data/Alderney/States/names.csv",
         "lastmod": "1537785712",
         "person_count": 14,
@@ -125,7 +125,7 @@
             "start_date": "2017-01-01",
             "slug": "2017",
             "csv": "data/Alderney/States/term-2017.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Alderney/States/term-2017.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Alderney/States/term-2017.csv"
           },
           {
             "end_date": "2016-12-31",
@@ -134,7 +134,7 @@
             "start_date": "2015-01-01",
             "slug": "2014",
             "csv": "data/Alderney/States/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Alderney/States/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Alderney/States/term-2014.csv"
           }
         ],
         "statement_count": 869,
@@ -153,7 +153,7 @@
         "slug": "Majlis",
         "sources_directory": "data/Algeria/Majlis/sources",
         "popolo": "data/Algeria/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e089f3a4830ee5e50e38bc3c8094e9df9c6a2dd6/data/Algeria/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e089f3a4830ee5e50e38bc3c8094e9df9c6a2dd6/data/Algeria/Majlis/ep-popolo-v1.0.json",
         "names": "data/Algeria/Majlis/names.csv",
         "lastmod": "1537865963",
         "person_count": 478,
@@ -165,7 +165,7 @@
             "start_date": "2012-05-10",
             "slug": "7",
             "csv": "data/Algeria/Majlis/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Algeria/Majlis/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Algeria/Majlis/term-7.csv"
           }
         ],
         "statement_count": 8726,
@@ -184,7 +184,7 @@
         "slug": "House",
         "sources_directory": "data/American_Samoa/House/sources",
         "popolo": "data/American_Samoa/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/American_Samoa/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/American_Samoa/House/ep-popolo-v1.0.json",
         "names": "data/American_Samoa/House/names.csv",
         "lastmod": "1528387224",
         "person_count": 17,
@@ -196,7 +196,7 @@
             "start_date": "2015-01-03",
             "slug": "2014",
             "csv": "data/American_Samoa/House/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9c714427c4569e46ed69ee999c3a7b44a50e0337/data/American_Samoa/House/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9c714427c4569e46ed69ee999c3a7b44a50e0337/data/American_Samoa/House/term-2014.csv"
           }
         ],
         "statement_count": 893,
@@ -215,7 +215,7 @@
         "slug": "General-Council",
         "sources_directory": "data/Andorra/General_Council/sources",
         "popolo": "data/Andorra/General_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b353c4f0cbeadf97686de302e97ba84beb1bf376/data/Andorra/General_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b353c4f0cbeadf97686de302e97ba84beb1bf376/data/Andorra/General_Council/ep-popolo-v1.0.json",
         "names": "data/Andorra/General_Council/names.csv",
         "lastmod": "1536520791",
         "person_count": 31,
@@ -227,7 +227,7 @@
             "start_date": "2015-03-23",
             "slug": "2015",
             "csv": "data/Andorra/General_Council/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Andorra/General_Council/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Andorra/General_Council/term-2015.csv"
           }
         ],
         "statement_count": 944,
@@ -246,7 +246,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Angola/National_Assembly/sources",
         "popolo": "data/Angola/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/63e5c3a482a60bf54e39381d10df011d980e1078/data/Angola/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@63e5c3a482a60bf54e39381d10df011d980e1078/data/Angola/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Angola/National_Assembly/names.csv",
         "lastmod": "1538566435",
         "person_count": 343,
@@ -258,7 +258,7 @@
             "start_date": "2017-08-23",
             "slug": "4",
             "csv": "data/Angola/National_Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/63e5c3a482a60bf54e39381d10df011d980e1078/data/Angola/National_Assembly/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@63e5c3a482a60bf54e39381d10df011d980e1078/data/Angola/National_Assembly/term-4.csv"
           },
           {
             "end_date": "2017-08-22",
@@ -267,7 +267,7 @@
             "start_date": "2012-09-27",
             "slug": "3",
             "csv": "data/Angola/National_Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/63e5c3a482a60bf54e39381d10df011d980e1078/data/Angola/National_Assembly/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@63e5c3a482a60bf54e39381d10df011d980e1078/data/Angola/National_Assembly/term-3.csv"
           }
         ],
         "statement_count": 6997,
@@ -286,7 +286,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Anguilla/Assembly/sources",
         "popolo": "data/Anguilla/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7dbeee46f6e54e600a7d2d0c40557bf6ffb50eae/data/Anguilla/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7dbeee46f6e54e600a7d2d0c40557bf6ffb50eae/data/Anguilla/Assembly/ep-popolo-v1.0.json",
         "names": "data/Anguilla/Assembly/names.csv",
         "lastmod": "1538406890",
         "person_count": 18,
@@ -298,7 +298,7 @@
             "start_date": "2015-04-22",
             "slug": "2015",
             "csv": "data/Anguilla/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bee90cf27d0a1a8ed83325de9500ed8dfd8e6361/data/Anguilla/Assembly/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bee90cf27d0a1a8ed83325de9500ed8dfd8e6361/data/Anguilla/Assembly/term-2015.csv"
           },
           {
             "end_date": "2015",
@@ -307,7 +307,7 @@
             "start_date": "2010",
             "slug": "2010",
             "csv": "data/Anguilla/Assembly/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bee90cf27d0a1a8ed83325de9500ed8dfd8e6361/data/Anguilla/Assembly/term-2010.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bee90cf27d0a1a8ed83325de9500ed8dfd8e6361/data/Anguilla/Assembly/term-2010.csv"
           },
           {
             "end_date": "2010",
@@ -316,7 +316,7 @@
             "start_date": "2005",
             "slug": "2005",
             "csv": "data/Anguilla/Assembly/term-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bee90cf27d0a1a8ed83325de9500ed8dfd8e6361/data/Anguilla/Assembly/term-2005.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bee90cf27d0a1a8ed83325de9500ed8dfd8e6361/data/Anguilla/Assembly/term-2005.csv"
           },
           {
             "end_date": "2005",
@@ -325,7 +325,7 @@
             "start_date": "2000",
             "slug": "2000",
             "csv": "data/Anguilla/Assembly/term-2000.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bee90cf27d0a1a8ed83325de9500ed8dfd8e6361/data/Anguilla/Assembly/term-2000.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bee90cf27d0a1a8ed83325de9500ed8dfd8e6361/data/Anguilla/Assembly/term-2000.csv"
           },
           {
             "end_date": "2000",
@@ -334,7 +334,7 @@
             "start_date": "1999",
             "slug": "1999",
             "csv": "data/Anguilla/Assembly/term-1999.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bee90cf27d0a1a8ed83325de9500ed8dfd8e6361/data/Anguilla/Assembly/term-1999.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bee90cf27d0a1a8ed83325de9500ed8dfd8e6361/data/Anguilla/Assembly/term-1999.csv"
           },
           {
             "end_date": "1999",
@@ -343,7 +343,7 @@
             "start_date": "1994",
             "slug": "1994",
             "csv": "data/Anguilla/Assembly/term-1994.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bee90cf27d0a1a8ed83325de9500ed8dfd8e6361/data/Anguilla/Assembly/term-1994.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bee90cf27d0a1a8ed83325de9500ed8dfd8e6361/data/Anguilla/Assembly/term-1994.csv"
           },
           {
             "end_date": "1994",
@@ -352,7 +352,7 @@
             "start_date": "1989",
             "slug": "1989",
             "csv": "data/Anguilla/Assembly/term-1989.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bee90cf27d0a1a8ed83325de9500ed8dfd8e6361/data/Anguilla/Assembly/term-1989.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bee90cf27d0a1a8ed83325de9500ed8dfd8e6361/data/Anguilla/Assembly/term-1989.csv"
           }
         ],
         "statement_count": 1387,
@@ -371,7 +371,7 @@
         "slug": "Representatives",
         "sources_directory": "data/Antigua_and_Barbuda/Representatives/sources",
         "popolo": "data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be84b76a737a231ae7b6a324f10d5a9edeb58c7e/data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@be84b76a737a231ae7b6a324f10d5a9edeb58c7e/data/Antigua_and_Barbuda/Representatives/ep-popolo-v1.0.json",
         "names": "data/Antigua_and_Barbuda/Representatives/names.csv",
         "lastmod": "1537785738",
         "person_count": 63,
@@ -383,7 +383,7 @@
             "start_date": "2014-06-25",
             "slug": "2014",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-2014.csv"
           },
           {
             "end_date": "2014-04-26",
@@ -392,7 +392,7 @@
             "start_date": "2009-04-27",
             "slug": "2009",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-2009.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-2009.csv"
           },
           {
             "end_date": "2009-02-09",
@@ -401,7 +401,7 @@
             "start_date": "2004-03-24",
             "slug": "2004",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-2004.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-2004.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-2004.csv"
           },
           {
             "end_date": "2004",
@@ -410,7 +410,7 @@
             "start_date": "1999",
             "slug": "1999",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1999.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-1999.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-1999.csv"
           },
           {
             "end_date": "1999",
@@ -419,7 +419,7 @@
             "start_date": "1994",
             "slug": "1994",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1994.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-1994.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-1994.csv"
           },
           {
             "end_date": "1994",
@@ -428,7 +428,7 @@
             "start_date": "1989",
             "slug": "1989",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1989.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-1989.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-1989.csv"
           },
           {
             "end_date": "1989",
@@ -437,7 +437,7 @@
             "start_date": "1984",
             "slug": "1984",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1984.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-1984.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-1984.csv"
           },
           {
             "end_date": "1984",
@@ -446,7 +446,7 @@
             "start_date": "1980",
             "slug": "1980",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1980.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-1980.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-1980.csv"
           },
           {
             "end_date": "1980",
@@ -455,7 +455,7 @@
             "start_date": "1976",
             "slug": "1976",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1976.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-1976.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-1976.csv"
           },
           {
             "end_date": "1976",
@@ -464,7 +464,7 @@
             "start_date": "1971",
             "slug": "1971",
             "csv": "data/Antigua_and_Barbuda/Representatives/term-1971.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-1971.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Antigua_and_Barbuda/Representatives/term-1971.csv"
           }
         ],
         "statement_count": 2725,
@@ -483,11 +483,11 @@
         "slug": "Diputados",
         "sources_directory": "data/Argentina/Diputados/sources",
         "popolo": "data/Argentina/Diputados/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/22239c2e59bc078e8a8d4471e2df319bdb41b083/data/Argentina/Diputados/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@77ee31919f40376a27ff95ee0c251933bb4111b5/data/Argentina/Diputados/ep-popolo-v1.0.json",
         "names": "data/Argentina/Diputados/names.csv",
-        "lastmod": "1538725823",
+        "lastmod": "1539593476",
         "person_count": 396,
-        "sha": "22239c2e59bc078e8a8d4471e2df319bdb41b083",
+        "sha": "77ee31919f40376a27ff95ee0c251933bb4111b5",
         "legislative_periods": [
           {
             "end_date": "2017-11-30",
@@ -496,7 +496,7 @@
             "start_date": "2017-03-01",
             "slug": "135",
             "csv": "data/Argentina/Diputados/term-135.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/114ffc1511b18855eb73e0cba25af0d83e213873/data/Argentina/Diputados/term-135.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6f82123d29191d09d3601569f8c9ef3ea8d18cb9/data/Argentina/Diputados/term-135.csv"
           },
           {
             "end_date": "2016-11-30",
@@ -505,7 +505,7 @@
             "start_date": "2016-03-01",
             "slug": "134",
             "csv": "data/Argentina/Diputados/term-134.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/114ffc1511b18855eb73e0cba25af0d83e213873/data/Argentina/Diputados/term-134.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6f82123d29191d09d3601569f8c9ef3ea8d18cb9/data/Argentina/Diputados/term-134.csv"
           },
           {
             "end_date": "2015-11-30",
@@ -514,10 +514,10 @@
             "start_date": "2015-03-01",
             "slug": "133",
             "csv": "data/Argentina/Diputados/term-133.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/114ffc1511b18855eb73e0cba25af0d83e213873/data/Argentina/Diputados/term-133.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6f82123d29191d09d3601569f8c9ef3ea8d18cb9/data/Argentina/Diputados/term-133.csv"
           }
         ],
-        "statement_count": 19530,
+        "statement_count": 19538,
         "type": "lower house"
       },
       {
@@ -525,7 +525,7 @@
         "slug": "Senado",
         "sources_directory": "data/Argentina/Senado/sources",
         "popolo": "data/Argentina/Senado/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/932094bc90c1335b6e7a1becf2c501cc325c5f85/data/Argentina/Senado/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@932094bc90c1335b6e7a1becf2c501cc325c5f85/data/Argentina/Senado/ep-popolo-v1.0.json",
         "names": "data/Argentina/Senado/names.csv",
         "lastmod": "1539258327",
         "person_count": 73,
@@ -538,7 +538,7 @@
             "start_date": "2017-03-01",
             "slug": "2017",
             "csv": "data/Argentina/Senado/term-2017.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/77ccfec90d6893ac9b7a164d8f27e978debc2dcf/data/Argentina/Senado/term-2017.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@77ccfec90d6893ac9b7a164d8f27e978debc2dcf/data/Argentina/Senado/term-2017.csv"
           },
           {
             "end_date": "2016-11-30",
@@ -547,7 +547,7 @@
             "start_date": "2016-03-01",
             "slug": "2016",
             "csv": "data/Argentina/Senado/term-2016.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/77ccfec90d6893ac9b7a164d8f27e978debc2dcf/data/Argentina/Senado/term-2016.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@77ccfec90d6893ac9b7a164d8f27e978debc2dcf/data/Argentina/Senado/term-2016.csv"
           },
           {
             "end_date": "2015-11-30",
@@ -556,7 +556,7 @@
             "start_date": "2015-03-01",
             "slug": "2015",
             "csv": "data/Argentina/Senado/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/77ccfec90d6893ac9b7a164d8f27e978debc2dcf/data/Argentina/Senado/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@77ccfec90d6893ac9b7a164d8f27e978debc2dcf/data/Argentina/Senado/term-2015.csv"
           }
         ],
         "statement_count": 9141,
@@ -575,7 +575,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Armenia/Assembly/sources",
         "popolo": "data/Armenia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/473acf705686d9ce33640f510ae0695c25d7bcb1/data/Armenia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@473acf705686d9ce33640f510ae0695c25d7bcb1/data/Armenia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Armenia/Assembly/names.csv",
         "lastmod": "1539242788",
         "person_count": 186,
@@ -587,7 +587,7 @@
             "start_date": "2017-05-18",
             "slug": "6",
             "csv": "data/Armenia/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/473acf705686d9ce33640f510ae0695c25d7bcb1/data/Armenia/Assembly/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@473acf705686d9ce33640f510ae0695c25d7bcb1/data/Armenia/Assembly/term-6.csv"
           },
           {
             "end_date": "2017-03-02",
@@ -596,7 +596,7 @@
             "start_date": "2012-05-31",
             "slug": "5",
             "csv": "data/Armenia/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/473acf705686d9ce33640f510ae0695c25d7bcb1/data/Armenia/Assembly/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@473acf705686d9ce33640f510ae0695c25d7bcb1/data/Armenia/Assembly/term-5.csv"
           }
         ],
         "statement_count": 9188,
@@ -615,7 +615,7 @@
         "slug": "Estates",
         "sources_directory": "data/Aruba/Estates/sources",
         "popolo": "data/Aruba/Estates/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df906e305085483d4ad963e45cf6d180a07db473/data/Aruba/Estates/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@df906e305085483d4ad963e45cf6d180a07db473/data/Aruba/Estates/ep-popolo-v1.0.json",
         "names": "data/Aruba/Estates/names.csv",
         "lastmod": "1485067851",
         "person_count": 21,
@@ -627,7 +627,7 @@
             "start_date": "2013",
             "slug": "7",
             "csv": "data/Aruba/Estates/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Aruba/Estates/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Aruba/Estates/term-7.csv"
           }
         ],
         "statement_count": 626,
@@ -646,11 +646,11 @@
         "slug": "Representatives",
         "sources_directory": "data/Australia/Representatives/sources",
         "popolo": "data/Australia/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3e72ad49b6c11d129ab01da7cb3297a38922e681/data/Australia/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d24625f9d3a1c521401b0466698442ecf8e10625/data/Australia/Representatives/ep-popolo-v1.0.json",
         "names": "data/Australia/Representatives/names.csv",
-        "lastmod": "1539149258",
-        "person_count": 512,
-        "sha": "3e72ad49b6c11d129ab01da7cb3297a38922e681",
+        "lastmod": "1539367900",
+        "person_count": 514,
+        "sha": "d24625f9d3a1c521401b0466698442ecf8e10625",
         "legislative_periods": [
           {
             "id": "term/45",
@@ -658,7 +658,7 @@
             "start_date": "2016-07-02",
             "slug": "45",
             "csv": "data/Australia/Representatives/term-45.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-45.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d24625f9d3a1c521401b0466698442ecf8e10625/data/Australia/Representatives/term-45.csv"
           },
           {
             "end_date": "2016-05-09",
@@ -667,7 +667,7 @@
             "start_date": "2013-09-07",
             "slug": "44",
             "csv": "data/Australia/Representatives/term-44.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-44.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@56c49c750f1fdf26e7294a1703f83be1c09139d6/data/Australia/Representatives/term-44.csv"
           },
           {
             "end_date": "2013-09-07",
@@ -676,7 +676,7 @@
             "start_date": "2010-08-21",
             "slug": "43",
             "csv": "data/Australia/Representatives/term-43.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-43.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@56c49c750f1fdf26e7294a1703f83be1c09139d6/data/Australia/Representatives/term-43.csv"
           },
           {
             "end_date": "2010-08-21",
@@ -685,7 +685,7 @@
             "start_date": "2007-11-24",
             "slug": "42",
             "csv": "data/Australia/Representatives/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-42.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@af564b5d224cdc17c041d216a2b46188d2e4e326/data/Australia/Representatives/term-42.csv"
           },
           {
             "end_date": "2007-11-24",
@@ -694,7 +694,7 @@
             "start_date": "2004-10-09",
             "slug": "41",
             "csv": "data/Australia/Representatives/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-41.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-41.csv"
           },
           {
             "end_date": "2004-10-09",
@@ -703,7 +703,7 @@
             "start_date": "2001-11-10",
             "slug": "40",
             "csv": "data/Australia/Representatives/term-40.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-40.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-40.csv"
           },
           {
             "end_date": "2001-11-10",
@@ -712,7 +712,7 @@
             "start_date": "1998-10-03",
             "slug": "39",
             "csv": "data/Australia/Representatives/term-39.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-39.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-39.csv"
           },
           {
             "end_date": "1998-10-03",
@@ -721,7 +721,7 @@
             "start_date": "1996-03-02",
             "slug": "38",
             "csv": "data/Australia/Representatives/term-38.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-38.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-38.csv"
           },
           {
             "end_date": "1996-03-02",
@@ -730,7 +730,7 @@
             "start_date": "1993-03-13",
             "slug": "37",
             "csv": "data/Australia/Representatives/term-37.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-37.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-37.csv"
           },
           {
             "end_date": "1993-03-13",
@@ -739,7 +739,7 @@
             "start_date": "1990-03-24",
             "slug": "36",
             "csv": "data/Australia/Representatives/term-36.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-36.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-36.csv"
           },
           {
             "end_date": "1990-03-24",
@@ -748,10 +748,10 @@
             "start_date": "1987-07-11",
             "slug": "35",
             "csv": "data/Australia/Representatives/term-35.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-35.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9655130ec207ac43c7521484c666eece3fe772eb/data/Australia/Representatives/term-35.csv"
           }
         ],
-        "statement_count": 34558,
+        "statement_count": 34732,
         "type": "lower house"
       },
       {
@@ -759,11 +759,11 @@
         "slug": "Senate",
         "sources_directory": "data/Australia/Senate/sources",
         "popolo": "data/Australia/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/683a9d96fc737e5fed8b7bfa82740106d4736825/data/Australia/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@be77ba847a5455f3d359b77c4b09b968f3aebd79/data/Australia/Senate/ep-popolo-v1.0.json",
         "names": "data/Australia/Senate/names.csv",
-        "lastmod": "1539158669",
+        "lastmod": "1539597126",
         "person_count": 270,
-        "sha": "683a9d96fc737e5fed8b7bfa82740106d4736825",
+        "sha": "be77ba847a5455f3d359b77c4b09b968f3aebd79",
         "legislative_periods": [
           {
             "id": "term/45",
@@ -771,7 +771,7 @@
             "start_date": "2016-07-02",
             "slug": "45",
             "csv": "data/Australia/Senate/term-45.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/683a9d96fc737e5fed8b7bfa82740106d4736825/data/Australia/Senate/term-45.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@683a9d96fc737e5fed8b7bfa82740106d4736825/data/Australia/Senate/term-45.csv"
           },
           {
             "end_date": "2016-05-09",
@@ -780,7 +780,7 @@
             "start_date": "2013-09-07",
             "slug": "44",
             "csv": "data/Australia/Senate/term-44.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-44.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-44.csv"
           },
           {
             "end_date": "2013-09-07",
@@ -789,7 +789,7 @@
             "start_date": "2010-08-21",
             "slug": "43",
             "csv": "data/Australia/Senate/term-43.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-43.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-43.csv"
           },
           {
             "end_date": "2010-08-21",
@@ -798,7 +798,7 @@
             "start_date": "2007-11-24",
             "slug": "42",
             "csv": "data/Australia/Senate/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-42.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-42.csv"
           },
           {
             "end_date": "2007-11-24",
@@ -807,7 +807,7 @@
             "start_date": "2004-10-09",
             "slug": "41",
             "csv": "data/Australia/Senate/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-41.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-41.csv"
           },
           {
             "end_date": "2004-10-09",
@@ -816,7 +816,7 @@
             "start_date": "2001-11-10",
             "slug": "40",
             "csv": "data/Australia/Senate/term-40.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-40.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-40.csv"
           },
           {
             "end_date": "2001-11-10",
@@ -825,7 +825,7 @@
             "start_date": "1998-10-03",
             "slug": "39",
             "csv": "data/Australia/Senate/term-39.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-39.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-39.csv"
           },
           {
             "end_date": "1998-10-03",
@@ -834,7 +834,7 @@
             "start_date": "1996-03-02",
             "slug": "38",
             "csv": "data/Australia/Senate/term-38.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-38.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-38.csv"
           },
           {
             "end_date": "1996-03-02",
@@ -843,7 +843,7 @@
             "start_date": "1993-03-13",
             "slug": "37",
             "csv": "data/Australia/Senate/term-37.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-37.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-37.csv"
           },
           {
             "end_date": "1993-03-13",
@@ -852,7 +852,7 @@
             "start_date": "1990-03-24",
             "slug": "36",
             "csv": "data/Australia/Senate/term-36.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-36.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-36.csv"
           },
           {
             "end_date": "1990-03-24",
@@ -861,10 +861,10 @@
             "start_date": "1987-07-11",
             "slug": "35",
             "csv": "data/Australia/Senate/term-35.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-35.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@698f5af4400c09c0d0f0a90424fdb20516f6f683/data/Australia/Senate/term-35.csv"
           }
         ],
-        "statement_count": 20107,
+        "statement_count": 20114,
         "type": "upper house"
       }
     ]
@@ -880,11 +880,11 @@
         "slug": "Nationalrat",
         "sources_directory": "data/Austria/Nationalrat/sources",
         "popolo": "data/Austria/Nationalrat/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b2d7d9932b44f51d4449ff3f4ed4745833d062fb/data/Austria/Nationalrat/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@56677a1a092bd3fddf52172936ec74adcff31112/data/Austria/Nationalrat/ep-popolo-v1.0.json",
         "names": "data/Austria/Nationalrat/names.csv",
-        "lastmod": "1538578099",
+        "lastmod": "1539591637",
         "person_count": 182,
-        "sha": "b2d7d9932b44f51d4449ff3f4ed4745833d062fb",
+        "sha": "56677a1a092bd3fddf52172936ec74adcff31112",
         "legislative_periods": [
           {
             "end_date": "2017-11-08",
@@ -893,10 +893,10 @@
             "start_date": "2013-10-29",
             "slug": "25",
             "csv": "data/Austria/Nationalrat/term-25.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/26669cf7743825fe786809688ffef2117d4fb9e0/data/Austria/Nationalrat/term-25.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@26669cf7743825fe786809688ffef2117d4fb9e0/data/Austria/Nationalrat/term-25.csv"
           }
         ],
-        "statement_count": 9336,
+        "statement_count": 9344,
         "type": "lower house"
       }
     ]
@@ -912,11 +912,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Azerbaijan/National_Assembly/sources",
         "popolo": "data/Azerbaijan/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/92ff0a5ed0e2ae64eb2bc682a0ee5cc13fab77d1/data/Azerbaijan/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0604b04786523708dfa8b6624e065d3266323325/data/Azerbaijan/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Azerbaijan/National_Assembly/names.csv",
-        "lastmod": "1539250609",
+        "lastmod": "1539444717",
         "person_count": 152,
-        "sha": "92ff0a5ed0e2ae64eb2bc682a0ee5cc13fab77d1",
+        "sha": "0604b04786523708dfa8b6624e065d3266323325",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -924,7 +924,7 @@
             "start_date": "2015-12-01",
             "slug": "5",
             "csv": "data/Azerbaijan/National_Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/306ada7fd41a13554ab95ee52bb3ed2ae9c81aa1/data/Azerbaijan/National_Assembly/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@306ada7fd41a13554ab95ee52bb3ed2ae9c81aa1/data/Azerbaijan/National_Assembly/term-5.csv"
           },
           {
             "end_date": "2015-01-01",
@@ -933,10 +933,10 @@
             "start_date": "2010-01-01",
             "slug": "4",
             "csv": "data/Azerbaijan/National_Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b264b7ad91a247d61fdccdbf55e93a2cae92bb32/data/Azerbaijan/National_Assembly/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b264b7ad91a247d61fdccdbf55e93a2cae92bb32/data/Azerbaijan/National_Assembly/term-4.csv"
           }
         ],
-        "statement_count": 5594,
+        "statement_count": 5597,
         "type": "unicameral legislature"
       }
     ]
@@ -952,7 +952,7 @@
         "slug": "House-of-Assembly",
         "sources_directory": "data/Bahamas/House_of_Assembly/sources",
         "popolo": "data/Bahamas/House_of_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a481259cf22a653df44160fc00af944ebfc58d6c/data/Bahamas/House_of_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a481259cf22a653df44160fc00af944ebfc58d6c/data/Bahamas/House_of_Assembly/ep-popolo-v1.0.json",
         "names": "data/Bahamas/House_of_Assembly/names.csv",
         "lastmod": "1538405247",
         "person_count": 38,
@@ -964,7 +964,7 @@
             "start_date": "2012-05-08",
             "slug": "2012",
             "csv": "data/Bahamas/House_of_Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Bahamas/House_of_Assembly/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Bahamas/House_of_Assembly/term-2012.csv"
           }
         ],
         "statement_count": 1290,
@@ -983,7 +983,7 @@
         "slug": "Council-of-Representatives",
         "sources_directory": "data/Bahrain/Council_of_Representatives/sources",
         "popolo": "data/Bahrain/Council_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/07268df560cc2dc4b72b65e740e61470b6797253/data/Bahrain/Council_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@07268df560cc2dc4b72b65e740e61470b6797253/data/Bahrain/Council_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Bahrain/Council_of_Representatives/names.csv",
         "lastmod": "1507395608",
         "person_count": 40,
@@ -995,7 +995,7 @@
             "start_date": "2014-12-14",
             "slug": "2014",
             "csv": "data/Bahrain/Council_of_Representatives/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Bahrain/Council_of_Representatives/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Bahrain/Council_of_Representatives/term-2014.csv"
           }
         ],
         "statement_count": 536,
@@ -1014,7 +1014,7 @@
         "slug": "House",
         "sources_directory": "data/Bangladesh/House/sources",
         "popolo": "data/Bangladesh/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0053952c6a87939c852f12a37b6a43197e2fad19/data/Bangladesh/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0053952c6a87939c852f12a37b6a43197e2fad19/data/Bangladesh/House/ep-popolo-v1.0.json",
         "names": "data/Bangladesh/House/names.csv",
         "lastmod": "1539070964",
         "person_count": 550,
@@ -1026,7 +1026,7 @@
             "start_date": "2014-01-29",
             "slug": "10",
             "csv": "data/Bangladesh/House/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/653d9fa43a94a89bd949f171beca0ce80ba5aed1/data/Bangladesh/House/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@653d9fa43a94a89bd949f171beca0ce80ba5aed1/data/Bangladesh/House/term-10.csv"
           },
           {
             "end_date": "2014-01-24",
@@ -1035,7 +1035,7 @@
             "start_date": "2009-01-25",
             "slug": "9",
             "csv": "data/Bangladesh/House/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/653d9fa43a94a89bd949f171beca0ce80ba5aed1/data/Bangladesh/House/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@653d9fa43a94a89bd949f171beca0ce80ba5aed1/data/Bangladesh/House/term-9.csv"
           }
         ],
         "statement_count": 14896,
@@ -1054,7 +1054,7 @@
         "slug": "House-of-Assembly",
         "sources_directory": "data/Barbados/House_of_Assembly/sources",
         "popolo": "data/Barbados/House_of_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Barbados/House_of_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Barbados/House_of_Assembly/ep-popolo-v1.0.json",
         "names": "data/Barbados/House_of_Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 30,
@@ -1066,7 +1066,7 @@
             "start_date": "2013-03-06",
             "slug": "2013",
             "csv": "data/Barbados/House_of_Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Barbados/House_of_Assembly/term-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Barbados/House_of_Assembly/term-2013.csv"
           }
         ],
         "statement_count": 946,
@@ -1085,7 +1085,7 @@
         "slug": "Chamber",
         "sources_directory": "data/Belarus/Chamber/sources",
         "popolo": "data/Belarus/Chamber/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7c62727a1e1b15c1443894dacfc2e050a29c20bc/data/Belarus/Chamber/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7c62727a1e1b15c1443894dacfc2e050a29c20bc/data/Belarus/Chamber/ep-popolo-v1.0.json",
         "names": "data/Belarus/Chamber/names.csv",
         "lastmod": "1537800697",
         "person_count": 192,
@@ -1097,7 +1097,7 @@
             "start_date": "2016-09-11",
             "slug": "6",
             "csv": "data/Belarus/Chamber/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0d3e7a63dba201b662a796a429bdad5f065dcc64/data/Belarus/Chamber/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0d3e7a63dba201b662a796a429bdad5f065dcc64/data/Belarus/Chamber/term-6.csv"
           },
           {
             "end_date": "2016-09-10",
@@ -1106,7 +1106,7 @@
             "start_date": "2012-09-23",
             "slug": "5",
             "csv": "data/Belarus/Chamber/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7c62727a1e1b15c1443894dacfc2e050a29c20bc/data/Belarus/Chamber/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7c62727a1e1b15c1443894dacfc2e050a29c20bc/data/Belarus/Chamber/term-5.csv"
           }
         ],
         "statement_count": 5129,
@@ -1125,7 +1125,7 @@
         "slug": "Representatives",
         "sources_directory": "data/Belgium/Representatives/sources",
         "popolo": "data/Belgium/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/408aea0847ea79bfce33565d0beb7993b5ea2d51/data/Belgium/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@408aea0847ea79bfce33565d0beb7993b5ea2d51/data/Belgium/Representatives/ep-popolo-v1.0.json",
         "names": "data/Belgium/Representatives/names.csv",
         "lastmod": "1539027148",
         "person_count": 177,
@@ -1137,7 +1137,7 @@
             "start_date": "2014-06-19",
             "slug": "54",
             "csv": "data/Belgium/Representatives/term-54.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7862f79e253b64cd79e306affb17a537ce2647c6/data/Belgium/Representatives/term-54.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7862f79e253b64cd79e306affb17a537ce2647c6/data/Belgium/Representatives/term-54.csv"
           }
         ],
         "statement_count": 11361,
@@ -1156,7 +1156,7 @@
         "slug": "Representatives",
         "sources_directory": "data/Belize/Representatives/sources",
         "popolo": "data/Belize/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/95f3c675590976eaebf71e1abc6f1fbe56601c8e/data/Belize/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@95f3c675590976eaebf71e1abc6f1fbe56601c8e/data/Belize/Representatives/ep-popolo-v1.0.json",
         "names": "data/Belize/Representatives/names.csv",
         "lastmod": "1534575942",
         "person_count": 41,
@@ -1168,7 +1168,7 @@
             "start_date": "2015-11-05",
             "slug": "2015",
             "csv": "data/Belize/Representatives/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Belize/Representatives/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Belize/Representatives/term-2015.csv"
           },
           {
             "end_date": "2015-11-04",
@@ -1177,7 +1177,7 @@
             "start_date": "2012-03-21",
             "slug": "2012",
             "csv": "data/Belize/Representatives/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Belize/Representatives/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Belize/Representatives/term-2012.csv"
           }
         ],
         "statement_count": 1369,
@@ -1196,7 +1196,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Benin/National_Assembly/sources",
         "popolo": "data/Benin/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43504c7e3d57a675e837f83f6242d69b2cfeba15/data/Benin/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@43504c7e3d57a675e837f83f6242d69b2cfeba15/data/Benin/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Benin/National_Assembly/names.csv",
         "lastmod": "1538927602",
         "person_count": 83,
@@ -1208,7 +1208,7 @@
             "start_date": "2015-04-26",
             "slug": "7",
             "csv": "data/Benin/National_Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43504c7e3d57a675e837f83f6242d69b2cfeba15/data/Benin/National_Assembly/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@43504c7e3d57a675e837f83f6242d69b2cfeba15/data/Benin/National_Assembly/term-7.csv"
           }
         ],
         "statement_count": 1878,
@@ -1227,7 +1227,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Bermuda/Assembly/sources",
         "popolo": "data/Bermuda/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ea4517d9a8bda2ed4819d2d86da0187d0a966dcd/data/Bermuda/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ea4517d9a8bda2ed4819d2d86da0187d0a966dcd/data/Bermuda/Assembly/ep-popolo-v1.0.json",
         "names": "data/Bermuda/Assembly/names.csv",
         "lastmod": "1537800724",
         "person_count": 48,
@@ -1239,7 +1239,7 @@
             "start_date": "2017-07-17",
             "slug": "2017",
             "csv": "data/Bermuda/Assembly/term-2017.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6efd2607a68de493082ccb8a375c82d963546164/data/Bermuda/Assembly/term-2017.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6efd2607a68de493082ccb8a375c82d963546164/data/Bermuda/Assembly/term-2017.csv"
           },
           {
             "end_date": "2017-07-17",
@@ -1248,7 +1248,7 @@
             "start_date": "2012-12-17",
             "slug": "2012",
             "csv": "data/Bermuda/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ea4517d9a8bda2ed4819d2d86da0187d0a966dcd/data/Bermuda/Assembly/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ea4517d9a8bda2ed4819d2d86da0187d0a966dcd/data/Bermuda/Assembly/term-2012.csv"
           }
         ],
         "statement_count": 1993,
@@ -1267,7 +1267,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Bhutan/Assembly/sources",
         "popolo": "data/Bhutan/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c12ae5ff7f1817c9862a9db4ace378e15b9ccb2/data/Bhutan/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@5c12ae5ff7f1817c9862a9db4ace378e15b9ccb2/data/Bhutan/Assembly/ep-popolo-v1.0.json",
         "names": "data/Bhutan/Assembly/names.csv",
         "lastmod": "1538996173",
         "person_count": 48,
@@ -1279,7 +1279,7 @@
             "start_date": "2013-07-13",
             "slug": "2",
             "csv": "data/Bhutan/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4bb4537800be12c16338644c5c305e9dbdc58587/data/Bhutan/Assembly/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4bb4537800be12c16338644c5c305e9dbdc58587/data/Bhutan/Assembly/term-2.csv"
           }
         ],
         "statement_count": 1526,
@@ -1298,7 +1298,7 @@
         "slug": "Deputies",
         "sources_directory": "data/Bolivia/Deputies/sources",
         "popolo": "data/Bolivia/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Bolivia/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Bolivia/Deputies/ep-popolo-v1.0.json",
         "names": "data/Bolivia/Deputies/names.csv",
         "lastmod": "1528387224",
         "person_count": 130,
@@ -1310,7 +1310,7 @@
             "start_date": "2015-01-21",
             "slug": "2015",
             "csv": "data/Bolivia/Deputies/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Bolivia/Deputies/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Bolivia/Deputies/term-2015.csv"
           }
         ],
         "statement_count": 2540,
@@ -1329,7 +1329,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Bosnia_and_Herzegovina/House_of_Representatives/sources",
         "popolo": "data/Bosnia_and_Herzegovina/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Bosnia_and_Herzegovina/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Bosnia_and_Herzegovina/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Bosnia_and_Herzegovina/House_of_Representatives/names.csv",
         "lastmod": "1528387224",
         "person_count": 42,
@@ -1341,7 +1341,7 @@
             "start_date": "2014-12-09",
             "slug": "7",
             "csv": "data/Bosnia_and_Herzegovina/House_of_Representatives/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Bosnia_and_Herzegovina/House_of_Representatives/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Bosnia_and_Herzegovina/House_of_Representatives/term-7.csv"
           }
         ],
         "statement_count": 1534,
@@ -1360,22 +1360,22 @@
         "slug": "Assembly",
         "sources_directory": "data/Botswana/Assembly/sources",
         "popolo": "data/Botswana/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a138ea1992830287c8b6fa5f86be63142f134126/data/Botswana/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f0c151de5751640161bbde94872f7ef0d6c8fb93/data/Botswana/Assembly/ep-popolo-v1.0.json",
         "names": "data/Botswana/Assembly/names.csv",
-        "lastmod": "1538386829",
+        "lastmod": "1539665614",
         "person_count": 64,
-        "sha": "a138ea1992830287c8b6fa5f86be63142f134126",
+        "sha": "f0c151de5751640161bbde94872f7ef0d6c8fb93",
         "legislative_periods": [
           {
-            "id": "term/2014",
-            "name": "11th Parliament",
+            "id": "term/11",
+            "name": "11th Parliament of Botswana",
             "start_date": "2014-10-29",
-            "slug": "2014",
-            "csv": "data/Botswana/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c8b41256465a119f5356c71ab2b9163bd190e400/data/Botswana/Assembly/term-2014.csv"
+            "slug": "11",
+            "csv": "data/Botswana/Assembly/term-11.csv",
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f0c151de5751640161bbde94872f7ef0d6c8fb93/data/Botswana/Assembly/term-11.csv"
           }
         ],
-        "statement_count": 1689,
+        "statement_count": 1691,
         "type": "unicameral legislature"
       }
     ]
@@ -1391,11 +1391,11 @@
         "slug": "Deputies",
         "sources_directory": "data/Brazil/Deputies/sources",
         "popolo": "data/Brazil/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dfc6072debfe33e23696cc878abe4f920f45c4f6/data/Brazil/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@15e44706c34f6830fb8bcae40b2edc9b72c4ce7c/data/Brazil/Deputies/ep-popolo-v1.0.json",
         "names": "data/Brazil/Deputies/names.csv",
-        "lastmod": "1539054314",
+        "lastmod": "1539603671",
         "person_count": 942,
-        "sha": "dfc6072debfe33e23696cc878abe4f920f45c4f6",
+        "sha": "15e44706c34f6830fb8bcae40b2edc9b72c4ce7c",
         "legislative_periods": [
           {
             "id": "term/55",
@@ -1403,7 +1403,7 @@
             "start_date": "2015-02-01",
             "slug": "55",
             "csv": "data/Brazil/Deputies/term-55.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1fde43c0db95e215ee5c45f8cebadb1ee9f3f83b/data/Brazil/Deputies/term-55.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e8ea05eef0bf7f31aa9d2b1f8d44b9486b7b4567/data/Brazil/Deputies/term-55.csv"
           },
           {
             "end_date": "2015-01-31",
@@ -1412,10 +1412,10 @@
             "start_date": "2011-02-01",
             "slug": "54",
             "csv": "data/Brazil/Deputies/term-54.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1fde43c0db95e215ee5c45f8cebadb1ee9f3f83b/data/Brazil/Deputies/term-54.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e8ea05eef0bf7f31aa9d2b1f8d44b9486b7b4567/data/Brazil/Deputies/term-54.csv"
           }
         ],
-        "statement_count": 34132,
+        "statement_count": 34162,
         "type": "lower house"
       }
     ]
@@ -1431,7 +1431,7 @@
         "slug": "Assembly",
         "sources_directory": "data/British_Virgin_Islands/Assembly/sources",
         "popolo": "data/British_Virgin_Islands/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b913265e3c1246dc45f4bda2792ea75a625def23/data/British_Virgin_Islands/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b913265e3c1246dc45f4bda2792ea75a625def23/data/British_Virgin_Islands/Assembly/ep-popolo-v1.0.json",
         "names": "data/British_Virgin_Islands/Assembly/names.csv",
         "lastmod": "1536546897",
         "person_count": 23,
@@ -1443,7 +1443,7 @@
             "start_date": "2015-06-08",
             "slug": "2015",
             "csv": "data/British_Virgin_Islands/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/British_Virgin_Islands/Assembly/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/British_Virgin_Islands/Assembly/term-2015.csv"
           },
           {
             "end_date": "2015",
@@ -1452,7 +1452,7 @@
             "start_date": "2011",
             "slug": "2011",
             "csv": "data/British_Virgin_Islands/Assembly/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/British_Virgin_Islands/Assembly/term-2011.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/British_Virgin_Islands/Assembly/term-2011.csv"
           },
           {
             "end_date": "2011",
@@ -1461,7 +1461,7 @@
             "start_date": "2007",
             "slug": "2007",
             "csv": "data/British_Virgin_Islands/Assembly/term-2007.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/50b73dccfe52da713846de8bdf30b4e8bd957cfa/data/British_Virgin_Islands/Assembly/term-2007.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@50b73dccfe52da713846de8bdf30b4e8bd957cfa/data/British_Virgin_Islands/Assembly/term-2007.csv"
           }
         ],
         "statement_count": 1338,
@@ -1472,7 +1472,7 @@
         "slug": "Council",
         "sources_directory": "data/British_Virgin_Islands/Council/sources",
         "popolo": "data/British_Virgin_Islands/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0fee4fbbbfaf0c2eb2763f310d8e9aaa55af7fc3/data/British_Virgin_Islands/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0fee4fbbbfaf0c2eb2763f310d8e9aaa55af7fc3/data/British_Virgin_Islands/Council/ep-popolo-v1.0.json",
         "names": "data/British_Virgin_Islands/Council/names.csv",
         "lastmod": "1536481005",
         "person_count": 36,
@@ -1485,7 +1485,7 @@
             "start_date": "2003-06-16",
             "slug": "2003",
             "csv": "data/British_Virgin_Islands/Council/term-2003.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/British_Virgin_Islands/Council/term-2003.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/British_Virgin_Islands/Council/term-2003.csv"
           },
           {
             "end_date": "2003",
@@ -1494,7 +1494,7 @@
             "start_date": "1999",
             "slug": "1999",
             "csv": "data/British_Virgin_Islands/Council/term-1999.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/British_Virgin_Islands/Council/term-1999.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/British_Virgin_Islands/Council/term-1999.csv"
           },
           {
             "end_date": "1999",
@@ -1503,7 +1503,7 @@
             "start_date": "1995",
             "slug": "1995",
             "csv": "data/British_Virgin_Islands/Council/term-1995.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e66f3c304bb54dd6b4837f16c189f1c6a4c8792/data/British_Virgin_Islands/Council/term-1995.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9e66f3c304bb54dd6b4837f16c189f1c6a4c8792/data/British_Virgin_Islands/Council/term-1995.csv"
           },
           {
             "end_date": "1995",
@@ -1512,7 +1512,7 @@
             "start_date": "1990",
             "slug": "1990",
             "csv": "data/British_Virgin_Islands/Council/term-1990.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e66f3c304bb54dd6b4837f16c189f1c6a4c8792/data/British_Virgin_Islands/Council/term-1990.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9e66f3c304bb54dd6b4837f16c189f1c6a4c8792/data/British_Virgin_Islands/Council/term-1990.csv"
           },
           {
             "end_date": "1990",
@@ -1521,7 +1521,7 @@
             "start_date": "1986",
             "slug": "1986",
             "csv": "data/British_Virgin_Islands/Council/term-1986.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e66f3c304bb54dd6b4837f16c189f1c6a4c8792/data/British_Virgin_Islands/Council/term-1986.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9e66f3c304bb54dd6b4837f16c189f1c6a4c8792/data/British_Virgin_Islands/Council/term-1986.csv"
           },
           {
             "end_date": "1986",
@@ -1530,7 +1530,7 @@
             "start_date": "1983",
             "slug": "1983",
             "csv": "data/British_Virgin_Islands/Council/term-1983.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e66f3c304bb54dd6b4837f16c189f1c6a4c8792/data/British_Virgin_Islands/Council/term-1983.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9e66f3c304bb54dd6b4837f16c189f1c6a4c8792/data/British_Virgin_Islands/Council/term-1983.csv"
           },
           {
             "end_date": "1983",
@@ -1539,7 +1539,7 @@
             "start_date": "1979",
             "slug": "1979",
             "csv": "data/British_Virgin_Islands/Council/term-1979.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a83b85b639f66814a53faedba3d219fa35159aa8/data/British_Virgin_Islands/Council/term-1979.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a83b85b639f66814a53faedba3d219fa35159aa8/data/British_Virgin_Islands/Council/term-1979.csv"
           },
           {
             "end_date": "1979",
@@ -1548,7 +1548,7 @@
             "start_date": "1975",
             "slug": "1975",
             "csv": "data/British_Virgin_Islands/Council/term-1975.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a83b85b639f66814a53faedba3d219fa35159aa8/data/British_Virgin_Islands/Council/term-1975.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a83b85b639f66814a53faedba3d219fa35159aa8/data/British_Virgin_Islands/Council/term-1975.csv"
           },
           {
             "end_date": "1975",
@@ -1557,7 +1557,7 @@
             "start_date": "1971",
             "slug": "1971",
             "csv": "data/British_Virgin_Islands/Council/term-1971.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/British_Virgin_Islands/Council/term-1971.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/British_Virgin_Islands/Council/term-1971.csv"
           }
         ],
         "statement_count": 1787,
@@ -1576,7 +1576,7 @@
         "slug": "Legislative-Council",
         "sources_directory": "data/Brunei/Legislative_Council/sources",
         "popolo": "data/Brunei/Legislative_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Brunei/Legislative_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Brunei/Legislative_Council/ep-popolo-v1.0.json",
         "names": "data/Brunei/Legislative_Council/names.csv",
         "lastmod": "1528387224",
         "person_count": 19,
@@ -1589,7 +1589,7 @@
             "start_date": "2015-03-05",
             "slug": "11",
             "csv": "data/Brunei/Legislative_Council/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Brunei/Legislative_Council/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Brunei/Legislative_Council/term-11.csv"
           }
         ],
         "statement_count": 311,
@@ -1608,11 +1608,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Bulgaria/National_Assembly/sources",
         "popolo": "data/Bulgaria/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/600e7ecb87f18b88462aa2f0ff892136a87061f2/data/Bulgaria/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a5f386edce282e0a146db594f8abe0e979bd65c/data/Bulgaria/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Bulgaria/National_Assembly/names.csv",
-        "lastmod": "1539053391",
+        "lastmod": "1539303389",
         "person_count": 1106,
-        "sha": "600e7ecb87f18b88462aa2f0ff892136a87061f2",
+        "sha": "9a5f386edce282e0a146db594f8abe0e979bd65c",
         "legislative_periods": [
           {
             "id": "term/44",
@@ -1620,7 +1620,7 @@
             "start_date": "2017-04-19",
             "slug": "44",
             "csv": "data/Bulgaria/National_Assembly/term-44.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7cde2f76d1f55b5202d8cc1910f3999579bb0702/data/Bulgaria/National_Assembly/term-44.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7cde2f76d1f55b5202d8cc1910f3999579bb0702/data/Bulgaria/National_Assembly/term-44.csv"
           },
           {
             "end_date": "2017-01-26",
@@ -1629,7 +1629,7 @@
             "start_date": "2014-10-27",
             "slug": "43",
             "csv": "data/Bulgaria/National_Assembly/term-43.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7cde2f76d1f55b5202d8cc1910f3999579bb0702/data/Bulgaria/National_Assembly/term-43.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7cde2f76d1f55b5202d8cc1910f3999579bb0702/data/Bulgaria/National_Assembly/term-43.csv"
           },
           {
             "end_date": "2014-08-05",
@@ -1638,7 +1638,7 @@
             "start_date": "2013-05-21",
             "slug": "42",
             "csv": "data/Bulgaria/National_Assembly/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7cde2f76d1f55b5202d8cc1910f3999579bb0702/data/Bulgaria/National_Assembly/term-42.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7cde2f76d1f55b5202d8cc1910f3999579bb0702/data/Bulgaria/National_Assembly/term-42.csv"
           },
           {
             "end_date": "2013-03-14",
@@ -1647,7 +1647,7 @@
             "start_date": "2009-07-14",
             "slug": "41",
             "csv": "data/Bulgaria/National_Assembly/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7cde2f76d1f55b5202d8cc1910f3999579bb0702/data/Bulgaria/National_Assembly/term-41.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7cde2f76d1f55b5202d8cc1910f3999579bb0702/data/Bulgaria/National_Assembly/term-41.csv"
           },
           {
             "end_date": "2009-06-25",
@@ -1656,7 +1656,7 @@
             "start_date": "2005-07-11",
             "slug": "40",
             "csv": "data/Bulgaria/National_Assembly/term-40.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7cde2f76d1f55b5202d8cc1910f3999579bb0702/data/Bulgaria/National_Assembly/term-40.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7cde2f76d1f55b5202d8cc1910f3999579bb0702/data/Bulgaria/National_Assembly/term-40.csv"
           },
           {
             "end_date": "2005-06-17",
@@ -1665,10 +1665,10 @@
             "start_date": "2001-07-05",
             "slug": "39",
             "csv": "data/Bulgaria/National_Assembly/term-39.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7cde2f76d1f55b5202d8cc1910f3999579bb0702/data/Bulgaria/National_Assembly/term-39.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7cde2f76d1f55b5202d8cc1910f3999579bb0702/data/Bulgaria/National_Assembly/term-39.csv"
           }
         ],
-        "statement_count": 44939,
+        "statement_count": 44942,
         "type": "unicameral legislature"
       }
     ]
@@ -1684,7 +1684,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Burkina_Faso/Assembly/sources",
         "popolo": "data/Burkina_Faso/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6975793b23c84e27452757468bcfff6c76f48f38/data/Burkina_Faso/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6975793b23c84e27452757468bcfff6c76f48f38/data/Burkina_Faso/Assembly/ep-popolo-v1.0.json",
         "names": "data/Burkina_Faso/Assembly/names.csv",
         "lastmod": "1537800763",
         "person_count": 476,
@@ -1696,7 +1696,7 @@
             "start_date": "2015-12-30",
             "slug": "7",
             "csv": "data/Burkina_Faso/Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Burkina_Faso/Assembly/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Burkina_Faso/Assembly/term-7.csv"
           },
           {
             "end_date": "2014-10-30",
@@ -1705,7 +1705,7 @@
             "start_date": "2012-12-02",
             "slug": "2012",
             "csv": "data/Burkina_Faso/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6975793b23c84e27452757468bcfff6c76f48f38/data/Burkina_Faso/Assembly/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6975793b23c84e27452757468bcfff6c76f48f38/data/Burkina_Faso/Assembly/term-2012.csv"
           },
           {
             "end_date": "2007-05-06",
@@ -1714,7 +1714,7 @@
             "start_date": "2002-06-05",
             "slug": "3",
             "csv": "data/Burkina_Faso/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6975793b23c84e27452757468bcfff6c76f48f38/data/Burkina_Faso/Assembly/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6975793b23c84e27452757468bcfff6c76f48f38/data/Burkina_Faso/Assembly/term-3.csv"
           },
           {
             "end_date": "2002-05-05",
@@ -1723,7 +1723,7 @@
             "start_date": "1997-06-07",
             "slug": "2",
             "csv": "data/Burkina_Faso/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6975793b23c84e27452757468bcfff6c76f48f38/data/Burkina_Faso/Assembly/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6975793b23c84e27452757468bcfff6c76f48f38/data/Burkina_Faso/Assembly/term-2.csv"
           },
           {
             "end_date": "1997-05-11",
@@ -1732,7 +1732,7 @@
             "start_date": "1992-06-15",
             "slug": "1",
             "csv": "data/Burkina_Faso/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6975793b23c84e27452757468bcfff6c76f48f38/data/Burkina_Faso/Assembly/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6975793b23c84e27452757468bcfff6c76f48f38/data/Burkina_Faso/Assembly/term-1.csv"
           }
         ],
         "statement_count": 6984,
@@ -1751,7 +1751,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Burundi/Assembly/sources",
         "popolo": "data/Burundi/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Burundi/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Burundi/Assembly/ep-popolo-v1.0.json",
         "names": "data/Burundi/Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 227,
@@ -1763,7 +1763,7 @@
             "start_date": "2015-07-27",
             "slug": "2015",
             "csv": "data/Burundi/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Burundi/Assembly/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Burundi/Assembly/term-2015.csv"
           },
           {
             "end_date": "2015-04-30",
@@ -1772,7 +1772,7 @@
             "start_date": "2010",
             "slug": "2010",
             "csv": "data/Burundi/Assembly/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Burundi/Assembly/term-2010.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Burundi/Assembly/term-2010.csv"
           }
         ],
         "statement_count": 3101,
@@ -1791,7 +1791,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Cabo_Verde/Assembly/sources",
         "popolo": "data/Cabo_Verde/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/418d8fa0dacc32003d7ebd10e3b84167c4556a0e/data/Cabo_Verde/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@418d8fa0dacc32003d7ebd10e3b84167c4556a0e/data/Cabo_Verde/Assembly/ep-popolo-v1.0.json",
         "names": "data/Cabo_Verde/Assembly/names.csv",
         "lastmod": "1533173214",
         "person_count": 131,
@@ -1803,7 +1803,7 @@
             "start_date": "2016-04-20",
             "slug": "9",
             "csv": "data/Cabo_Verde/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Cabo_Verde/Assembly/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Cabo_Verde/Assembly/term-9.csv"
           },
           {
             "end_date": "2016-03-20",
@@ -1812,7 +1812,7 @@
             "start_date": "2011-03-11",
             "slug": "8",
             "csv": "data/Cabo_Verde/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Cabo_Verde/Assembly/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Cabo_Verde/Assembly/term-8.csv"
           }
         ],
         "statement_count": 2334,
@@ -1831,7 +1831,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Cambodia/National_Assembly/sources",
         "popolo": "data/Cambodia/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e129af2c0e16916a799ed4c4922ff6449f9a1ac9/data/Cambodia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e129af2c0e16916a799ed4c4922ff6449f9a1ac9/data/Cambodia/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Cambodia/National_Assembly/names.csv",
         "lastmod": "1538840088",
         "person_count": 123,
@@ -1843,7 +1843,7 @@
             "start_date": "2013-09-23",
             "slug": "5",
             "csv": "data/Cambodia/National_Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e3a829d7f6f43f0430c94944d0adb47a63cfa536/data/Cambodia/National_Assembly/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e3a829d7f6f43f0430c94944d0adb47a63cfa536/data/Cambodia/National_Assembly/term-5.csv"
           }
         ],
         "statement_count": 2815,
@@ -1862,7 +1862,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Cameroon/Assembly/sources",
         "popolo": "data/Cameroon/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37a65e37a70ff4dfea4290d872f2ba47d0a20d11/data/Cameroon/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@37a65e37a70ff4dfea4290d872f2ba47d0a20d11/data/Cameroon/Assembly/ep-popolo-v1.0.json",
         "names": "data/Cameroon/Assembly/names.csv",
         "lastmod": "1537800774",
         "person_count": 964,
@@ -1874,7 +1874,7 @@
             "start_date": "2013-10-29",
             "slug": "9",
             "csv": "data/Cameroon/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Cameroon/Assembly/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Cameroon/Assembly/term-9.csv"
           },
           {
             "end_date": "2013-07-22",
@@ -1883,7 +1883,7 @@
             "start_date": "2007",
             "slug": "8",
             "csv": "data/Cameroon/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37a65e37a70ff4dfea4290d872f2ba47d0a20d11/data/Cameroon/Assembly/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@37a65e37a70ff4dfea4290d872f2ba47d0a20d11/data/Cameroon/Assembly/term-8.csv"
           },
           {
             "end_date": "2007",
@@ -1892,7 +1892,7 @@
             "start_date": "2002",
             "slug": "7",
             "csv": "data/Cameroon/Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37a65e37a70ff4dfea4290d872f2ba47d0a20d11/data/Cameroon/Assembly/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@37a65e37a70ff4dfea4290d872f2ba47d0a20d11/data/Cameroon/Assembly/term-7.csv"
           },
           {
             "end_date": "2002",
@@ -1901,7 +1901,7 @@
             "start_date": "1997",
             "slug": "6",
             "csv": "data/Cameroon/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37a65e37a70ff4dfea4290d872f2ba47d0a20d11/data/Cameroon/Assembly/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@37a65e37a70ff4dfea4290d872f2ba47d0a20d11/data/Cameroon/Assembly/term-6.csv"
           },
           {
             "end_date": "1997",
@@ -1910,7 +1910,7 @@
             "start_date": "1992",
             "slug": "5",
             "csv": "data/Cameroon/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37a65e37a70ff4dfea4290d872f2ba47d0a20d11/data/Cameroon/Assembly/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@37a65e37a70ff4dfea4290d872f2ba47d0a20d11/data/Cameroon/Assembly/term-5.csv"
           },
           {
             "end_date": "1992",
@@ -1919,7 +1919,7 @@
             "start_date": "1988",
             "slug": "4",
             "csv": "data/Cameroon/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37a65e37a70ff4dfea4290d872f2ba47d0a20d11/data/Cameroon/Assembly/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@37a65e37a70ff4dfea4290d872f2ba47d0a20d11/data/Cameroon/Assembly/term-4.csv"
           },
           {
             "end_date": "1988",
@@ -1928,7 +1928,7 @@
             "start_date": "1983",
             "slug": "3",
             "csv": "data/Cameroon/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37a65e37a70ff4dfea4290d872f2ba47d0a20d11/data/Cameroon/Assembly/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@37a65e37a70ff4dfea4290d872f2ba47d0a20d11/data/Cameroon/Assembly/term-3.csv"
           },
           {
             "end_date": "1978",
@@ -1937,7 +1937,7 @@
             "start_date": "1973",
             "slug": "1",
             "csv": "data/Cameroon/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37a65e37a70ff4dfea4290d872f2ba47d0a20d11/data/Cameroon/Assembly/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@37a65e37a70ff4dfea4290d872f2ba47d0a20d11/data/Cameroon/Assembly/term-1.csv"
           }
         ],
         "statement_count": 11536,
@@ -1948,7 +1948,7 @@
         "slug": "Senate",
         "sources_directory": "data/Cameroon/Senate/sources",
         "popolo": "data/Cameroon/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Cameroon/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Cameroon/Senate/ep-popolo-v1.0.json",
         "names": "data/Cameroon/Senate/names.csv",
         "lastmod": "1528387224",
         "person_count": 100,
@@ -1960,7 +1960,7 @@
             "start_date": "2013",
             "slug": "9",
             "csv": "data/Cameroon/Senate/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Cameroon/Senate/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Cameroon/Senate/term-9.csv"
           }
         ],
         "statement_count": 1339,
@@ -1979,31 +1979,31 @@
         "slug": "Commons",
         "sources_directory": "data/Canada/Commons/sources",
         "popolo": "data/Canada/Commons/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bb1add6b2eb49237f5bd249bbba2a5ce9ecb06a2/data/Canada/Commons/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@17563eab9afa122aeb4cef1d4c22b3474325a156/data/Canada/Commons/ep-popolo-v1.0.json",
         "names": "data/Canada/Commons/names.csv",
-        "lastmod": "1539073491",
+        "lastmod": "1539616860",
         "person_count": 550,
-        "sha": "bb1add6b2eb49237f5bd249bbba2a5ce9ecb06a2",
+        "sha": "17563eab9afa122aeb4cef1d4c22b3474325a156",
         "legislative_periods": [
           {
             "id": "term/42",
-            "name": "42nd Parliament",
+            "name": "42nd Canadian Parliament",
             "start_date": "2015-12-03",
             "slug": "42",
             "csv": "data/Canada/Commons/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6156066165bb43a1c9d6c6f5fc691ae240b4f34d/data/Canada/Commons/term-42.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e1a0707d2dbe466e19a1b481e112032951196237/data/Canada/Commons/term-42.csv"
           },
           {
             "end_date": "2015-08-02",
             "id": "term/41",
-            "name": "41st Parliament",
+            "name": "41st Canadian Parliament",
             "start_date": "2011-06-02",
             "slug": "41",
             "csv": "data/Canada/Commons/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bb1add6b2eb49237f5bd249bbba2a5ce9ecb06a2/data/Canada/Commons/term-41.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e1a0707d2dbe466e19a1b481e112032951196237/data/Canada/Commons/term-41.csv"
           }
         ],
-        "statement_count": 30081,
+        "statement_count": 30087,
         "type": "lower house"
       },
       {
@@ -2011,11 +2011,11 @@
         "slug": "Senate",
         "sources_directory": "data/Canada/Senate/sources",
         "popolo": "data/Canada/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9320b925f69ed906f462ef13c540940bba6d7d80/data/Canada/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7de227d6ac00427b2dde7ec685e944c7ff629060/data/Canada/Senate/ep-popolo-v1.0.json",
         "names": "data/Canada/Senate/names.csv",
-        "lastmod": "1538982011",
+        "lastmod": "1539607511",
         "person_count": 114,
-        "sha": "9320b925f69ed906f462ef13c540940bba6d7d80",
+        "sha": "7de227d6ac00427b2dde7ec685e944c7ff629060",
         "legislative_periods": [
           {
             "id": "term/42",
@@ -2023,10 +2023,10 @@
             "start_date": "2015-12-03",
             "slug": "42",
             "csv": "data/Canada/Senate/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9320b925f69ed906f462ef13c540940bba6d7d80/data/Canada/Senate/term-42.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9320b925f69ed906f462ef13c540940bba6d7d80/data/Canada/Senate/term-42.csv"
           }
         ],
-        "statement_count": 5260,
+        "statement_count": 5264,
         "type": "upper house"
       }
     ]
@@ -2042,7 +2042,7 @@
         "slug": "Legislative-Assembly",
         "sources_directory": "data/Cayman_Islands/Legislative_Assembly/sources",
         "popolo": "data/Cayman_Islands/Legislative_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b276d34776ac2e5221515e88b72d9851523be53f/data/Cayman_Islands/Legislative_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b276d34776ac2e5221515e88b72d9851523be53f/data/Cayman_Islands/Legislative_Assembly/ep-popolo-v1.0.json",
         "names": "data/Cayman_Islands/Legislative_Assembly/names.csv",
         "lastmod": "1533134691",
         "person_count": 18,
@@ -2054,7 +2054,7 @@
             "start_date": "2013",
             "slug": "2013",
             "csv": "data/Cayman_Islands/Legislative_Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Cayman_Islands/Legislative_Assembly/term-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Cayman_Islands/Legislative_Assembly/term-2013.csv"
           }
         ],
         "statement_count": 959,
@@ -2073,7 +2073,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Chad/Assembly/sources",
         "popolo": "data/Chad/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8e7a892d4aa2d65411603cd8cb7363de26adba4f/data/Chad/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@8e7a892d4aa2d65411603cd8cb7363de26adba4f/data/Chad/Assembly/ep-popolo-v1.0.json",
         "names": "data/Chad/Assembly/names.csv",
         "lastmod": "1538592044",
         "person_count": 191,
@@ -2085,7 +2085,7 @@
             "start_date": "2011-06-23",
             "slug": "3",
             "csv": "data/Chad/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Chad/Assembly/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Chad/Assembly/term-3.csv"
           }
         ],
         "statement_count": 2928,
@@ -2104,11 +2104,11 @@
         "slug": "Deputies",
         "sources_directory": "data/Chile/Deputies/sources",
         "popolo": "data/Chile/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fb8d6c61fd57e5965d94e40594b82c1b3e34d5c8/data/Chile/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@812f7269a2e38d24637cfb72b82d844ba28ca2de/data/Chile/Deputies/ep-popolo-v1.0.json",
         "names": "data/Chile/Deputies/names.csv",
-        "lastmod": "1538957468",
+        "lastmod": "1539543616",
         "person_count": 375,
-        "sha": "fb8d6c61fd57e5965d94e40594b82c1b3e34d5c8",
+        "sha": "812f7269a2e38d24637cfb72b82d844ba28ca2de",
         "legislative_periods": [
           {
             "end_date": "2018-03-10",
@@ -2117,7 +2117,7 @@
             "start_date": "2014-03-11",
             "slug": "8",
             "csv": "data/Chile/Deputies/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f287a99ed1b2277ed96635c5030f9c2be0545548/data/Chile/Deputies/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f287a99ed1b2277ed96635c5030f9c2be0545548/data/Chile/Deputies/term-8.csv"
           },
           {
             "end_date": "2014-03-10",
@@ -2126,7 +2126,7 @@
             "start_date": "2010-03-11",
             "slug": "6",
             "csv": "data/Chile/Deputies/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/750ec948dd33c6bf64ac0588c5d45a02cf5ca3a2/data/Chile/Deputies/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@750ec948dd33c6bf64ac0588c5d45a02cf5ca3a2/data/Chile/Deputies/term-6.csv"
           },
           {
             "end_date": "2010-03-10",
@@ -2135,7 +2135,7 @@
             "start_date": "2006-03-11",
             "slug": "5",
             "csv": "data/Chile/Deputies/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/750ec948dd33c6bf64ac0588c5d45a02cf5ca3a2/data/Chile/Deputies/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@750ec948dd33c6bf64ac0588c5d45a02cf5ca3a2/data/Chile/Deputies/term-5.csv"
           },
           {
             "end_date": "2006-03-10",
@@ -2144,7 +2144,7 @@
             "start_date": "2002-03-11",
             "slug": "4",
             "csv": "data/Chile/Deputies/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/750ec948dd33c6bf64ac0588c5d45a02cf5ca3a2/data/Chile/Deputies/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@750ec948dd33c6bf64ac0588c5d45a02cf5ca3a2/data/Chile/Deputies/term-4.csv"
           },
           {
             "end_date": "2002-03-10",
@@ -2153,7 +2153,7 @@
             "start_date": "1998-03-11",
             "slug": "3",
             "csv": "data/Chile/Deputies/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/750ec948dd33c6bf64ac0588c5d45a02cf5ca3a2/data/Chile/Deputies/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@750ec948dd33c6bf64ac0588c5d45a02cf5ca3a2/data/Chile/Deputies/term-3.csv"
           },
           {
             "end_date": "1998-03-10",
@@ -2162,7 +2162,7 @@
             "start_date": "1994-03-11",
             "slug": "2",
             "csv": "data/Chile/Deputies/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f287a99ed1b2277ed96635c5030f9c2be0545548/data/Chile/Deputies/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f287a99ed1b2277ed96635c5030f9c2be0545548/data/Chile/Deputies/term-2.csv"
           },
           {
             "end_date": "1994-03-10",
@@ -2171,10 +2171,10 @@
             "start_date": "1990-03-11",
             "slug": "1",
             "csv": "data/Chile/Deputies/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/750ec948dd33c6bf64ac0588c5d45a02cf5ca3a2/data/Chile/Deputies/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@750ec948dd33c6bf64ac0588c5d45a02cf5ca3a2/data/Chile/Deputies/term-1.csv"
           }
         ],
-        "statement_count": 14041,
+        "statement_count": 14045,
         "type": "unicameral legislature"
       }
     ]
@@ -2190,7 +2190,7 @@
         "slug": "Congress",
         "sources_directory": "data/China/Congress/sources",
         "popolo": "data/China/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/943177f792ab62e01409661a6fc10a1df3a112da/data/China/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@943177f792ab62e01409661a6fc10a1df3a112da/data/China/Congress/ep-popolo-v1.0.json",
         "names": "data/China/Congress/names.csv",
         "lastmod": "1534134956",
         "person_count": 2956,
@@ -2202,7 +2202,7 @@
             "start_date": "2013-03-05",
             "slug": "12",
             "csv": "data/China/Congress/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/China/Congress/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/China/Congress/term-12.csv"
           }
         ],
         "statement_count": 38170,
@@ -2221,11 +2221,11 @@
         "slug": "Representatives",
         "sources_directory": "data/Colombia/Representatives/sources",
         "popolo": "data/Colombia/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1f9406dae89750d02dd834f13e64eac9ccbec10d/data/Colombia/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ae179db0b466c94a8424779427cb90532e4695ce/data/Colombia/Representatives/ep-popolo-v1.0.json",
         "names": "data/Colombia/Representatives/names.csv",
-        "lastmod": "1539154606",
+        "lastmod": "1539336955",
         "person_count": 171,
-        "sha": "1f9406dae89750d02dd834f13e64eac9ccbec10d",
+        "sha": "ae179db0b466c94a8424779427cb90532e4695ce",
         "legislative_periods": [
           {
             "end_date": "2018-07-19",
@@ -2234,10 +2234,10 @@
             "start_date": "2014-07-20",
             "slug": "2014",
             "csv": "data/Colombia/Representatives/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/97f3265626ab0a7c49f4eaa3baf3e9e05585e741/data/Colombia/Representatives/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@97f3265626ab0a7c49f4eaa3baf3e9e05585e741/data/Colombia/Representatives/term-2014.csv"
           }
         ],
-        "statement_count": 4315,
+        "statement_count": 4316,
         "type": "lower house"
       },
       {
@@ -2245,7 +2245,7 @@
         "slug": "Senate",
         "sources_directory": "data/Colombia/Senate/sources",
         "popolo": "data/Colombia/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/92487d3a8fb7154fb0cd5321a1c5eac648518296/data/Colombia/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@92487d3a8fb7154fb0cd5321a1c5eac648518296/data/Colombia/Senate/ep-popolo-v1.0.json",
         "names": "data/Colombia/Senate/names.csv",
         "lastmod": "1537885155",
         "person_count": 101,
@@ -2258,7 +2258,7 @@
             "start_date": "2014-07-20",
             "slug": "2014",
             "csv": "data/Colombia/Senate/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/92487d3a8fb7154fb0cd5321a1c5eac648518296/data/Colombia/Senate/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@92487d3a8fb7154fb0cd5321a1c5eac648518296/data/Colombia/Senate/term-2014.csv"
           }
         ],
         "statement_count": 3817,
@@ -2277,7 +2277,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Comoros/Assembly/sources",
         "popolo": "data/Comoros/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Comoros/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Comoros/Assembly/ep-popolo-v1.0.json",
         "names": "data/Comoros/Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 24,
@@ -2289,7 +2289,7 @@
             "start_date": "2015-04-03",
             "slug": "2015",
             "csv": "data/Comoros/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Comoros/Assembly/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Comoros/Assembly/term-2015.csv"
           }
         ],
         "statement_count": 874,
@@ -2308,7 +2308,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Congo-Brazzaville/Assembly/sources",
         "popolo": "data/Congo-Brazzaville/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5f61dcaa9ae08350fe343aea558406e498042d9d/data/Congo-Brazzaville/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@5f61dcaa9ae08350fe343aea558406e498042d9d/data/Congo-Brazzaville/Assembly/ep-popolo-v1.0.json",
         "names": "data/Congo-Brazzaville/Assembly/names.csv",
         "lastmod": "1538187162",
         "person_count": 122,
@@ -2320,7 +2320,7 @@
             "start_date": "2012-09-05",
             "slug": "13",
             "csv": "data/Congo-Brazzaville/Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Congo-Brazzaville/Assembly/term-13.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Congo-Brazzaville/Assembly/term-13.csv"
           }
         ],
         "statement_count": 3019,
@@ -2339,7 +2339,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Congo-Kinshasa/Assembly/sources",
         "popolo": "data/Congo-Kinshasa/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c9ef6ee0079b032c20c42f74c261a5801ea948f/data/Congo-Kinshasa/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@5c9ef6ee0079b032c20c42f74c261a5801ea948f/data/Congo-Kinshasa/Assembly/ep-popolo-v1.0.json",
         "names": "data/Congo-Kinshasa/Assembly/names.csv",
         "lastmod": "1531807835",
         "person_count": 498,
@@ -2351,7 +2351,7 @@
             "start_date": "2012-02-16",
             "slug": "2012",
             "csv": "data/Congo-Kinshasa/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a3da8479d41774bf179381629c7d14edc5712707/data/Congo-Kinshasa/Assembly/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a3da8479d41774bf179381629c7d14edc5712707/data/Congo-Kinshasa/Assembly/term-2012.csv"
           }
         ],
         "statement_count": 7139,
@@ -2370,7 +2370,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Cook_Islands/Parliament/sources",
         "popolo": "data/Cook_Islands/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9ce8b98872dfa073a33f234145a696355a57efa5/data/Cook_Islands/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9ce8b98872dfa073a33f234145a696355a57efa5/data/Cook_Islands/Parliament/ep-popolo-v1.0.json",
         "names": "data/Cook_Islands/Parliament/names.csv",
         "lastmod": "1535031075",
         "person_count": 49,
@@ -2382,7 +2382,7 @@
             "start_date": "2014-10-08",
             "slug": "14",
             "csv": "data/Cook_Islands/Parliament/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d15ea55b75488ae898227235d82539635b55a834/data/Cook_Islands/Parliament/term-14.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d15ea55b75488ae898227235d82539635b55a834/data/Cook_Islands/Parliament/term-14.csv"
           },
           {
             "end_date": "2014-04-17",
@@ -2391,7 +2391,7 @@
             "start_date": "2011-02-18",
             "slug": "13",
             "csv": "data/Cook_Islands/Parliament/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Cook_Islands/Parliament/term-13.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Cook_Islands/Parliament/term-13.csv"
           },
           {
             "end_date": "2010-09-24",
@@ -2400,7 +2400,7 @@
             "start_date": "2006-09-27",
             "slug": "12",
             "csv": "data/Cook_Islands/Parliament/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Cook_Islands/Parliament/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Cook_Islands/Parliament/term-12.csv"
           }
         ],
         "statement_count": 2090,
@@ -2419,7 +2419,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Costa_Rica/Assembly/sources",
         "popolo": "data/Costa_Rica/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/777b42a0dea981750b5744f16a36200d04acf6cf/data/Costa_Rica/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@777b42a0dea981750b5744f16a36200d04acf6cf/data/Costa_Rica/Assembly/ep-popolo-v1.0.json",
         "names": "data/Costa_Rica/Assembly/names.csv",
         "lastmod": "1537800838",
         "person_count": 57,
@@ -2432,7 +2432,7 @@
             "start_date": "2014-05-01",
             "slug": "2014",
             "csv": "data/Costa_Rica/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/777b42a0dea981750b5744f16a36200d04acf6cf/data/Costa_Rica/Assembly/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@777b42a0dea981750b5744f16a36200d04acf6cf/data/Costa_Rica/Assembly/term-2014.csv"
           }
         ],
         "statement_count": 2135,
@@ -2451,40 +2451,40 @@
         "slug": "Sabor",
         "sources_directory": "data/Croatia/Sabor/sources",
         "popolo": "data/Croatia/Sabor/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d948d028d0089c6338ece389acffa97da3c36b1c/data/Croatia/Sabor/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@3ed0e563df9519b3591a3dd2a3d054fdd11c41e6/data/Croatia/Sabor/ep-popolo-v1.0.json",
         "names": "data/Croatia/Sabor/names.csv",
-        "lastmod": "1538457335",
+        "lastmod": "1539497704",
         "person_count": 354,
-        "sha": "d948d028d0089c6338ece389acffa97da3c36b1c",
+        "sha": "3ed0e563df9519b3591a3dd2a3d054fdd11c41e6",
         "legislative_periods": [
           {
             "id": "term/9",
-            "name": "9th Assembly",
+            "name": "9th Sabor",
             "start_date": "2016-10-14",
             "slug": "9",
             "csv": "data/Croatia/Sabor/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Croatia/Sabor/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Croatia/Sabor/term-9.csv"
           },
           {
             "end_date": "2016-07-15",
             "id": "term/8",
-            "name": "8th Assembly",
+            "name": "8th Sabor",
             "start_date": "2015-12-28",
             "slug": "8",
             "csv": "data/Croatia/Sabor/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Croatia/Sabor/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Croatia/Sabor/term-8.csv"
           },
           {
             "end_date": "2015-09-28",
             "id": "term/7",
-            "name": "7th Assembly",
+            "name": "7th Sabor",
             "start_date": "2011-12-22",
             "slug": "7",
             "csv": "data/Croatia/Sabor/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/858ef90b4cb9c5fdfd7f38f4d98383bfef540150/data/Croatia/Sabor/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@858ef90b4cb9c5fdfd7f38f4d98383bfef540150/data/Croatia/Sabor/term-7.csv"
           }
         ],
-        "statement_count": 12172,
+        "statement_count": 12173,
         "type": "unicameral legislature"
       }
     ]
@@ -2500,7 +2500,7 @@
         "slug": "Estates",
         "sources_directory": "data/Curacao/Estates/sources",
         "popolo": "data/Curacao/Estates/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7eb71fdef78a6f141b27e9a965894b5221d6d38d/data/Curacao/Estates/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7eb71fdef78a6f141b27e9a965894b5221d6d38d/data/Curacao/Estates/ep-popolo-v1.0.json",
         "names": "data/Curacao/Estates/names.csv",
         "lastmod": "1537810456",
         "person_count": 21,
@@ -2513,7 +2513,7 @@
             "start_date": "2012-11-02",
             "slug": "2",
             "csv": "data/Curacao/Estates/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7eb71fdef78a6f141b27e9a965894b5221d6d38d/data/Curacao/Estates/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7eb71fdef78a6f141b27e9a965894b5221d6d38d/data/Curacao/Estates/term-2.csv"
           }
         ],
         "statement_count": 1365,
@@ -2532,7 +2532,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Cyprus/House_of_Representatives/sources",
         "popolo": "data/Cyprus/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9f4370c7f9445b58a02dda9dd9de5e5a12f80e75/data/Cyprus/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9f4370c7f9445b58a02dda9dd9de5e5a12f80e75/data/Cyprus/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Cyprus/House_of_Representatives/names.csv",
         "lastmod": "1538043981",
         "person_count": 91,
@@ -2544,7 +2544,7 @@
             "start_date": "2016-06-02",
             "slug": "11",
             "csv": "data/Cyprus/House_of_Representatives/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Cyprus/House_of_Representatives/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Cyprus/House_of_Representatives/term-11.csv"
           },
           {
             "end_date": "2016-04-14",
@@ -2553,7 +2553,7 @@
             "start_date": "2011-06-02",
             "slug": "10",
             "csv": "data/Cyprus/House_of_Representatives/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Cyprus/House_of_Representatives/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Cyprus/House_of_Representatives/term-10.csv"
           }
         ],
         "statement_count": 6077,
@@ -2572,11 +2572,11 @@
         "slug": "Deputies",
         "sources_directory": "data/Czech_Republic/Deputies/sources",
         "popolo": "data/Czech_Republic/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e5d34cd54739f60f283916caa4905986208e9464/data/Czech_Republic/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@27753ed7ce45dc901581fb2325f53a85ba725538/data/Czech_Republic/Deputies/ep-popolo-v1.0.json",
         "names": "data/Czech_Republic/Deputies/names.csv",
-        "lastmod": "1539241390",
+        "lastmod": "1539303538",
         "person_count": 892,
-        "sha": "e5d34cd54739f60f283916caa4905986208e9464",
+        "sha": "27753ed7ce45dc901581fb2325f53a85ba725538",
         "legislative_periods": [
           {
             "id": "term/7",
@@ -2584,7 +2584,7 @@
             "start_date": "2013-10-26",
             "slug": "7",
             "csv": "data/Czech_Republic/Deputies/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbc9ab53890f0eeed91c363f82d3870d9f3c55ae/data/Czech_Republic/Deputies/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@dbc9ab53890f0eeed91c363f82d3870d9f3c55ae/data/Czech_Republic/Deputies/term-7.csv"
           },
           {
             "end_date": "2013-08-28",
@@ -2593,7 +2593,7 @@
             "start_date": "2010-05-29",
             "slug": "6",
             "csv": "data/Czech_Republic/Deputies/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbc9ab53890f0eeed91c363f82d3870d9f3c55ae/data/Czech_Republic/Deputies/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@dbc9ab53890f0eeed91c363f82d3870d9f3c55ae/data/Czech_Republic/Deputies/term-6.csv"
           },
           {
             "end_date": "2010-05-28",
@@ -2602,7 +2602,7 @@
             "start_date": "2006-06-03",
             "slug": "5",
             "csv": "data/Czech_Republic/Deputies/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f606a841122121c09f1f9788f0900973dd92bc2f/data/Czech_Republic/Deputies/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f606a841122121c09f1f9788f0900973dd92bc2f/data/Czech_Republic/Deputies/term-5.csv"
           },
           {
             "end_date": "2006-06-02",
@@ -2611,7 +2611,7 @@
             "start_date": "2002-06-15",
             "slug": "4",
             "csv": "data/Czech_Republic/Deputies/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f606a841122121c09f1f9788f0900973dd92bc2f/data/Czech_Republic/Deputies/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f606a841122121c09f1f9788f0900973dd92bc2f/data/Czech_Republic/Deputies/term-4.csv"
           },
           {
             "end_date": "2002-06-14",
@@ -2620,7 +2620,7 @@
             "start_date": "1998-06-20",
             "slug": "3",
             "csv": "data/Czech_Republic/Deputies/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e3ae4db782cd190aafd5f356bdf36a8338930e32/data/Czech_Republic/Deputies/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e3ae4db782cd190aafd5f356bdf36a8338930e32/data/Czech_Republic/Deputies/term-3.csv"
           },
           {
             "end_date": "1998-06-19",
@@ -2629,7 +2629,7 @@
             "start_date": "1996-06-01",
             "slug": "2",
             "csv": "data/Czech_Republic/Deputies/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e3ae4db782cd190aafd5f356bdf36a8338930e32/data/Czech_Republic/Deputies/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e3ae4db782cd190aafd5f356bdf36a8338930e32/data/Czech_Republic/Deputies/term-2.csv"
           },
           {
             "end_date": "1996-05-31",
@@ -2638,10 +2638,10 @@
             "start_date": "1992-06-06",
             "slug": "1",
             "csv": "data/Czech_Republic/Deputies/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e3ae4db782cd190aafd5f356bdf36a8338930e32/data/Czech_Republic/Deputies/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e3ae4db782cd190aafd5f356bdf36a8338930e32/data/Czech_Republic/Deputies/term-1.csv"
           }
         ],
-        "statement_count": 51691,
+        "statement_count": 51693,
         "type": "lower house"
       }
     ]
@@ -2657,7 +2657,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Ivory_Coast/Assembly/sources",
         "popolo": "data/Ivory_Coast/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Ivory_Coast/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Ivory_Coast/Assembly/ep-popolo-v1.0.json",
         "names": "data/Ivory_Coast/Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 241,
@@ -2669,7 +2669,7 @@
             "start_date": "2012-03-12",
             "slug": "2.2",
             "csv": "data/Ivory_Coast/Assembly/term-2.2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Ivory_Coast/Assembly/term-2.2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Ivory_Coast/Assembly/term-2.2.csv"
           }
         ],
         "statement_count": 4613,
@@ -2688,11 +2688,11 @@
         "slug": "Folketing",
         "sources_directory": "data/Denmark/Folketing/sources",
         "popolo": "data/Denmark/Folketing/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a0a6a54e4bc78ad5a150385c89d59c88140e03e3/data/Denmark/Folketing/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@34655d302176afc1f0a8a78cbe78c45ed615ce96/data/Denmark/Folketing/ep-popolo-v1.0.json",
         "names": "data/Denmark/Folketing/names.csv",
-        "lastmod": "1538998823",
+        "lastmod": "1539535675",
         "person_count": 613,
-        "sha": "a0a6a54e4bc78ad5a150385c89d59c88140e03e3",
+        "sha": "34655d302176afc1f0a8a78cbe78c45ed615ce96",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -2700,7 +2700,7 @@
             "start_date": "2015-06-20",
             "slug": "2015",
             "csv": "data/Denmark/Folketing/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ce387b4b1dcfdc11ae77cbcd3462b71c57d53697/data/Denmark/Folketing/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ce387b4b1dcfdc11ae77cbcd3462b71c57d53697/data/Denmark/Folketing/term-2015.csv"
           },
           {
             "end_date": "2015-06-19",
@@ -2709,7 +2709,7 @@
             "start_date": "2011-09-15",
             "slug": "2011",
             "csv": "data/Denmark/Folketing/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/124d0df20c02663f460c1d3739f9736997a58d96/data/Denmark/Folketing/term-2011.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@124d0df20c02663f460c1d3739f9736997a58d96/data/Denmark/Folketing/term-2011.csv"
           },
           {
             "end_date": "2011-09-14",
@@ -2718,7 +2718,7 @@
             "start_date": "2007-11-13",
             "slug": "2007",
             "csv": "data/Denmark/Folketing/term-2007.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ed70ce77b26226d0d5d080b6a63b16ce8920585/data/Denmark/Folketing/term-2007.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@5ed70ce77b26226d0d5d080b6a63b16ce8920585/data/Denmark/Folketing/term-2007.csv"
           },
           {
             "end_date": "2007-11-12",
@@ -2727,7 +2727,7 @@
             "start_date": "2005-02-08",
             "slug": "2005",
             "csv": "data/Denmark/Folketing/term-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af3384d80477b00268eca1b9480a340d9be0b84f/data/Denmark/Folketing/term-2005.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@af3384d80477b00268eca1b9480a340d9be0b84f/data/Denmark/Folketing/term-2005.csv"
           },
           {
             "end_date": "2005-02-07",
@@ -2736,7 +2736,7 @@
             "start_date": "2001-11-20",
             "slug": "2001",
             "csv": "data/Denmark/Folketing/term-2001.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af3384d80477b00268eca1b9480a340d9be0b84f/data/Denmark/Folketing/term-2001.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@af3384d80477b00268eca1b9480a340d9be0b84f/data/Denmark/Folketing/term-2001.csv"
           },
           {
             "end_date": "2001-11-19",
@@ -2745,7 +2745,7 @@
             "start_date": "1998-11-03",
             "slug": "1998",
             "csv": "data/Denmark/Folketing/term-1998.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ce387b4b1dcfdc11ae77cbcd3462b71c57d53697/data/Denmark/Folketing/term-1998.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ce387b4b1dcfdc11ae77cbcd3462b71c57d53697/data/Denmark/Folketing/term-1998.csv"
           },
           {
             "end_date": "1998-11-02",
@@ -2754,7 +2754,7 @@
             "start_date": "1994-09-21",
             "slug": "1994",
             "csv": "data/Denmark/Folketing/term-1994.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ce387b4b1dcfdc11ae77cbcd3462b71c57d53697/data/Denmark/Folketing/term-1994.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ce387b4b1dcfdc11ae77cbcd3462b71c57d53697/data/Denmark/Folketing/term-1994.csv"
           },
           {
             "end_date": "1994-09-20",
@@ -2763,10 +2763,10 @@
             "start_date": "1990-12-12",
             "slug": "1990",
             "csv": "data/Denmark/Folketing/term-1990.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ce387b4b1dcfdc11ae77cbcd3462b71c57d53697/data/Denmark/Folketing/term-1990.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ce387b4b1dcfdc11ae77cbcd3462b71c57d53697/data/Denmark/Folketing/term-1990.csv"
           }
         ],
-        "statement_count": 29153,
+        "statement_count": 29155,
         "type": "unicameral legislature"
       }
     ]
@@ -2782,7 +2782,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Djibouti/Assembly/sources",
         "popolo": "data/Djibouti/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Djibouti/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Djibouti/Assembly/ep-popolo-v1.0.json",
         "names": "data/Djibouti/Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 65,
@@ -2794,7 +2794,7 @@
             "start_date": "2013-03-05",
             "slug": "6",
             "csv": "data/Djibouti/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Djibouti/Assembly/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Djibouti/Assembly/term-6.csv"
           }
         ],
         "statement_count": 865,
@@ -2813,7 +2813,7 @@
         "slug": "House-of-Assembly",
         "sources_directory": "data/Dominica/House_of_Assembly/sources",
         "popolo": "data/Dominica/House_of_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Dominica/House_of_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Dominica/House_of_Assembly/ep-popolo-v1.0.json",
         "names": "data/Dominica/House_of_Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 21,
@@ -2825,7 +2825,7 @@
             "start_date": "2014",
             "slug": "2014",
             "csv": "data/Dominica/House_of_Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Dominica/House_of_Assembly/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Dominica/House_of_Assembly/term-2014.csv"
           }
         ],
         "statement_count": 596,
@@ -2844,7 +2844,7 @@
         "slug": "Diputados",
         "sources_directory": "data/Dominican_Republic/Diputados/sources",
         "popolo": "data/Dominican_Republic/Diputados/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c6c17be0104b663137564c38228535df5ce201cf/data/Dominican_Republic/Diputados/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c6c17be0104b663137564c38228535df5ce201cf/data/Dominican_Republic/Diputados/ep-popolo-v1.0.json",
         "names": "data/Dominican_Republic/Diputados/names.csv",
         "lastmod": "1537800867",
         "person_count": 190,
@@ -2857,7 +2857,7 @@
             "start_date": "2010",
             "slug": "2010",
             "csv": "data/Dominican_Republic/Diputados/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c6c17be0104b663137564c38228535df5ce201cf/data/Dominican_Republic/Diputados/term-2010.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c6c17be0104b663137564c38228535df5ce201cf/data/Dominican_Republic/Diputados/term-2010.csv"
           }
         ],
         "statement_count": 3297,
@@ -2876,22 +2876,23 @@
         "slug": "Asamblea",
         "sources_directory": "data/Ecuador/Asamblea/sources",
         "popolo": "data/Ecuador/Asamblea/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d45caf9b98816accd93ec65a34635e96d5fd7035/data/Ecuador/Asamblea/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@8b5c2674cb8047640d065c6876168fd9a3fe54c2/data/Ecuador/Asamblea/ep-popolo-v1.0.json",
         "names": "data/Ecuador/Asamblea/names.csv",
-        "lastmod": "1538999752",
+        "lastmod": "1539664825",
         "person_count": 146,
-        "sha": "d45caf9b98816accd93ec65a34635e96d5fd7035",
+        "sha": "8b5c2674cb8047640d065c6876168fd9a3fe54c2",
         "legislative_periods": [
           {
-            "id": "term/2013",
-            "name": "2013–2017",
+            "end_date": "2017-05-11",
+            "id": "term/2",
+            "name": "2nd Legislative Assembly of Ecuador",
             "start_date": "2013-05-14",
-            "slug": "2013",
-            "csv": "data/Ecuador/Asamblea/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Ecuador/Asamblea/term-2013.csv"
+            "slug": "2",
+            "csv": "data/Ecuador/Asamblea/term-2.csv",
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@8b5c2674cb8047640d065c6876168fd9a3fe54c2/data/Ecuador/Asamblea/term-2.csv"
           }
         ],
-        "statement_count": 4892,
+        "statement_count": 4899,
         "type": "unicameral legislature"
       }
     ]
@@ -2907,7 +2908,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Egypt/Parliament/sources",
         "popolo": "data/Egypt/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/23eae7ded66214313e79e7048d1a39cba47dbd03/data/Egypt/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@23eae7ded66214313e79e7048d1a39cba47dbd03/data/Egypt/Parliament/ep-popolo-v1.0.json",
         "names": "data/Egypt/Parliament/names.csv",
         "lastmod": "1538669997",
         "person_count": 600,
@@ -2919,7 +2920,7 @@
             "start_date": "2016-01-10",
             "slug": "2015",
             "csv": "data/Egypt/Parliament/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02fc9a2f8fda520af85409a41299a95206ba3286/data/Egypt/Parliament/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@02fc9a2f8fda520af85409a41299a95206ba3286/data/Egypt/Parliament/term-2015.csv"
           }
         ],
         "statement_count": 8477,
@@ -2938,7 +2939,7 @@
         "slug": "Legislative-Assembly",
         "sources_directory": "data/El_Salvador/Legislative_Assembly/sources",
         "popolo": "data/El_Salvador/Legislative_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa7ab555eec9fb6d31dfcb120b02135083924250/data/El_Salvador/Legislative_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@fa7ab555eec9fb6d31dfcb120b02135083924250/data/El_Salvador/Legislative_Assembly/ep-popolo-v1.0.json",
         "names": "data/El_Salvador/Legislative_Assembly/names.csv",
         "lastmod": "1537785762",
         "person_count": 84,
@@ -2950,7 +2951,7 @@
             "start_date": "2015-05-14",
             "slug": "2015-2018",
             "csv": "data/El_Salvador/Legislative_Assembly/term-2015-2018.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/El_Salvador/Legislative_Assembly/term-2015-2018.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/El_Salvador/Legislative_Assembly/term-2015-2018.csv"
           }
         ],
         "statement_count": 2346,
@@ -2969,7 +2970,7 @@
         "slug": "Riigikogu",
         "sources_directory": "data/Estonia/Riigikogu/sources",
         "popolo": "data/Estonia/Riigikogu/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ea4f1c43928b6c7ef49149e81f6c90c2f557a09f/data/Estonia/Riigikogu/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ea4f1c43928b6c7ef49149e81f6c90c2f557a09f/data/Estonia/Riigikogu/ep-popolo-v1.0.json",
         "names": "data/Estonia/Riigikogu/names.csv",
         "lastmod": "1539226304",
         "person_count": 214,
@@ -2981,7 +2982,7 @@
             "start_date": "2015-03-30",
             "slug": "13",
             "csv": "data/Estonia/Riigikogu/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ea4f1c43928b6c7ef49149e81f6c90c2f557a09f/data/Estonia/Riigikogu/term-13.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ea4f1c43928b6c7ef49149e81f6c90c2f557a09f/data/Estonia/Riigikogu/term-13.csv"
           },
           {
             "end_date": "2015-03-23",
@@ -2990,7 +2991,7 @@
             "start_date": "2011-03-27",
             "slug": "12",
             "csv": "data/Estonia/Riigikogu/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ea4f1c43928b6c7ef49149e81f6c90c2f557a09f/data/Estonia/Riigikogu/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ea4f1c43928b6c7ef49149e81f6c90c2f557a09f/data/Estonia/Riigikogu/term-12.csv"
           }
         ],
         "statement_count": 11645,
@@ -3009,7 +3010,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Falkland_Islands/Assembly/sources",
         "popolo": "data/Falkland_Islands/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5ffc7f6f10ffdd04191f95c6c7f757173d116f52/data/Falkland_Islands/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@5ffc7f6f10ffdd04191f95c6c7f757173d116f52/data/Falkland_Islands/Assembly/ep-popolo-v1.0.json",
         "names": "data/Falkland_Islands/Assembly/names.csv",
         "lastmod": "1535098420",
         "person_count": 49,
@@ -3022,7 +3023,7 @@
             "start_date": "2013-11-07",
             "slug": "2013",
             "csv": "data/Falkland_Islands/Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-2013.csv"
           },
           {
             "end_date": "2013",
@@ -3031,7 +3032,7 @@
             "start_date": "2009",
             "slug": "2009",
             "csv": "data/Falkland_Islands/Assembly/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-2009.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-2009.csv"
           },
           {
             "end_date": "2009",
@@ -3040,7 +3041,7 @@
             "start_date": "2005",
             "slug": "2005",
             "csv": "data/Falkland_Islands/Assembly/term-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-2005.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-2005.csv"
           },
           {
             "end_date": "2005",
@@ -3049,7 +3050,7 @@
             "start_date": "2001",
             "slug": "2001",
             "csv": "data/Falkland_Islands/Assembly/term-2001.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-2001.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-2001.csv"
           },
           {
             "end_date": "2001",
@@ -3058,7 +3059,7 @@
             "start_date": "1997",
             "slug": "1997",
             "csv": "data/Falkland_Islands/Assembly/term-1997.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-1997.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-1997.csv"
           },
           {
             "end_date": "1997",
@@ -3067,7 +3068,7 @@
             "start_date": "1993",
             "slug": "1993",
             "csv": "data/Falkland_Islands/Assembly/term-1993.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-1993.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-1993.csv"
           },
           {
             "end_date": "1993",
@@ -3076,7 +3077,7 @@
             "start_date": "1989",
             "slug": "1989",
             "csv": "data/Falkland_Islands/Assembly/term-1989.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-1989.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-1989.csv"
           },
           {
             "end_date": "1989",
@@ -3085,7 +3086,7 @@
             "start_date": "1985",
             "slug": "1985",
             "csv": "data/Falkland_Islands/Assembly/term-1985.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-1985.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-1985.csv"
           },
           {
             "end_date": "1985",
@@ -3094,7 +3095,7 @@
             "start_date": "1981",
             "slug": "1981",
             "csv": "data/Falkland_Islands/Assembly/term-1981.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-1981.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-1981.csv"
           },
           {
             "end_date": "1981",
@@ -3103,7 +3104,7 @@
             "start_date": "1977",
             "slug": "1977",
             "csv": "data/Falkland_Islands/Assembly/term-1977.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-1977.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Falkland_Islands/Assembly/term-1977.csv"
           }
         ],
         "statement_count": 1849,
@@ -3122,11 +3123,11 @@
         "slug": "Logting",
         "sources_directory": "data/Faroe_Islands/Logting/sources",
         "popolo": "data/Faroe_Islands/Logting/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d0ee2f731531150158d232ec6052869c887b5d99/data/Faroe_Islands/Logting/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d9b05c39eb843d1543f3719a999fc8698af5e660/data/Faroe_Islands/Logting/ep-popolo-v1.0.json",
         "names": "data/Faroe_Islands/Logting/names.csv",
-        "lastmod": "1537422309",
+        "lastmod": "1539315144",
         "person_count": 103,
-        "sha": "d0ee2f731531150158d232ec6052869c887b5d99",
+        "sha": "d9b05c39eb843d1543f3719a999fc8698af5e660",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -3134,7 +3135,7 @@
             "start_date": "2015-09-01",
             "slug": "2015",
             "csv": "data/Faroe_Islands/Logting/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Faroe_Islands/Logting/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Faroe_Islands/Logting/term-2015.csv"
           },
           {
             "end_date": "2015-09-01",
@@ -3143,7 +3144,7 @@
             "start_date": "2011-10-29",
             "slug": "2011",
             "csv": "data/Faroe_Islands/Logting/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Faroe_Islands/Logting/term-2011.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Faroe_Islands/Logting/term-2011.csv"
           },
           {
             "end_date": "2011-10-29",
@@ -3152,7 +3153,7 @@
             "start_date": "2008-01-19",
             "slug": "2008",
             "csv": "data/Faroe_Islands/Logting/term-2008.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Faroe_Islands/Logting/term-2008.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Faroe_Islands/Logting/term-2008.csv"
           },
           {
             "end_date": "2008-01-19",
@@ -3161,7 +3162,7 @@
             "start_date": "2004",
             "slug": "2004",
             "csv": "data/Faroe_Islands/Logting/term-2004.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Faroe_Islands/Logting/term-2004.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Faroe_Islands/Logting/term-2004.csv"
           },
           {
             "end_date": "2004",
@@ -3170,7 +3171,7 @@
             "start_date": "2002",
             "slug": "2002",
             "csv": "data/Faroe_Islands/Logting/term-2002.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Faroe_Islands/Logting/term-2002.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Faroe_Islands/Logting/term-2002.csv"
           },
           {
             "end_date": "2002",
@@ -3179,7 +3180,7 @@
             "start_date": "1998",
             "slug": "1998",
             "csv": "data/Faroe_Islands/Logting/term-1998.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Faroe_Islands/Logting/term-1998.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Faroe_Islands/Logting/term-1998.csv"
           },
           {
             "end_date": "1998",
@@ -3188,7 +3189,7 @@
             "start_date": "1994",
             "slug": "1994",
             "csv": "data/Faroe_Islands/Logting/term-1994.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Faroe_Islands/Logting/term-1994.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Faroe_Islands/Logting/term-1994.csv"
           },
           {
             "end_date": "1994",
@@ -3197,10 +3198,10 @@
             "start_date": "1990",
             "slug": "1990",
             "csv": "data/Faroe_Islands/Logting/term-1990.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Faroe_Islands/Logting/term-1990.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Faroe_Islands/Logting/term-1990.csv"
           }
         ],
-        "statement_count": 5771,
+        "statement_count": 5775,
         "type": "unicameral legislature"
       }
     ]
@@ -3216,7 +3217,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Fiji/Parliament/sources",
         "popolo": "data/Fiji/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9954cfd96bc33b929ea37eaad601fb2befa9d4e4/data/Fiji/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9954cfd96bc33b929ea37eaad601fb2befa9d4e4/data/Fiji/Parliament/ep-popolo-v1.0.json",
         "names": "data/Fiji/Parliament/names.csv",
         "lastmod": "1527098814",
         "person_count": 54,
@@ -3228,7 +3229,7 @@
             "start_date": "2014-10-06",
             "slug": "2014",
             "csv": "data/Fiji/Parliament/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Fiji/Parliament/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Fiji/Parliament/term-2014.csv"
           }
         ],
         "statement_count": 921,
@@ -3247,130 +3248,130 @@
         "slug": "Eduskunta",
         "sources_directory": "data/Finland/Eduskunta/sources",
         "popolo": "data/Finland/Eduskunta/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d1e69aff8450aaebe98b02a6ccdd77e90cf3d990/data/Finland/Eduskunta/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@66a179bb24b279feb553f95219de724f4058c5f2/data/Finland/Eduskunta/ep-popolo-v1.0.json",
         "names": "data/Finland/Eduskunta/names.csv",
-        "lastmod": "1539095249",
+        "lastmod": "1539354412",
         "person_count": 500,
-        "sha": "d1e69aff8450aaebe98b02a6ccdd77e90cf3d990",
+        "sha": "66a179bb24b279feb553f95219de724f4058c5f2",
         "legislative_periods": [
           {
             "id": "term/37",
-            "name": "Eduskunta 37",
+            "name": "37th Parliament of Finland",
             "start_date": "2015-04-28",
             "slug": "37",
             "csv": "data/Finland/Eduskunta/term-37.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/581c6ab89c62d547c79dac90358bfbdde7540435/data/Finland/Eduskunta/term-37.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@581c6ab89c62d547c79dac90358bfbdde7540435/data/Finland/Eduskunta/term-37.csv"
           },
           {
             "end_date": "2015-03-14",
             "id": "term/36",
-            "name": "Eduskunta 36",
+            "name": "36th Parliament of Finland",
             "start_date": "2011-04-20",
             "slug": "36",
             "csv": "data/Finland/Eduskunta/term-36.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-36.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-36.csv"
           },
           {
             "end_date": "2011-04-19",
             "id": "term/35",
-            "name": "Eduskunta 35",
+            "name": "35th Parliament of Finland",
             "start_date": "2007-03-21",
             "slug": "35",
             "csv": "data/Finland/Eduskunta/term-35.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-35.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-35.csv"
           },
           {
             "end_date": "2007-03-20",
             "id": "term/34",
-            "name": "Eduskunta 34",
+            "name": "34th Parliament of Finland",
             "start_date": "2003-03-19",
             "slug": "34",
             "csv": "data/Finland/Eduskunta/term-34.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-34.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-34.csv"
           },
           {
             "end_date": "2003-03-18",
             "id": "term/33",
-            "name": "Eduskunta 33",
+            "name": "33rd Parliament of Finland",
             "start_date": "1999-03-24",
             "slug": "33",
             "csv": "data/Finland/Eduskunta/term-33.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-33.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-33.csv"
           },
           {
             "end_date": "1999-03-23",
             "id": "term/32",
-            "name": "Eduskunta 32",
+            "name": "32nd Parliament of Finland",
             "start_date": "1995-03-24",
             "slug": "32",
             "csv": "data/Finland/Eduskunta/term-32.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-32.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-32.csv"
           },
           {
             "end_date": "1995-03-23",
             "id": "term/31",
-            "name": "Eduskunta 31",
+            "name": "31st Parliament of Finland",
             "start_date": "1991-03-22",
             "slug": "31",
             "csv": "data/Finland/Eduskunta/term-31.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-31.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-31.csv"
           },
           {
             "end_date": "1991-03-21",
             "id": "term/30",
-            "name": "Eduskunta 30",
+            "name": "30th Parliament of Finland",
             "start_date": "1987-03-21",
             "slug": "30",
             "csv": "data/Finland/Eduskunta/term-30.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-30.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-30.csv"
           },
           {
             "end_date": "1987-03-20",
             "id": "term/29",
-            "name": "Eduskunta 29",
+            "name": "29th Parliament of Finland",
             "start_date": "1983-03-26",
             "slug": "29",
             "csv": "data/Finland/Eduskunta/term-29.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-29.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-29.csv"
           },
           {
             "end_date": "1983-03-25",
             "id": "term/28",
-            "name": "Eduskunta 28",
+            "name": "28th Parliament of Finland",
             "start_date": "1979-03-24",
             "slug": "28",
             "csv": "data/Finland/Eduskunta/term-28.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-28.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bc2f2f9c557267d8e72e52eff8fca1baa12cb6d8/data/Finland/Eduskunta/term-28.csv"
           },
           {
             "end_date": "1979-03-23",
             "id": "term/27",
-            "name": "Eduskunta 27",
+            "name": "27th Parliament of Finland",
             "start_date": "1975-09-27",
             "slug": "27",
             "csv": "data/Finland/Eduskunta/term-27.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f2b5957807cf28dd8f7c28e24ffdaf547f8fe39e/data/Finland/Eduskunta/term-27.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f2b5957807cf28dd8f7c28e24ffdaf547f8fe39e/data/Finland/Eduskunta/term-27.csv"
           },
           {
             "end_date": "1975-09-26",
             "id": "term/26",
-            "name": "Eduskunta 26",
+            "name": "26th Parliament of Finland",
             "start_date": "1972-01-22",
             "slug": "26",
             "csv": "data/Finland/Eduskunta/term-26.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f2b5957807cf28dd8f7c28e24ffdaf547f8fe39e/data/Finland/Eduskunta/term-26.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f2b5957807cf28dd8f7c28e24ffdaf547f8fe39e/data/Finland/Eduskunta/term-26.csv"
           },
           {
             "end_date": "1972-01-21",
             "id": "term/25",
-            "name": "Eduskunta 25",
+            "name": "25th Parliament of Finland",
             "start_date": "1970-03-23",
             "slug": "25",
             "csv": "data/Finland/Eduskunta/term-25.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f2b5957807cf28dd8f7c28e24ffdaf547f8fe39e/data/Finland/Eduskunta/term-25.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f2b5957807cf28dd8f7c28e24ffdaf547f8fe39e/data/Finland/Eduskunta/term-25.csv"
           }
         ],
-        "statement_count": 32236,
+        "statement_count": 32264,
         "type": "unicameral legislature"
       }
     ]
@@ -3386,7 +3387,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/France/National_Assembly/sources",
         "popolo": "data/France/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47896e5ee4c6d03d011113338857f96115424d01/data/France/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@47896e5ee4c6d03d011113338857f96115424d01/data/France/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/France/National_Assembly/names.csv",
         "lastmod": "1539158395",
         "person_count": 1552,
@@ -3398,7 +3399,7 @@
             "start_date": "2017-06-21",
             "slug": "15",
             "csv": "data/France/National_Assembly/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47896e5ee4c6d03d011113338857f96115424d01/data/France/National_Assembly/term-15.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@47896e5ee4c6d03d011113338857f96115424d01/data/France/National_Assembly/term-15.csv"
           },
           {
             "end_date": "2017-06-20",
@@ -3407,7 +3408,7 @@
             "start_date": "2012-06-20",
             "slug": "14",
             "csv": "data/France/National_Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47896e5ee4c6d03d011113338857f96115424d01/data/France/National_Assembly/term-14.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@47896e5ee4c6d03d011113338857f96115424d01/data/France/National_Assembly/term-14.csv"
           },
           {
             "end_date": "2012-06-19",
@@ -3416,7 +3417,7 @@
             "start_date": "2007-06-20",
             "slug": "13",
             "csv": "data/France/National_Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47896e5ee4c6d03d011113338857f96115424d01/data/France/National_Assembly/term-13.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@47896e5ee4c6d03d011113338857f96115424d01/data/France/National_Assembly/term-13.csv"
           },
           {
             "end_date": "2007-06-19",
@@ -3425,7 +3426,7 @@
             "start_date": "2002-06-19",
             "slug": "12",
             "csv": "data/France/National_Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47896e5ee4c6d03d011113338857f96115424d01/data/France/National_Assembly/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@47896e5ee4c6d03d011113338857f96115424d01/data/France/National_Assembly/term-12.csv"
           }
         ],
         "statement_count": 93944,
@@ -3444,11 +3445,11 @@
         "slug": "Assembly",
         "sources_directory": "data/French_Polynesia/Assembly/sources",
         "popolo": "data/French_Polynesia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0c2b6d46ebbe011df46ecf241a7a1f2a90dc8b3e/data/French_Polynesia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@5b6f03769629e25b2147316b57356d053cbd5c5c/data/French_Polynesia/Assembly/ep-popolo-v1.0.json",
         "names": "data/French_Polynesia/Assembly/names.csv",
-        "lastmod": "1536475793",
+        "lastmod": "1539516512",
         "person_count": 59,
-        "sha": "0c2b6d46ebbe011df46ecf241a7a1f2a90dc8b3e",
+        "sha": "5b6f03769629e25b2147316b57356d053cbd5c5c",
         "legislative_periods": [
           {
             "id": "term/2013",
@@ -3456,10 +3457,10 @@
             "start_date": "2013-05-17",
             "slug": "2013",
             "csv": "data/French_Polynesia/Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/French_Polynesia/Assembly/term-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/French_Polynesia/Assembly/term-2013.csv"
           }
         ],
-        "statement_count": 1822,
+        "statement_count": 1824,
         "type": "unicameral legislature"
       }
     ]
@@ -3475,7 +3476,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Gabon/Assembly/sources",
         "popolo": "data/Gabon/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4490bdad418d5e82f4716b54d009507c919c7d80/data/Gabon/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4490bdad418d5e82f4716b54d009507c919c7d80/data/Gabon/Assembly/ep-popolo-v1.0.json",
         "names": "data/Gabon/Assembly/names.csv",
         "lastmod": "1538470733",
         "person_count": 114,
@@ -3487,7 +3488,7 @@
             "start_date": "2012-02-27",
             "slug": "12",
             "csv": "data/Gabon/Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4490bdad418d5e82f4716b54d009507c919c7d80/data/Gabon/Assembly/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4490bdad418d5e82f4716b54d009507c919c7d80/data/Gabon/Assembly/term-12.csv"
           }
         ],
         "statement_count": 1664,
@@ -3506,7 +3507,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Gambia/National_Assembly/sources",
         "popolo": "data/Gambia/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Gambia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Gambia/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Gambia/National_Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 53,
@@ -3518,7 +3519,7 @@
             "start_date": "2012-04-20",
             "slug": "2012",
             "csv": "data/Gambia/National_Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Gambia/National_Assembly/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Gambia/National_Assembly/term-2012.csv"
           }
         ],
         "statement_count": 1354,
@@ -3537,11 +3538,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Georgia/Parliament/sources",
         "popolo": "data/Georgia/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/183f9eafd3e71b943d002579dd2b4a2215cb4e07/data/Georgia/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@2d5282ffe56115172f1a95b9e49d39bb1ed658f2/data/Georgia/Parliament/ep-popolo-v1.0.json",
         "names": "data/Georgia/Parliament/names.csv",
-        "lastmod": "1538860132",
+        "lastmod": "1539662379",
         "person_count": 249,
-        "sha": "183f9eafd3e71b943d002579dd2b4a2215cb4e07",
+        "sha": "2d5282ffe56115172f1a95b9e49d39bb1ed658f2",
         "legislative_periods": [
           {
             "id": "term/9",
@@ -3549,7 +3550,7 @@
             "start_date": "2016-11-18",
             "slug": "9",
             "csv": "data/Georgia/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Georgia/Parliament/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Georgia/Parliament/term-9.csv"
           },
           {
             "end_date": "2016-10-01",
@@ -3558,10 +3559,10 @@
             "start_date": "2012-10-20",
             "slug": "8",
             "csv": "data/Georgia/Parliament/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ecbc1d048b3c652b16dfc936d24be3a8aa60f6ef/data/Georgia/Parliament/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ecbc1d048b3c652b16dfc936d24be3a8aa60f6ef/data/Georgia/Parliament/term-8.csv"
           }
         ],
-        "statement_count": 6685,
+        "statement_count": 6689,
         "type": "unicameral legislature"
       }
     ]
@@ -3577,7 +3578,7 @@
         "slug": "Bundestag",
         "sources_directory": "data/Germany/Bundestag/sources",
         "popolo": "data/Germany/Bundestag/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/ep-popolo-v1.0.json",
         "names": "data/Germany/Bundestag/names.csv",
         "lastmod": "1538472340",
         "person_count": 4073,
@@ -3589,7 +3590,7 @@
             "start_date": "2017-10-24",
             "slug": "19",
             "csv": "data/Germany/Bundestag/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-19.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-19.csv"
           },
           {
             "end_date": "2017-10-24",
@@ -3598,7 +3599,7 @@
             "start_date": "2013-10-22",
             "slug": "18",
             "csv": "data/Germany/Bundestag/term-18.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-18.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-18.csv"
           },
           {
             "end_date": "2013-10-22",
@@ -3607,7 +3608,7 @@
             "start_date": "2009-10-27",
             "slug": "17",
             "csv": "data/Germany/Bundestag/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-17.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-17.csv"
           },
           {
             "end_date": "2009-10-27",
@@ -3616,7 +3617,7 @@
             "start_date": "2005-10-18",
             "slug": "16",
             "csv": "data/Germany/Bundestag/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-16.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-16.csv"
           },
           {
             "end_date": "2005-10-18",
@@ -3625,7 +3626,7 @@
             "start_date": "2002-10-17",
             "slug": "15",
             "csv": "data/Germany/Bundestag/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-15.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-15.csv"
           },
           {
             "end_date": "2002-10-17",
@@ -3634,7 +3635,7 @@
             "start_date": "1998-10-26",
             "slug": "14",
             "csv": "data/Germany/Bundestag/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-14.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-14.csv"
           },
           {
             "end_date": "1998-10-26",
@@ -3643,7 +3644,7 @@
             "start_date": "1994-11-10",
             "slug": "13",
             "csv": "data/Germany/Bundestag/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-13.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-13.csv"
           },
           {
             "end_date": "1994-11-10",
@@ -3652,7 +3653,7 @@
             "start_date": "1990-12-20",
             "slug": "12",
             "csv": "data/Germany/Bundestag/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-12.csv"
           },
           {
             "end_date": "1990-12-20",
@@ -3661,7 +3662,7 @@
             "start_date": "1987-02-18",
             "slug": "11",
             "csv": "data/Germany/Bundestag/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-11.csv"
           },
           {
             "end_date": "1987-02-18",
@@ -3670,7 +3671,7 @@
             "start_date": "1983-03-29",
             "slug": "10",
             "csv": "data/Germany/Bundestag/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-10.csv"
           },
           {
             "end_date": "1983-03-29",
@@ -3679,7 +3680,7 @@
             "start_date": "1980-11-04",
             "slug": "9",
             "csv": "data/Germany/Bundestag/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-9.csv"
           },
           {
             "end_date": "1980-11-04",
@@ -3688,7 +3689,7 @@
             "start_date": "1976-12-14",
             "slug": "8",
             "csv": "data/Germany/Bundestag/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-8.csv"
           },
           {
             "end_date": "1976-12-14",
@@ -3697,7 +3698,7 @@
             "start_date": "1972-12-13",
             "slug": "7",
             "csv": "data/Germany/Bundestag/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-7.csv"
           },
           {
             "end_date": "1972-12-13",
@@ -3706,7 +3707,7 @@
             "start_date": "1969-10-20",
             "slug": "6",
             "csv": "data/Germany/Bundestag/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@225837259784522f5fcc4c246ddebea943f85947/data/Germany/Bundestag/term-6.csv"
           },
           {
             "end_date": "1969-10-20",
@@ -3715,7 +3716,7 @@
             "start_date": "1965-10-19",
             "slug": "5",
             "csv": "data/Germany/Bundestag/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6554dafd4ae9abf7a9247932b78eb28a70cc30b4/data/Germany/Bundestag/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6554dafd4ae9abf7a9247932b78eb28a70cc30b4/data/Germany/Bundestag/term-5.csv"
           },
           {
             "end_date": "1965-10-19",
@@ -3724,7 +3725,7 @@
             "start_date": "1961-10-17",
             "slug": "4",
             "csv": "data/Germany/Bundestag/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-4.csv"
           },
           {
             "end_date": "1961-10-17",
@@ -3733,7 +3734,7 @@
             "start_date": "1957-10-15",
             "slug": "3",
             "csv": "data/Germany/Bundestag/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-3.csv"
           },
           {
             "end_date": "1957-10-15",
@@ -3742,7 +3743,7 @@
             "start_date": "1953-10-06",
             "slug": "2",
             "csv": "data/Germany/Bundestag/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-2.csv"
           },
           {
             "end_date": "1953-10-06",
@@ -3751,7 +3752,7 @@
             "start_date": "1949-09-07",
             "slug": "1",
             "csv": "data/Germany/Bundestag/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9e04b4a2785a49500db17e906d662279379bbcfa/data/Germany/Bundestag/term-1.csv"
           }
         ],
         "statement_count": 212496,
@@ -3770,7 +3771,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Ghana/Parliament/sources",
         "popolo": "data/Ghana/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4f31ef742478bccc91c8e51f664cad3f19194fa6/data/Ghana/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4f31ef742478bccc91c8e51f664cad3f19194fa6/data/Ghana/Parliament/ep-popolo-v1.0.json",
         "names": "data/Ghana/Parliament/names.csv",
         "lastmod": "1538810772",
         "person_count": 413,
@@ -3782,7 +3783,7 @@
             "start_date": "2017-01-07",
             "slug": "7",
             "csv": "data/Ghana/Parliament/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/078a15832d9a990740b955ca7e45794152b6af01/data/Ghana/Parliament/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@078a15832d9a990740b955ca7e45794152b6af01/data/Ghana/Parliament/term-7.csv"
           },
           {
             "end_date": "2017-01-06",
@@ -3791,7 +3792,7 @@
             "start_date": "2013-01-07",
             "slug": "6",
             "csv": "data/Ghana/Parliament/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/078a15832d9a990740b955ca7e45794152b6af01/data/Ghana/Parliament/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@078a15832d9a990740b955ca7e45794152b6af01/data/Ghana/Parliament/term-6.csv"
           }
         ],
         "statement_count": 9729,
@@ -3810,7 +3811,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Gibraltar/Parliament/sources",
         "popolo": "data/Gibraltar/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6a8d9f08c6ab6cadfeb08a6dcaec298f865eff9/data/Gibraltar/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a6a8d9f08c6ab6cadfeb08a6dcaec298f865eff9/data/Gibraltar/Parliament/ep-popolo-v1.0.json",
         "names": "data/Gibraltar/Parliament/names.csv",
         "lastmod": "1535086380",
         "person_count": 83,
@@ -3823,7 +3824,7 @@
             "start_date": "2011-12-21",
             "slug": "12",
             "csv": "data/Gibraltar/Parliament/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e127654ae12a5d968bc5555405aa25440817a48e/data/Gibraltar/Parliament/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e127654ae12a5d968bc5555405aa25440817a48e/data/Gibraltar/Parliament/term-12.csv"
           },
           {
             "end_date": "2011-11-03",
@@ -3832,7 +3833,7 @@
             "start_date": "2007-11-08",
             "slug": "11",
             "csv": "data/Gibraltar/Parliament/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-11.csv"
           },
           {
             "end_date": "2007-09-07",
@@ -3841,7 +3842,7 @@
             "start_date": "2003-12-18",
             "slug": "10",
             "csv": "data/Gibraltar/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-10.csv"
           },
           {
             "end_date": "2003-10-24",
@@ -3850,7 +3851,7 @@
             "start_date": "2000-02-23",
             "slug": "9",
             "csv": "data/Gibraltar/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-9.csv"
           },
           {
             "end_date": "2000",
@@ -3859,7 +3860,7 @@
             "start_date": "1996",
             "slug": "8",
             "csv": "data/Gibraltar/Parliament/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-8.csv"
           },
           {
             "end_date": "1996",
@@ -3868,7 +3869,7 @@
             "start_date": "1992",
             "slug": "7",
             "csv": "data/Gibraltar/Parliament/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-7.csv"
           },
           {
             "end_date": "1992",
@@ -3877,7 +3878,7 @@
             "start_date": "1988",
             "slug": "6",
             "csv": "data/Gibraltar/Parliament/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-6.csv"
           },
           {
             "end_date": "1988",
@@ -3886,7 +3887,7 @@
             "start_date": "1984",
             "slug": "5",
             "csv": "data/Gibraltar/Parliament/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-5.csv"
           },
           {
             "end_date": "1984",
@@ -3895,7 +3896,7 @@
             "start_date": "1980",
             "slug": "4",
             "csv": "data/Gibraltar/Parliament/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-4.csv"
           },
           {
             "end_date": "1980",
@@ -3904,7 +3905,7 @@
             "start_date": "1976",
             "slug": "3",
             "csv": "data/Gibraltar/Parliament/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-3.csv"
           },
           {
             "end_date": "1976",
@@ -3913,7 +3914,7 @@
             "start_date": "1972",
             "slug": "2",
             "csv": "data/Gibraltar/Parliament/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-2.csv"
           },
           {
             "end_date": "1972",
@@ -3922,7 +3923,7 @@
             "start_date": "1969",
             "slug": "1",
             "csv": "data/Gibraltar/Parliament/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Gibraltar/Parliament/term-1.csv"
           }
         ],
         "statement_count": 2567,
@@ -3941,11 +3942,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Greece/Parliament/sources",
         "popolo": "data/Greece/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fe38c36585757ac7c6bbe205030529198e8782dd/data/Greece/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6ed90409f675127478c58f9a03c63cfd3d4dd9de/data/Greece/Parliament/ep-popolo-v1.0.json",
         "names": "data/Greece/Parliament/names.csv",
-        "lastmod": "1539117398",
+        "lastmod": "1539480558",
         "person_count": 1783,
-        "sha": "fe38c36585757ac7c6bbe205030529198e8782dd",
+        "sha": "6ed90409f675127478c58f9a03c63cfd3d4dd9de",
         "legislative_periods": [
           {
             "id": "term/17",
@@ -3953,7 +3954,7 @@
             "start_date": "2015-09-20",
             "slug": "17",
             "csv": "data/Greece/Parliament/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0c8740d752200c465997ca28a76f131b1cb46313/data/Greece/Parliament/term-17.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0c8740d752200c465997ca28a76f131b1cb46313/data/Greece/Parliament/term-17.csv"
           },
           {
             "end_date": "2015-08-28",
@@ -3962,7 +3963,7 @@
             "start_date": "2015-01-25",
             "slug": "16",
             "csv": "data/Greece/Parliament/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/121159d88db57ebb4399233dff2bae079ba99bca/data/Greece/Parliament/term-16.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@121159d88db57ebb4399233dff2bae079ba99bca/data/Greece/Parliament/term-16.csv"
           },
           {
             "end_date": "2014-12-31",
@@ -3971,7 +3972,7 @@
             "start_date": "2012-06-17",
             "slug": "15",
             "csv": "data/Greece/Parliament/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fe97feb9aafe82430cd9ba7ca014159a52638b67/data/Greece/Parliament/term-15.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@fe97feb9aafe82430cd9ba7ca014159a52638b67/data/Greece/Parliament/term-15.csv"
           },
           {
             "end_date": "2012-05-19",
@@ -3980,7 +3981,7 @@
             "start_date": "2012-05-06",
             "slug": "14",
             "csv": "data/Greece/Parliament/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fe97feb9aafe82430cd9ba7ca014159a52638b67/data/Greece/Parliament/term-14.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@fe97feb9aafe82430cd9ba7ca014159a52638b67/data/Greece/Parliament/term-14.csv"
           },
           {
             "end_date": "2012-04-11",
@@ -3989,7 +3990,7 @@
             "start_date": "2009-10-04",
             "slug": "13",
             "csv": "data/Greece/Parliament/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fe97feb9aafe82430cd9ba7ca014159a52638b67/data/Greece/Parliament/term-13.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@fe97feb9aafe82430cd9ba7ca014159a52638b67/data/Greece/Parliament/term-13.csv"
           },
           {
             "end_date": "2009-09-07",
@@ -3998,7 +3999,7 @@
             "start_date": "2007-09-16",
             "slug": "12",
             "csv": "data/Greece/Parliament/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2610f90457a216943763be33b1ead940e361fdc8/data/Greece/Parliament/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@2610f90457a216943763be33b1ead940e361fdc8/data/Greece/Parliament/term-12.csv"
           },
           {
             "end_date": "2007-08-18",
@@ -4007,7 +4008,7 @@
             "start_date": "2004-03-07",
             "slug": "11",
             "csv": "data/Greece/Parliament/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2610f90457a216943763be33b1ead940e361fdc8/data/Greece/Parliament/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@2610f90457a216943763be33b1ead940e361fdc8/data/Greece/Parliament/term-11.csv"
           },
           {
             "end_date": "2004-02-11",
@@ -4016,7 +4017,7 @@
             "start_date": "2000-04-09",
             "slug": "10",
             "csv": "data/Greece/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2610f90457a216943763be33b1ead940e361fdc8/data/Greece/Parliament/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@2610f90457a216943763be33b1ead940e361fdc8/data/Greece/Parliament/term-10.csv"
           },
           {
             "end_date": "2000-03-14",
@@ -4025,7 +4026,7 @@
             "start_date": "1996-09-22",
             "slug": "9",
             "csv": "data/Greece/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e66d5d687cc0a56829522041b62ef0fb85208b3a/data/Greece/Parliament/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e66d5d687cc0a56829522041b62ef0fb85208b3a/data/Greece/Parliament/term-9.csv"
           },
           {
             "end_date": "1996-08-24",
@@ -4034,7 +4035,7 @@
             "start_date": "1993-10-10",
             "slug": "8",
             "csv": "data/Greece/Parliament/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4825f6f6d236c2e5673f4474decc55c77c2dfe17/data/Greece/Parliament/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4825f6f6d236c2e5673f4474decc55c77c2dfe17/data/Greece/Parliament/term-8.csv"
           },
           {
             "end_date": "1993-09-11",
@@ -4043,7 +4044,7 @@
             "start_date": "1990-04-08",
             "slug": "7",
             "csv": "data/Greece/Parliament/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4825f6f6d236c2e5673f4474decc55c77c2dfe17/data/Greece/Parliament/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4825f6f6d236c2e5673f4474decc55c77c2dfe17/data/Greece/Parliament/term-7.csv"
           },
           {
             "end_date": "1990-03-12",
@@ -4052,7 +4053,7 @@
             "start_date": "1989-11-05",
             "slug": "6",
             "csv": "data/Greece/Parliament/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0c8740d752200c465997ca28a76f131b1cb46313/data/Greece/Parliament/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0c8740d752200c465997ca28a76f131b1cb46313/data/Greece/Parliament/term-6.csv"
           },
           {
             "end_date": "1989-10-12",
@@ -4061,7 +4062,7 @@
             "start_date": "1989-06-18",
             "slug": "5",
             "csv": "data/Greece/Parliament/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43bf83827624050cc2876c08b7088e1e1337b4ab/data/Greece/Parliament/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@43bf83827624050cc2876c08b7088e1e1337b4ab/data/Greece/Parliament/term-5.csv"
           },
           {
             "end_date": "1989-06-02",
@@ -4070,7 +4071,7 @@
             "start_date": "1985-06-02",
             "slug": "4",
             "csv": "data/Greece/Parliament/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4825f6f6d236c2e5673f4474decc55c77c2dfe17/data/Greece/Parliament/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4825f6f6d236c2e5673f4474decc55c77c2dfe17/data/Greece/Parliament/term-4.csv"
           },
           {
             "end_date": "1985-05-07",
@@ -4079,7 +4080,7 @@
             "start_date": "1981-10-18",
             "slug": "3",
             "csv": "data/Greece/Parliament/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7e7c346e29022bd97a6f7187d7efd95ea8e1b164/data/Greece/Parliament/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7e7c346e29022bd97a6f7187d7efd95ea8e1b164/data/Greece/Parliament/term-3.csv"
           },
           {
             "end_date": "1981-09-19",
@@ -4088,7 +4089,7 @@
             "start_date": "1977-11-20",
             "slug": "2",
             "csv": "data/Greece/Parliament/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4825f6f6d236c2e5673f4474decc55c77c2dfe17/data/Greece/Parliament/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4825f6f6d236c2e5673f4474decc55c77c2dfe17/data/Greece/Parliament/term-2.csv"
           },
           {
             "end_date": "1977-10-22",
@@ -4097,10 +4098,10 @@
             "start_date": "1974-11-17",
             "slug": "1",
             "csv": "data/Greece/Parliament/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4825f6f6d236c2e5673f4474decc55c77c2dfe17/data/Greece/Parliament/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4825f6f6d236c2e5673f4474decc55c77c2dfe17/data/Greece/Parliament/term-1.csv"
           }
         ],
-        "statement_count": 88273,
+        "statement_count": 88278,
         "type": "unicameral legislature"
       }
     ]
@@ -4116,11 +4117,11 @@
         "slug": "Inatsisartut",
         "sources_directory": "data/Greenland/Inatsisartut/sources",
         "popolo": "data/Greenland/Inatsisartut/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/446911afeabde259fe6c2ac78e81fbd1aa84da74/data/Greenland/Inatsisartut/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f57e8122d10683b75e4682267939c9e87b6116a2/data/Greenland/Inatsisartut/ep-popolo-v1.0.json",
         "names": "data/Greenland/Inatsisartut/names.csv",
-        "lastmod": "1538905887",
+        "lastmod": "1539617125",
         "person_count": 161,
-        "sha": "446911afeabde259fe6c2ac78e81fbd1aa84da74",
+        "sha": "f57e8122d10683b75e4682267939c9e87b6116a2",
         "legislative_periods": [
           {
             "id": "term/12",
@@ -4128,7 +4129,7 @@
             "start_date": "2014-11-28",
             "slug": "12",
             "csv": "data/Greenland/Inatsisartut/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-12.csv"
           },
           {
             "end_date": "2014-11-27",
@@ -4137,7 +4138,7 @@
             "start_date": "2013-03-12",
             "slug": "11",
             "csv": "data/Greenland/Inatsisartut/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c0d407fcbc6f51c9b89517e82d163b97cd324628/data/Greenland/Inatsisartut/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c0d407fcbc6f51c9b89517e82d163b97cd324628/data/Greenland/Inatsisartut/term-11.csv"
           },
           {
             "end_date": "2013-03-11",
@@ -4146,7 +4147,7 @@
             "start_date": "2009-06-02",
             "slug": "10",
             "csv": "data/Greenland/Inatsisartut/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-10.csv"
           },
           {
             "end_date": "2009-06-01",
@@ -4155,7 +4156,7 @@
             "start_date": "2005-11-15",
             "slug": "9",
             "csv": "data/Greenland/Inatsisartut/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-9.csv"
           },
           {
             "end_date": "2005-11-14",
@@ -4164,7 +4165,7 @@
             "start_date": "2002-12-03",
             "slug": "8",
             "csv": "data/Greenland/Inatsisartut/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-8.csv"
           },
           {
             "end_date": "2002-12-02",
@@ -4173,7 +4174,7 @@
             "start_date": "1999-02-16",
             "slug": "7",
             "csv": "data/Greenland/Inatsisartut/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-7.csv"
           },
           {
             "end_date": "1999-02-15",
@@ -4182,7 +4183,7 @@
             "start_date": "1995-03-04",
             "slug": "6",
             "csv": "data/Greenland/Inatsisartut/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-6.csv"
           },
           {
             "end_date": "1995-03-03",
@@ -4191,7 +4192,7 @@
             "start_date": "1991-03-05",
             "slug": "5",
             "csv": "data/Greenland/Inatsisartut/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-5.csv"
           },
           {
             "end_date": "1991-03-04",
@@ -4200,7 +4201,7 @@
             "start_date": "1987-05-26",
             "slug": "4",
             "csv": "data/Greenland/Inatsisartut/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-4.csv"
           },
           {
             "end_date": "1987-05-25",
@@ -4209,7 +4210,7 @@
             "start_date": "1984-06-06",
             "slug": "3",
             "csv": "data/Greenland/Inatsisartut/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-3.csv"
           },
           {
             "end_date": "1984-06-05",
@@ -4218,7 +4219,7 @@
             "start_date": "1983-04-12",
             "slug": "2",
             "csv": "data/Greenland/Inatsisartut/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-2.csv"
           },
           {
             "end_date": "1983-04-11",
@@ -4227,10 +4228,10 @@
             "start_date": "1979-04-04",
             "slug": "1",
             "csv": "data/Greenland/Inatsisartut/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ab68272e9c69984e9891854cde86e8d3365c3123/data/Greenland/Inatsisartut/term-1.csv"
           }
         ],
-        "statement_count": 6333,
+        "statement_count": 6341,
         "type": "unicameral legislature"
       }
     ]
@@ -4246,7 +4247,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Grenada/House_of_Representatives/sources",
         "popolo": "data/Grenada/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ed3152efe621825e730a24e34b06400f5e11f26c/data/Grenada/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ed3152efe621825e730a24e34b06400f5e11f26c/data/Grenada/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Grenada/House_of_Representatives/names.csv",
         "lastmod": "1537450511",
         "person_count": 15,
@@ -4258,7 +4259,7 @@
             "start_date": "2013-03-27",
             "slug": "2013",
             "csv": "data/Grenada/House_of_Representatives/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Grenada/House_of_Representatives/term-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Grenada/House_of_Representatives/term-2013.csv"
           }
         ],
         "statement_count": 452,
@@ -4277,7 +4278,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Guam/Parliament/sources",
         "popolo": "data/Guam/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/109b412aeaeb22868ca31796eb0ef61df5279a2d/data/Guam/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@109b412aeaeb22868ca31796eb0ef61df5279a2d/data/Guam/Parliament/ep-popolo-v1.0.json",
         "names": "data/Guam/Parliament/names.csv",
         "lastmod": "1537800929",
         "person_count": 28,
@@ -4289,7 +4290,7 @@
             "start_date": "2015-02-16",
             "slug": "33",
             "csv": "data/Guam/Parliament/term-33.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Guam/Parliament/term-33.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Guam/Parliament/term-33.csv"
           },
           {
             "end_date": "2015-01-02",
@@ -4298,7 +4299,7 @@
             "start_date": "2013-01-11",
             "slug": "32",
             "csv": "data/Guam/Parliament/term-32.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/109b412aeaeb22868ca31796eb0ef61df5279a2d/data/Guam/Parliament/term-32.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@109b412aeaeb22868ca31796eb0ef61df5279a2d/data/Guam/Parliament/term-32.csv"
           },
           {
             "end_date": "2013-01-04",
@@ -4307,7 +4308,7 @@
             "start_date": "2011-02-21",
             "slug": "31",
             "csv": "data/Guam/Parliament/term-31.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/109b412aeaeb22868ca31796eb0ef61df5279a2d/data/Guam/Parliament/term-31.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@109b412aeaeb22868ca31796eb0ef61df5279a2d/data/Guam/Parliament/term-31.csv"
           },
           {
             "end_date": "2010-12-22",
@@ -4316,7 +4317,7 @@
             "start_date": "2009-02-16",
             "slug": "30",
             "csv": "data/Guam/Parliament/term-30.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/109b412aeaeb22868ca31796eb0ef61df5279a2d/data/Guam/Parliament/term-30.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@109b412aeaeb22868ca31796eb0ef61df5279a2d/data/Guam/Parliament/term-30.csv"
           }
         ],
         "statement_count": 1088,
@@ -4335,31 +4336,31 @@
         "slug": "Congress",
         "sources_directory": "data/Guatemala/Congress/sources",
         "popolo": "data/Guatemala/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2543c758e119c2e66f74c4e03792bdfa73f9f6de/data/Guatemala/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@56002d245714c29a3122281e498832d718a96890/data/Guatemala/Congress/ep-popolo-v1.0.json",
         "names": "data/Guatemala/Congress/names.csv",
-        "lastmod": "1537800936",
+        "lastmod": "1539666153",
         "person_count": 255,
-        "sha": "2543c758e119c2e66f74c4e03792bdfa73f9f6de",
+        "sha": "56002d245714c29a3122281e498832d718a96890",
         "legislative_periods": [
           {
             "id": "term/8",
-            "name": "VIII Legislatura",
+            "name": "8th legislature of Guatemala",
             "start_date": "2016-01-14",
             "slug": "8",
             "csv": "data/Guatemala/Congress/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8f9d5bb62948d2504adb7ce7c8c2196ddaadddb9/data/Guatemala/Congress/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@8f9d5bb62948d2504adb7ce7c8c2196ddaadddb9/data/Guatemala/Congress/term-8.csv"
           },
           {
             "end_date": "2016-01-14",
             "id": "term/7",
-            "name": "VII Legislatura",
+            "name": "7th legislature of Guatemala",
             "start_date": "2012-01-14",
             "slug": "7",
             "csv": "data/Guatemala/Congress/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2543c758e119c2e66f74c4e03792bdfa73f9f6de/data/Guatemala/Congress/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@2543c758e119c2e66f74c4e03792bdfa73f9f6de/data/Guatemala/Congress/term-7.csv"
           }
         ],
-        "statement_count": 6470,
+        "statement_count": 6474,
         "type": "unicameral legislature"
       }
     ]
@@ -4375,7 +4376,7 @@
         "slug": "States",
         "sources_directory": "data/Guernsey/States/sources",
         "popolo": "data/Guernsey/States/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/64728e52c3c84398eb3b1f5c4c9c57c627e46ab4/data/Guernsey/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@64728e52c3c84398eb3b1f5c4c9c57c627e46ab4/data/Guernsey/States/ep-popolo-v1.0.json",
         "names": "data/Guernsey/States/names.csv",
         "lastmod": "1537800943",
         "person_count": 68,
@@ -4387,7 +4388,7 @@
             "start_date": "2016-04-27",
             "slug": "2016",
             "csv": "data/Guernsey/States/term-2016.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/64728e52c3c84398eb3b1f5c4c9c57c627e46ab4/data/Guernsey/States/term-2016.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@64728e52c3c84398eb3b1f5c4c9c57c627e46ab4/data/Guernsey/States/term-2016.csv"
           },
           {
             "end_date": "2016-04-26",
@@ -4396,7 +4397,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Guernsey/States/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/64728e52c3c84398eb3b1f5c4c9c57c627e46ab4/data/Guernsey/States/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@64728e52c3c84398eb3b1f5c4c9c57c627e46ab4/data/Guernsey/States/term-2012.csv"
           }
         ],
         "statement_count": 1770,
@@ -4415,7 +4416,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Guinea-Bissau/Assembly/sources",
         "popolo": "data/Guinea-Bissau/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/addb879b07b17064d3d2c05f0d138cc216771cf7/data/Guinea-Bissau/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@addb879b07b17064d3d2c05f0d138cc216771cf7/data/Guinea-Bissau/Assembly/ep-popolo-v1.0.json",
         "names": "data/Guinea-Bissau/Assembly/names.csv",
         "lastmod": "1485067905",
         "person_count": 100,
@@ -4427,7 +4428,7 @@
             "start_date": "2014-06-16",
             "slug": "2014",
             "csv": "data/Guinea-Bissau/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Guinea-Bissau/Assembly/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Guinea-Bissau/Assembly/term-2014.csv"
           }
         ],
         "statement_count": 1434,
@@ -4446,7 +4447,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Guyana/National_Assembly/sources",
         "popolo": "data/Guyana/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b636fd5448600b10d205e160ffa954bc64284602/data/Guyana/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b636fd5448600b10d205e160ffa954bc64284602/data/Guyana/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Guyana/National_Assembly/names.csv",
         "lastmod": "1534981926",
         "person_count": 64,
@@ -4458,7 +4459,7 @@
             "start_date": "2015-06-10",
             "slug": "11",
             "csv": "data/Guyana/National_Assembly/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Guyana/National_Assembly/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Guyana/National_Assembly/term-11.csv"
           }
         ],
         "statement_count": 1103,
@@ -4477,7 +4478,7 @@
         "slug": "Deputies",
         "sources_directory": "data/Haiti/Deputies/sources",
         "popolo": "data/Haiti/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aa62f92525015bdab4ce9bdfd1fc4ad50aee9f42/data/Haiti/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@aa62f92525015bdab4ce9bdfd1fc4ad50aee9f42/data/Haiti/Deputies/ep-popolo-v1.0.json",
         "names": "data/Haiti/Deputies/names.csv",
         "lastmod": "1531711209",
         "person_count": 99,
@@ -4490,7 +4491,7 @@
             "start_date": "2011-05-14",
             "slug": "2011",
             "csv": "data/Haiti/Deputies/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a1e6e91c50e622ece73b7db1d1c44b9beb8dd44b/data/Haiti/Deputies/term-2011.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a1e6e91c50e622ece73b7db1d1c44b9beb8dd44b/data/Haiti/Deputies/term-2011.csv"
           }
         ],
         "statement_count": 2245,
@@ -4509,7 +4510,7 @@
         "slug": "Congreso-Nacional",
         "sources_directory": "data/Honduras/Congreso_Nacional/sources",
         "popolo": "data/Honduras/Congreso_Nacional/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/748e4efc26b7ee68f1f3cd7a0d38bd2822690b5a/data/Honduras/Congreso_Nacional/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@748e4efc26b7ee68f1f3cd7a0d38bd2822690b5a/data/Honduras/Congreso_Nacional/ep-popolo-v1.0.json",
         "names": "data/Honduras/Congreso_Nacional/names.csv",
         "lastmod": "1537785791",
         "person_count": 131,
@@ -4521,7 +4522,7 @@
             "start_date": "2014-01-21",
             "slug": "8",
             "csv": "data/Honduras/Congreso_Nacional/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Honduras/Congreso_Nacional/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Honduras/Congreso_Nacional/term-8.csv"
           }
         ],
         "statement_count": 2358,
@@ -4540,7 +4541,7 @@
         "slug": "Legislative-Council",
         "sources_directory": "data/Hong_Kong/Legislative_Council/sources",
         "popolo": "data/Hong_Kong/Legislative_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bc859b47d3ce140899c44fbbbbe649bb69d13adc/data/Hong_Kong/Legislative_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bc859b47d3ce140899c44fbbbbe649bb69d13adc/data/Hong_Kong/Legislative_Council/ep-popolo-v1.0.json",
         "names": "data/Hong_Kong/Legislative_Council/names.csv",
         "lastmod": "1538633174",
         "person_count": 100,
@@ -4552,7 +4553,7 @@
             "start_date": "2016-10-01",
             "slug": "6",
             "csv": "data/Hong_Kong/Legislative_Council/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/68b098edf8dc61da37218c417aaf8156507ac723/data/Hong_Kong/Legislative_Council/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@68b098edf8dc61da37218c417aaf8156507ac723/data/Hong_Kong/Legislative_Council/term-6.csv"
           },
           {
             "end_date": "2016-09-30",
@@ -4561,7 +4562,7 @@
             "start_date": "2012-10-01",
             "slug": "5",
             "csv": "data/Hong_Kong/Legislative_Council/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/50a4e7668c054d42617f5eeaf50310f110203c29/data/Hong_Kong/Legislative_Council/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@50a4e7668c054d42617f5eeaf50310f110203c29/data/Hong_Kong/Legislative_Council/term-5.csv"
           }
         ],
         "statement_count": 8482,
@@ -4580,7 +4581,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Hungary/Assembly/sources",
         "popolo": "data/Hungary/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47b6c064c75589dadcfed3ea66d76103c77bf8fb/data/Hungary/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@47b6c064c75589dadcfed3ea66d76103c77bf8fb/data/Hungary/Assembly/ep-popolo-v1.0.json",
         "names": "data/Hungary/Assembly/names.csv",
         "lastmod": "1539121606",
         "person_count": 245,
@@ -4592,7 +4593,7 @@
             "start_date": "2018-05-08",
             "slug": "41",
             "csv": "data/Hungary/Assembly/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47b6c064c75589dadcfed3ea66d76103c77bf8fb/data/Hungary/Assembly/term-41.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@47b6c064c75589dadcfed3ea66d76103c77bf8fb/data/Hungary/Assembly/term-41.csv"
           },
           {
             "end_date": "2018-05-07",
@@ -4601,7 +4602,7 @@
             "start_date": "2014-05-10",
             "slug": "40",
             "csv": "data/Hungary/Assembly/term-40.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/47b6c064c75589dadcfed3ea66d76103c77bf8fb/data/Hungary/Assembly/term-40.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@47b6c064c75589dadcfed3ea66d76103c77bf8fb/data/Hungary/Assembly/term-40.csv"
           }
         ],
         "statement_count": 12040,
@@ -4620,11 +4621,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Iceland/Assembly/sources",
         "popolo": "data/Iceland/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d9814a3f0eb7edb2f2a182b126a36e7786bf9e30/data/Iceland/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@748f3e2e4380026fbe48310b6b95a2daafd73e0f/data/Iceland/Assembly/ep-popolo-v1.0.json",
         "names": "data/Iceland/Assembly/names.csv",
-        "lastmod": "1539270543",
-        "person_count": 251,
-        "sha": "d9814a3f0eb7edb2f2a182b126a36e7786bf9e30",
+        "lastmod": "1539277999",
+        "person_count": 243,
+        "sha": "748f3e2e4380026fbe48310b6b95a2daafd73e0f",
         "legislative_periods": [
           {
             "id": "term/2017",
@@ -4632,7 +4633,7 @@
             "start_date": "2017-12-14",
             "slug": "2017",
             "csv": "data/Iceland/Assembly/term-2017.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d9814a3f0eb7edb2f2a182b126a36e7786bf9e30/data/Iceland/Assembly/term-2017.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ff590ca3075989270999a0d31620f762ffbfff9c/data/Iceland/Assembly/term-2017.csv"
           },
           {
             "end_date": "2017-10-27",
@@ -4641,7 +4642,7 @@
             "start_date": "2016-12-06",
             "slug": "2016",
             "csv": "data/Iceland/Assembly/term-2016.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a46796bd437cf4dcf1814c158001605727c5081b/data/Iceland/Assembly/term-2016.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ff590ca3075989270999a0d31620f762ffbfff9c/data/Iceland/Assembly/term-2016.csv"
           },
           {
             "end_date": "2016-10-13",
@@ -4650,7 +4651,7 @@
             "start_date": "2013-06-06",
             "slug": "2013",
             "csv": "data/Iceland/Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69f6213c3e7208fea23f9a79c1b36dd8033ed756/data/Iceland/Assembly/term-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@748f3e2e4380026fbe48310b6b95a2daafd73e0f/data/Iceland/Assembly/term-2013.csv"
           },
           {
             "end_date": "2013-03-27",
@@ -4659,7 +4660,7 @@
             "start_date": "2009-05-15",
             "slug": "2009",
             "csv": "data/Iceland/Assembly/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69f6213c3e7208fea23f9a79c1b36dd8033ed756/data/Iceland/Assembly/term-2009.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@748f3e2e4380026fbe48310b6b95a2daafd73e0f/data/Iceland/Assembly/term-2009.csv"
           },
           {
             "end_date": "2009-04-17",
@@ -4668,7 +4669,7 @@
             "start_date": "2007-06-13",
             "slug": "2007",
             "csv": "data/Iceland/Assembly/term-2007.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/69f6213c3e7208fea23f9a79c1b36dd8033ed756/data/Iceland/Assembly/term-2007.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@748f3e2e4380026fbe48310b6b95a2daafd73e0f/data/Iceland/Assembly/term-2007.csv"
           },
           {
             "end_date": "2007-03-17",
@@ -4677,7 +4678,7 @@
             "start_date": "2003-05-26",
             "slug": "2003",
             "csv": "data/Iceland/Assembly/term-2003.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Iceland/Assembly/term-2003.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@748f3e2e4380026fbe48310b6b95a2daafd73e0f/data/Iceland/Assembly/term-2003.csv"
           },
           {
             "end_date": "2003-03-15",
@@ -4686,7 +4687,7 @@
             "start_date": "1999-05-08",
             "slug": "1999",
             "csv": "data/Iceland/Assembly/term-1999.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Iceland/Assembly/term-1999.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@748f3e2e4380026fbe48310b6b95a2daafd73e0f/data/Iceland/Assembly/term-1999.csv"
           },
           {
             "end_date": "1999-03-25",
@@ -4695,10 +4696,10 @@
             "start_date": "1995-04-08",
             "slug": "1995",
             "csv": "data/Iceland/Assembly/term-1995.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Iceland/Assembly/term-1995.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@748f3e2e4380026fbe48310b6b95a2daafd73e0f/data/Iceland/Assembly/term-1995.csv"
           }
         ],
-        "statement_count": 13388,
+        "statement_count": 13366,
         "type": "unicameral legislature"
       }
     ]
@@ -4714,11 +4715,11 @@
         "slug": "Lok-Sabha",
         "sources_directory": "data/India/Lok_Sabha/sources",
         "popolo": "data/India/Lok_Sabha/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8237f34ec1b24e50a1ea197a8b2f2957f879d7dc/data/India/Lok_Sabha/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e1fc1808a97990ecf3f912c9a034e188e8508b52/data/India/Lok_Sabha/ep-popolo-v1.0.json",
         "names": "data/India/Lok_Sabha/names.csv",
-        "lastmod": "1539018536",
+        "lastmod": "1539446636",
         "person_count": 541,
-        "sha": "8237f34ec1b24e50a1ea197a8b2f2957f879d7dc",
+        "sha": "e1fc1808a97990ecf3f912c9a034e188e8508b52",
         "legislative_periods": [
           {
             "id": "term/16",
@@ -4726,10 +4727,10 @@
             "start_date": "2014-05-26",
             "slug": "16",
             "csv": "data/India/Lok_Sabha/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d042af93644b9b2481c5f01f4c0e5ba01565a19f/data/India/Lok_Sabha/term-16.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d042af93644b9b2481c5f01f4c0e5ba01565a19f/data/India/Lok_Sabha/term-16.csv"
           }
         ],
-        "statement_count": 38540,
+        "statement_count": 38556,
         "type": "unicameral legislature"
       }
     ]
@@ -4745,7 +4746,7 @@
         "slug": "Council",
         "sources_directory": "data/Indonesia/Council/sources",
         "popolo": "data/Indonesia/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/579ec013dbcdb494f0f0ceb707c7bab140010bed/data/Indonesia/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@579ec013dbcdb494f0f0ceb707c7bab140010bed/data/Indonesia/Council/ep-popolo-v1.0.json",
         "names": "data/Indonesia/Council/names.csv",
         "lastmod": "1539055495",
         "person_count": 583,
@@ -4757,7 +4758,7 @@
             "start_date": "2014-10-01",
             "slug": "18",
             "csv": "data/Indonesia/Council/term-18.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/64e16d6cab51d250099879e3ec9da7606cf227b7/data/Indonesia/Council/term-18.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@64e16d6cab51d250099879e3ec9da7606cf227b7/data/Indonesia/Council/term-18.csv"
           }
         ],
         "statement_count": 12255,
@@ -4776,7 +4777,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Iran/Assembly/sources",
         "popolo": "data/Iran/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Iran/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Iran/Assembly/ep-popolo-v1.0.json",
         "names": "data/Iran/Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 508,
@@ -4788,7 +4789,7 @@
             "start_date": "2016-05-28",
             "slug": "10",
             "csv": "data/Iran/Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Iran/Assembly/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Iran/Assembly/term-10.csv"
           },
           {
             "end_date": "2016-05-26",
@@ -4797,7 +4798,7 @@
             "start_date": "2012-05-27",
             "slug": "9",
             "csv": "data/Iran/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Iran/Assembly/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Iran/Assembly/term-9.csv"
           }
         ],
         "statement_count": 7977,
@@ -4816,7 +4817,7 @@
         "slug": "Majlis",
         "sources_directory": "data/Iraq/Majlis/sources",
         "popolo": "data/Iraq/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Iraq/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Iraq/Majlis/ep-popolo-v1.0.json",
         "names": "data/Iraq/Majlis/names.csv",
         "lastmod": "1528387224",
         "person_count": 328,
@@ -4828,7 +4829,7 @@
             "start_date": "2014-07-01",
             "slug": "2014",
             "csv": "data/Iraq/Majlis/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Iraq/Majlis/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Iraq/Majlis/term-2014.csv"
           }
         ],
         "statement_count": 4128,
@@ -4847,11 +4848,11 @@
         "slug": "Dail",
         "sources_directory": "data/Ireland/Dail/sources",
         "popolo": "data/Ireland/Dail/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/93dbc6b5cc8e1d58cfd65a84ffb5c0d3082c58ef/data/Ireland/Dail/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@39ddc82292558ee41adb46420bb1a87f31dcf38a/data/Ireland/Dail/ep-popolo-v1.0.json",
         "names": "data/Ireland/Dail/names.csv",
-        "lastmod": "1539238239",
+        "lastmod": "1539488235",
         "person_count": 657,
-        "sha": "93dbc6b5cc8e1d58cfd65a84ffb5c0d3082c58ef",
+        "sha": "39ddc82292558ee41adb46420bb1a87f31dcf38a",
         "legislative_periods": [
           {
             "id": "term/32",
@@ -4859,7 +4860,7 @@
             "start_date": "2016-03-10",
             "slug": "32",
             "csv": "data/Ireland/Dail/term-32.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/da756ac796e511a8e342b3af3bc4288f1b6fd17c/data/Ireland/Dail/term-32.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@da756ac796e511a8e342b3af3bc4288f1b6fd17c/data/Ireland/Dail/term-32.csv"
           },
           {
             "end_date": "2016-02-03",
@@ -4868,7 +4869,7 @@
             "start_date": "2011-03-09",
             "slug": "31",
             "csv": "data/Ireland/Dail/term-31.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1771b75c1147a4c298dcbcf49a09c3373f6dc889/data/Ireland/Dail/term-31.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1771b75c1147a4c298dcbcf49a09c3373f6dc889/data/Ireland/Dail/term-31.csv"
           },
           {
             "end_date": "2011-02-01",
@@ -4877,7 +4878,7 @@
             "start_date": "2007-06-14",
             "slug": "30",
             "csv": "data/Ireland/Dail/term-30.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1771b75c1147a4c298dcbcf49a09c3373f6dc889/data/Ireland/Dail/term-30.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1771b75c1147a4c298dcbcf49a09c3373f6dc889/data/Ireland/Dail/term-30.csv"
           },
           {
             "end_date": "2007-04-26",
@@ -4886,7 +4887,7 @@
             "start_date": "2002-06-06",
             "slug": "29",
             "csv": "data/Ireland/Dail/term-29.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1771b75c1147a4c298dcbcf49a09c3373f6dc889/data/Ireland/Dail/term-29.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1771b75c1147a4c298dcbcf49a09c3373f6dc889/data/Ireland/Dail/term-29.csv"
           },
           {
             "end_date": "2002-04-25",
@@ -4895,7 +4896,7 @@
             "start_date": "1997-06-26",
             "slug": "28",
             "csv": "data/Ireland/Dail/term-28.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1771b75c1147a4c298dcbcf49a09c3373f6dc889/data/Ireland/Dail/term-28.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1771b75c1147a4c298dcbcf49a09c3373f6dc889/data/Ireland/Dail/term-28.csv"
           },
           {
             "end_date": "1997-05-15",
@@ -4904,7 +4905,7 @@
             "start_date": "1992-12-14",
             "slug": "27",
             "csv": "data/Ireland/Dail/term-27.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43799a20fa719266f2b1b764d4b3c643b9245c3f/data/Ireland/Dail/term-27.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@43799a20fa719266f2b1b764d4b3c643b9245c3f/data/Ireland/Dail/term-27.csv"
           },
           {
             "end_date": "1992-11-05",
@@ -4913,7 +4914,7 @@
             "start_date": "1989-06-29",
             "slug": "26",
             "csv": "data/Ireland/Dail/term-26.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b1000e47de64d62d0e5bd970222ccdacd1193737/data/Ireland/Dail/term-26.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b1000e47de64d62d0e5bd970222ccdacd1193737/data/Ireland/Dail/term-26.csv"
           },
           {
             "end_date": "1989-05-25",
@@ -4922,7 +4923,7 @@
             "start_date": "1987-03-10",
             "slug": "25",
             "csv": "data/Ireland/Dail/term-25.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b1000e47de64d62d0e5bd970222ccdacd1193737/data/Ireland/Dail/term-25.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b1000e47de64d62d0e5bd970222ccdacd1193737/data/Ireland/Dail/term-25.csv"
           },
           {
             "end_date": "1987-01-20",
@@ -4931,7 +4932,7 @@
             "start_date": "1982-12-14",
             "slug": "24",
             "csv": "data/Ireland/Dail/term-24.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b1000e47de64d62d0e5bd970222ccdacd1193737/data/Ireland/Dail/term-24.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b1000e47de64d62d0e5bd970222ccdacd1193737/data/Ireland/Dail/term-24.csv"
           },
           {
             "end_date": "1982-11-04",
@@ -4940,7 +4941,7 @@
             "start_date": "1982-03-09",
             "slug": "23",
             "csv": "data/Ireland/Dail/term-23.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb59112d9ff60210b697213646f3c25bd28ff1a4/data/Ireland/Dail/term-23.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@eb59112d9ff60210b697213646f3c25bd28ff1a4/data/Ireland/Dail/term-23.csv"
           },
           {
             "end_date": "1982-01-27",
@@ -4949,7 +4950,7 @@
             "start_date": "1981-06-30",
             "slug": "22",
             "csv": "data/Ireland/Dail/term-22.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ecd8dcd25fd02ace73b368aa0b30bc806542f0f1/data/Ireland/Dail/term-22.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ecd8dcd25fd02ace73b368aa0b30bc806542f0f1/data/Ireland/Dail/term-22.csv"
           },
           {
             "end_date": "1981-05-21",
@@ -4958,7 +4959,7 @@
             "start_date": "1977-07-05",
             "slug": "21",
             "csv": "data/Ireland/Dail/term-21.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb59112d9ff60210b697213646f3c25bd28ff1a4/data/Ireland/Dail/term-21.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@eb59112d9ff60210b697213646f3c25bd28ff1a4/data/Ireland/Dail/term-21.csv"
           },
           {
             "end_date": "1977-05-25",
@@ -4967,10 +4968,10 @@
             "start_date": "1973-03-14",
             "slug": "20",
             "csv": "data/Ireland/Dail/term-20.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eb59112d9ff60210b697213646f3c25bd28ff1a4/data/Ireland/Dail/term-20.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@eb59112d9ff60210b697213646f3c25bd28ff1a4/data/Ireland/Dail/term-20.csv"
           }
         ],
-        "statement_count": 34863,
+        "statement_count": 34867,
         "type": "lower house"
       }
     ]
@@ -4986,7 +4987,7 @@
         "slug": "House-of-Keys",
         "sources_directory": "data/Isle_of_Man/House_of_Keys/sources",
         "popolo": "data/Isle_of_Man/House_of_Keys/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9ad241b03212c5535bcfc8d7018da6cecff08707/data/Isle_of_Man/House_of_Keys/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9ad241b03212c5535bcfc8d7018da6cecff08707/data/Isle_of_Man/House_of_Keys/ep-popolo-v1.0.json",
         "names": "data/Isle_of_Man/House_of_Keys/names.csv",
         "lastmod": "1534427523",
         "person_count": 29,
@@ -4998,7 +4999,7 @@
             "start_date": "2011-10-04",
             "slug": "2011",
             "csv": "data/Isle_of_Man/House_of_Keys/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Isle_of_Man/House_of_Keys/term-2011.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Isle_of_Man/House_of_Keys/term-2011.csv"
           }
         ],
         "statement_count": 1405,
@@ -5017,11 +5018,11 @@
         "slug": "Knesset",
         "sources_directory": "data/Israel/Knesset/sources",
         "popolo": "data/Israel/Knesset/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dbb0ef7fb0aa194c8fa1fc259c133d614ca08743/data/Israel/Knesset/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9cba123d8cc526c3f1149b2a5ee850911eb02027/data/Israel/Knesset/ep-popolo-v1.0.json",
         "names": "data/Israel/Knesset/names.csv",
-        "lastmod": "1539172898",
+        "lastmod": "1539351524",
         "person_count": 933,
-        "sha": "dbb0ef7fb0aa194c8fa1fc259c133d614ca08743",
+        "sha": "9cba123d8cc526c3f1149b2a5ee850911eb02027",
         "legislative_periods": [
           {
             "end_date": "2016-06-01",
@@ -5030,7 +5031,7 @@
             "start_date": "2015-03-31",
             "slug": "20",
             "csv": "data/Israel/Knesset/term-20.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0b61d08e81a90265b516974fd9c8da9aea3d9b6c/data/Israel/Knesset/term-20.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0b61d08e81a90265b516974fd9c8da9aea3d9b6c/data/Israel/Knesset/term-20.csv"
           },
           {
             "end_date": "2015-03-31",
@@ -5039,7 +5040,7 @@
             "start_date": "2013-02-05",
             "slug": "19",
             "csv": "data/Israel/Knesset/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/da1de6cb3cdd029509f14fe7e1e43d82baed7af8/data/Israel/Knesset/term-19.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@da1de6cb3cdd029509f14fe7e1e43d82baed7af8/data/Israel/Knesset/term-19.csv"
           },
           {
             "end_date": "2013-02-05",
@@ -5048,7 +5049,7 @@
             "start_date": "2009-02-24",
             "slug": "18",
             "csv": "data/Israel/Knesset/term-18.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/da1de6cb3cdd029509f14fe7e1e43d82baed7af8/data/Israel/Knesset/term-18.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@da1de6cb3cdd029509f14fe7e1e43d82baed7af8/data/Israel/Knesset/term-18.csv"
           },
           {
             "end_date": "2009-02-24",
@@ -5057,7 +5058,7 @@
             "start_date": "2006-04-17",
             "slug": "17",
             "csv": "data/Israel/Knesset/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/95e1a97c29fbdfcbbdee354cf99ea88c25c8a9c8/data/Israel/Knesset/term-17.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d1343d919e8804c0f45d28b62d347cd417295cea/data/Israel/Knesset/term-17.csv"
           },
           {
             "end_date": "2006-04-17",
@@ -5066,7 +5067,7 @@
             "start_date": "2003-02-17",
             "slug": "16",
             "csv": "data/Israel/Knesset/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4debe24fbc2e77debf7d97cc0e40615b3e3da54e/data/Israel/Knesset/term-16.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d1343d919e8804c0f45d28b62d347cd417295cea/data/Israel/Knesset/term-16.csv"
           },
           {
             "end_date": "2003-02-17",
@@ -5075,7 +5076,7 @@
             "start_date": "1999-06-07",
             "slug": "15",
             "csv": "data/Israel/Knesset/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/95e1a97c29fbdfcbbdee354cf99ea88c25c8a9c8/data/Israel/Knesset/term-15.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d1343d919e8804c0f45d28b62d347cd417295cea/data/Israel/Knesset/term-15.csv"
           },
           {
             "end_date": "1999-06-07",
@@ -5084,7 +5085,7 @@
             "start_date": "1996-06-17",
             "slug": "14",
             "csv": "data/Israel/Knesset/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4debe24fbc2e77debf7d97cc0e40615b3e3da54e/data/Israel/Knesset/term-14.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4debe24fbc2e77debf7d97cc0e40615b3e3da54e/data/Israel/Knesset/term-14.csv"
           },
           {
             "end_date": "1996-06-17",
@@ -5093,7 +5094,7 @@
             "start_date": "1992-07-13",
             "slug": "13",
             "csv": "data/Israel/Knesset/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4debe24fbc2e77debf7d97cc0e40615b3e3da54e/data/Israel/Knesset/term-13.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4debe24fbc2e77debf7d97cc0e40615b3e3da54e/data/Israel/Knesset/term-13.csv"
           },
           {
             "end_date": "1992-07-13",
@@ -5102,7 +5103,7 @@
             "start_date": "1988-11-21",
             "slug": "12",
             "csv": "data/Israel/Knesset/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4debe24fbc2e77debf7d97cc0e40615b3e3da54e/data/Israel/Knesset/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4debe24fbc2e77debf7d97cc0e40615b3e3da54e/data/Israel/Knesset/term-12.csv"
           },
           {
             "end_date": "1988-11-21",
@@ -5111,7 +5112,7 @@
             "start_date": "1984-08-13",
             "slug": "11",
             "csv": "data/Israel/Knesset/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/75cc2ea663f45ed4dd3bd2526a26212419166c36/data/Israel/Knesset/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@75cc2ea663f45ed4dd3bd2526a26212419166c36/data/Israel/Knesset/term-11.csv"
           },
           {
             "end_date": "1984-08-13",
@@ -5120,7 +5121,7 @@
             "start_date": "1981-07-20",
             "slug": "10",
             "csv": "data/Israel/Knesset/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4debe24fbc2e77debf7d97cc0e40615b3e3da54e/data/Israel/Knesset/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4debe24fbc2e77debf7d97cc0e40615b3e3da54e/data/Israel/Knesset/term-10.csv"
           },
           {
             "end_date": "1981-07-20",
@@ -5129,7 +5130,7 @@
             "start_date": "1977-06-13",
             "slug": "9",
             "csv": "data/Israel/Knesset/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4debe24fbc2e77debf7d97cc0e40615b3e3da54e/data/Israel/Knesset/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4debe24fbc2e77debf7d97cc0e40615b3e3da54e/data/Israel/Knesset/term-9.csv"
           },
           {
             "end_date": "1977-06-13",
@@ -5138,7 +5139,7 @@
             "start_date": "1974-01-21",
             "slug": "8",
             "csv": "data/Israel/Knesset/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f1521d24009507e81b04948930a759838418b468/data/Israel/Knesset/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f1521d24009507e81b04948930a759838418b468/data/Israel/Knesset/term-8.csv"
           },
           {
             "end_date": "1974-01-21",
@@ -5147,7 +5148,7 @@
             "start_date": "1969-11-17",
             "slug": "7",
             "csv": "data/Israel/Knesset/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f1521d24009507e81b04948930a759838418b468/data/Israel/Knesset/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f1521d24009507e81b04948930a759838418b468/data/Israel/Knesset/term-7.csv"
           },
           {
             "end_date": "1969-11-17",
@@ -5156,7 +5157,7 @@
             "start_date": "1965-11-22",
             "slug": "6",
             "csv": "data/Israel/Knesset/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/95e1a97c29fbdfcbbdee354cf99ea88c25c8a9c8/data/Israel/Knesset/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@95e1a97c29fbdfcbbdee354cf99ea88c25c8a9c8/data/Israel/Knesset/term-6.csv"
           },
           {
             "end_date": "1965-11-22",
@@ -5165,7 +5166,7 @@
             "start_date": "1961-09-04",
             "slug": "5",
             "csv": "data/Israel/Knesset/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f1521d24009507e81b04948930a759838418b468/data/Israel/Knesset/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f1521d24009507e81b04948930a759838418b468/data/Israel/Knesset/term-5.csv"
           },
           {
             "end_date": "1961-09-04",
@@ -5174,7 +5175,7 @@
             "start_date": "1959-11-30",
             "slug": "4",
             "csv": "data/Israel/Knesset/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f1521d24009507e81b04948930a759838418b468/data/Israel/Knesset/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f1521d24009507e81b04948930a759838418b468/data/Israel/Knesset/term-4.csv"
           },
           {
             "end_date": "1959-11-30",
@@ -5183,7 +5184,7 @@
             "start_date": "1955-08-15",
             "slug": "3",
             "csv": "data/Israel/Knesset/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/95e1a97c29fbdfcbbdee354cf99ea88c25c8a9c8/data/Israel/Knesset/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@95e1a97c29fbdfcbbdee354cf99ea88c25c8a9c8/data/Israel/Knesset/term-3.csv"
           },
           {
             "end_date": "1955-08-15",
@@ -5192,7 +5193,7 @@
             "start_date": "1951-08-20",
             "slug": "2",
             "csv": "data/Israel/Knesset/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/95e1a97c29fbdfcbbdee354cf99ea88c25c8a9c8/data/Israel/Knesset/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@95e1a97c29fbdfcbbdee354cf99ea88c25c8a9c8/data/Israel/Knesset/term-2.csv"
           },
           {
             "end_date": "1951-08-20",
@@ -5201,10 +5202,10 @@
             "start_date": "1949-02-14",
             "slug": "1",
             "csv": "data/Israel/Knesset/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/95e1a97c29fbdfcbbdee354cf99ea88c25c8a9c8/data/Israel/Knesset/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@95e1a97c29fbdfcbbdee354cf99ea88c25c8a9c8/data/Israel/Knesset/term-1.csv"
           }
         ],
-        "statement_count": 73039,
+        "statement_count": 73062,
         "type": "unicameral legislature"
       }
     ]
@@ -5220,11 +5221,11 @@
         "slug": "House",
         "sources_directory": "data/Italy/House/sources",
         "popolo": "data/Italy/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/180074504b391c652aa85e45b7e0508916b8f5d2/data/Italy/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b0cad326a1d066b3ce92e7a52e3151fb254b471b/data/Italy/House/ep-popolo-v1.0.json",
         "names": "data/Italy/House/names.csv",
-        "lastmod": "1538951450",
+        "lastmod": "1539513809",
         "person_count": 668,
-        "sha": "180074504b391c652aa85e45b7e0508916b8f5d2",
+        "sha": "b0cad326a1d066b3ce92e7a52e3151fb254b471b",
         "legislative_periods": [
           {
             "end_date": "2018-03-22",
@@ -5233,10 +5234,10 @@
             "start_date": "2013-03-15",
             "slug": "17",
             "csv": "data/Italy/House/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/bf5475a6badf4ad7dc61373378565558ea2ada16/data/Italy/House/term-17.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bf5475a6badf4ad7dc61373378565558ea2ada16/data/Italy/House/term-17.csv"
           }
         ],
-        "statement_count": 37279,
+        "statement_count": 37287,
         "type": "lower house"
       },
       {
@@ -5244,11 +5245,11 @@
         "slug": "Senate",
         "sources_directory": "data/Italy/Senate/sources",
         "popolo": "data/Italy/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0ae74655cd901fe8f2248760fa696eec05654ec7/data/Italy/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1adc47ad07443f9b2421ba704abf7e20f8c653c0/data/Italy/Senate/ep-popolo-v1.0.json",
         "names": "data/Italy/Senate/names.csv",
-        "lastmod": "1539079067",
+        "lastmod": "1539606913",
         "person_count": 566,
-        "sha": "0ae74655cd901fe8f2248760fa696eec05654ec7",
+        "sha": "1adc47ad07443f9b2421ba704abf7e20f8c653c0",
         "legislative_periods": [
           {
             "id": "term/18",
@@ -5256,7 +5257,7 @@
             "start_date": "2018-03-23",
             "slug": "18",
             "csv": "data/Italy/Senate/term-18.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0ae74655cd901fe8f2248760fa696eec05654ec7/data/Italy/Senate/term-18.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bfb373015152246e71f878d7525102d104bb253a/data/Italy/Senate/term-18.csv"
           },
           {
             "end_date": "2018-03-22",
@@ -5265,10 +5266,10 @@
             "start_date": "2013-03-15",
             "slug": "17",
             "csv": "data/Italy/Senate/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d8b48d831c6bc0c7ec73898ac2bc921e3317dc00/data/Italy/Senate/term-17.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d8b48d831c6bc0c7ec73898ac2bc921e3317dc00/data/Italy/Senate/term-17.csv"
           }
         ],
-        "statement_count": 25096,
+        "statement_count": 25196,
         "type": "upper house"
       }
     ]
@@ -5284,11 +5285,11 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Jamaica/House_of_Representatives/sources",
         "popolo": "data/Jamaica/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e7a1b6529bc377a19338fa6a297e1db72ea7ae2c/data/Jamaica/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a1a53c82f79ede07d2040730516ae50318a6e2d/data/Jamaica/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Jamaica/House_of_Representatives/names.csv",
-        "lastmod": "1536824627",
+        "lastmod": "1539616141",
         "person_count": 81,
-        "sha": "e7a1b6529bc377a19338fa6a297e1db72ea7ae2c",
+        "sha": "9a1a53c82f79ede07d2040730516ae50318a6e2d",
         "legislative_periods": [
           {
             "id": "term/2016",
@@ -5296,7 +5297,7 @@
             "start_date": "2016-03-10",
             "slug": "2016",
             "csv": "data/Jamaica/House_of_Representatives/term-2016.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1109cf4dbfd9b091ffbac227bddb21efccab08c3/data/Jamaica/House_of_Representatives/term-2016.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1109cf4dbfd9b091ffbac227bddb21efccab08c3/data/Jamaica/House_of_Representatives/term-2016.csv"
           },
           {
             "end_date": "2016-02-25",
@@ -5305,10 +5306,10 @@
             "start_date": "2012-01-17",
             "slug": "2011",
             "csv": "data/Jamaica/House_of_Representatives/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c773281250a453666a8f9bc80b45cac0c03965e6/data/Jamaica/House_of_Representatives/term-2011.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c773281250a453666a8f9bc80b45cac0c03965e6/data/Jamaica/House_of_Representatives/term-2011.csv"
           }
         ],
-        "statement_count": 2728,
+        "statement_count": 2731,
         "type": "lower house"
       }
     ]
@@ -5324,23 +5325,31 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Japan/House_of_Representatives/sources",
         "popolo": "data/Japan/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/92738b5cd911418ae477c5d750581c7265bdb8ad/data/Japan/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c4409a23ce37634658ac8cad607270d4a159c10d/data/Japan/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Japan/House_of_Representatives/names.csv",
-        "lastmod": "1539090829",
-        "person_count": 479,
-        "sha": "92738b5cd911418ae477c5d750581c7265bdb8ad",
+        "lastmod": "1539675410",
+        "person_count": 567,
+        "sha": "c4409a23ce37634658ac8cad607270d4a159c10d",
         "legislative_periods": [
+          {
+            "id": "term/48",
+            "name": "48th House of Representatives",
+            "start_date": "2017-11-01",
+            "slug": "48",
+            "csv": "data/Japan/House_of_Representatives/term-48.csv",
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c4409a23ce37634658ac8cad607270d4a159c10d/data/Japan/House_of_Representatives/term-48.csv"
+          },
           {
             "end_date": "2017-09-28",
             "id": "term/47",
-            "name": "The 47th House of Representatives",
+            "name": "47th House of Representatives",
             "start_date": "2014-12-14",
             "slug": "47",
             "csv": "data/Japan/House_of_Representatives/term-47.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/88138017f5b359165ff9564596d87a751eb52612/data/Japan/House_of_Representatives/term-47.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c4409a23ce37634658ac8cad607270d4a159c10d/data/Japan/House_of_Representatives/term-47.csv"
           }
         ],
-        "statement_count": 30199,
+        "statement_count": 34268,
         "type": "lower house"
       }
     ]
@@ -5356,7 +5365,7 @@
         "slug": "States",
         "sources_directory": "data/Jersey/States/sources",
         "popolo": "data/Jersey/States/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Jersey/States/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Jersey/States/ep-popolo-v1.0.json",
         "names": "data/Jersey/States/names.csv",
         "lastmod": "1528387224",
         "person_count": 62,
@@ -5368,7 +5377,7 @@
             "start_date": "2014-11-03",
             "slug": "2011",
             "csv": "data/Jersey/States/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Jersey/States/term-2011.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Jersey/States/term-2011.csv"
           }
         ],
         "statement_count": 1693,
@@ -5387,7 +5396,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Jordan/House_of_Representatives/sources",
         "popolo": "data/Jordan/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d62fc66c91716b8eca9a840bf55fc0d60a27e2a4/data/Jordan/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d62fc66c91716b8eca9a840bf55fc0d60a27e2a4/data/Jordan/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Jordan/House_of_Representatives/names.csv",
         "lastmod": "1533886260",
         "person_count": 150,
@@ -5399,7 +5408,7 @@
             "start_date": "2013-02-10",
             "slug": "2013",
             "csv": "data/Jordan/House_of_Representatives/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Jordan/House_of_Representatives/term-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Jordan/House_of_Representatives/term-2013.csv"
           }
         ],
         "statement_count": 1983,
@@ -5418,7 +5427,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Kazakhstan/Assembly/sources",
         "popolo": "data/Kazakhstan/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c89aa4c9708eec0f38d1a8e0d86c4ad943efb242/data/Kazakhstan/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c89aa4c9708eec0f38d1a8e0d86c4ad943efb242/data/Kazakhstan/Assembly/ep-popolo-v1.0.json",
         "names": "data/Kazakhstan/Assembly/names.csv",
         "lastmod": "1485067920",
         "person_count": 171,
@@ -5430,7 +5439,7 @@
             "start_date": "2016-03-25",
             "slug": "6",
             "csv": "data/Kazakhstan/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Kazakhstan/Assembly/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Kazakhstan/Assembly/term-6.csv"
           },
           {
             "end_date": "2016-01-20",
@@ -5439,7 +5448,7 @@
             "start_date": "2012-01-15",
             "slug": "5",
             "csv": "data/Kazakhstan/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Kazakhstan/Assembly/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Kazakhstan/Assembly/term-5.csv"
           }
         ],
         "statement_count": 3991,
@@ -5458,7 +5467,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Kenya/Assembly/sources",
         "popolo": "data/Kenya/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5e06740f319f09b4d1b1821a15c539c1bfabd73a/data/Kenya/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@5e06740f319f09b4d1b1821a15c539c1bfabd73a/data/Kenya/Assembly/ep-popolo-v1.0.json",
         "names": "data/Kenya/Assembly/names.csv",
         "lastmod": "1537801010",
         "person_count": 355,
@@ -5470,7 +5479,7 @@
             "start_date": "2013-03-28",
             "slug": "11",
             "csv": "data/Kenya/Assembly/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5e06740f319f09b4d1b1821a15c539c1bfabd73a/data/Kenya/Assembly/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@5e06740f319f09b4d1b1821a15c539c1bfabd73a/data/Kenya/Assembly/term-11.csv"
           }
         ],
         "statement_count": 11531,
@@ -5489,11 +5498,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Kiribati/Parliament/sources",
         "popolo": "data/Kiribati/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3dea8a7e97081b969395508b209ca1a896cfbb7a/data/Kiribati/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@da253d8d631b64adff31836569a6e7aac0db5f87/data/Kiribati/Parliament/ep-popolo-v1.0.json",
         "names": "data/Kiribati/Parliament/names.csv",
-        "lastmod": "1538699853",
+        "lastmod": "1539512129",
         "person_count": 62,
-        "sha": "3dea8a7e97081b969395508b209ca1a896cfbb7a",
+        "sha": "da253d8d631b64adff31836569a6e7aac0db5f87",
         "legislative_periods": [
           {
             "end_date": "2015-11-25",
@@ -5502,7 +5511,7 @@
             "start_date": "2011-11-25",
             "slug": "10",
             "csv": "data/Kiribati/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Kiribati/Parliament/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Kiribati/Parliament/term-10.csv"
           },
           {
             "end_date": "2011-10-20",
@@ -5511,10 +5520,10 @@
             "start_date": "2007-09-17",
             "slug": "9",
             "csv": "data/Kiribati/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/426353d412c888c3b194bbcf7af2cf9d1f920c73/data/Kiribati/Parliament/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@426353d412c888c3b194bbcf7af2cf9d1f920c73/data/Kiribati/Parliament/term-9.csv"
           }
         ],
-        "statement_count": 2112,
+        "statement_count": 2121,
         "type": "unicameral legislature"
       }
     ]
@@ -5530,7 +5539,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Kosovo/Assembly/sources",
         "popolo": "data/Kosovo/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/201c5f7443c8958fb1cffd2a326b8d79ec511e09/data/Kosovo/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@201c5f7443c8958fb1cffd2a326b8d79ec511e09/data/Kosovo/Assembly/ep-popolo-v1.0.json",
         "names": "data/Kosovo/Assembly/names.csv",
         "lastmod": "1537785467",
         "person_count": 399,
@@ -5543,7 +5552,7 @@
             "start_date": "2014-07-17",
             "slug": "chamber_2014-07-17",
             "csv": "data/Kosovo/Assembly/term-chamber_2014-07-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7710d8478f6bed092c6939d40a6cc0df42b000f6/data/Kosovo/Assembly/term-chamber_2014-07-17.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7710d8478f6bed092c6939d40a6cc0df42b000f6/data/Kosovo/Assembly/term-chamber_2014-07-17.csv"
           },
           {
             "end_date": "2014-05-07",
@@ -5552,7 +5561,7 @@
             "start_date": "2010-12-12",
             "slug": "chamber_2010-12-12",
             "csv": "data/Kosovo/Assembly/term-chamber_2010-12-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7710d8478f6bed092c6939d40a6cc0df42b000f6/data/Kosovo/Assembly/term-chamber_2010-12-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7710d8478f6bed092c6939d40a6cc0df42b000f6/data/Kosovo/Assembly/term-chamber_2010-12-12.csv"
           },
           {
             "end_date": "2010-11-03",
@@ -5561,7 +5570,7 @@
             "start_date": "2007-12-13",
             "slug": "chamber_2007-12-13",
             "csv": "data/Kosovo/Assembly/term-chamber_2007-12-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ece42663d1b563432105fc171ac551c09ffd8709/data/Kosovo/Assembly/term-chamber_2007-12-13.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ece42663d1b563432105fc171ac551c09ffd8709/data/Kosovo/Assembly/term-chamber_2007-12-13.csv"
           },
           {
             "end_date": "2007-12-12",
@@ -5570,7 +5579,7 @@
             "start_date": "2004-11-23",
             "slug": "chamber_2004-11-23",
             "csv": "data/Kosovo/Assembly/term-chamber_2004-11-23.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ece42663d1b563432105fc171ac551c09ffd8709/data/Kosovo/Assembly/term-chamber_2004-11-23.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ece42663d1b563432105fc171ac551c09ffd8709/data/Kosovo/Assembly/term-chamber_2004-11-23.csv"
           },
           {
             "end_date": "2004-11-23",
@@ -5579,7 +5588,7 @@
             "start_date": "2001-11-17",
             "slug": "chamber_2001-11-17",
             "csv": "data/Kosovo/Assembly/term-chamber_2001-11-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ece42663d1b563432105fc171ac551c09ffd8709/data/Kosovo/Assembly/term-chamber_2001-11-17.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ece42663d1b563432105fc171ac551c09ffd8709/data/Kosovo/Assembly/term-chamber_2001-11-17.csv"
           }
         ],
         "statement_count": 10522,
@@ -5598,7 +5607,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Kuwait/National_Assembly/sources",
         "popolo": "data/Kuwait/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aa8402ac43e3adbd569c5c3f8faa8d84687dbdce/data/Kuwait/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@aa8402ac43e3adbd569c5c3f8faa8d84687dbdce/data/Kuwait/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Kuwait/National_Assembly/names.csv",
         "lastmod": "1538468308",
         "person_count": 45,
@@ -5610,7 +5619,7 @@
             "start_date": "2013-08-06",
             "slug": "14",
             "csv": "data/Kuwait/National_Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Kuwait/National_Assembly/term-14.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Kuwait/National_Assembly/term-14.csv"
           }
         ],
         "statement_count": 1756,
@@ -5629,7 +5638,7 @@
         "slug": "Council",
         "sources_directory": "data/Kyrgyzstan/Council/sources",
         "popolo": "data/Kyrgyzstan/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/02452cf18e4c1c1737069dcaa9e7af1dfaa1f23c/data/Kyrgyzstan/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@02452cf18e4c1c1737069dcaa9e7af1dfaa1f23c/data/Kyrgyzstan/Council/ep-popolo-v1.0.json",
         "names": "data/Kyrgyzstan/Council/names.csv",
         "lastmod": "1536700211",
         "person_count": 209,
@@ -5641,7 +5650,7 @@
             "start_date": "2015-10-28",
             "slug": "6",
             "csv": "data/Kyrgyzstan/Council/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/95a68797bcc3d229c870f944c14e1b9adb34a76f/data/Kyrgyzstan/Council/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@95a68797bcc3d229c870f944c14e1b9adb34a76f/data/Kyrgyzstan/Council/term-6.csv"
           },
           {
             "end_date": "2015-10-15",
@@ -5650,7 +5659,7 @@
             "start_date": "2010",
             "slug": "5",
             "csv": "data/Kyrgyzstan/Council/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/95a68797bcc3d229c870f944c14e1b9adb34a76f/data/Kyrgyzstan/Council/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@95a68797bcc3d229c870f944c14e1b9adb34a76f/data/Kyrgyzstan/Council/term-5.csv"
           }
         ],
         "statement_count": 4337,
@@ -5669,7 +5678,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Laos/Assembly/sources",
         "popolo": "data/Laos/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b9ac6dbc6cf91960735260dcbc1ea44c0de532df/data/Laos/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b9ac6dbc6cf91960735260dcbc1ea44c0de532df/data/Laos/Assembly/ep-popolo-v1.0.json",
         "names": "data/Laos/Assembly/names.csv",
         "lastmod": "1520303783",
         "person_count": 236,
@@ -5681,7 +5690,7 @@
             "start_date": "2016-04-20",
             "slug": "2016",
             "csv": "data/Laos/Assembly/term-2016.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Laos/Assembly/term-2016.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Laos/Assembly/term-2016.csv"
           },
           {
             "end_date": "2016-03-20",
@@ -5690,7 +5699,7 @@
             "start_date": "2011-06-15",
             "slug": "2011",
             "csv": "data/Laos/Assembly/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Laos/Assembly/term-2011.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Laos/Assembly/term-2011.csv"
           }
         ],
         "statement_count": 3012,
@@ -5709,11 +5718,11 @@
         "slug": "Saeima",
         "sources_directory": "data/Latvia/Saeima/sources",
         "popolo": "data/Latvia/Saeima/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5da890b73e310317fff114a8b6e9e1aa1b45359b/data/Latvia/Saeima/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@70292bc0dea43915dcc0fa62098653fda7d1c6f5/data/Latvia/Saeima/ep-popolo-v1.0.json",
         "names": "data/Latvia/Saeima/names.csv",
-        "lastmod": "1539134228",
+        "lastmod": "1539479734",
         "person_count": 213,
-        "sha": "5da890b73e310317fff114a8b6e9e1aa1b45359b",
+        "sha": "70292bc0dea43915dcc0fa62098653fda7d1c6f5",
         "legislative_periods": [
           {
             "id": "term/12",
@@ -5721,7 +5730,7 @@
             "start_date": "2014-11-04",
             "slug": "12",
             "csv": "data/Latvia/Saeima/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/22fc9f047b83ce52104ec5c724ae696b06d47613/data/Latvia/Saeima/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@22fc9f047b83ce52104ec5c724ae696b06d47613/data/Latvia/Saeima/term-12.csv"
           },
           {
             "end_date": "2014-11-03",
@@ -5730,7 +5739,7 @@
             "start_date": "2011-10-17",
             "slug": "11",
             "csv": "data/Latvia/Saeima/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1fc6fe3431cf2fed514576af94ccc6a9a7ee7935/data/Latvia/Saeima/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1fc6fe3431cf2fed514576af94ccc6a9a7ee7935/data/Latvia/Saeima/term-11.csv"
           },
           {
             "end_date": "2011-10-16",
@@ -5739,10 +5748,10 @@
             "start_date": "2010-11-02",
             "slug": "10",
             "csv": "data/Latvia/Saeima/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1fc6fe3431cf2fed514576af94ccc6a9a7ee7935/data/Latvia/Saeima/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1fc6fe3431cf2fed514576af94ccc6a9a7ee7935/data/Latvia/Saeima/term-10.csv"
           }
         ],
-        "statement_count": 11756,
+        "statement_count": 11758,
         "type": "unicameral legislature"
       }
     ]
@@ -5758,7 +5767,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Lebanon/Parliament/sources",
         "popolo": "data/Lebanon/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/25a49db313e9e8e66d7d0050894de20bc48f8098/data/Lebanon/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@25a49db313e9e8e66d7d0050894de20bc48f8098/data/Lebanon/Parliament/ep-popolo-v1.0.json",
         "names": "data/Lebanon/Parliament/names.csv",
         "lastmod": "1539023965",
         "person_count": 130,
@@ -5771,7 +5780,7 @@
             "start_date": "2009-06-20",
             "slug": "2009",
             "csv": "data/Lebanon/Parliament/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e5fc4d78295077c30f7a1a7ed0e40e8187d75a9c/data/Lebanon/Parliament/term-2009.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e5fc4d78295077c30f7a1a7ed0e40e8187d75a9c/data/Lebanon/Parliament/term-2009.csv"
           }
         ],
         "statement_count": 8264,
@@ -5790,7 +5799,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Lesotho/Assembly/sources",
         "popolo": "data/Lesotho/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2f8bad6364f9f0a8a9e459812686e74ea7d2f002/data/Lesotho/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@2f8bad6364f9f0a8a9e459812686e74ea7d2f002/data/Lesotho/Assembly/ep-popolo-v1.0.json",
         "names": "data/Lesotho/Assembly/names.csv",
         "lastmod": "1534343742",
         "person_count": 185,
@@ -5802,7 +5811,7 @@
             "start_date": "2017-06-12",
             "slug": "10",
             "csv": "data/Lesotho/Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2f8bad6364f9f0a8a9e459812686e74ea7d2f002/data/Lesotho/Assembly/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@2f8bad6364f9f0a8a9e459812686e74ea7d2f002/data/Lesotho/Assembly/term-10.csv"
           },
           {
             "end_date": "2017-03-07",
@@ -5811,7 +5820,7 @@
             "start_date": "2015-03-10",
             "slug": "9",
             "csv": "data/Lesotho/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Lesotho/Assembly/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Lesotho/Assembly/term-9.csv"
           }
         ],
         "statement_count": 3214,
@@ -5830,7 +5839,7 @@
         "slug": "House",
         "sources_directory": "data/Liberia/House/sources",
         "popolo": "data/Liberia/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Liberia/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Liberia/House/ep-popolo-v1.0.json",
         "names": "data/Liberia/House/names.csv",
         "lastmod": "1528387224",
         "person_count": 73,
@@ -5842,7 +5851,7 @@
             "start_date": "2012-01-09",
             "slug": "53",
             "csv": "data/Liberia/House/term-53.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Liberia/House/term-53.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Liberia/House/term-53.csv"
           }
         ],
         "statement_count": 2133,
@@ -5861,7 +5870,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Libya/House_of_Representatives/sources",
         "popolo": "data/Libya/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Libya/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Libya/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Libya/House_of_Representatives/names.csv",
         "lastmod": "1528387224",
         "person_count": 189,
@@ -5873,7 +5882,7 @@
             "start_date": "2014-08-04",
             "slug": "1",
             "csv": "data/Libya/House_of_Representatives/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Libya/House_of_Representatives/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Libya/House_of_Representatives/term-1.csv"
           }
         ],
         "statement_count": 2943,
@@ -5892,7 +5901,7 @@
         "slug": "Landtag",
         "sources_directory": "data/Liechtenstein/Landtag/sources",
         "popolo": "data/Liechtenstein/Landtag/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f183412f49d5a457f8c12a281ca10d513889a79e/data/Liechtenstein/Landtag/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f183412f49d5a457f8c12a281ca10d513889a79e/data/Liechtenstein/Landtag/ep-popolo-v1.0.json",
         "names": "data/Liechtenstein/Landtag/names.csv",
         "lastmod": "1537801023",
         "person_count": 62,
@@ -5904,7 +5913,7 @@
             "start_date": "2017-02-05",
             "slug": "2017",
             "csv": "data/Liechtenstein/Landtag/term-2017.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/efff54a7f6c02dc2d0a99333d0ada8234c68a1ad/data/Liechtenstein/Landtag/term-2017.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@efff54a7f6c02dc2d0a99333d0ada8234c68a1ad/data/Liechtenstein/Landtag/term-2017.csv"
           },
           {
             "end_date": "2017-02-04",
@@ -5913,7 +5922,7 @@
             "start_date": "2013-03-27",
             "slug": "2013",
             "csv": "data/Liechtenstein/Landtag/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f183412f49d5a457f8c12a281ca10d513889a79e/data/Liechtenstein/Landtag/term-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f183412f49d5a457f8c12a281ca10d513889a79e/data/Liechtenstein/Landtag/term-2013.csv"
           },
           {
             "end_date": "2013-02-02",
@@ -5922,7 +5931,7 @@
             "start_date": "2009-03-18",
             "slug": "2009",
             "csv": "data/Liechtenstein/Landtag/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f183412f49d5a457f8c12a281ca10d513889a79e/data/Liechtenstein/Landtag/term-2009.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f183412f49d5a457f8c12a281ca10d513889a79e/data/Liechtenstein/Landtag/term-2009.csv"
           },
           {
             "end_date": "2009-02-07",
@@ -5931,7 +5940,7 @@
             "start_date": "2005-04-14",
             "slug": "2005",
             "csv": "data/Liechtenstein/Landtag/term-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/efff54a7f6c02dc2d0a99333d0ada8234c68a1ad/data/Liechtenstein/Landtag/term-2005.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@efff54a7f6c02dc2d0a99333d0ada8234c68a1ad/data/Liechtenstein/Landtag/term-2005.csv"
           }
         ],
         "statement_count": 2658,
@@ -5950,7 +5959,7 @@
         "slug": "Seimas",
         "sources_directory": "data/Lithuania/Seimas/sources",
         "popolo": "data/Lithuania/Seimas/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a0e7952d85074c082c555ccfa8a0c60fcdbc1435/data/Lithuania/Seimas/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a0e7952d85074c082c555ccfa8a0c60fcdbc1435/data/Lithuania/Seimas/ep-popolo-v1.0.json",
         "names": "data/Lithuania/Seimas/names.csv",
         "lastmod": "1538114403",
         "person_count": 150,
@@ -5963,7 +5972,7 @@
             "start_date": "2012-11-17",
             "slug": "11",
             "csv": "data/Lithuania/Seimas/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f6441cce7b66546581a36a9115cd6a4233544bd3/data/Lithuania/Seimas/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f6441cce7b66546581a36a9115cd6a4233544bd3/data/Lithuania/Seimas/term-11.csv"
           }
         ],
         "statement_count": 7551,
@@ -5982,7 +5991,7 @@
         "slug": "Chamber",
         "sources_directory": "data/Luxembourg/Chamber/sources",
         "popolo": "data/Luxembourg/Chamber/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e1f90595a5fa14a8765b81dc066e510b9ebc265e/data/Luxembourg/Chamber/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e1f90595a5fa14a8765b81dc066e510b9ebc265e/data/Luxembourg/Chamber/ep-popolo-v1.0.json",
         "names": "data/Luxembourg/Chamber/names.csv",
         "lastmod": "1538049337",
         "person_count": 63,
@@ -5994,7 +6003,7 @@
             "start_date": "2013-11-13",
             "slug": "2013",
             "csv": "data/Luxembourg/Chamber/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0bd77f1ade0deaf0fd8b8c8088875b8b03f5f9f2/data/Luxembourg/Chamber/term-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0bd77f1ade0deaf0fd8b8c8088875b8b03f5f9f2/data/Luxembourg/Chamber/term-2013.csv"
           }
         ],
         "statement_count": 3453,
@@ -6013,7 +6022,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Macao/Assembly/sources",
         "popolo": "data/Macao/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fbc11313f52ce95134e53dedfa6dd6900b9f2c63/data/Macao/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@fbc11313f52ce95134e53dedfa6dd6900b9f2c63/data/Macao/Assembly/ep-popolo-v1.0.json",
         "names": "data/Macao/Assembly/names.csv",
         "lastmod": "1536793863",
         "person_count": 33,
@@ -6026,7 +6035,7 @@
             "start_date": "2013",
             "slug": "10",
             "csv": "data/Macao/Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Macao/Assembly/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Macao/Assembly/term-10.csv"
           }
         ],
         "statement_count": 932,
@@ -6045,22 +6054,23 @@
         "slug": "Sobranie",
         "sources_directory": "data/Macedonia/Sobranie/sources",
         "popolo": "data/Macedonia/Sobranie/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/96b367b7da8228a6c0e58283c829bb29d347726c/data/Macedonia/Sobranie/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b55e517eba404d8e049ee6ffee0995d574af09c2/data/Macedonia/Sobranie/ep-popolo-v1.0.json",
         "names": "data/Macedonia/Sobranie/names.csv",
-        "lastmod": "1538505388",
+        "lastmod": "1539667241",
         "person_count": 92,
-        "sha": "96b367b7da8228a6c0e58283c829bb29d347726c",
+        "sha": "b55e517eba404d8e049ee6ffee0995d574af09c2",
         "legislative_periods": [
           {
+            "end_date": "2016-10-17",
             "id": "term/2014",
-            "name": "2014–2018",
+            "name": "Sobranie 2014-2016",
             "start_date": "2014-05-10",
             "slug": "2014",
             "csv": "data/Macedonia/Sobranie/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/66e01d3fb391002362595627addcf3f22295ea63/data/Macedonia/Sobranie/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@66e01d3fb391002362595627addcf3f22295ea63/data/Macedonia/Sobranie/term-2014.csv"
           }
         ],
-        "statement_count": 3754,
+        "statement_count": 3761,
         "type": "unicameral legislature"
       }
     ]
@@ -6076,7 +6086,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Madagascar/Assembly/sources",
         "popolo": "data/Madagascar/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/59c89a90d53685d11ba85311f761f6a2c633ec28/data/Madagascar/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@59c89a90d53685d11ba85311f761f6a2c633ec28/data/Madagascar/Assembly/ep-popolo-v1.0.json",
         "names": "data/Madagascar/Assembly/names.csv",
         "lastmod": "1537785801",
         "person_count": 157,
@@ -6088,7 +6098,7 @@
             "start_date": "2013-12-20",
             "slug": "2013",
             "csv": "data/Madagascar/Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Madagascar/Assembly/term-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Madagascar/Assembly/term-2013.csv"
           }
         ],
         "statement_count": 3248,
@@ -6107,7 +6117,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Malawi/Assembly/sources",
         "popolo": "data/Malawi/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/81362d4f718c0b403764f5322ae3521b797c752e/data/Malawi/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@81362d4f718c0b403764f5322ae3521b797c752e/data/Malawi/Assembly/ep-popolo-v1.0.json",
         "names": "data/Malawi/Assembly/names.csv",
         "lastmod": "1538291147",
         "person_count": 193,
@@ -6119,7 +6129,7 @@
             "start_date": "2014-06-19",
             "slug": "2014",
             "csv": "data/Malawi/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/81362d4f718c0b403764f5322ae3521b797c752e/data/Malawi/Assembly/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@81362d4f718c0b403764f5322ae3521b797c752e/data/Malawi/Assembly/term-2014.csv"
           }
         ],
         "statement_count": 4952,
@@ -6138,11 +6148,11 @@
         "slug": "Dewan-Rakyat",
         "sources_directory": "data/Malaysia/Dewan_Rakyat/sources",
         "popolo": "data/Malaysia/Dewan_Rakyat/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7f79ab388bbed4c2d7804325ff9278d9120a63bd/data/Malaysia/Dewan_Rakyat/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@3f2a34f96aa79dc0096f3e92835b7e16a0b0bec4/data/Malaysia/Dewan_Rakyat/ep-popolo-v1.0.json",
         "names": "data/Malaysia/Dewan_Rakyat/names.csv",
-        "lastmod": "1539113937",
+        "lastmod": "1539345798",
         "person_count": 1121,
-        "sha": "7f79ab388bbed4c2d7804325ff9278d9120a63bd",
+        "sha": "3f2a34f96aa79dc0096f3e92835b7e16a0b0bec4",
         "legislative_periods": [
           {
             "end_date": "2018-04-07",
@@ -6151,7 +6161,7 @@
             "start_date": "2013-06-24",
             "slug": "13",
             "csv": "data/Malaysia/Dewan_Rakyat/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/78fb5494e4da6389a2c5e972dd08cae529411ea1/data/Malaysia/Dewan_Rakyat/term-13.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@3f2a34f96aa79dc0096f3e92835b7e16a0b0bec4/data/Malaysia/Dewan_Rakyat/term-13.csv"
           },
           {
             "end_date": "2013-04-03",
@@ -6160,7 +6170,7 @@
             "start_date": "2008-04-28",
             "slug": "12",
             "csv": "data/Malaysia/Dewan_Rakyat/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d0d92eb26a34c81baf58dee88fd8f480b9b90ecc/data/Malaysia/Dewan_Rakyat/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@3f2a34f96aa79dc0096f3e92835b7e16a0b0bec4/data/Malaysia/Dewan_Rakyat/term-12.csv"
           },
           {
             "end_date": "2008-02-13",
@@ -6169,7 +6179,7 @@
             "start_date": "2004-05-17",
             "slug": "11",
             "csv": "data/Malaysia/Dewan_Rakyat/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1bb22a4e3df4c2db42b8efd5d027e80bd597a3e1/data/Malaysia/Dewan_Rakyat/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1bb22a4e3df4c2db42b8efd5d027e80bd597a3e1/data/Malaysia/Dewan_Rakyat/term-11.csv"
           },
           {
             "end_date": "2004-03-04",
@@ -6178,7 +6188,7 @@
             "start_date": "1999-12-20",
             "slug": "10",
             "csv": "data/Malaysia/Dewan_Rakyat/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9b392d89d77c4643e20d63e009abf26e49703184/data/Malaysia/Dewan_Rakyat/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9b392d89d77c4643e20d63e009abf26e49703184/data/Malaysia/Dewan_Rakyat/term-10.csv"
           },
           {
             "end_date": "1999-11-11",
@@ -6187,7 +6197,7 @@
             "start_date": "1995-06-07",
             "slug": "9",
             "csv": "data/Malaysia/Dewan_Rakyat/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/adca07d668ec9c2c73345e5144580003db0e06a7/data/Malaysia/Dewan_Rakyat/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@adca07d668ec9c2c73345e5144580003db0e06a7/data/Malaysia/Dewan_Rakyat/term-9.csv"
           },
           {
             "end_date": "1995-04-06",
@@ -6196,7 +6206,7 @@
             "start_date": "1990-12-03",
             "slug": "8",
             "csv": "data/Malaysia/Dewan_Rakyat/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/adca07d668ec9c2c73345e5144580003db0e06a7/data/Malaysia/Dewan_Rakyat/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@adca07d668ec9c2c73345e5144580003db0e06a7/data/Malaysia/Dewan_Rakyat/term-8.csv"
           },
           {
             "end_date": "1990-10-05",
@@ -6205,7 +6215,7 @@
             "start_date": "1986-10-06",
             "slug": "7",
             "csv": "data/Malaysia/Dewan_Rakyat/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/adca07d668ec9c2c73345e5144580003db0e06a7/data/Malaysia/Dewan_Rakyat/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@adca07d668ec9c2c73345e5144580003db0e06a7/data/Malaysia/Dewan_Rakyat/term-7.csv"
           },
           {
             "end_date": "1986-07-19",
@@ -6214,7 +6224,7 @@
             "start_date": "1982-06-14",
             "slug": "6",
             "csv": "data/Malaysia/Dewan_Rakyat/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/adca07d668ec9c2c73345e5144580003db0e06a7/data/Malaysia/Dewan_Rakyat/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@adca07d668ec9c2c73345e5144580003db0e06a7/data/Malaysia/Dewan_Rakyat/term-6.csv"
           },
           {
             "end_date": "1982-03-29",
@@ -6223,7 +6233,7 @@
             "start_date": "1978-07-31",
             "slug": "5",
             "csv": "data/Malaysia/Dewan_Rakyat/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d0d92eb26a34c81baf58dee88fd8f480b9b90ecc/data/Malaysia/Dewan_Rakyat/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d0d92eb26a34c81baf58dee88fd8f480b9b90ecc/data/Malaysia/Dewan_Rakyat/term-5.csv"
           },
           {
             "end_date": "1978-06-12",
@@ -6232,7 +6242,7 @@
             "start_date": "1974-11-04",
             "slug": "4",
             "csv": "data/Malaysia/Dewan_Rakyat/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d0d92eb26a34c81baf58dee88fd8f480b9b90ecc/data/Malaysia/Dewan_Rakyat/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d0d92eb26a34c81baf58dee88fd8f480b9b90ecc/data/Malaysia/Dewan_Rakyat/term-4.csv"
           },
           {
             "end_date": "1974-07-31",
@@ -6241,7 +6251,7 @@
             "start_date": "1971-02-20",
             "slug": "3",
             "csv": "data/Malaysia/Dewan_Rakyat/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d0d92eb26a34c81baf58dee88fd8f480b9b90ecc/data/Malaysia/Dewan_Rakyat/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d0d92eb26a34c81baf58dee88fd8f480b9b90ecc/data/Malaysia/Dewan_Rakyat/term-3.csv"
           },
           {
             "end_date": "1969-03-20",
@@ -6250,7 +6260,7 @@
             "start_date": "1964-05-18",
             "slug": "2",
             "csv": "data/Malaysia/Dewan_Rakyat/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d0d92eb26a34c81baf58dee88fd8f480b9b90ecc/data/Malaysia/Dewan_Rakyat/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d0d92eb26a34c81baf58dee88fd8f480b9b90ecc/data/Malaysia/Dewan_Rakyat/term-2.csv"
           },
           {
             "end_date": "1964-03-01",
@@ -6259,10 +6269,10 @@
             "start_date": "1959-09-11",
             "slug": "1",
             "csv": "data/Malaysia/Dewan_Rakyat/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1bb22a4e3df4c2db42b8efd5d027e80bd597a3e1/data/Malaysia/Dewan_Rakyat/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1bb22a4e3df4c2db42b8efd5d027e80bd597a3e1/data/Malaysia/Dewan_Rakyat/term-1.csv"
           }
         ],
-        "statement_count": 42600,
+        "statement_count": 42610,
         "type": "lower house"
       }
     ]
@@ -6278,7 +6288,7 @@
         "slug": "Majlis",
         "sources_directory": "data/Maldives/Majlis/sources",
         "popolo": "data/Maldives/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2c944d29ab81dc64af9470b15ba8b7a95537a22a/data/Maldives/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@2c944d29ab81dc64af9470b15ba8b7a95537a22a/data/Maldives/Majlis/ep-popolo-v1.0.json",
         "names": "data/Maldives/Majlis/names.csv",
         "lastmod": "1538926867",
         "person_count": 85,
@@ -6290,7 +6300,7 @@
             "start_date": "2014-05-28",
             "slug": "2014",
             "csv": "data/Maldives/Majlis/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/21d690a3a4cace2c74df57f4f13119e63b01119e/data/Maldives/Majlis/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@21d690a3a4cace2c74df57f4f13119e63b01119e/data/Maldives/Majlis/term-2014.csv"
           }
         ],
         "statement_count": 1881,
@@ -6309,7 +6319,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Mali/Assembly/sources",
         "popolo": "data/Mali/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8655acd5b1cf9aec45001b7fecd2ea0cbd3c5e9d/data/Mali/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@8655acd5b1cf9aec45001b7fecd2ea0cbd3c5e9d/data/Mali/Assembly/ep-popolo-v1.0.json",
         "names": "data/Mali/Assembly/names.csv",
         "lastmod": "1538453011",
         "person_count": 142,
@@ -6321,7 +6331,7 @@
             "start_date": "2014-01-01",
             "slug": "2014",
             "csv": "data/Mali/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Mali/Assembly/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Mali/Assembly/term-2014.csv"
           }
         ],
         "statement_count": 2947,
@@ -6340,7 +6350,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Malta/Assembly/sources",
         "popolo": "data/Malta/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cd4041314e273f02dd7beccae45c64f126c24bf6/data/Malta/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@cd4041314e273f02dd7beccae45c64f126c24bf6/data/Malta/Assembly/ep-popolo-v1.0.json",
         "names": "data/Malta/Assembly/names.csv",
         "lastmod": "1538646296",
         "person_count": 93,
@@ -6352,7 +6362,7 @@
             "start_date": "2017-06-24",
             "slug": "13",
             "csv": "data/Malta/Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5b06ba593fa7dfe46b71f5a0e1e677af1050f180/data/Malta/Assembly/term-13.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@5b06ba593fa7dfe46b71f5a0e1e677af1050f180/data/Malta/Assembly/term-13.csv"
           },
           {
             "end_date": "2017-05-01",
@@ -6361,7 +6371,7 @@
             "start_date": "2013-04-06",
             "slug": "12",
             "csv": "data/Malta/Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4515db3ac8f2b1d9a1f5e0d877ee0ec8f893a30c/data/Malta/Assembly/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4515db3ac8f2b1d9a1f5e0d877ee0ec8f893a30c/data/Malta/Assembly/term-12.csv"
           }
         ],
         "statement_count": 3203,
@@ -6380,7 +6390,7 @@
         "slug": "Nitijela",
         "sources_directory": "data/Marshall_Islands/Nitijela/sources",
         "popolo": "data/Marshall_Islands/Nitijela/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5aacc8155afd0f63a9caff86f63cdc6bb92e948f/data/Marshall_Islands/Nitijela/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@5aacc8155afd0f63a9caff86f63cdc6bb92e948f/data/Marshall_Islands/Nitijela/ep-popolo-v1.0.json",
         "names": "data/Marshall_Islands/Nitijela/names.csv",
         "lastmod": "1533088797",
         "person_count": 33,
@@ -6393,7 +6403,7 @@
             "start_date": "2012-01-03",
             "slug": "2012",
             "csv": "data/Marshall_Islands/Nitijela/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Marshall_Islands/Nitijela/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Marshall_Islands/Nitijela/term-2012.csv"
           }
         ],
         "statement_count": 1160,
@@ -6412,7 +6422,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Mauritania/National_Assembly/sources",
         "popolo": "data/Mauritania/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Mauritania/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Mauritania/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Mauritania/National_Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 147,
@@ -6424,7 +6434,7 @@
             "start_date": "2013-12-21",
             "slug": "12",
             "csv": "data/Mauritania/National_Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Mauritania/National_Assembly/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Mauritania/National_Assembly/term-12.csv"
           }
         ],
         "statement_count": 1916,
@@ -6443,7 +6453,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Mauritius/National_Assembly/sources",
         "popolo": "data/Mauritius/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Mauritius/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Mauritius/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Mauritius/National_Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 62,
@@ -6455,7 +6465,7 @@
             "start_date": "2014-12-10",
             "slug": "2014",
             "csv": "data/Mauritius/National_Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Mauritius/National_Assembly/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Mauritius/National_Assembly/term-2014.csv"
           }
         ],
         "statement_count": 1100,
@@ -6474,31 +6484,32 @@
         "slug": "Deputies",
         "sources_directory": "data/Mexico/Deputies/sources",
         "popolo": "data/Mexico/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1642886b5cd93bca7a2394ade7d03aa50a10e697/data/Mexico/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1412288b0397e6f6da94c511c33aea4c0b78fa56/data/Mexico/Deputies/ep-popolo-v1.0.json",
         "names": "data/Mexico/Deputies/names.csv",
-        "lastmod": "1538955907",
+        "lastmod": "1539353812",
         "person_count": 1031,
-        "sha": "1642886b5cd93bca7a2394ade7d03aa50a10e697",
+        "sha": "1412288b0397e6f6da94c511c33aea4c0b78fa56",
         "legislative_periods": [
           {
+            "end_date": "2018-08-31",
             "id": "term/63",
-            "name": "LXIII Legislature",
+            "name": "LXIII Legislature of the Mexican Congress",
             "start_date": "2015-09-01",
             "slug": "63",
             "csv": "data/Mexico/Deputies/term-63.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7d3afae320757ef3498fc5fc8850b734fa1d95be/data/Mexico/Deputies/term-63.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1412288b0397e6f6da94c511c33aea4c0b78fa56/data/Mexico/Deputies/term-63.csv"
           },
           {
             "end_date": "2015-08-31",
             "id": "term/62",
-            "name": "LXII Legislature",
+            "name": "LXII Legislature of the Mexican Congress",
             "start_date": "2012-09-01",
             "slug": "62",
             "csv": "data/Mexico/Deputies/term-62.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/10a22c40c4d6fc1571a97ddb595bd14d1954fff3/data/Mexico/Deputies/term-62.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@10a22c40c4d6fc1571a97ddb595bd14d1954fff3/data/Mexico/Deputies/term-62.csv"
           }
         ],
-        "statement_count": 25799,
+        "statement_count": 24318,
         "type": "lower house"
       }
     ]
@@ -6514,7 +6525,7 @@
         "slug": "Congress",
         "sources_directory": "data/Micronesia/Congress/sources",
         "popolo": "data/Micronesia/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/04eaade6b91c2b299d72282928b3bfa5c416cc3a/data/Micronesia/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@04eaade6b91c2b299d72282928b3bfa5c416cc3a/data/Micronesia/Congress/ep-popolo-v1.0.json",
         "names": "data/Micronesia/Congress/names.csv",
         "lastmod": "1537790161",
         "person_count": 24,
@@ -6526,7 +6537,7 @@
             "start_date": "2015-05-11",
             "slug": "19",
             "csv": "data/Micronesia/Congress/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Micronesia/Congress/term-19.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Micronesia/Congress/term-19.csv"
           },
           {
             "end_date": "2015-05-10",
@@ -6535,7 +6546,7 @@
             "start_date": "2013-05-11",
             "slug": "18",
             "csv": "data/Micronesia/Congress/term-18.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Micronesia/Congress/term-18.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Micronesia/Congress/term-18.csv"
           },
           {
             "end_date": "2013-05-10",
@@ -6544,7 +6555,7 @@
             "start_date": "2011-05-11",
             "slug": "17",
             "csv": "data/Micronesia/Congress/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Micronesia/Congress/term-17.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Micronesia/Congress/term-17.csv"
           }
         ],
         "statement_count": 1336,
@@ -6563,7 +6574,7 @@
         "slug": "Parlamentul",
         "sources_directory": "data/Moldova/Parlamentul/sources",
         "popolo": "data/Moldova/Parlamentul/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e15c6a56a224bce0f9912d2f01f70a50d0638db1/data/Moldova/Parlamentul/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e15c6a56a224bce0f9912d2f01f70a50d0638db1/data/Moldova/Parlamentul/ep-popolo-v1.0.json",
         "names": "data/Moldova/Parlamentul/names.csv",
         "lastmod": "1538900161",
         "person_count": 129,
@@ -6575,7 +6586,7 @@
             "start_date": "2014-12-29",
             "slug": "2014",
             "csv": "data/Moldova/Parlamentul/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f7218f4de0f7b43e70b281439dd9fdd00e9c4e05/data/Moldova/Parlamentul/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f7218f4de0f7b43e70b281439dd9fdd00e9c4e05/data/Moldova/Parlamentul/term-2014.csv"
           }
         ],
         "statement_count": 5745,
@@ -6594,7 +6605,7 @@
         "slug": "Council",
         "sources_directory": "data/Monaco/Council/sources",
         "popolo": "data/Monaco/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5b58b562eb7027c085e3ed3dc18426fdb43e6477/data/Monaco/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@5b58b562eb7027c085e3ed3dc18426fdb43e6477/data/Monaco/Council/ep-popolo-v1.0.json",
         "names": "data/Monaco/Council/names.csv",
         "lastmod": "1538547867",
         "person_count": 63,
@@ -6606,7 +6617,7 @@
             "start_date": "2018-02-22",
             "slug": "2018",
             "csv": "data/Monaco/Council/term-2018.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1ee10d9e9abbbb775d46dfb2d859347ce66ff9e2/data/Monaco/Council/term-2018.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1ee10d9e9abbbb775d46dfb2d859347ce66ff9e2/data/Monaco/Council/term-2018.csv"
           },
           {
             "end_date": "2018-02-10",
@@ -6615,7 +6626,7 @@
             "start_date": "2013-02-21",
             "slug": "2013",
             "csv": "data/Monaco/Council/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b938225498433b7483a295a97c332f505625f19c/data/Monaco/Council/term-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b938225498433b7483a295a97c332f505625f19c/data/Monaco/Council/term-2013.csv"
           },
           {
             "end_date": "2013",
@@ -6624,7 +6635,7 @@
             "start_date": "2008",
             "slug": "2008",
             "csv": "data/Monaco/Council/term-2008.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b938225498433b7483a295a97c332f505625f19c/data/Monaco/Council/term-2008.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b938225498433b7483a295a97c332f505625f19c/data/Monaco/Council/term-2008.csv"
           },
           {
             "end_date": "2008",
@@ -6633,7 +6644,7 @@
             "start_date": "2003",
             "slug": "2003",
             "csv": "data/Monaco/Council/term-2003.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b938225498433b7483a295a97c332f505625f19c/data/Monaco/Council/term-2003.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b938225498433b7483a295a97c332f505625f19c/data/Monaco/Council/term-2003.csv"
           }
         ],
         "statement_count": 1743,
@@ -6652,7 +6663,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Mongolia/Assembly/sources",
         "popolo": "data/Mongolia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3b785c6b253d4a8b6390117add367243899cff53/data/Mongolia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@3b785c6b253d4a8b6390117add367243899cff53/data/Mongolia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Mongolia/Assembly/names.csv",
         "lastmod": "1538742416",
         "person_count": 160,
@@ -6664,7 +6675,7 @@
             "start_date": "2016-07-05",
             "slug": "2016",
             "csv": "data/Mongolia/Assembly/term-2016.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3b785c6b253d4a8b6390117add367243899cff53/data/Mongolia/Assembly/term-2016.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@3b785c6b253d4a8b6390117add367243899cff53/data/Mongolia/Assembly/term-2016.csv"
           },
           {
             "end_date": "2016-06-28",
@@ -6673,7 +6684,7 @@
             "start_date": "2012-06-28",
             "slug": "2012",
             "csv": "data/Mongolia/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3b785c6b253d4a8b6390117add367243899cff53/data/Mongolia/Assembly/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@3b785c6b253d4a8b6390117add367243899cff53/data/Mongolia/Assembly/term-2012.csv"
           },
           {
             "end_date": "2012-06-28",
@@ -6682,7 +6693,7 @@
             "start_date": "2008-07-23",
             "slug": "2008",
             "csv": "data/Mongolia/Assembly/term-2008.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/14eda629327a139ba6233735069e02b3dcebace6/data/Mongolia/Assembly/term-2008.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@14eda629327a139ba6233735069e02b3dcebace6/data/Mongolia/Assembly/term-2008.csv"
           }
         ],
         "statement_count": 6497,
@@ -6701,7 +6712,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Montenegro/Assembly/sources",
         "popolo": "data/Montenegro/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/91be26af6a9b67ad09335cfabc68fd3ffccf7ba5/data/Montenegro/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@91be26af6a9b67ad09335cfabc68fd3ffccf7ba5/data/Montenegro/Assembly/ep-popolo-v1.0.json",
         "names": "data/Montenegro/Assembly/names.csv",
         "lastmod": "1539155606",
         "person_count": 82,
@@ -6714,7 +6725,7 @@
             "start_date": "2012-11-06",
             "slug": "25",
             "csv": "data/Montenegro/Assembly/term-25.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f93ecce20a907eff09517de00d970968d18b9fc3/data/Montenegro/Assembly/term-25.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f93ecce20a907eff09517de00d970968d18b9fc3/data/Montenegro/Assembly/term-25.csv"
           }
         ],
         "statement_count": 2281,
@@ -6733,7 +6744,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Montserrat/Assembly/sources",
         "popolo": "data/Montserrat/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Montserrat/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Montserrat/Assembly/ep-popolo-v1.0.json",
         "names": "data/Montserrat/Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 9,
@@ -6745,7 +6756,7 @@
             "start_date": "2014",
             "slug": "1",
             "csv": "data/Montserrat/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Montserrat/Assembly/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Montserrat/Assembly/term-1.csv"
           }
         ],
         "statement_count": 259,
@@ -6764,7 +6775,7 @@
         "slug": "House",
         "sources_directory": "data/Morocco/House/sources",
         "popolo": "data/Morocco/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ae0e40b61e53db229fff0fc840048f60b61fd098/data/Morocco/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ae0e40b61e53db229fff0fc840048f60b61fd098/data/Morocco/House/ep-popolo-v1.0.json",
         "names": "data/Morocco/House/names.csv",
         "lastmod": "1539151791",
         "person_count": 677,
@@ -6776,7 +6787,7 @@
             "start_date": "2016-10-07",
             "slug": "10",
             "csv": "data/Morocco/House/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d8ef85465cc2954aff73718828c8755971f0463b/data/Morocco/House/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d8ef85465cc2954aff73718828c8755971f0463b/data/Morocco/House/term-10.csv"
           },
           {
             "end_date": "2016-10-06",
@@ -6785,7 +6796,7 @@
             "start_date": "2011-12-19",
             "slug": "9",
             "csv": "data/Morocco/House/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/863de878eb9946e0fe8955cc52e9b4c058f0a8c2/data/Morocco/House/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@863de878eb9946e0fe8955cc52e9b4c058f0a8c2/data/Morocco/House/term-9.csv"
           }
         ],
         "statement_count": 15280,
@@ -6804,7 +6815,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Mozambique/Assembly/sources",
         "popolo": "data/Mozambique/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Mozambique/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Mozambique/Assembly/ep-popolo-v1.0.json",
         "names": "data/Mozambique/Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 250,
@@ -6816,7 +6827,7 @@
             "start_date": "2015-01-12",
             "slug": "8",
             "csv": "data/Mozambique/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Mozambique/Assembly/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Mozambique/Assembly/term-8.csv"
           }
         ],
         "statement_count": 3383,
@@ -6835,7 +6846,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Myanmar/House_of_Representatives/sources",
         "popolo": "data/Myanmar/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Myanmar/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Myanmar/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Myanmar/House_of_Representatives/names.csv",
         "lastmod": "1528387224",
         "person_count": 314,
@@ -6848,7 +6859,7 @@
             "start_date": "2011-01-31",
             "slug": "1",
             "csv": "data/Myanmar/House_of_Representatives/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Myanmar/House_of_Representatives/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Myanmar/House_of_Representatives/term-1.csv"
           }
         ],
         "statement_count": 5199,
@@ -6867,7 +6878,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Nagorno_Karabakh/Assembly/sources",
         "popolo": "data/Nagorno_Karabakh/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Nagorno_Karabakh/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Nagorno_Karabakh/Assembly/ep-popolo-v1.0.json",
         "names": "data/Nagorno_Karabakh/Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 33,
@@ -6879,7 +6890,7 @@
             "start_date": "2015-05-21",
             "slug": "6",
             "csv": "data/Nagorno_Karabakh/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Nagorno_Karabakh/Assembly/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Nagorno_Karabakh/Assembly/term-6.csv"
           }
         ],
         "statement_count": 1286,
@@ -6898,7 +6909,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Namibia/Assembly/sources",
         "popolo": "data/Namibia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0dbafd087e4fd39d20f5329ab3e4ef080756a988/data/Namibia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0dbafd087e4fd39d20f5329ab3e4ef080756a988/data/Namibia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Namibia/Assembly/names.csv",
         "lastmod": "1537801059",
         "person_count": 270,
@@ -6910,7 +6921,7 @@
             "start_date": "2015-03-20",
             "slug": "6",
             "csv": "data/Namibia/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ba66e59d36e7fca1abd20aad089c3e6df0d3b6ae/data/Namibia/Assembly/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ba66e59d36e7fca1abd20aad089c3e6df0d3b6ae/data/Namibia/Assembly/term-6.csv"
           },
           {
             "end_date": "2015-03-19",
@@ -6919,7 +6930,7 @@
             "start_date": "2010-03-19",
             "slug": "5",
             "csv": "data/Namibia/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0dbafd087e4fd39d20f5329ab3e4ef080756a988/data/Namibia/Assembly/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0dbafd087e4fd39d20f5329ab3e4ef080756a988/data/Namibia/Assembly/term-5.csv"
           },
           {
             "end_date": "2010-03-19",
@@ -6928,7 +6939,7 @@
             "start_date": "2005-03-20",
             "slug": "4",
             "csv": "data/Namibia/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0dbafd087e4fd39d20f5329ab3e4ef080756a988/data/Namibia/Assembly/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0dbafd087e4fd39d20f5329ab3e4ef080756a988/data/Namibia/Assembly/term-4.csv"
           },
           {
             "end_date": "2005",
@@ -6937,7 +6948,7 @@
             "start_date": "2000",
             "slug": "3",
             "csv": "data/Namibia/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0dbafd087e4fd39d20f5329ab3e4ef080756a988/data/Namibia/Assembly/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0dbafd087e4fd39d20f5329ab3e4ef080756a988/data/Namibia/Assembly/term-3.csv"
           },
           {
             "end_date": "2000",
@@ -6946,7 +6957,7 @@
             "start_date": "1995",
             "slug": "2",
             "csv": "data/Namibia/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0dbafd087e4fd39d20f5329ab3e4ef080756a988/data/Namibia/Assembly/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0dbafd087e4fd39d20f5329ab3e4ef080756a988/data/Namibia/Assembly/term-2.csv"
           },
           {
             "end_date": "1995",
@@ -6955,7 +6966,7 @@
             "start_date": "1990",
             "slug": "1",
             "csv": "data/Namibia/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0dbafd087e4fd39d20f5329ab3e4ef080756a988/data/Namibia/Assembly/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0dbafd087e4fd39d20f5329ab3e4ef080756a988/data/Namibia/Assembly/term-1.csv"
           },
           {
             "end_date": "1990",
@@ -6964,7 +6975,7 @@
             "start_date": "1989",
             "slug": "0",
             "csv": "data/Namibia/Assembly/term-0.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0dbafd087e4fd39d20f5329ab3e4ef080756a988/data/Namibia/Assembly/term-0.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0dbafd087e4fd39d20f5329ab3e4ef080756a988/data/Namibia/Assembly/term-0.csv"
           }
         ],
         "statement_count": 8216,
@@ -6975,7 +6986,7 @@
         "slug": "Council",
         "sources_directory": "data/Namibia/Council/sources",
         "popolo": "data/Namibia/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dab6d7b1529576fcc8790a7d10cf84e95d29d526/data/Namibia/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@dab6d7b1529576fcc8790a7d10cf84e95d29d526/data/Namibia/Council/ep-popolo-v1.0.json",
         "names": "data/Namibia/Council/names.csv",
         "lastmod": "1537801063",
         "person_count": 115,
@@ -6987,7 +6998,7 @@
             "start_date": "2015-12-18",
             "slug": "5",
             "csv": "data/Namibia/Council/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Namibia/Council/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Namibia/Council/term-5.csv"
           },
           {
             "end_date": "2015-12-17",
@@ -6996,7 +7007,7 @@
             "start_date": "2010",
             "slug": "4",
             "csv": "data/Namibia/Council/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dab6d7b1529576fcc8790a7d10cf84e95d29d526/data/Namibia/Council/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@dab6d7b1529576fcc8790a7d10cf84e95d29d526/data/Namibia/Council/term-4.csv"
           },
           {
             "end_date": "2010",
@@ -7005,7 +7016,7 @@
             "start_date": "2004",
             "slug": "3",
             "csv": "data/Namibia/Council/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dab6d7b1529576fcc8790a7d10cf84e95d29d526/data/Namibia/Council/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@dab6d7b1529576fcc8790a7d10cf84e95d29d526/data/Namibia/Council/term-3.csv"
           },
           {
             "end_date": "2004",
@@ -7014,7 +7025,7 @@
             "start_date": "1998",
             "slug": "2",
             "csv": "data/Namibia/Council/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dab6d7b1529576fcc8790a7d10cf84e95d29d526/data/Namibia/Council/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@dab6d7b1529576fcc8790a7d10cf84e95d29d526/data/Namibia/Council/term-2.csv"
           },
           {
             "end_date": "1998",
@@ -7023,7 +7034,7 @@
             "start_date": "1993",
             "slug": "1",
             "csv": "data/Namibia/Council/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dab6d7b1529576fcc8790a7d10cf84e95d29d526/data/Namibia/Council/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@dab6d7b1529576fcc8790a7d10cf84e95d29d526/data/Namibia/Council/term-1.csv"
           }
         ],
         "statement_count": 2065,
@@ -7042,7 +7053,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Nauru/Parliament/sources",
         "popolo": "data/Nauru/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f992ec14e2ca90e8f66a039623abe6acda50fc8f/data/Nauru/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f992ec14e2ca90e8f66a039623abe6acda50fc8f/data/Nauru/Parliament/ep-popolo-v1.0.json",
         "names": "data/Nauru/Parliament/names.csv",
         "lastmod": "1534992094",
         "person_count": 34,
@@ -7054,7 +7065,7 @@
             "start_date": "2016-07-11",
             "slug": "22",
             "csv": "data/Nauru/Parliament/term-22.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Nauru/Parliament/term-22.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Nauru/Parliament/term-22.csv"
           },
           {
             "end_date": "2016-05-14",
@@ -7063,7 +7074,7 @@
             "start_date": "2013-06-11",
             "slug": "21",
             "csv": "data/Nauru/Parliament/term-21.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Nauru/Parliament/term-21.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Nauru/Parliament/term-21.csv"
           },
           {
             "end_date": "2013-05-23",
@@ -7072,7 +7083,7 @@
             "start_date": "2010-06-22",
             "slug": "20",
             "csv": "data/Nauru/Parliament/term-20.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Nauru/Parliament/term-20.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Nauru/Parliament/term-20.csv"
           },
           {
             "end_date": "2010-05-23",
@@ -7081,7 +7092,7 @@
             "start_date": "2000-06-19",
             "slug": "19",
             "csv": "data/Nauru/Parliament/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Nauru/Parliament/term-19.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Nauru/Parliament/term-19.csv"
           }
         ],
         "statement_count": 2220,
@@ -7100,7 +7111,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Nepal/Assembly/sources",
         "popolo": "data/Nepal/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/557c9e7c22cbe1f8c23cd75d6353752c04b480e5/data/Nepal/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@557c9e7c22cbe1f8c23cd75d6353752c04b480e5/data/Nepal/Assembly/ep-popolo-v1.0.json",
         "names": "data/Nepal/Assembly/names.csv",
         "lastmod": "1538971955",
         "person_count": 550,
@@ -7112,7 +7123,7 @@
             "start_date": "2014-01-22",
             "slug": "ca2",
             "csv": "data/Nepal/Assembly/term-ca2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Nepal/Assembly/term-ca2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Nepal/Assembly/term-ca2.csv"
           }
         ],
         "statement_count": 13442,
@@ -7131,11 +7142,11 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Netherlands/House_of_Representatives/sources",
         "popolo": "data/Netherlands/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ddc0eb495e0feb98489303e5c63316c092a8bebc/data/Netherlands/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f2f44dfac246c2d1fb47e52940fa3f2ce1483465/data/Netherlands/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Netherlands/House_of_Representatives/names.csv",
-        "lastmod": "1538971266",
-        "person_count": 275,
-        "sha": "ddc0eb495e0feb98489303e5c63316c092a8bebc",
+        "lastmod": "1539511988",
+        "person_count": 277,
+        "sha": "f2f44dfac246c2d1fb47e52940fa3f2ce1483465",
         "legislative_periods": [
           {
             "id": "term/2017",
@@ -7143,7 +7154,7 @@
             "start_date": "2017-03-23",
             "slug": "2017",
             "csv": "data/Netherlands/House_of_Representatives/term-2017.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ddc0eb495e0feb98489303e5c63316c092a8bebc/data/Netherlands/House_of_Representatives/term-2017.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f9d05afc6e71ed61ae19a907d1d8f170c288f3db/data/Netherlands/House_of_Representatives/term-2017.csv"
           },
           {
             "end_date": "2017-03-23",
@@ -7152,10 +7163,10 @@
             "start_date": "2012-09-20",
             "slug": "2012",
             "csv": "data/Netherlands/House_of_Representatives/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a8f7b81cd1817d3a6dad9f54b72e2fe37cb600ad/data/Netherlands/House_of_Representatives/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@aa5cf781d362d3952cc6cc0b3c13a0140a4d8646/data/Netherlands/House_of_Representatives/term-2012.csv"
           }
         ],
-        "statement_count": 15743,
+        "statement_count": 15789,
         "type": "lower house"
       }
     ]
@@ -7171,7 +7182,7 @@
         "slug": "Congress",
         "sources_directory": "data/New_Caledonia/Congress/sources",
         "popolo": "data/New_Caledonia/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e5dbf86fe3e86a5d58a6e1e3923339ed7744bf25/data/New_Caledonia/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e5dbf86fe3e86a5d58a6e1e3923339ed7744bf25/data/New_Caledonia/Congress/ep-popolo-v1.0.json",
         "names": "data/New_Caledonia/Congress/names.csv",
         "lastmod": "1538118397",
         "person_count": 56,
@@ -7183,7 +7194,7 @@
             "start_date": "2014",
             "slug": "4",
             "csv": "data/New_Caledonia/Congress/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e5dbf86fe3e86a5d58a6e1e3923339ed7744bf25/data/New_Caledonia/Congress/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e5dbf86fe3e86a5d58a6e1e3923339ed7744bf25/data/New_Caledonia/Congress/term-4.csv"
           }
         ],
         "statement_count": 2141,
@@ -7202,7 +7213,7 @@
         "slug": "House",
         "sources_directory": "data/New_Zealand/House/sources",
         "popolo": "data/New_Zealand/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/eadedd2d6dbaeb16c8cc02d1a758fe092543f1fa/data/New_Zealand/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@eadedd2d6dbaeb16c8cc02d1a758fe092543f1fa/data/New_Zealand/House/ep-popolo-v1.0.json",
         "names": "data/New_Zealand/House/names.csv",
         "lastmod": "1539235812",
         "person_count": 266,
@@ -7214,7 +7225,7 @@
             "start_date": "2017-10-12",
             "slug": "52",
             "csv": "data/New_Zealand/House/term-52.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c6e854dc24ba61be471b203cd859bad604b9c64/data/New_Zealand/House/term-52.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@5c6e854dc24ba61be471b203cd859bad604b9c64/data/New_Zealand/House/term-52.csv"
           },
           {
             "end_date": "2017-08-18",
@@ -7223,7 +7234,7 @@
             "start_date": "2014-10-20",
             "slug": "51",
             "csv": "data/New_Zealand/House/term-51.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7b6beec95f93647ea43c1160192041b9816aca58/data/New_Zealand/House/term-51.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7b6beec95f93647ea43c1160192041b9816aca58/data/New_Zealand/House/term-51.csv"
           },
           {
             "end_date": "2014-09-19",
@@ -7232,7 +7243,7 @@
             "start_date": "2011-12-20",
             "slug": "50",
             "csv": "data/New_Zealand/House/term-50.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7b6beec95f93647ea43c1160192041b9816aca58/data/New_Zealand/House/term-50.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7b6beec95f93647ea43c1160192041b9816aca58/data/New_Zealand/House/term-50.csv"
           },
           {
             "end_date": "2011-10-20",
@@ -7241,7 +7252,7 @@
             "start_date": "2008-12-08",
             "slug": "49",
             "csv": "data/New_Zealand/House/term-49.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7b6beec95f93647ea43c1160192041b9816aca58/data/New_Zealand/House/term-49.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7b6beec95f93647ea43c1160192041b9816aca58/data/New_Zealand/House/term-49.csv"
           },
           {
             "end_date": "2008-10-03",
@@ -7250,7 +7261,7 @@
             "start_date": "2005-11-07",
             "slug": "48",
             "csv": "data/New_Zealand/House/term-48.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7b6beec95f93647ea43c1160192041b9816aca58/data/New_Zealand/House/term-48.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7b6beec95f93647ea43c1160192041b9816aca58/data/New_Zealand/House/term-48.csv"
           }
         ],
         "statement_count": 15470,
@@ -7269,7 +7280,7 @@
         "slug": "Asamblea",
         "sources_directory": "data/Nicaragua/Asamblea/sources",
         "popolo": "data/Nicaragua/Asamblea/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Nicaragua/Asamblea/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Nicaragua/Asamblea/ep-popolo-v1.0.json",
         "names": "data/Nicaragua/Asamblea/names.csv",
         "lastmod": "1528387224",
         "person_count": 90,
@@ -7281,7 +7292,7 @@
             "start_date": "2012-01-09",
             "slug": "2012",
             "csv": "data/Nicaragua/Asamblea/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Nicaragua/Asamblea/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Nicaragua/Asamblea/term-2012.csv"
           }
         ],
         "statement_count": 2280,
@@ -7300,7 +7311,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Niger/Assembly/sources",
         "popolo": "data/Niger/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70462461f81424b7b171ec1be139e3b8ce8e11a7/data/Niger/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@70462461f81424b7b171ec1be139e3b8ce8e11a7/data/Niger/Assembly/ep-popolo-v1.0.json",
         "names": "data/Niger/Assembly/names.csv",
         "lastmod": "1485067939",
         "person_count": 113,
@@ -7313,7 +7324,7 @@
             "start_date": "2011-10-06",
             "slug": "7.1",
             "csv": "data/Niger/Assembly/term-7.1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Niger/Assembly/term-7.1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Niger/Assembly/term-7.1.csv"
           }
         ],
         "statement_count": 1447,
@@ -7332,19 +7343,19 @@
         "slug": "Representatives",
         "sources_directory": "data/Nigeria/Representatives/sources",
         "popolo": "data/Nigeria/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/76ed24a5474cba5c94d92ab823667ff9e1296a04/data/Nigeria/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@cf7d74b1599bf191f4d1313f253981559bc7aedc/data/Nigeria/Representatives/ep-popolo-v1.0.json",
         "names": "data/Nigeria/Representatives/names.csv",
-        "lastmod": "1539157354",
+        "lastmod": "1539666645",
         "person_count": 370,
-        "sha": "76ed24a5474cba5c94d92ab823667ff9e1296a04",
+        "sha": "cf7d74b1599bf191f4d1313f253981559bc7aedc",
         "legislative_periods": [
           {
             "id": "term/8",
-            "name": "8th National Assembly",
+            "name": "8th National Assembly of Nigeria",
             "start_date": "2015-06-09",
             "slug": "8",
             "csv": "data/Nigeria/Representatives/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/76ed24a5474cba5c94d92ab823667ff9e1296a04/data/Nigeria/Representatives/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@76ed24a5474cba5c94d92ab823667ff9e1296a04/data/Nigeria/Representatives/term-8.csv"
           }
         ],
         "statement_count": 10097,
@@ -7355,22 +7366,22 @@
         "slug": "Senate",
         "sources_directory": "data/Nigeria/Senate/sources",
         "popolo": "data/Nigeria/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/404478c3931c4fb68721a4dea2bd4c00e616225d/data/Nigeria/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@034db6e7a053861a56bda362f80dd6f2d033d94e/data/Nigeria/Senate/ep-popolo-v1.0.json",
         "names": "data/Nigeria/Senate/names.csv",
-        "lastmod": "1538477052",
+        "lastmod": "1539666522",
         "person_count": 115,
-        "sha": "404478c3931c4fb68721a4dea2bd4c00e616225d",
+        "sha": "034db6e7a053861a56bda362f80dd6f2d033d94e",
         "legislative_periods": [
           {
             "id": "term/8",
-            "name": "8th National Assembly",
+            "name": "8th National Assembly of Nigeria",
             "start_date": "2015-06-09",
             "slug": "8",
             "csv": "data/Nigeria/Senate/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/404478c3931c4fb68721a4dea2bd4c00e616225d/data/Nigeria/Senate/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@404478c3931c4fb68721a4dea2bd4c00e616225d/data/Nigeria/Senate/term-8.csv"
           }
         ],
-        "statement_count": 3720,
+        "statement_count": 3722,
         "type": "upper house"
       }
     ]
@@ -7386,7 +7397,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Niue/Assembly/sources",
         "popolo": "data/Niue/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1c573c69b0f3983e2e9ea1b714132a0c43731ec5/data/Niue/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1c573c69b0f3983e2e9ea1b714132a0c43731ec5/data/Niue/Assembly/ep-popolo-v1.0.json",
         "names": "data/Niue/Assembly/names.csv",
         "lastmod": "1538818223",
         "person_count": 25,
@@ -7398,7 +7409,7 @@
             "start_date": "2017-05-06",
             "slug": "16",
             "csv": "data/Niue/Assembly/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/07936233d36a566e502aa1679b56cd7d8333aa48/data/Niue/Assembly/term-16.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@07936233d36a566e502aa1679b56cd7d8333aa48/data/Niue/Assembly/term-16.csv"
           },
           {
             "end_date": "2017-05-06",
@@ -7407,7 +7418,7 @@
             "start_date": "2014-04-23",
             "slug": "15",
             "csv": "data/Niue/Assembly/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Niue/Assembly/term-15.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Niue/Assembly/term-15.csv"
           }
         ],
         "statement_count": 1289,
@@ -7426,7 +7437,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Norfolk_Island/Assembly/sources",
         "popolo": "data/Norfolk_Island/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Norfolk_Island/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Norfolk_Island/Assembly/ep-popolo-v1.0.json",
         "names": "data/Norfolk_Island/Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 9,
@@ -7439,7 +7450,7 @@
             "start_date": "2013-03-20",
             "slug": "14",
             "csv": "data/Norfolk_Island/Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Norfolk_Island/Assembly/term-14.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Norfolk_Island/Assembly/term-14.csv"
           }
         ],
         "statement_count": 501,
@@ -7458,7 +7469,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/North_Korea/National_Assembly/sources",
         "popolo": "data/North_Korea/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ce834ecf4744959c487a2a37bca1d61fbd869d81/data/North_Korea/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ce834ecf4744959c487a2a37bca1d61fbd869d81/data/North_Korea/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/North_Korea/National_Assembly/names.csv",
         "lastmod": "1539019389",
         "person_count": 687,
@@ -7470,7 +7481,7 @@
             "start_date": "2014-03-09",
             "slug": "13",
             "csv": "data/North_Korea/National_Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7bb5414cd492966a7714d440bb8d7f729e7b4f89/data/North_Korea/National_Assembly/term-13.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7bb5414cd492966a7714d440bb8d7f729e7b4f89/data/North_Korea/National_Assembly/term-13.csv"
           }
         ],
         "statement_count": 12338,
@@ -7489,7 +7500,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Northern_Cyprus/Assembly/sources",
         "popolo": "data/Northern_Cyprus/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37afd835246d9d6e6864a7938e6ab29ed7ff5f5a/data/Northern_Cyprus/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@37afd835246d9d6e6864a7938e6ab29ed7ff5f5a/data/Northern_Cyprus/Assembly/ep-popolo-v1.0.json",
         "names": "data/Northern_Cyprus/Assembly/names.csv",
         "lastmod": "1531706028",
         "person_count": 50,
@@ -7501,7 +7512,7 @@
             "start_date": "2013-08-12",
             "slug": "14",
             "csv": "data/Northern_Cyprus/Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Northern_Cyprus/Assembly/term-14.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Northern_Cyprus/Assembly/term-14.csv"
           }
         ],
         "statement_count": 1582,
@@ -7520,11 +7531,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Northern_Ireland/Assembly/sources",
         "popolo": "data/Northern_Ireland/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/065b499a1e809ea4f99753d2134e65ae7b06c212/data/Northern_Ireland/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@606483e4e137101d9c693850868815d331e7f10b/data/Northern_Ireland/Assembly/ep-popolo-v1.0.json",
         "names": "data/Northern_Ireland/Assembly/names.csv",
-        "lastmod": "1539267787",
+        "lastmod": "1539429406",
         "person_count": 283,
-        "sha": "065b499a1e809ea4f99753d2134e65ae7b06c212",
+        "sha": "606483e4e137101d9c693850868815d331e7f10b",
         "legislative_periods": [
           {
             "id": "term/6",
@@ -7532,7 +7543,7 @@
             "start_date": "2017-03-03",
             "slug": "6",
             "csv": "data/Northern_Ireland/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/37300d3f18421e391838f11921ce5cefd8dbb6f3/data/Northern_Ireland/Assembly/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@37300d3f18421e391838f11921ce5cefd8dbb6f3/data/Northern_Ireland/Assembly/term-6.csv"
           },
           {
             "end_date": "2017-01-26",
@@ -7541,7 +7552,7 @@
             "start_date": "2016-05-05",
             "slug": "5",
             "csv": "data/Northern_Ireland/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b8a7dc12b6b20051e021490224c01669136d2b97/data/Northern_Ireland/Assembly/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b8a7dc12b6b20051e021490224c01669136d2b97/data/Northern_Ireland/Assembly/term-5.csv"
           },
           {
             "end_date": "2016-03-24",
@@ -7550,7 +7561,7 @@
             "start_date": "2011-05-06",
             "slug": "4",
             "csv": "data/Northern_Ireland/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b8a7dc12b6b20051e021490224c01669136d2b97/data/Northern_Ireland/Assembly/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b8a7dc12b6b20051e021490224c01669136d2b97/data/Northern_Ireland/Assembly/term-4.csv"
           },
           {
             "end_date": "2011-03-24",
@@ -7559,7 +7570,7 @@
             "start_date": "2007-03-09",
             "slug": "3",
             "csv": "data/Northern_Ireland/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b8a7dc12b6b20051e021490224c01669136d2b97/data/Northern_Ireland/Assembly/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b8a7dc12b6b20051e021490224c01669136d2b97/data/Northern_Ireland/Assembly/term-3.csv"
           },
           {
             "end_date": "2007-01-30",
@@ -7568,7 +7579,7 @@
             "start_date": "2003-11-26",
             "slug": "2",
             "csv": "data/Northern_Ireland/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a8d5e5a2dff88ef7300e103c279888d51f0c930f/data/Northern_Ireland/Assembly/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a8d5e5a2dff88ef7300e103c279888d51f0c930f/data/Northern_Ireland/Assembly/term-2.csv"
           },
           {
             "end_date": "2003-04-28",
@@ -7577,10 +7588,10 @@
             "start_date": "1998-06-25",
             "slug": "1",
             "csv": "data/Northern_Ireland/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a8d5e5a2dff88ef7300e103c279888d51f0c930f/data/Northern_Ireland/Assembly/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a8d5e5a2dff88ef7300e103c279888d51f0c930f/data/Northern_Ireland/Assembly/term-1.csv"
           }
         ],
-        "statement_count": 15093,
+        "statement_count": 15096,
         "type": "unicameral legislature"
       }
     ]
@@ -7596,7 +7607,7 @@
         "slug": "House",
         "sources_directory": "data/Northern_Mariana_Islands/House/sources",
         "popolo": "data/Northern_Mariana_Islands/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/82f1a0b16969e021e3e03f6d9605c1752a05cec3/data/Northern_Mariana_Islands/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@82f1a0b16969e021e3e03f6d9605c1752a05cec3/data/Northern_Mariana_Islands/House/ep-popolo-v1.0.json",
         "names": "data/Northern_Mariana_Islands/House/names.csv",
         "lastmod": "1531676529",
         "person_count": 20,
@@ -7608,7 +7619,7 @@
             "start_date": "2014",
             "slug": "19",
             "csv": "data/Northern_Mariana_Islands/House/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/31a469101fd5d1b3c38cbc612746ac3930ccdd2e/data/Northern_Mariana_Islands/House/term-19.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@31a469101fd5d1b3c38cbc612746ac3930ccdd2e/data/Northern_Mariana_Islands/House/term-19.csv"
           }
         ],
         "statement_count": 1053,
@@ -7627,11 +7638,11 @@
         "slug": "Storting",
         "sources_directory": "data/Norway/Storting/sources",
         "popolo": "data/Norway/Storting/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/127f076d75fe1f0e8e80be016a7af2c0f26ad681/data/Norway/Storting/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bb488090657abd124a835dbbc56bf426d48d1455/data/Norway/Storting/ep-popolo-v1.0.json",
         "names": "data/Norway/Storting/names.csv",
-        "lastmod": "1539141203",
+        "lastmod": "1539601937",
         "person_count": 1209,
-        "sha": "127f076d75fe1f0e8e80be016a7af2c0f26ad681",
+        "sha": "bb488090657abd124a835dbbc56bf426d48d1455",
         "legislative_periods": [
           {
             "id": "term/2017-2021",
@@ -7639,7 +7650,7 @@
             "start_date": "2017-10-01",
             "slug": "2017-2021",
             "csv": "data/Norway/Storting/term-2017-2021.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9798f45a445f36e67043744d57bcda5121d63ff7/data/Norway/Storting/term-2017-2021.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9798f45a445f36e67043744d57bcda5121d63ff7/data/Norway/Storting/term-2017-2021.csv"
           },
           {
             "end_date": "2017-09-30",
@@ -7648,7 +7659,7 @@
             "start_date": "2013-10-01",
             "slug": "2013-2017",
             "csv": "data/Norway/Storting/term-2013-2017.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c6465a7dfadf646fb9452ebe81793086f9428e06/data/Norway/Storting/term-2013-2017.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c6465a7dfadf646fb9452ebe81793086f9428e06/data/Norway/Storting/term-2013-2017.csv"
           },
           {
             "end_date": "2013-09-30",
@@ -7657,7 +7668,7 @@
             "start_date": "2009-10-01",
             "slug": "2009-2013",
             "csv": "data/Norway/Storting/term-2009-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c6465a7dfadf646fb9452ebe81793086f9428e06/data/Norway/Storting/term-2009-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c6465a7dfadf646fb9452ebe81793086f9428e06/data/Norway/Storting/term-2009-2013.csv"
           },
           {
             "end_date": "2009-09-30",
@@ -7666,7 +7677,7 @@
             "start_date": "2005-10-01",
             "slug": "2005-2009",
             "csv": "data/Norway/Storting/term-2005-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c6465a7dfadf646fb9452ebe81793086f9428e06/data/Norway/Storting/term-2005-2009.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c6465a7dfadf646fb9452ebe81793086f9428e06/data/Norway/Storting/term-2005-2009.csv"
           },
           {
             "end_date": "2005-09-30",
@@ -7675,7 +7686,7 @@
             "start_date": "2001-10-01",
             "slug": "2001-2005",
             "csv": "data/Norway/Storting/term-2001-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/904ca30a0d78f099eb635bc3f5f30eb7a1c775fc/data/Norway/Storting/term-2001-2005.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@904ca30a0d78f099eb635bc3f5f30eb7a1c775fc/data/Norway/Storting/term-2001-2005.csv"
           },
           {
             "end_date": "2001-09-30",
@@ -7684,7 +7695,7 @@
             "start_date": "1997-10-01",
             "slug": "1997-2001",
             "csv": "data/Norway/Storting/term-1997-2001.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2f71af82753785467e4bbca6708888f063416629/data/Norway/Storting/term-1997-2001.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@2f71af82753785467e4bbca6708888f063416629/data/Norway/Storting/term-1997-2001.csv"
           },
           {
             "end_date": "1997-09-30",
@@ -7693,7 +7704,7 @@
             "start_date": "1993-10-01",
             "slug": "1993-97",
             "csv": "data/Norway/Storting/term-1993-97.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2f71af82753785467e4bbca6708888f063416629/data/Norway/Storting/term-1993-97.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@bafc283616e5f6338545daea981b4ff497176e17/data/Norway/Storting/term-1993-97.csv"
           },
           {
             "end_date": "1993-09-30",
@@ -7702,7 +7713,7 @@
             "start_date": "1989-10-01",
             "slug": "1989-93",
             "csv": "data/Norway/Storting/term-1989-93.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/77b8243a6f5050f9956d4ab5d176a0c9062e51ad/data/Norway/Storting/term-1989-93.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@77b8243a6f5050f9956d4ab5d176a0c9062e51ad/data/Norway/Storting/term-1989-93.csv"
           },
           {
             "end_date": "1989-09-30",
@@ -7711,7 +7722,7 @@
             "start_date": "1985-10-01",
             "slug": "1985-89",
             "csv": "data/Norway/Storting/term-1985-89.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7264278c963d968573b16fa854944a86398daed5/data/Norway/Storting/term-1985-89.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7264278c963d968573b16fa854944a86398daed5/data/Norway/Storting/term-1985-89.csv"
           },
           {
             "end_date": "1985-09-30",
@@ -7720,7 +7731,7 @@
             "start_date": "1981-10-01",
             "slug": "1981-85",
             "csv": "data/Norway/Storting/term-1981-85.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/848e9e764a1bd1c8e4798e3f4b8be36f61ebe698/data/Norway/Storting/term-1981-85.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@848e9e764a1bd1c8e4798e3f4b8be36f61ebe698/data/Norway/Storting/term-1981-85.csv"
           },
           {
             "end_date": "1981-09-30",
@@ -7729,7 +7740,7 @@
             "start_date": "1977-10-01",
             "slug": "1977-81",
             "csv": "data/Norway/Storting/term-1977-81.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/848e9e764a1bd1c8e4798e3f4b8be36f61ebe698/data/Norway/Storting/term-1977-81.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@848e9e764a1bd1c8e4798e3f4b8be36f61ebe698/data/Norway/Storting/term-1977-81.csv"
           },
           {
             "end_date": "1977-09-30",
@@ -7738,7 +7749,7 @@
             "start_date": "1973-10-01",
             "slug": "1973-77",
             "csv": "data/Norway/Storting/term-1973-77.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7264278c963d968573b16fa854944a86398daed5/data/Norway/Storting/term-1973-77.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7264278c963d968573b16fa854944a86398daed5/data/Norway/Storting/term-1973-77.csv"
           },
           {
             "end_date": "1973-09-30",
@@ -7747,7 +7758,7 @@
             "start_date": "1969-10-01",
             "slug": "1969-73",
             "csv": "data/Norway/Storting/term-1969-73.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7264278c963d968573b16fa854944a86398daed5/data/Norway/Storting/term-1969-73.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7264278c963d968573b16fa854944a86398daed5/data/Norway/Storting/term-1969-73.csv"
           },
           {
             "end_date": "1969-09-30",
@@ -7756,7 +7767,7 @@
             "start_date": "1965-10-01",
             "slug": "1965-69",
             "csv": "data/Norway/Storting/term-1965-69.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d3c17619198c64dd32a22e6934836b9184a53c1d/data/Norway/Storting/term-1965-69.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d3c17619198c64dd32a22e6934836b9184a53c1d/data/Norway/Storting/term-1965-69.csv"
           },
           {
             "end_date": "1965-09-30",
@@ -7765,7 +7776,7 @@
             "start_date": "1961-10-01",
             "slug": "1961-65",
             "csv": "data/Norway/Storting/term-1961-65.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/497a8eef874581372b7c19816e1853b55f46efd2/data/Norway/Storting/term-1961-65.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@497a8eef874581372b7c19816e1853b55f46efd2/data/Norway/Storting/term-1961-65.csv"
           },
           {
             "end_date": "1961-09-30",
@@ -7774,7 +7785,7 @@
             "start_date": "1958-01-11",
             "slug": "1958-61",
             "csv": "data/Norway/Storting/term-1958-61.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/497a8eef874581372b7c19816e1853b55f46efd2/data/Norway/Storting/term-1958-61.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@497a8eef874581372b7c19816e1853b55f46efd2/data/Norway/Storting/term-1958-61.csv"
           },
           {
             "end_date": "1958-01-10",
@@ -7783,7 +7794,7 @@
             "start_date": "1954-01-11",
             "slug": "1954-57",
             "csv": "data/Norway/Storting/term-1954-57.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/497a8eef874581372b7c19816e1853b55f46efd2/data/Norway/Storting/term-1954-57.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@497a8eef874581372b7c19816e1853b55f46efd2/data/Norway/Storting/term-1954-57.csv"
           },
           {
             "end_date": "1954-01-10",
@@ -7792,7 +7803,7 @@
             "start_date": "1950-01-11",
             "slug": "1950-53",
             "csv": "data/Norway/Storting/term-1950-53.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/497a8eef874581372b7c19816e1853b55f46efd2/data/Norway/Storting/term-1950-53.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@497a8eef874581372b7c19816e1853b55f46efd2/data/Norway/Storting/term-1950-53.csv"
           },
           {
             "end_date": "1950-01-10",
@@ -7801,10 +7812,10 @@
             "start_date": "1945-12-04",
             "slug": "1945-49",
             "csv": "data/Norway/Storting/term-1945-49.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e5533aea3a4b3b5051079f459e9bac448256021/data/Norway/Storting/term-1945-49.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9e5533aea3a4b3b5051079f459e9bac448256021/data/Norway/Storting/term-1945-49.csv"
           }
         ],
-        "statement_count": 57829,
+        "statement_count": 58057,
         "type": "unicameral legislature"
       }
     ]
@@ -7820,7 +7831,7 @@
         "slug": "Majlis",
         "sources_directory": "data/Oman/Majlis/sources",
         "popolo": "data/Oman/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a6a0b42f5de8e226bf142092662eb939394c4d42/data/Oman/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a6a0b42f5de8e226bf142092662eb939394c4d42/data/Oman/Majlis/ep-popolo-v1.0.json",
         "names": "data/Oman/Majlis/names.csv",
         "lastmod": "1533520999",
         "person_count": 84,
@@ -7833,7 +7844,7 @@
             "start_date": "2011-10-31",
             "slug": "7",
             "csv": "data/Oman/Majlis/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Oman/Majlis/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Oman/Majlis/term-7.csv"
           }
         ],
         "statement_count": 1776,
@@ -7852,11 +7863,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Pakistan/Assembly/sources",
         "popolo": "data/Pakistan/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/994917fea60a4110bcbefe7b2c2e81ffd850fa6f/data/Pakistan/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e7e0c91f97188d424acfcd7c040449676399c0d5/data/Pakistan/Assembly/ep-popolo-v1.0.json",
         "names": "data/Pakistan/Assembly/names.csv",
-        "lastmod": "1539157428",
+        "lastmod": "1539359343",
         "person_count": 352,
-        "sha": "994917fea60a4110bcbefe7b2c2e81ffd850fa6f",
+        "sha": "e7e0c91f97188d424acfcd7c040449676399c0d5",
         "legislative_periods": [
           {
             "end_date": "2018-07-25",
@@ -7865,10 +7876,10 @@
             "start_date": "2013-06-01",
             "slug": "14",
             "csv": "data/Pakistan/Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8896876ff4a131c92b5e70d4c8fa0279d49cf791/data/Pakistan/Assembly/term-14.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@8896876ff4a131c92b5e70d4c8fa0279d49cf791/data/Pakistan/Assembly/term-14.csv"
           }
         ],
-        "statement_count": 15039,
+        "statement_count": 15117,
         "type": "lower house"
       }
     ]
@@ -7884,7 +7895,7 @@
         "slug": "House-of-Delegates",
         "sources_directory": "data/Palau/House_of_Delegates/sources",
         "popolo": "data/Palau/House_of_Delegates/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6627c65db9b9d3598ec13d91adedb5c5cf8afe31/data/Palau/House_of_Delegates/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6627c65db9b9d3598ec13d91adedb5c5cf8afe31/data/Palau/House_of_Delegates/ep-popolo-v1.0.json",
         "names": "data/Palau/House_of_Delegates/names.csv",
         "lastmod": "1531774146",
         "person_count": 16,
@@ -7896,7 +7907,7 @@
             "start_date": "2013-01-17",
             "slug": "2012",
             "csv": "data/Palau/House_of_Delegates/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Palau/House_of_Delegates/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Palau/House_of_Delegates/term-2012.csv"
           }
         ],
         "statement_count": 878,
@@ -7915,11 +7926,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Panama/Assembly/sources",
         "popolo": "data/Panama/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aa05fa30347b5f86bdcd7bca28a50ecbf0080305/data/Panama/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0758ef5b01ba9122824fae39e4459e0ef482457b/data/Panama/Assembly/ep-popolo-v1.0.json",
         "names": "data/Panama/Assembly/names.csv",
-        "lastmod": "1533523086",
+        "lastmod": "1539614994",
         "person_count": 75,
-        "sha": "aa05fa30347b5f86bdcd7bca28a50ecbf0080305",
+        "sha": "0758ef5b01ba9122824fae39e4459e0ef482457b",
         "legislative_periods": [
           {
             "id": "term/2014",
@@ -7927,10 +7938,10 @@
             "start_date": "2014-07-01",
             "slug": "2014",
             "csv": "data/Panama/Assembly/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Panama/Assembly/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Panama/Assembly/term-2014.csv"
           }
         ],
-        "statement_count": 2187,
+        "statement_count": 2191,
         "type": "unicameral legislature"
       }
     ]
@@ -7946,7 +7957,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Papua_New_Guinea/Parliament/sources",
         "popolo": "data/Papua_New_Guinea/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c841fb229d5b9b70ec7e6cc925485853fa322c51/data/Papua_New_Guinea/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c841fb229d5b9b70ec7e6cc925485853fa322c51/data/Papua_New_Guinea/Parliament/ep-popolo-v1.0.json",
         "names": "data/Papua_New_Guinea/Parliament/names.csv",
         "lastmod": "1533173004",
         "person_count": 111,
@@ -7958,7 +7969,7 @@
             "start_date": "2012-08-03",
             "slug": "2012",
             "csv": "data/Papua_New_Guinea/Parliament/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Papua_New_Guinea/Parliament/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Papua_New_Guinea/Parliament/term-2012.csv"
           }
         ],
         "statement_count": 3822,
@@ -7977,12 +7988,20 @@
         "slug": "Deputies",
         "sources_directory": "data/Paraguay/Deputies/sources",
         "popolo": "data/Paraguay/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1decde7da7aa872b0db60d41cd871b6380ecdfc4/data/Paraguay/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e8f23b6bc736d1fae1e59ecafb4cad935b50804d/data/Paraguay/Deputies/ep-popolo-v1.0.json",
         "names": "data/Paraguay/Deputies/names.csv",
-        "lastmod": "1537864558",
-        "person_count": 82,
-        "sha": "1decde7da7aa872b0db60d41cd871b6380ecdfc4",
+        "lastmod": "1539328969",
+        "person_count": 137,
+        "sha": "e8f23b6bc736d1fae1e59ecafb4cad935b50804d",
         "legislative_periods": [
+          {
+            "id": "term/2018",
+            "name": "2018–",
+            "start_date": "2018-04-22",
+            "slug": "2018",
+            "csv": "data/Paraguay/Deputies/term-2018.csv",
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e8f23b6bc736d1fae1e59ecafb4cad935b50804d/data/Paraguay/Deputies/term-2018.csv"
+          },
           {
             "end_date": "2018-04-22",
             "id": "term/2013",
@@ -7990,10 +8009,10 @@
             "start_date": "2013-04-21",
             "slug": "2013",
             "csv": "data/Paraguay/Deputies/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1decde7da7aa872b0db60d41cd871b6380ecdfc4/data/Paraguay/Deputies/term-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1303eb3f7767cfa82f880e68949d7d171e185101/data/Paraguay/Deputies/term-2013.csv"
           }
         ],
-        "statement_count": 2535,
+        "statement_count": 3622,
         "type": "lower house"
       }
     ]
@@ -8009,11 +8028,11 @@
         "slug": "Congreso",
         "sources_directory": "data/Peru/Congreso/sources",
         "popolo": "data/Peru/Congreso/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9e25a2b08bed314edf58dbcd50aab6590755614e/data/Peru/Congreso/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@21d5abaa23cf44c85169dde898f365a157471154/data/Peru/Congreso/ep-popolo-v1.0.json",
         "names": "data/Peru/Congreso/names.csv",
-        "lastmod": "1539047367",
+        "lastmod": "1539449702",
         "person_count": 127,
-        "sha": "9e25a2b08bed314edf58dbcd50aab6590755614e",
+        "sha": "21d5abaa23cf44c85169dde898f365a157471154",
         "legislative_periods": [
           {
             "end_date": "2016-07-26",
@@ -8022,10 +8041,10 @@
             "start_date": "2011-07-27",
             "slug": "2011",
             "csv": "data/Peru/Congreso/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0931052added484f5012f44f7aaa1026bef2338f/data/Peru/Congreso/term-2011.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0931052added484f5012f44f7aaa1026bef2338f/data/Peru/Congreso/term-2011.csv"
           }
         ],
-        "statement_count": 5634,
+        "statement_count": 5637,
         "type": "unicameral legislature"
       }
     ]
@@ -8041,11 +8060,11 @@
         "slug": "House",
         "sources_directory": "data/Philippines/House/sources",
         "popolo": "data/Philippines/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/405520d20d3d3b6745d9378b45ae17374face484/data/Philippines/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@595a2705dec25cb4d769ff2f3a4ba00a4c99b95d/data/Philippines/House/ep-popolo-v1.0.json",
         "names": "data/Philippines/House/names.csv",
-        "lastmod": "1539033059",
+        "lastmod": "1539409387",
         "person_count": 436,
-        "sha": "405520d20d3d3b6745d9378b45ae17374face484",
+        "sha": "595a2705dec25cb4d769ff2f3a4ba00a4c99b95d",
         "legislative_periods": [
           {
             "id": "term/17",
@@ -8053,7 +8072,7 @@
             "start_date": "2016-07-25",
             "slug": "17",
             "csv": "data/Philippines/House/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/266b681e9f8fae8bd37f225bcd7ae952bb728e3b/data/Philippines/House/term-17.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@595a2705dec25cb4d769ff2f3a4ba00a4c99b95d/data/Philippines/House/term-17.csv"
           },
           {
             "end_date": "2016-06-06",
@@ -8062,10 +8081,10 @@
             "start_date": "2013-07-22",
             "slug": "16",
             "csv": "data/Philippines/House/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ec011af217268a18249581b35817f6719e349f05/data/Philippines/House/term-16.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ec011af217268a18249581b35817f6719e349f05/data/Philippines/House/term-16.csv"
           }
         ],
-        "statement_count": 10919,
+        "statement_count": 10928,
         "type": "lower house"
       }
     ]
@@ -8081,7 +8100,7 @@
         "slug": "Island-Council",
         "sources_directory": "data/Pitcairn/Island_Council/sources",
         "popolo": "data/Pitcairn/Island_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c808d577caa5b6ea15e7a0ba34328012ba39e994/data/Pitcairn/Island_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c808d577caa5b6ea15e7a0ba34328012ba39e994/data/Pitcairn/Island_Council/ep-popolo-v1.0.json",
         "names": "data/Pitcairn/Island_Council/names.csv",
         "lastmod": "1536521823",
         "person_count": 12,
@@ -8093,7 +8112,7 @@
             "start_date": "2013-11-12",
             "slug": "2013",
             "csv": "data/Pitcairn/Island_Council/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Pitcairn/Island_Council/term-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Pitcairn/Island_Council/term-2013.csv"
           },
           {
             "end_date": "2013-11-11",
@@ -8102,7 +8121,7 @@
             "start_date": "2011-12-12",
             "slug": "2011",
             "csv": "data/Pitcairn/Island_Council/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Pitcairn/Island_Council/term-2011.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Pitcairn/Island_Council/term-2011.csv"
           },
           {
             "end_date": "2011-12-11",
@@ -8111,7 +8130,7 @@
             "start_date": "2009-12-11",
             "slug": "2009",
             "csv": "data/Pitcairn/Island_Council/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Pitcairn/Island_Council/term-2009.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Pitcairn/Island_Council/term-2009.csv"
           }
         ],
         "statement_count": 835,
@@ -8130,11 +8149,11 @@
         "slug": "Sejm",
         "sources_directory": "data/Poland/Sejm/sources",
         "popolo": "data/Poland/Sejm/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0282d92b3ab2817385920db9241177f13a83ca02/data/Poland/Sejm/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c7539bb9e5160f180f40725e76e1221c1dba016d/data/Poland/Sejm/ep-popolo-v1.0.json",
         "names": "data/Poland/Sejm/names.csv",
-        "lastmod": "1539255373",
+        "lastmod": "1539334961",
         "person_count": 2181,
-        "sha": "0282d92b3ab2817385920db9241177f13a83ca02",
+        "sha": "c7539bb9e5160f180f40725e76e1221c1dba016d",
         "legislative_periods": [
           {
             "id": "term/8",
@@ -8142,7 +8161,7 @@
             "start_date": "2015-11-12",
             "slug": "8",
             "csv": "data/Poland/Sejm/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5829e4f7bad4f74df12e4496902fa4a8109d5029/data/Poland/Sejm/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@5829e4f7bad4f74df12e4496902fa4a8109d5029/data/Poland/Sejm/term-8.csv"
           },
           {
             "end_date": "2015-11-11",
@@ -8151,7 +8170,7 @@
             "start_date": "2011-11-08",
             "slug": "7",
             "csv": "data/Poland/Sejm/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6909e18bf6d7ddba2f51808a2c82562ade21d63c/data/Poland/Sejm/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6909e18bf6d7ddba2f51808a2c82562ade21d63c/data/Poland/Sejm/term-7.csv"
           },
           {
             "end_date": "2011-11-07",
@@ -8160,7 +8179,7 @@
             "start_date": "2007-11-05",
             "slug": "6",
             "csv": "data/Poland/Sejm/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20f4a3b99669bcc2917a7197be21f1bff4615c55/data/Poland/Sejm/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@20f4a3b99669bcc2917a7197be21f1bff4615c55/data/Poland/Sejm/term-6.csv"
           },
           {
             "end_date": "2007-11-04",
@@ -8169,7 +8188,7 @@
             "start_date": "2005-10-19",
             "slug": "5",
             "csv": "data/Poland/Sejm/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/20f4a3b99669bcc2917a7197be21f1bff4615c55/data/Poland/Sejm/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@20f4a3b99669bcc2917a7197be21f1bff4615c55/data/Poland/Sejm/term-5.csv"
           },
           {
             "end_date": "2005-10-18",
@@ -8178,7 +8197,7 @@
             "start_date": "2001-10-19",
             "slug": "4",
             "csv": "data/Poland/Sejm/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd5336079894839fc787b9d4009290bf0f7f3682/data/Poland/Sejm/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@fd5336079894839fc787b9d4009290bf0f7f3682/data/Poland/Sejm/term-4.csv"
           },
           {
             "end_date": "2001-10-18",
@@ -8187,7 +8206,7 @@
             "start_date": "1997-10-20",
             "slug": "3",
             "csv": "data/Poland/Sejm/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd5336079894839fc787b9d4009290bf0f7f3682/data/Poland/Sejm/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@fd5336079894839fc787b9d4009290bf0f7f3682/data/Poland/Sejm/term-3.csv"
           },
           {
             "end_date": "1997-10-19",
@@ -8196,7 +8215,7 @@
             "start_date": "1993-09-19",
             "slug": "2",
             "csv": "data/Poland/Sejm/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd5336079894839fc787b9d4009290bf0f7f3682/data/Poland/Sejm/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@fd5336079894839fc787b9d4009290bf0f7f3682/data/Poland/Sejm/term-2.csv"
           },
           {
             "end_date": "1993-09-18",
@@ -8205,10 +8224,10 @@
             "start_date": "1991-11-25",
             "slug": "1",
             "csv": "data/Poland/Sejm/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fd5336079894839fc787b9d4009290bf0f7f3682/data/Poland/Sejm/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@fd5336079894839fc787b9d4009290bf0f7f3682/data/Poland/Sejm/term-1.csv"
           }
         ],
-        "statement_count": 76448,
+        "statement_count": 76450,
         "type": "lower house"
       }
     ]
@@ -8224,121 +8243,121 @@
         "slug": "Assembly",
         "sources_directory": "data/Portugal/Assembly/sources",
         "popolo": "data/Portugal/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8942d7998adf497d3c4214cdd57423f36b8ed513/data/Portugal/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@829348dd5103240c104598deb277ee3c5c6c035a/data/Portugal/Assembly/ep-popolo-v1.0.json",
         "names": "data/Portugal/Assembly/names.csv",
-        "lastmod": "1539113746",
+        "lastmod": "1539671365",
         "person_count": 2169,
-        "sha": "8942d7998adf497d3c4214cdd57423f36b8ed513",
+        "sha": "829348dd5103240c104598deb277ee3c5c6c035a",
         "legislative_periods": [
           {
             "id": "term/13",
-            "name": "13ª Legislatura",
+            "name": "13th Portuguese Assembly",
             "start_date": "2015-10-23",
             "slug": "13",
             "csv": "data/Portugal/Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/768c9f18ebe558b71f9c1734faeff72c804f4c15/data/Portugal/Assembly/term-13.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@768c9f18ebe558b71f9c1734faeff72c804f4c15/data/Portugal/Assembly/term-13.csv"
           },
           {
             "end_date": "2015-10-22",
             "id": "term/12",
-            "name": "12ª Legislatura",
+            "name": "12th Portuguese Assembly",
             "start_date": "2011-06-20",
             "slug": "12",
             "csv": "data/Portugal/Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df0fcae064d9f22b7bca43a2f783bf132ed6e663/data/Portugal/Assembly/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@df0fcae064d9f22b7bca43a2f783bf132ed6e663/data/Portugal/Assembly/term-12.csv"
           },
           {
             "end_date": "2011-06-19",
             "id": "term/11",
-            "name": "11ª Legislatura",
+            "name": "11th Portuguese Assembly",
             "start_date": "2009-10-15",
             "slug": "11",
             "csv": "data/Portugal/Assembly/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df0fcae064d9f22b7bca43a2f783bf132ed6e663/data/Portugal/Assembly/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@df0fcae064d9f22b7bca43a2f783bf132ed6e663/data/Portugal/Assembly/term-11.csv"
           },
           {
             "end_date": "2009-09-14",
             "id": "term/10",
-            "name": "10ª Legislatura",
+            "name": "10th Portuguese Assembly",
             "start_date": "2005-03-10",
             "slug": "10",
             "csv": "data/Portugal/Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df0fcae064d9f22b7bca43a2f783bf132ed6e663/data/Portugal/Assembly/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@df0fcae064d9f22b7bca43a2f783bf132ed6e663/data/Portugal/Assembly/term-10.csv"
           },
           {
             "end_date": "2005-03-09",
             "id": "term/9",
-            "name": "9ª Legislatura",
+            "name": "9th Portuguese Assembly",
             "start_date": "2002-04-05",
             "slug": "9",
             "csv": "data/Portugal/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df0fcae064d9f22b7bca43a2f783bf132ed6e663/data/Portugal/Assembly/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@df0fcae064d9f22b7bca43a2f783bf132ed6e663/data/Portugal/Assembly/term-9.csv"
           },
           {
             "end_date": "2002-04-04",
             "id": "term/8",
-            "name": "8ª Legislatura",
+            "name": "8th Portuguese Assembly",
             "start_date": "1999-10-25",
             "slug": "8",
             "csv": "data/Portugal/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/df0fcae064d9f22b7bca43a2f783bf132ed6e663/data/Portugal/Assembly/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@df0fcae064d9f22b7bca43a2f783bf132ed6e663/data/Portugal/Assembly/term-8.csv"
           },
           {
             "end_date": "1999-10-14",
             "id": "term/7",
-            "name": "7ª Legislatura",
+            "name": "7th Portuguese Assembly",
             "start_date": "1995-10-27",
             "slug": "7",
             "csv": "data/Portugal/Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0d4406e071dbf936904759f90a39614a8302ce22/data/Portugal/Assembly/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0d4406e071dbf936904759f90a39614a8302ce22/data/Portugal/Assembly/term-7.csv"
           },
           {
             "end_date": "1995-10-26",
             "id": "term/6",
-            "name": "6ª Legislatura",
+            "name": "6th Portuguese Assembly",
             "start_date": "1991-11-04",
             "slug": "6",
             "csv": "data/Portugal/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0d4406e071dbf936904759f90a39614a8302ce22/data/Portugal/Assembly/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0d4406e071dbf936904759f90a39614a8302ce22/data/Portugal/Assembly/term-6.csv"
           },
           {
             "end_date": "1991-11-03",
             "id": "term/5",
-            "name": "5ª Legislatura",
+            "name": "5th Portuguese Assembly",
             "start_date": "1987-08-13",
             "slug": "5",
             "csv": "data/Portugal/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0d4406e071dbf936904759f90a39614a8302ce22/data/Portugal/Assembly/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0d4406e071dbf936904759f90a39614a8302ce22/data/Portugal/Assembly/term-5.csv"
           },
           {
             "end_date": "1987-08-12",
             "id": "term/4",
-            "name": "4ª Legislatura",
+            "name": "4th Portuguese Assembly",
             "start_date": "1985-11-04",
             "slug": "4",
             "csv": "data/Portugal/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0d4406e071dbf936904759f90a39614a8302ce22/data/Portugal/Assembly/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0d4406e071dbf936904759f90a39614a8302ce22/data/Portugal/Assembly/term-4.csv"
           },
           {
             "end_date": "1985-11-03",
             "id": "term/3",
-            "name": "3ª Legislatura",
+            "name": "3rd Portguese Assembly",
             "start_date": "1983-05-31",
             "slug": "3",
             "csv": "data/Portugal/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0d4406e071dbf936904759f90a39614a8302ce22/data/Portugal/Assembly/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0d4406e071dbf936904759f90a39614a8302ce22/data/Portugal/Assembly/term-3.csv"
           },
           {
             "end_date": "1983-05-30",
             "id": "term/2",
-            "name": "2ª Legislatura",
+            "name": "2nd Portuguese Assembly",
             "start_date": "1980-01-03",
             "slug": "2",
             "csv": "data/Portugal/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0d4406e071dbf936904759f90a39614a8302ce22/data/Portugal/Assembly/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0d4406e071dbf936904759f90a39614a8302ce22/data/Portugal/Assembly/term-2.csv"
           }
         ],
-        "statement_count": 65053,
+        "statement_count": 65062,
         "type": "unicameral legislature"
       }
     ]
@@ -8354,7 +8373,7 @@
         "slug": "House-of-Representatives",
         "sources_directory": "data/Puerto_Rico/House_of_Representatives/sources",
         "popolo": "data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3ea06810cfa35a3114638fc9443333edd53b8f06/data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@3ea06810cfa35a3114638fc9443333edd53b8f06/data/Puerto_Rico/House_of_Representatives/ep-popolo-v1.0.json",
         "names": "data/Puerto_Rico/House_of_Representatives/names.csv",
         "lastmod": "1538057918",
         "person_count": 74,
@@ -8366,7 +8385,7 @@
             "start_date": "2017-01-02",
             "slug": "30",
             "csv": "data/Puerto_Rico/House_of_Representatives/term-30.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3ea06810cfa35a3114638fc9443333edd53b8f06/data/Puerto_Rico/House_of_Representatives/term-30.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@3ea06810cfa35a3114638fc9443333edd53b8f06/data/Puerto_Rico/House_of_Representatives/term-30.csv"
           },
           {
             "end_date": "2017-01-01",
@@ -8375,7 +8394,7 @@
             "start_date": "2013-01-02",
             "slug": "29",
             "csv": "data/Puerto_Rico/House_of_Representatives/term-29.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/acee8a7f4d93f1745b64888171928cd0bfc4c528/data/Puerto_Rico/House_of_Representatives/term-29.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@acee8a7f4d93f1745b64888171928cd0bfc4c528/data/Puerto_Rico/House_of_Representatives/term-29.csv"
           }
         ],
         "statement_count": 3172,
@@ -8394,23 +8413,31 @@
         "slug": "Deputies",
         "sources_directory": "data/Romania/Deputies/sources",
         "popolo": "data/Romania/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/773b6854476386218a479c9614ae3a420355d9fe/data/Romania/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@06ccb84dfb9ff003a55152f4f80802f1d748b403/data/Romania/Deputies/ep-popolo-v1.0.json",
         "names": "data/Romania/Deputies/names.csv",
-        "lastmod": "1539084773",
-        "person_count": 416,
-        "sha": "773b6854476386218a479c9614ae3a420355d9fe",
+        "lastmod": "1539599157",
+        "person_count": 648,
+        "sha": "06ccb84dfb9ff003a55152f4f80802f1d748b403",
         "legislative_periods": [
           {
+            "id": "term/8",
+            "name": "2016–2020 legislature of the Romanian Parliament",
+            "start_date": "2016-12-20",
+            "slug": "8",
+            "csv": "data/Romania/Deputies/term-8.csv",
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@06ccb84dfb9ff003a55152f4f80802f1d748b403/data/Romania/Deputies/term-8.csv"
+          },
+          {
             "end_date": "2016-12-10",
-            "id": "term/2012",
-            "name": "7th Legislature",
+            "id": "term/7",
+            "name": "2012–2016 legislature of the Romanian Parliament",
             "start_date": "2012-12-12",
-            "slug": "2012",
-            "csv": "data/Romania/Deputies/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8305d38178634d74c553c49f6b295d433db9cf07/data/Romania/Deputies/term-2012.csv"
+            "slug": "7",
+            "csv": "data/Romania/Deputies/term-7.csv",
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0fdc6b48c837c2ceca4c1193b39d12a27fa4e3ba/data/Romania/Deputies/term-7.csv"
           }
         ],
-        "statement_count": 22076,
+        "statement_count": 28706,
         "type": "lower house"
       }
     ]
@@ -8426,11 +8453,11 @@
         "slug": "Duma",
         "sources_directory": "data/Russia/Duma/sources",
         "popolo": "data/Russia/Duma/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d92ee7f159d8a8847ae0015886db559420cf70a6/data/Russia/Duma/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@aa33b1c980fbbe042931487cc3d3d2479daa8ce0/data/Russia/Duma/ep-popolo-v1.0.json",
         "names": "data/Russia/Duma/names.csv",
-        "lastmod": "1539109658",
+        "lastmod": "1539532186",
         "person_count": 700,
-        "sha": "d92ee7f159d8a8847ae0015886db559420cf70a6",
+        "sha": "aa33b1c980fbbe042931487cc3d3d2479daa8ce0",
         "legislative_periods": [
           {
             "id": "term/7",
@@ -8438,7 +8465,7 @@
             "start_date": "2016-10-05",
             "slug": "7",
             "csv": "data/Russia/Duma/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6cfb36e04fb34b8bbd036ed9721783699800925b/data/Russia/Duma/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@5550cce7d3ee32cb8968f5093d75245364e8efe1/data/Russia/Duma/term-7.csv"
           },
           {
             "end_date": "2016-10-05",
@@ -8447,10 +8474,10 @@
             "start_date": "2011-12-21",
             "slug": "6",
             "csv": "data/Russia/Duma/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f4e6430256f1a279e31ec24dd7bc41c89a73fd51/data/Russia/Duma/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f4e6430256f1a279e31ec24dd7bc41c89a73fd51/data/Russia/Duma/term-6.csv"
           }
         ],
-        "statement_count": 32433,
+        "statement_count": 32451,
         "type": "lower house"
       }
     ]
@@ -8466,7 +8493,7 @@
         "slug": "Deputies",
         "sources_directory": "data/Rwanda/Deputies/sources",
         "popolo": "data/Rwanda/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Rwanda/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Rwanda/Deputies/ep-popolo-v1.0.json",
         "names": "data/Rwanda/Deputies/names.csv",
         "lastmod": "1528387224",
         "person_count": 77,
@@ -8478,7 +8505,7 @@
             "start_date": "2013-10-05",
             "slug": "3",
             "csv": "data/Rwanda/Deputies/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Rwanda/Deputies/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Rwanda/Deputies/term-3.csv"
           }
         ],
         "statement_count": 1774,
@@ -8497,7 +8524,7 @@
         "slug": "Council",
         "sources_directory": "data/Saint_Barthelemy/Council/sources",
         "popolo": "data/Saint_Barthelemy/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f0159eed3b7b34c07db93e73c0c5a932c006e6b9/data/Saint_Barthelemy/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f0159eed3b7b34c07db93e73c0c5a932c006e6b9/data/Saint_Barthelemy/Council/ep-popolo-v1.0.json",
         "names": "data/Saint_Barthelemy/Council/names.csv",
         "lastmod": "1538408440",
         "person_count": 19,
@@ -8510,7 +8537,7 @@
             "start_date": "2012-03-18",
             "slug": "2012",
             "csv": "data/Saint_Barthelemy/Council/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/03073e4006c40a45dde3882562f0218c803c981b/data/Saint_Barthelemy/Council/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@03073e4006c40a45dde3882562f0218c803c981b/data/Saint_Barthelemy/Council/term-2012.csv"
           }
         ],
         "statement_count": 317,
@@ -8529,7 +8556,7 @@
         "slug": "Legislative-Council",
         "sources_directory": "data/Saint_Helena/Legislative_Council/sources",
         "popolo": "data/Saint_Helena/Legislative_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4d93e369d545909a4fce75b3596a36486d3fd79b/data/Saint_Helena/Legislative_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4d93e369d545909a4fce75b3596a36486d3fd79b/data/Saint_Helena/Legislative_Council/ep-popolo-v1.0.json",
         "names": "data/Saint_Helena/Legislative_Council/names.csv",
         "lastmod": "1485067951",
         "person_count": 12,
@@ -8541,7 +8568,7 @@
             "start_date": "2013-07-17",
             "slug": "2013",
             "csv": "data/Saint_Helena/Legislative_Council/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Saint_Helena/Legislative_Council/term-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Saint_Helena/Legislative_Council/term-2013.csv"
           }
         ],
         "statement_count": 562,
@@ -8560,7 +8587,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Saint_Kitts_and_Nevis/Assembly/sources",
         "popolo": "data/Saint_Kitts_and_Nevis/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af7b618869df3c45fbedf8feea77705e1bd56581/data/Saint_Kitts_and_Nevis/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@af7b618869df3c45fbedf8feea77705e1bd56581/data/Saint_Kitts_and_Nevis/Assembly/ep-popolo-v1.0.json",
         "names": "data/Saint_Kitts_and_Nevis/Assembly/names.csv",
         "lastmod": "1538283238",
         "person_count": 30,
@@ -8572,7 +8599,7 @@
             "start_date": "2015-05-14",
             "slug": "2015",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af7b618869df3c45fbedf8feea77705e1bd56581/data/Saint_Kitts_and_Nevis/Assembly/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@af7b618869df3c45fbedf8feea77705e1bd56581/data/Saint_Kitts_and_Nevis/Assembly/term-2015.csv"
           },
           {
             "end_date": "2015-01-16",
@@ -8581,7 +8608,7 @@
             "start_date": "2010-03-10",
             "slug": "2010",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af7b618869df3c45fbedf8feea77705e1bd56581/data/Saint_Kitts_and_Nevis/Assembly/term-2010.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@af7b618869df3c45fbedf8feea77705e1bd56581/data/Saint_Kitts_and_Nevis/Assembly/term-2010.csv"
           },
           {
             "end_date": "2010",
@@ -8590,7 +8617,7 @@
             "start_date": "2004-10-26",
             "slug": "2004",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-2004.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af7b618869df3c45fbedf8feea77705e1bd56581/data/Saint_Kitts_and_Nevis/Assembly/term-2004.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@af7b618869df3c45fbedf8feea77705e1bd56581/data/Saint_Kitts_and_Nevis/Assembly/term-2004.csv"
           },
           {
             "end_date": "2004",
@@ -8599,7 +8626,7 @@
             "start_date": "2000",
             "slug": "2000",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-2000.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af7b618869df3c45fbedf8feea77705e1bd56581/data/Saint_Kitts_and_Nevis/Assembly/term-2000.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@af7b618869df3c45fbedf8feea77705e1bd56581/data/Saint_Kitts_and_Nevis/Assembly/term-2000.csv"
           },
           {
             "end_date": "2000",
@@ -8608,7 +8635,7 @@
             "start_date": "1995",
             "slug": "1995",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-1995.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af7b618869df3c45fbedf8feea77705e1bd56581/data/Saint_Kitts_and_Nevis/Assembly/term-1995.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@af7b618869df3c45fbedf8feea77705e1bd56581/data/Saint_Kitts_and_Nevis/Assembly/term-1995.csv"
           },
           {
             "end_date": "1995",
@@ -8617,7 +8644,7 @@
             "start_date": "1993",
             "slug": "1993",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-1993.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af7b618869df3c45fbedf8feea77705e1bd56581/data/Saint_Kitts_and_Nevis/Assembly/term-1993.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@af7b618869df3c45fbedf8feea77705e1bd56581/data/Saint_Kitts_and_Nevis/Assembly/term-1993.csv"
           },
           {
             "end_date": "1993",
@@ -8626,7 +8653,7 @@
             "start_date": "1989",
             "slug": "1989",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-1989.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/af7b618869df3c45fbedf8feea77705e1bd56581/data/Saint_Kitts_and_Nevis/Assembly/term-1989.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@af7b618869df3c45fbedf8feea77705e1bd56581/data/Saint_Kitts_and_Nevis/Assembly/term-1989.csv"
           },
           {
             "end_date": "1989",
@@ -8635,7 +8662,7 @@
             "start_date": "1984",
             "slug": "1984",
             "csv": "data/Saint_Kitts_and_Nevis/Assembly/term-1984.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Saint_Kitts_and_Nevis/Assembly/term-1984.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Saint_Kitts_and_Nevis/Assembly/term-1984.csv"
           }
         ],
         "statement_count": 1468,
@@ -8654,7 +8681,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Saint_Lucia/Assembly/sources",
         "popolo": "data/Saint_Lucia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7d12d1976db7dd5df3ab152f9f1ad4b8b4eb5656/data/Saint_Lucia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7d12d1976db7dd5df3ab152f9f1ad4b8b4eb5656/data/Saint_Lucia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Saint_Lucia/Assembly/names.csv",
         "lastmod": "1536547023",
         "person_count": 30,
@@ -8666,7 +8693,7 @@
             "start_date": "2016-06-06",
             "slug": "10",
             "csv": "data/Saint_Lucia/Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Saint_Lucia/Assembly/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Saint_Lucia/Assembly/term-10.csv"
           },
           {
             "end_date": "2016-06-05",
@@ -8675,7 +8702,7 @@
             "start_date": "2012-01-05",
             "slug": "9",
             "csv": "data/Saint_Lucia/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Saint_Lucia/Assembly/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Saint_Lucia/Assembly/term-9.csv"
           },
           {
             "end_date": "2011-11-27",
@@ -8684,7 +8711,7 @@
             "start_date": "2007-01-09",
             "slug": "8",
             "csv": "data/Saint_Lucia/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Saint_Lucia/Assembly/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Saint_Lucia/Assembly/term-8.csv"
           }
         ],
         "statement_count": 1853,
@@ -8703,7 +8730,7 @@
         "slug": "Council",
         "sources_directory": "data/Saint_Martin/Council/sources",
         "popolo": "data/Saint_Martin/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e7205341033ead083844e97ed9dde74d2d9cd169/data/Saint_Martin/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e7205341033ead083844e97ed9dde74d2d9cd169/data/Saint_Martin/Council/ep-popolo-v1.0.json",
         "names": "data/Saint_Martin/Council/names.csv",
         "lastmod": "1534427961",
         "person_count": 23,
@@ -8715,7 +8742,7 @@
             "start_date": "2012",
             "slug": "2012",
             "csv": "data/Saint_Martin/Council/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cc827fd1ee8a5e7d3e76e1ef1a04daa1a8d440c0/data/Saint_Martin/Council/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@cc827fd1ee8a5e7d3e76e1ef1a04daa1a8d440c0/data/Saint_Martin/Council/term-2012.csv"
           }
         ],
         "statement_count": 363,
@@ -8734,7 +8761,7 @@
         "slug": "Territorial-Council",
         "sources_directory": "data/Saint_Pierre_and_Miquelon/Territorial_Council/sources",
         "popolo": "data/Saint_Pierre_and_Miquelon/Territorial_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3d8a0d3d207c6f163834f61b33db4e2daa3224e6/data/Saint_Pierre_and_Miquelon/Territorial_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@3d8a0d3d207c6f163834f61b33db4e2daa3224e6/data/Saint_Pierre_and_Miquelon/Territorial_Council/ep-popolo-v1.0.json",
         "names": "data/Saint_Pierre_and_Miquelon/Territorial_Council/names.csv",
         "lastmod": "1537786343",
         "person_count": 43,
@@ -8746,7 +8773,7 @@
             "start_date": "2017-03-19",
             "slug": "2017",
             "csv": "data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2017.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2017.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2017.csv"
           },
           {
             "end_date": "2017-03-19",
@@ -8755,7 +8782,7 @@
             "start_date": "2012-03-18",
             "slug": "2012",
             "csv": "data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2012.csv"
           },
           {
             "end_date": "2012-03-18",
@@ -8764,7 +8791,7 @@
             "start_date": "2006-03-19",
             "slug": "2006",
             "csv": "data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2006.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2006.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Saint_Pierre_and_Miquelon/Territorial_Council/term-2006.csv"
           }
         ],
         "statement_count": 853,
@@ -8783,7 +8810,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Saint_Vincent_and_the_Grenadines/Assembly/sources",
         "popolo": "data/Saint_Vincent_and_the_Grenadines/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/93d71938db99b36a83fcb5885346aa982684d266/data/Saint_Vincent_and_the_Grenadines/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@93d71938db99b36a83fcb5885346aa982684d266/data/Saint_Vincent_and_the_Grenadines/Assembly/ep-popolo-v1.0.json",
         "names": "data/Saint_Vincent_and_the_Grenadines/Assembly/names.csv",
         "lastmod": "1533101607",
         "person_count": 18,
@@ -8795,7 +8822,7 @@
             "start_date": "2015-12-30",
             "slug": "9",
             "csv": "data/Saint_Vincent_and_the_Grenadines/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Saint_Vincent_and_the_Grenadines/Assembly/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Saint_Vincent_and_the_Grenadines/Assembly/term-9.csv"
           },
           {
             "end_date": "2015-11-07",
@@ -8804,7 +8831,7 @@
             "start_date": "2010-12-30",
             "slug": "8",
             "csv": "data/Saint_Vincent_and_the_Grenadines/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Saint_Vincent_and_the_Grenadines/Assembly/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Saint_Vincent_and_the_Grenadines/Assembly/term-8.csv"
           }
         ],
         "statement_count": 598,
@@ -8823,7 +8850,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Samoa/Parliament/sources",
         "popolo": "data/Samoa/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Samoa/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Samoa/Parliament/ep-popolo-v1.0.json",
         "names": "data/Samoa/Parliament/names.csv",
         "lastmod": "1528387224",
         "person_count": 81,
@@ -8835,7 +8862,7 @@
             "start_date": "2016-03-16",
             "slug": "16",
             "csv": "data/Samoa/Parliament/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Samoa/Parliament/term-16.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Samoa/Parliament/term-16.csv"
           },
           {
             "end_date": "2016-01-29",
@@ -8844,7 +8871,7 @@
             "start_date": "2011-03-18",
             "slug": "15",
             "csv": "data/Samoa/Parliament/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Samoa/Parliament/term-15.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Samoa/Parliament/term-15.csv"
           }
         ],
         "statement_count": 1968,
@@ -8863,11 +8890,11 @@
         "slug": "Council",
         "sources_directory": "data/San_Marino/Council/sources",
         "popolo": "data/San_Marino/Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa1423cacdfbb08822d87192a435ce6f61899bfb/data/San_Marino/Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e657bbf835889b07fe6d868e6c85ac6efaccd666/data/San_Marino/Council/ep-popolo-v1.0.json",
         "names": "data/San_Marino/Council/names.csv",
-        "lastmod": "1538985297",
+        "lastmod": "1539618767",
         "person_count": 102,
-        "sha": "fa1423cacdfbb08822d87192a435ce6f61899bfb",
+        "sha": "e657bbf835889b07fe6d868e6c85ac6efaccd666",
         "legislative_periods": [
           {
             "id": "term/2016",
@@ -8875,7 +8902,7 @@
             "start_date": "2016-11-20",
             "slug": "2016",
             "csv": "data/San_Marino/Council/term-2016.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/fa1423cacdfbb08822d87192a435ce6f61899bfb/data/San_Marino/Council/term-2016.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@fa1423cacdfbb08822d87192a435ce6f61899bfb/data/San_Marino/Council/term-2016.csv"
           },
           {
             "end_date": "2016-11-20",
@@ -8884,10 +8911,10 @@
             "start_date": "2012-12-26",
             "slug": "2012",
             "csv": "data/San_Marino/Council/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/56ba1464dc64c66d789d8d37ae969f38b8f3847c/data/San_Marino/Council/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@56ba1464dc64c66d789d8d37ae969f38b8f3847c/data/San_Marino/Council/term-2012.csv"
           }
         ],
-        "statement_count": 4460,
+        "statement_count": 4467,
         "type": "unicameral legislature"
       }
     ]
@@ -8903,7 +8930,7 @@
         "slug": "Chief-Pleas",
         "sources_directory": "data/Sark/Chief_Pleas/sources",
         "popolo": "data/Sark/Chief_Pleas/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/db9665e78c679c26d9c229bb9b695d02f7fb764d/data/Sark/Chief_Pleas/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@db9665e78c679c26d9c229bb9b695d02f7fb764d/data/Sark/Chief_Pleas/ep-popolo-v1.0.json",
         "names": "data/Sark/Chief_Pleas/names.csv",
         "lastmod": "1538467440",
         "person_count": 46,
@@ -8916,7 +8943,7 @@
             "start_date": "2015-01-01",
             "slug": "2015",
             "csv": "data/Sark/Chief_Pleas/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Sark/Chief_Pleas/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Sark/Chief_Pleas/term-2015.csv"
           },
           {
             "end_date": "2014-12-31",
@@ -8925,7 +8952,7 @@
             "start_date": "2013-01-01",
             "slug": "2013",
             "csv": "data/Sark/Chief_Pleas/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Sark/Chief_Pleas/term-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Sark/Chief_Pleas/term-2013.csv"
           },
           {
             "end_date": "2012-12-31",
@@ -8934,7 +8961,7 @@
             "start_date": "2011-01-01",
             "slug": "2011",
             "csv": "data/Sark/Chief_Pleas/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Sark/Chief_Pleas/term-2011.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Sark/Chief_Pleas/term-2011.csv"
           },
           {
             "end_date": "2010-12-31",
@@ -8943,7 +8970,7 @@
             "start_date": "2009-01-01",
             "slug": "2009",
             "csv": "data/Sark/Chief_Pleas/term-2009.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Sark/Chief_Pleas/term-2009.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Sark/Chief_Pleas/term-2009.csv"
           }
         ],
         "statement_count": 1298,
@@ -8962,7 +8989,7 @@
         "slug": "Shura",
         "sources_directory": "data/Saudi_Arabia/Shura/sources",
         "popolo": "data/Saudi_Arabia/Shura/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/364e676330d0d7b3a27318a82cb87d305a4d3baa/data/Saudi_Arabia/Shura/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@364e676330d0d7b3a27318a82cb87d305a4d3baa/data/Saudi_Arabia/Shura/ep-popolo-v1.0.json",
         "names": "data/Saudi_Arabia/Shura/names.csv",
         "lastmod": "1485067954",
         "person_count": 148,
@@ -8974,7 +9001,7 @@
             "start_date": "2013-02-24",
             "slug": "6",
             "csv": "data/Saudi_Arabia/Shura/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Saudi_Arabia/Shura/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Saudi_Arabia/Shura/term-6.csv"
           }
         ],
         "statement_count": 1984,
@@ -8993,11 +9020,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Scotland/Parliament/sources",
         "popolo": "data/Scotland/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3376a09ded96b13552f8f408ba2c2998b1570198/data/Scotland/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@38fd155c9983a15f5df6518389a54f89576140f4/data/Scotland/Parliament/ep-popolo-v1.0.json",
         "names": "data/Scotland/Parliament/names.csv",
-        "lastmod": "1539264020",
+        "lastmod": "1539510631",
         "person_count": 305,
-        "sha": "3376a09ded96b13552f8f408ba2c2998b1570198",
+        "sha": "38fd155c9983a15f5df6518389a54f89576140f4",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -9005,7 +9032,7 @@
             "start_date": "2016-05-05",
             "slug": "5",
             "csv": "data/Scotland/Parliament/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/91e5731bbfe312b6a5b633b0740d8a06f6f2df4b/data/Scotland/Parliament/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@91e5731bbfe312b6a5b633b0740d8a06f6f2df4b/data/Scotland/Parliament/term-5.csv"
           },
           {
             "end_date": "2016-03-24",
@@ -9014,7 +9041,7 @@
             "start_date": "2011-05-06",
             "slug": "4",
             "csv": "data/Scotland/Parliament/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/91e5731bbfe312b6a5b633b0740d8a06f6f2df4b/data/Scotland/Parliament/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@91e5731bbfe312b6a5b633b0740d8a06f6f2df4b/data/Scotland/Parliament/term-4.csv"
           },
           {
             "end_date": "2011-05-04",
@@ -9023,7 +9050,7 @@
             "start_date": "2007-05-03",
             "slug": "3",
             "csv": "data/Scotland/Parliament/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3376a09ded96b13552f8f408ba2c2998b1570198/data/Scotland/Parliament/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@3376a09ded96b13552f8f408ba2c2998b1570198/data/Scotland/Parliament/term-3.csv"
           },
           {
             "end_date": "2007-04-02",
@@ -9032,7 +9059,7 @@
             "start_date": "2003-05-01",
             "slug": "2",
             "csv": "data/Scotland/Parliament/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3376a09ded96b13552f8f408ba2c2998b1570198/data/Scotland/Parliament/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@3376a09ded96b13552f8f408ba2c2998b1570198/data/Scotland/Parliament/term-2.csv"
           },
           {
             "end_date": "2003-03-31",
@@ -9041,10 +9068,10 @@
             "start_date": "1999-05-06",
             "slug": "1",
             "csv": "data/Scotland/Parliament/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3376a09ded96b13552f8f408ba2c2998b1570198/data/Scotland/Parliament/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@3376a09ded96b13552f8f408ba2c2998b1570198/data/Scotland/Parliament/term-1.csv"
           }
         ],
-        "statement_count": 16496,
+        "statement_count": 16520,
         "type": "unicameral legislature"
       }
     ]
@@ -9060,7 +9087,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Senegal/Assembly/sources",
         "popolo": "data/Senegal/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b615cdee40ade88c2cbca0e2e04e242882c79724/data/Senegal/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b615cdee40ade88c2cbca0e2e04e242882c79724/data/Senegal/Assembly/ep-popolo-v1.0.json",
         "names": "data/Senegal/Assembly/names.csv",
         "lastmod": "1537358745",
         "person_count": 149,
@@ -9072,7 +9099,7 @@
             "start_date": "2012-07-30",
             "slug": "2012",
             "csv": "data/Senegal/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b4f74ef24b609216a0ee4a36e784db35aa447992/data/Senegal/Assembly/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b4f74ef24b609216a0ee4a36e784db35aa447992/data/Senegal/Assembly/term-2012.csv"
           }
         ],
         "statement_count": 2053,
@@ -9091,11 +9118,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Serbia/National_Assembly/sources",
         "popolo": "data/Serbia/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/3cfd91f842ffa44839c4ff2783abf74701da8fa7/data/Serbia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@58c0c75fd0c8ea17348bb77382055fa0471acb70/data/Serbia/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Serbia/National_Assembly/names.csv",
-        "lastmod": "1538905785",
+        "lastmod": "1539326761",
         "person_count": 406,
-        "sha": "3cfd91f842ffa44839c4ff2783abf74701da8fa7",
+        "sha": "58c0c75fd0c8ea17348bb77382055fa0471acb70",
         "legislative_periods": [
           {
             "id": "term/11",
@@ -9103,7 +9130,7 @@
             "start_date": "2016-06-03",
             "slug": "11",
             "csv": "data/Serbia/National_Assembly/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7a97f43c70182647146e6060d406ea3169601b11/data/Serbia/National_Assembly/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7a97f43c70182647146e6060d406ea3169601b11/data/Serbia/National_Assembly/term-11.csv"
           },
           {
             "end_date": "2016-06-03",
@@ -9112,10 +9139,10 @@
             "start_date": "2014-05-16",
             "slug": "10",
             "csv": "data/Serbia/National_Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/038cc5d0590b05115365ca40588175134a80ac20/data/Serbia/National_Assembly/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@038cc5d0590b05115365ca40588175134a80ac20/data/Serbia/National_Assembly/term-10.csv"
           }
         ],
-        "statement_count": 10834,
+        "statement_count": 10835,
         "type": "unicameral legislature"
       }
     ]
@@ -9131,7 +9158,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Seychelles/Assembly/sources",
         "popolo": "data/Seychelles/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Seychelles/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Seychelles/Assembly/ep-popolo-v1.0.json",
         "names": "data/Seychelles/Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 32,
@@ -9143,7 +9170,7 @@
             "start_date": "2011-10-11",
             "slug": "2011",
             "csv": "data/Seychelles/Assembly/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Seychelles/Assembly/term-2011.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Seychelles/Assembly/term-2011.csv"
           }
         ],
         "statement_count": 819,
@@ -9162,7 +9189,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Sierra_Leone/Parliament/sources",
         "popolo": "data/Sierra_Leone/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Sierra_Leone/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Sierra_Leone/Parliament/ep-popolo-v1.0.json",
         "names": "data/Sierra_Leone/Parliament/names.csv",
         "lastmod": "1528387224",
         "person_count": 124,
@@ -9174,7 +9201,7 @@
             "start_date": "2012-12-07",
             "slug": "2-4",
             "csv": "data/Sierra_Leone/Parliament/term-2-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Sierra_Leone/Parliament/term-2-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Sierra_Leone/Parliament/term-2-4.csv"
           }
         ],
         "statement_count": 1923,
@@ -9193,11 +9220,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Singapore/Parliament/sources",
         "popolo": "data/Singapore/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0c6a293ace4a4efa7aa7a399e996188fe7adac00/data/Singapore/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a7035da14fb05d9f5f997383e315c97447bbb382/data/Singapore/Parliament/ep-popolo-v1.0.json",
         "names": "data/Singapore/Parliament/names.csv",
-        "lastmod": "1538868589",
+        "lastmod": "1539466141",
         "person_count": 403,
-        "sha": "0c6a293ace4a4efa7aa7a399e996188fe7adac00",
+        "sha": "a7035da14fb05d9f5f997383e315c97447bbb382",
         "legislative_periods": [
           {
             "id": "term/13",
@@ -9205,7 +9232,7 @@
             "start_date": "2016-01-15",
             "slug": "13",
             "csv": "data/Singapore/Parliament/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e4524d4f44163ef0157bf0f362c1dc07fb324eb8/data/Singapore/Parliament/term-13.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e4524d4f44163ef0157bf0f362c1dc07fb324eb8/data/Singapore/Parliament/term-13.csv"
           },
           {
             "end_date": "2015-08-25",
@@ -9214,7 +9241,7 @@
             "start_date": "2011-10-10",
             "slug": "12",
             "csv": "data/Singapore/Parliament/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e4524d4f44163ef0157bf0f362c1dc07fb324eb8/data/Singapore/Parliament/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e4524d4f44163ef0157bf0f362c1dc07fb324eb8/data/Singapore/Parliament/term-12.csv"
           },
           {
             "end_date": "2011-04-19",
@@ -9223,7 +9250,7 @@
             "start_date": "2006-11-02",
             "slug": "11",
             "csv": "data/Singapore/Parliament/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/469930fccb229035b163d081a65a4f02ae35fc6b/data/Singapore/Parliament/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@469930fccb229035b163d081a65a4f02ae35fc6b/data/Singapore/Parliament/term-11.csv"
           },
           {
             "end_date": "2006-04-19",
@@ -9232,7 +9259,7 @@
             "start_date": "2002-03-25",
             "slug": "10",
             "csv": "data/Singapore/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/79ef17a81bf23d8548faf308924ff83d6c7d8365/data/Singapore/Parliament/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@79ef17a81bf23d8548faf308924ff83d6c7d8365/data/Singapore/Parliament/term-10.csv"
           },
           {
             "end_date": "2001-10-17",
@@ -9241,7 +9268,7 @@
             "start_date": "1997-05-26",
             "slug": "9",
             "csv": "data/Singapore/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/79ef17a81bf23d8548faf308924ff83d6c7d8365/data/Singapore/Parliament/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@79ef17a81bf23d8548faf308924ff83d6c7d8365/data/Singapore/Parliament/term-9.csv"
           },
           {
             "end_date": "1996-12-15",
@@ -9250,7 +9277,7 @@
             "start_date": "1992-01-06",
             "slug": "8",
             "csv": "data/Singapore/Parliament/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/79ef17a81bf23d8548faf308924ff83d6c7d8365/data/Singapore/Parliament/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@79ef17a81bf23d8548faf308924ff83d6c7d8365/data/Singapore/Parliament/term-8.csv"
           },
           {
             "end_date": "1991-08-13",
@@ -9259,7 +9286,7 @@
             "start_date": "1989-01-09",
             "slug": "7",
             "csv": "data/Singapore/Parliament/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/79ef17a81bf23d8548faf308924ff83d6c7d8365/data/Singapore/Parliament/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@79ef17a81bf23d8548faf308924ff83d6c7d8365/data/Singapore/Parliament/term-7.csv"
           },
           {
             "end_date": "1988-08-16",
@@ -9268,7 +9295,7 @@
             "start_date": "1985-02-25",
             "slug": "6",
             "csv": "data/Singapore/Parliament/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/79ef17a81bf23d8548faf308924ff83d6c7d8365/data/Singapore/Parliament/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@79ef17a81bf23d8548faf308924ff83d6c7d8365/data/Singapore/Parliament/term-6.csv"
           },
           {
             "end_date": "1984-12-03",
@@ -9277,7 +9304,7 @@
             "start_date": "1981-02-03",
             "slug": "5",
             "csv": "data/Singapore/Parliament/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Singapore/Parliament/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Singapore/Parliament/term-5.csv"
           },
           {
             "end_date": "1980-12-04",
@@ -9286,7 +9313,7 @@
             "start_date": "1977-02-07",
             "slug": "4",
             "csv": "data/Singapore/Parliament/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Singapore/Parliament/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Singapore/Parliament/term-4.csv"
           },
           {
             "end_date": "1976-12-06",
@@ -9295,7 +9322,7 @@
             "start_date": "1972-10-12",
             "slug": "3",
             "csv": "data/Singapore/Parliament/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Singapore/Parliament/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Singapore/Parliament/term-3.csv"
           },
           {
             "end_date": "1972-08-16",
@@ -9304,7 +9331,7 @@
             "start_date": "1968-05-06",
             "slug": "2",
             "csv": "data/Singapore/Parliament/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Singapore/Parliament/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Singapore/Parliament/term-2.csv"
           },
           {
             "end_date": "1968-02-08",
@@ -9313,10 +9340,10 @@
             "start_date": "1965-12-08",
             "slug": "1",
             "csv": "data/Singapore/Parliament/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Singapore/Parliament/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Singapore/Parliament/term-1.csv"
           }
         ],
-        "statement_count": 15540,
+        "statement_count": 15546,
         "type": "unicameral legislature"
       }
     ]
@@ -9332,7 +9359,7 @@
         "slug": "Estates",
         "sources_directory": "data/Sint_Maarten/Estates/sources",
         "popolo": "data/Sint_Maarten/Estates/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f4df5ff11508e80a148afe1799734ea21b77ab69/data/Sint_Maarten/Estates/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f4df5ff11508e80a148afe1799734ea21b77ab69/data/Sint_Maarten/Estates/ep-popolo-v1.0.json",
         "names": "data/Sint_Maarten/Estates/names.csv",
         "lastmod": "1537801114",
         "person_count": 29,
@@ -9344,7 +9371,7 @@
             "start_date": "2018-02-26",
             "slug": "4",
             "csv": "data/Sint_Maarten/Estates/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/186d70cd07a5610d13673731f71a1d3dbc9fe30c/data/Sint_Maarten/Estates/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@186d70cd07a5610d13673731f71a1d3dbc9fe30c/data/Sint_Maarten/Estates/term-4.csv"
           },
           {
             "end_date": "2018-02-25",
@@ -9353,7 +9380,7 @@
             "start_date": "2016-11-01",
             "slug": "3",
             "csv": "data/Sint_Maarten/Estates/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f4df5ff11508e80a148afe1799734ea21b77ab69/data/Sint_Maarten/Estates/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f4df5ff11508e80a148afe1799734ea21b77ab69/data/Sint_Maarten/Estates/term-3.csv"
           },
           {
             "end_date": "2016-10-31",
@@ -9362,7 +9389,7 @@
             "start_date": "2014-10-10",
             "slug": "2",
             "csv": "data/Sint_Maarten/Estates/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f4df5ff11508e80a148afe1799734ea21b77ab69/data/Sint_Maarten/Estates/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f4df5ff11508e80a148afe1799734ea21b77ab69/data/Sint_Maarten/Estates/term-2.csv"
           }
         ],
         "statement_count": 1371,
@@ -9381,67 +9408,67 @@
         "slug": "National-Council",
         "sources_directory": "data/Slovakia/National_Council/sources",
         "popolo": "data/Slovakia/National_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65599ee8fe67e445528c0ffdc7614d638e1c2d54/data/Slovakia/National_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6a3005d065b5ce680612a05674a913aaf09ea06e/data/Slovakia/National_Council/ep-popolo-v1.0.json",
         "names": "data/Slovakia/National_Council/names.csv",
-        "lastmod": "1538730360",
+        "lastmod": "1539596520",
         "person_count": 606,
-        "sha": "65599ee8fe67e445528c0ffdc7614d638e1c2d54",
+        "sha": "6a3005d065b5ce680612a05674a913aaf09ea06e",
         "legislative_periods": [
           {
             "id": "term/7",
-            "name": "7. Národná rada 2016-",
+            "name": "7th Národná rada",
             "start_date": "2016-03-23",
             "slug": "7",
             "csv": "data/Slovakia/National_Council/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/de0f201aad86ff35476c5c0c76434faadb741dd5/data/Slovakia/National_Council/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@de0f201aad86ff35476c5c0c76434faadb741dd5/data/Slovakia/National_Council/term-7.csv"
           },
           {
             "end_date": "2016-02-12",
             "id": "term/6",
-            "name": "6. Národná rada 2012-2016",
+            "name": "6th Národná rada",
             "start_date": "2012-03-11",
             "slug": "6",
             "csv": "data/Slovakia/National_Council/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/de0f201aad86ff35476c5c0c76434faadb741dd5/data/Slovakia/National_Council/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@de0f201aad86ff35476c5c0c76434faadb741dd5/data/Slovakia/National_Council/term-6.csv"
           },
           {
             "end_date": "2012-03-10",
             "id": "term/5",
-            "name": "5. Národná rada 2010-2012",
+            "name": "5th Národná rada",
             "start_date": "2010-06-13",
             "slug": "5",
             "csv": "data/Slovakia/National_Council/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/de0f201aad86ff35476c5c0c76434faadb741dd5/data/Slovakia/National_Council/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@de0f201aad86ff35476c5c0c76434faadb741dd5/data/Slovakia/National_Council/term-5.csv"
           },
           {
             "end_date": "2010-06-12",
             "id": "term/4",
-            "name": "4. Národná rada 2006-2010",
+            "name": "4th Národná rada",
             "start_date": "2006-06-17",
             "slug": "4",
             "csv": "data/Slovakia/National_Council/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/de0f201aad86ff35476c5c0c76434faadb741dd5/data/Slovakia/National_Council/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@de0f201aad86ff35476c5c0c76434faadb741dd5/data/Slovakia/National_Council/term-4.csv"
           },
           {
             "end_date": "2006-06-16",
             "id": "term/3",
-            "name": "3. Národná rada 2002-2006",
+            "name": "3rd Národná rada",
             "start_date": "2002-09-22",
             "slug": "3",
             "csv": "data/Slovakia/National_Council/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/de0f201aad86ff35476c5c0c76434faadb741dd5/data/Slovakia/National_Council/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@de0f201aad86ff35476c5c0c76434faadb741dd5/data/Slovakia/National_Council/term-3.csv"
           },
           {
             "end_date": "2002-09-21",
             "id": "term/2",
-            "name": "2. Národná rada 1998-2002",
+            "name": "2nd Národná rada",
             "start_date": "1998-09-26",
             "slug": "2",
             "csv": "data/Slovakia/National_Council/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/34d4f38e1fc8d0be0dcf03b0944767b1b4fd87e5/data/Slovakia/National_Council/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@34d4f38e1fc8d0be0dcf03b0944767b1b4fd87e5/data/Slovakia/National_Council/term-2.csv"
           }
         ],
-        "statement_count": 35674,
+        "statement_count": 35690,
         "type": "unicameral legislature"
       }
     ]
@@ -9457,7 +9484,7 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Slovenia/National_Assembly/sources",
         "popolo": "data/Slovenia/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d59182223416e5e0c2d0d7b8784f5d00e61def45/data/Slovenia/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d59182223416e5e0c2d0d7b8784f5d00e61def45/data/Slovenia/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Slovenia/National_Assembly/names.csv",
         "lastmod": "1538994361",
         "person_count": 152,
@@ -9469,7 +9496,7 @@
             "start_date": "2018-06-03",
             "slug": "8",
             "csv": "data/Slovenia/National_Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d59182223416e5e0c2d0d7b8784f5d00e61def45/data/Slovenia/National_Assembly/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d59182223416e5e0c2d0d7b8784f5d00e61def45/data/Slovenia/National_Assembly/term-8.csv"
           },
           {
             "end_date": "2018-04-15",
@@ -9478,7 +9505,7 @@
             "start_date": "2014-08-01",
             "slug": "7",
             "csv": "data/Slovenia/National_Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c0699882332e880e8f19d930d82e41337d996249/data/Slovenia/National_Assembly/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c0699882332e880e8f19d930d82e41337d996249/data/Slovenia/National_Assembly/term-7.csv"
           }
         ],
         "statement_count": 6124,
@@ -9497,7 +9524,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Solomon_Islands/Parliament/sources",
         "popolo": "data/Solomon_Islands/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/43dda7d0325404eb106316ff4287ca2f10f920c1/data/Solomon_Islands/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@43dda7d0325404eb106316ff4287ca2f10f920c1/data/Solomon_Islands/Parliament/ep-popolo-v1.0.json",
         "names": "data/Solomon_Islands/Parliament/names.csv",
         "lastmod": "1538295067",
         "person_count": 50,
@@ -9509,7 +9536,7 @@
             "start_date": "2014-12-09",
             "slug": "10",
             "csv": "data/Solomon_Islands/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Solomon_Islands/Parliament/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Solomon_Islands/Parliament/term-10.csv"
           }
         ],
         "statement_count": 2305,
@@ -9528,7 +9555,7 @@
         "slug": "Lower",
         "sources_directory": "data/Somalia/Lower/sources",
         "popolo": "data/Somalia/Lower/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d850b190147c9798f214f070663553602f2ee250/data/Somalia/Lower/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@d850b190147c9798f214f070663553602f2ee250/data/Somalia/Lower/ep-popolo-v1.0.json",
         "names": "data/Somalia/Lower/names.csv",
         "lastmod": "1538958999",
         "person_count": 204,
@@ -9540,7 +9567,7 @@
             "start_date": "2012-08-20",
             "slug": "2012",
             "csv": "data/Somalia/Lower/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/475a3a7b0fbf499c9959e5915ebc206790b6eaf5/data/Somalia/Lower/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@475a3a7b0fbf499c9959e5915ebc206790b6eaf5/data/Somalia/Lower/term-2012.csv"
           }
         ],
         "statement_count": 2532,
@@ -9559,7 +9586,7 @@
         "slug": "Representatives",
         "sources_directory": "data/Somaliland/Representatives/sources",
         "popolo": "data/Somaliland/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Somaliland/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Somaliland/Representatives/ep-popolo-v1.0.json",
         "names": "data/Somaliland/Representatives/names.csv",
         "lastmod": "1528387224",
         "person_count": 82,
@@ -9571,7 +9598,7 @@
             "start_date": "2005-09-29",
             "slug": "2005",
             "csv": "data/Somaliland/Representatives/term-2005.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Somaliland/Representatives/term-2005.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Somaliland/Representatives/term-2005.csv"
           }
         ],
         "statement_count": 951,
@@ -9590,7 +9617,7 @@
         "slug": "Assembly",
         "sources_directory": "data/South_Africa/Assembly/sources",
         "popolo": "data/South_Africa/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/207a1c4ecf340423135484f1cb7e26da0ea128bb/data/South_Africa/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@207a1c4ecf340423135484f1cb7e26da0ea128bb/data/South_Africa/Assembly/ep-popolo-v1.0.json",
         "names": "data/South_Africa/Assembly/names.csv",
         "lastmod": "1539252222",
         "person_count": 494,
@@ -9602,7 +9629,7 @@
             "start_date": "2014-05-21",
             "slug": "26",
             "csv": "data/South_Africa/Assembly/term-26.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71d4c198fcc5200ad7babc261edcbdf99be00588/data/South_Africa/Assembly/term-26.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@71d4c198fcc5200ad7babc261edcbdf99be00588/data/South_Africa/Assembly/term-26.csv"
           }
         ],
         "statement_count": 14844,
@@ -9621,31 +9648,31 @@
         "slug": "National-Assembly",
         "sources_directory": "data/South_Korea/National_Assembly/sources",
         "popolo": "data/South_Korea/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f6958d7a17b882a42509db118bbd2e447957a3a1/data/South_Korea/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@65528fe173a076c02fcbf41c9c6e4d7d7ca7569d/data/South_Korea/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/South_Korea/National_Assembly/names.csv",
-        "lastmod": "1539087049",
+        "lastmod": "1539595245",
         "person_count": 454,
-        "sha": "f6958d7a17b882a42509db118bbd2e447957a3a1",
+        "sha": "65528fe173a076c02fcbf41c9c6e4d7d7ca7569d",
         "legislative_periods": [
           {
             "id": "term/20",
-            "name": "20th National Assembly",
+            "name": "20th Legislative Assembly",
             "start_date": "2016-05-30",
             "slug": "20",
             "csv": "data/South_Korea/National_Assembly/term-20.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9f9d525a807cb1bf23bbe94446fd605446347969/data/South_Korea/National_Assembly/term-20.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9f9d525a807cb1bf23bbe94446fd605446347969/data/South_Korea/National_Assembly/term-20.csv"
           },
           {
             "end_date": "2016-05-29",
             "id": "term/19",
-            "name": "19th National Assembly",
+            "name": "19th Legislative Assembly",
             "start_date": "2012-05-30",
             "slug": "19",
             "csv": "data/South_Korea/National_Assembly/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9f9d525a807cb1bf23bbe94446fd605446347969/data/South_Korea/National_Assembly/term-19.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9f9d525a807cb1bf23bbe94446fd605446347969/data/South_Korea/National_Assembly/term-19.csv"
           }
         ],
-        "statement_count": 24409,
+        "statement_count": 24420,
         "type": "unicameral legislature"
       }
     ]
@@ -9661,7 +9688,7 @@
         "slug": "Parliament",
         "sources_directory": "data/South_Ossetia/Parliament/sources",
         "popolo": "data/South_Ossetia/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/South_Ossetia/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/South_Ossetia/Parliament/ep-popolo-v1.0.json",
         "names": "data/South_Ossetia/Parliament/names.csv",
         "lastmod": "1528387224",
         "person_count": 34,
@@ -9673,7 +9700,7 @@
             "start_date": "2014-06-09",
             "slug": "2014",
             "csv": "data/South_Ossetia/Parliament/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/South_Ossetia/Parliament/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/South_Ossetia/Parliament/term-2014.csv"
           }
         ],
         "statement_count": 446,
@@ -9692,7 +9719,7 @@
         "slug": "Assembly",
         "sources_directory": "data/South_Sudan/Assembly/sources",
         "popolo": "data/South_Sudan/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/South_Sudan/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/South_Sudan/Assembly/ep-popolo-v1.0.json",
         "names": "data/South_Sudan/Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 167,
@@ -9704,7 +9731,7 @@
             "start_date": "2011-07-09",
             "slug": "1",
             "csv": "data/South_Sudan/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/South_Sudan/Assembly/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/South_Sudan/Assembly/term-1.csv"
           }
         ],
         "statement_count": 2950,
@@ -9723,7 +9750,7 @@
         "slug": "Congress",
         "sources_directory": "data/Spain/Congress/sources",
         "popolo": "data/Spain/Congress/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7522cf73bd1c2648aeb8c691aed329ceada9e097/data/Spain/Congress/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@7522cf73bd1c2648aeb8c691aed329ceada9e097/data/Spain/Congress/ep-popolo-v1.0.json",
         "names": "data/Spain/Congress/names.csv",
         "lastmod": "1539146628",
         "person_count": 621,
@@ -9736,7 +9763,7 @@
             "start_date": "2016-01-13",
             "slug": "11",
             "csv": "data/Spain/Congress/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4469e53e6e80868df5a10323e5ddb1dd243c547c/data/Spain/Congress/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4469e53e6e80868df5a10323e5ddb1dd243c547c/data/Spain/Congress/term-11.csv"
           },
           {
             "end_date": "2015-10-27",
@@ -9745,7 +9772,7 @@
             "start_date": "2011-12-13",
             "slug": "10",
             "csv": "data/Spain/Congress/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4469e53e6e80868df5a10323e5ddb1dd243c547c/data/Spain/Congress/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4469e53e6e80868df5a10323e5ddb1dd243c547c/data/Spain/Congress/term-10.csv"
           }
         ],
         "statement_count": 30306,
@@ -9764,7 +9791,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Sri_Lanka/Parliament/sources",
         "popolo": "data/Sri_Lanka/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c4f3f816c0bba5ec05e21b8454b7010a53e9b9d3/data/Sri_Lanka/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c4f3f816c0bba5ec05e21b8454b7010a53e9b9d3/data/Sri_Lanka/Parliament/ep-popolo-v1.0.json",
         "names": "data/Sri_Lanka/Parliament/names.csv",
         "lastmod": "1536709491",
         "person_count": 228,
@@ -9776,7 +9803,7 @@
             "start_date": "2015-09-01",
             "slug": "15",
             "csv": "data/Sri_Lanka/Parliament/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Sri_Lanka/Parliament/term-15.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Sri_Lanka/Parliament/term-15.csv"
           }
         ],
         "statement_count": 7293,
@@ -9795,7 +9822,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Suriname/Assembly/sources",
         "popolo": "data/Suriname/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a18ac7d6c9e79dc8ee2843423450fe329ebbd5c2/data/Suriname/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a18ac7d6c9e79dc8ee2843423450fe329ebbd5c2/data/Suriname/Assembly/ep-popolo-v1.0.json",
         "names": "data/Suriname/Assembly/names.csv",
         "lastmod": "1537801535",
         "person_count": 87,
@@ -9807,7 +9834,7 @@
             "start_date": "2015-06-30",
             "slug": "2015",
             "csv": "data/Suriname/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Suriname/Assembly/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Suriname/Assembly/term-2015.csv"
           },
           {
             "end_date": "2015-06-30",
@@ -9816,7 +9843,7 @@
             "start_date": "2010",
             "slug": "2010",
             "csv": "data/Suriname/Assembly/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a18ac7d6c9e79dc8ee2843423450fe329ebbd5c2/data/Suriname/Assembly/term-2010.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a18ac7d6c9e79dc8ee2843423450fe329ebbd5c2/data/Suriname/Assembly/term-2010.csv"
           }
         ],
         "statement_count": 2826,
@@ -9835,7 +9862,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Swaziland/Assembly/sources",
         "popolo": "data/Swaziland/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Swaziland/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Swaziland/Assembly/ep-popolo-v1.0.json",
         "names": "data/Swaziland/Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 93,
@@ -9847,7 +9874,7 @@
             "start_date": "2013-10-17",
             "slug": "10",
             "csv": "data/Swaziland/Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Swaziland/Assembly/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Swaziland/Assembly/term-10.csv"
           },
           {
             "end_date": "2013-09-19",
@@ -9856,7 +9883,7 @@
             "start_date": "2008-10-10",
             "slug": "9",
             "csv": "data/Swaziland/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Swaziland/Assembly/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Swaziland/Assembly/term-9.csv"
           }
         ],
         "statement_count": 1273,
@@ -9875,11 +9902,11 @@
         "slug": "Riksdag",
         "sources_directory": "data/Sweden/Riksdag/sources",
         "popolo": "data/Sweden/Riksdag/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d58316869661e5053d56d1c22198ab18261e2ee0/data/Sweden/Riksdag/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@af247f4bc060b2b458de97024517b963b81a35f0/data/Sweden/Riksdag/ep-popolo-v1.0.json",
         "names": "data/Sweden/Riksdag/names.csv",
-        "lastmod": "1539237085",
+        "lastmod": "1539532907",
         "person_count": 1759,
-        "sha": "d58316869661e5053d56d1c22198ab18261e2ee0",
+        "sha": "af247f4bc060b2b458de97024517b963b81a35f0",
         "legislative_periods": [
           {
             "id": "term/2018",
@@ -9887,7 +9914,7 @@
             "start_date": "2018-09-24",
             "slug": "2018",
             "csv": "data/Sweden/Riksdag/term-2018.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/d58316869661e5053d56d1c22198ab18261e2ee0/data/Sweden/Riksdag/term-2018.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0bf96e9673170765fd5b4adf7682081ef9aa6444/data/Sweden/Riksdag/term-2018.csv"
           },
           {
             "end_date": "2018-09-24",
@@ -9896,7 +9923,7 @@
             "start_date": "2014-09-29",
             "slug": "2014",
             "csv": "data/Sweden/Riksdag/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ee78c74b3e4246a240f90474c205bf4b1447c2dc/data/Sweden/Riksdag/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@56c352ef3912f578473ae8d253f4bb9ba9a55774/data/Sweden/Riksdag/term-2014.csv"
           },
           {
             "end_date": "2014-09-29",
@@ -9905,7 +9932,7 @@
             "start_date": "2010-10-04",
             "slug": "2010",
             "csv": "data/Sweden/Riksdag/term-2010.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0b3c11eafa2563a275ebe45e977637b6d47513ff/data/Sweden/Riksdag/term-2010.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0b3c11eafa2563a275ebe45e977637b6d47513ff/data/Sweden/Riksdag/term-2010.csv"
           },
           {
             "end_date": "2010-10-04",
@@ -9914,7 +9941,7 @@
             "start_date": "2006-10-02",
             "slug": "2006",
             "csv": "data/Sweden/Riksdag/term-2006.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0b3c11eafa2563a275ebe45e977637b6d47513ff/data/Sweden/Riksdag/term-2006.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0b3c11eafa2563a275ebe45e977637b6d47513ff/data/Sweden/Riksdag/term-2006.csv"
           },
           {
             "end_date": "2006-10-02",
@@ -9923,7 +9950,7 @@
             "start_date": "2002-09-30",
             "slug": "2002",
             "csv": "data/Sweden/Riksdag/term-2002.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0b3c11eafa2563a275ebe45e977637b6d47513ff/data/Sweden/Riksdag/term-2002.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0b3c11eafa2563a275ebe45e977637b6d47513ff/data/Sweden/Riksdag/term-2002.csv"
           },
           {
             "end_date": "2002-09-30",
@@ -9932,7 +9959,7 @@
             "start_date": "1998-10-05",
             "slug": "1998",
             "csv": "data/Sweden/Riksdag/term-1998.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0b3c11eafa2563a275ebe45e977637b6d47513ff/data/Sweden/Riksdag/term-1998.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0b3c11eafa2563a275ebe45e977637b6d47513ff/data/Sweden/Riksdag/term-1998.csv"
           },
           {
             "end_date": "1998-10-05",
@@ -9941,7 +9968,7 @@
             "start_date": "1994-10-03",
             "slug": "1994",
             "csv": "data/Sweden/Riksdag/term-1994.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0b3c11eafa2563a275ebe45e977637b6d47513ff/data/Sweden/Riksdag/term-1994.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0b3c11eafa2563a275ebe45e977637b6d47513ff/data/Sweden/Riksdag/term-1994.csv"
           },
           {
             "end_date": "1994-10-03",
@@ -9950,7 +9977,7 @@
             "start_date": "1991-09-30",
             "slug": "1991",
             "csv": "data/Sweden/Riksdag/term-1991.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0b3c11eafa2563a275ebe45e977637b6d47513ff/data/Sweden/Riksdag/term-1991.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0b3c11eafa2563a275ebe45e977637b6d47513ff/data/Sweden/Riksdag/term-1991.csv"
           },
           {
             "end_date": "1991-09-30",
@@ -9959,7 +9986,7 @@
             "start_date": "1988-10-03",
             "slug": "1988",
             "csv": "data/Sweden/Riksdag/term-1988.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/405f90e48045abb575ad8d3437bf7f0446afc999/data/Sweden/Riksdag/term-1988.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@405f90e48045abb575ad8d3437bf7f0446afc999/data/Sweden/Riksdag/term-1988.csv"
           },
           {
             "end_date": "1988-10-03",
@@ -9968,7 +9995,7 @@
             "start_date": "1985-09-30",
             "slug": "1985",
             "csv": "data/Sweden/Riksdag/term-1985.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/405f90e48045abb575ad8d3437bf7f0446afc999/data/Sweden/Riksdag/term-1985.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@405f90e48045abb575ad8d3437bf7f0446afc999/data/Sweden/Riksdag/term-1985.csv"
           },
           {
             "end_date": "1985-09-30",
@@ -9977,7 +10004,7 @@
             "start_date": "1982-10-04",
             "slug": "1982",
             "csv": "data/Sweden/Riksdag/term-1982.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/405f90e48045abb575ad8d3437bf7f0446afc999/data/Sweden/Riksdag/term-1982.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@405f90e48045abb575ad8d3437bf7f0446afc999/data/Sweden/Riksdag/term-1982.csv"
           },
           {
             "end_date": "1982-10-04",
@@ -9986,7 +10013,7 @@
             "start_date": "1979-10-01",
             "slug": "1979",
             "csv": "data/Sweden/Riksdag/term-1979.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/405f90e48045abb575ad8d3437bf7f0446afc999/data/Sweden/Riksdag/term-1979.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@405f90e48045abb575ad8d3437bf7f0446afc999/data/Sweden/Riksdag/term-1979.csv"
           },
           {
             "end_date": "1979-10-01",
@@ -9995,10 +10022,10 @@
             "start_date": "1976-10-04",
             "slug": "1976",
             "csv": "data/Sweden/Riksdag/term-1976.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/405f90e48045abb575ad8d3437bf7f0446afc999/data/Sweden/Riksdag/term-1976.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@405f90e48045abb575ad8d3437bf7f0446afc999/data/Sweden/Riksdag/term-1976.csv"
           }
         ],
-        "statement_count": 84681,
+        "statement_count": 84699,
         "type": "unicameral legislature"
       }
     ]
@@ -10014,7 +10041,7 @@
         "slug": "National-Council",
         "sources_directory": "data/Switzerland/National_Council/sources",
         "popolo": "data/Switzerland/National_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/0d242e8cb22ac1a89e2c33d5808457e071cec805/data/Switzerland/National_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@0d242e8cb22ac1a89e2c33d5808457e071cec805/data/Switzerland/National_Council/ep-popolo-v1.0.json",
         "names": "data/Switzerland/National_Council/names.csv",
         "lastmod": "1539115479",
         "person_count": 1234,
@@ -10026,7 +10053,7 @@
             "start_date": "2015-11-30",
             "slug": "50",
             "csv": "data/Switzerland/National_Council/term-50.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e37fd0f893baf91be0d91b03520dc9c254fec778/data/Switzerland/National_Council/term-50.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e37fd0f893baf91be0d91b03520dc9c254fec778/data/Switzerland/National_Council/term-50.csv"
           },
           {
             "end_date": "2015-11-29",
@@ -10035,7 +10062,7 @@
             "start_date": "2011-12-05",
             "slug": "49",
             "csv": "data/Switzerland/National_Council/term-49.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e37fd0f893baf91be0d91b03520dc9c254fec778/data/Switzerland/National_Council/term-49.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e37fd0f893baf91be0d91b03520dc9c254fec778/data/Switzerland/National_Council/term-49.csv"
           },
           {
             "end_date": "2011-12-02",
@@ -10044,7 +10071,7 @@
             "start_date": "2007-12-03",
             "slug": "48",
             "csv": "data/Switzerland/National_Council/term-48.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e37fd0f893baf91be0d91b03520dc9c254fec778/data/Switzerland/National_Council/term-48.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e37fd0f893baf91be0d91b03520dc9c254fec778/data/Switzerland/National_Council/term-48.csv"
           },
           {
             "end_date": "2007-11-30",
@@ -10053,7 +10080,7 @@
             "start_date": "2003-12-01",
             "slug": "47",
             "csv": "data/Switzerland/National_Council/term-47.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/e37fd0f893baf91be0d91b03520dc9c254fec778/data/Switzerland/National_Council/term-47.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e37fd0f893baf91be0d91b03520dc9c254fec778/data/Switzerland/National_Council/term-47.csv"
           },
           {
             "end_date": "2003-11-30",
@@ -10062,7 +10089,7 @@
             "start_date": "1999-12-06",
             "slug": "46",
             "csv": "data/Switzerland/National_Council/term-46.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dd20b02f7959c5e992a915a82011c36fb4a57894/data/Switzerland/National_Council/term-46.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@dd20b02f7959c5e992a915a82011c36fb4a57894/data/Switzerland/National_Council/term-46.csv"
           },
           {
             "end_date": "1999-11-30",
@@ -10071,7 +10098,7 @@
             "start_date": "1995-12-04",
             "slug": "45",
             "csv": "data/Switzerland/National_Council/term-45.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8735be8c732662d1af778ad46e2688b457b43630/data/Switzerland/National_Council/term-45.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@8735be8c732662d1af778ad46e2688b457b43630/data/Switzerland/National_Council/term-45.csv"
           },
           {
             "end_date": "1995-12-03",
@@ -10080,7 +10107,7 @@
             "start_date": "1991-11-25",
             "slug": "44",
             "csv": "data/Switzerland/National_Council/term-44.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8735be8c732662d1af778ad46e2688b457b43630/data/Switzerland/National_Council/term-44.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@8735be8c732662d1af778ad46e2688b457b43630/data/Switzerland/National_Council/term-44.csv"
           },
           {
             "end_date": "1991-11-24",
@@ -10089,7 +10116,7 @@
             "start_date": "1987-11-30",
             "slug": "43",
             "csv": "data/Switzerland/National_Council/term-43.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8735be8c732662d1af778ad46e2688b457b43630/data/Switzerland/National_Council/term-43.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@8735be8c732662d1af778ad46e2688b457b43630/data/Switzerland/National_Council/term-43.csv"
           },
           {
             "end_date": "1987-11-29",
@@ -10098,7 +10125,7 @@
             "start_date": "1983-11-28",
             "slug": "42",
             "csv": "data/Switzerland/National_Council/term-42.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dd20b02f7959c5e992a915a82011c36fb4a57894/data/Switzerland/National_Council/term-42.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@dd20b02f7959c5e992a915a82011c36fb4a57894/data/Switzerland/National_Council/term-42.csv"
           },
           {
             "end_date": "1983-11-27",
@@ -10107,7 +10134,7 @@
             "start_date": "1979-11-26",
             "slug": "41",
             "csv": "data/Switzerland/National_Council/term-41.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8735be8c732662d1af778ad46e2688b457b43630/data/Switzerland/National_Council/term-41.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@8735be8c732662d1af778ad46e2688b457b43630/data/Switzerland/National_Council/term-41.csv"
           },
           {
             "end_date": "1979-11-25",
@@ -10116,7 +10143,7 @@
             "start_date": "1975-12-01",
             "slug": "40",
             "csv": "data/Switzerland/National_Council/term-40.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8735be8c732662d1af778ad46e2688b457b43630/data/Switzerland/National_Council/term-40.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@8735be8c732662d1af778ad46e2688b457b43630/data/Switzerland/National_Council/term-40.csv"
           },
           {
             "end_date": "1975-11-30",
@@ -10125,7 +10152,7 @@
             "start_date": "1971-11-29",
             "slug": "39",
             "csv": "data/Switzerland/National_Council/term-39.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8735be8c732662d1af778ad46e2688b457b43630/data/Switzerland/National_Council/term-39.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@8735be8c732662d1af778ad46e2688b457b43630/data/Switzerland/National_Council/term-39.csv"
           },
           {
             "end_date": "1971-11-28",
@@ -10134,7 +10161,7 @@
             "start_date": "1967-12-04",
             "slug": "38",
             "csv": "data/Switzerland/National_Council/term-38.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8735be8c732662d1af778ad46e2688b457b43630/data/Switzerland/National_Council/term-38.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@8735be8c732662d1af778ad46e2688b457b43630/data/Switzerland/National_Council/term-38.csv"
           },
           {
             "end_date": "1967-12-03",
@@ -10143,7 +10170,7 @@
             "start_date": "1963-12-02",
             "slug": "37",
             "csv": "data/Switzerland/National_Council/term-37.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8735be8c732662d1af778ad46e2688b457b43630/data/Switzerland/National_Council/term-37.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@8735be8c732662d1af778ad46e2688b457b43630/data/Switzerland/National_Council/term-37.csv"
           }
         ],
         "statement_count": 50970,
@@ -10162,7 +10189,7 @@
         "slug": "Majlis",
         "sources_directory": "data/Syria/Majlis/sources",
         "popolo": "data/Syria/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f661a8bb11fb6d9d5e34470c0a099b7f354078de/data/Syria/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f661a8bb11fb6d9d5e34470c0a099b7f354078de/data/Syria/Majlis/ep-popolo-v1.0.json",
         "names": "data/Syria/Majlis/names.csv",
         "lastmod": "1537801555",
         "person_count": 274,
@@ -10175,7 +10202,7 @@
             "start_date": "2012-05-24",
             "slug": "2012",
             "csv": "data/Syria/Majlis/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f661a8bb11fb6d9d5e34470c0a099b7f354078de/data/Syria/Majlis/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f661a8bb11fb6d9d5e34470c0a099b7f354078de/data/Syria/Majlis/term-2012.csv"
           }
         ],
         "statement_count": 4197,
@@ -10194,7 +10221,7 @@
         "slug": "Legislative-Yuan",
         "sources_directory": "data/Taiwan/Legislative_Yuan/sources",
         "popolo": "data/Taiwan/Legislative_Yuan/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/ce911fd411bc80266a552180b421b332c1de3d63/data/Taiwan/Legislative_Yuan/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@ce911fd411bc80266a552180b421b332c1de3d63/data/Taiwan/Legislative_Yuan/ep-popolo-v1.0.json",
         "names": "data/Taiwan/Legislative_Yuan/names.csv",
         "lastmod": "1539075657",
         "person_count": 170,
@@ -10206,7 +10233,7 @@
             "start_date": "2016-01-16",
             "slug": "9",
             "csv": "data/Taiwan/Legislative_Yuan/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/2da2fc3a9c1fa6664d0eb36fe2a78576b1211e8f/data/Taiwan/Legislative_Yuan/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@2da2fc3a9c1fa6664d0eb36fe2a78576b1211e8f/data/Taiwan/Legislative_Yuan/term-9.csv"
           },
           {
             "end_date": "2016-01-16",
@@ -10215,7 +10242,7 @@
             "start_date": "2012-02-01",
             "slug": "8",
             "csv": "data/Taiwan/Legislative_Yuan/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a952271f26f3c4d61bf47e42e882ad9c3dc54f72/data/Taiwan/Legislative_Yuan/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a952271f26f3c4d61bf47e42e882ad9c3dc54f72/data/Taiwan/Legislative_Yuan/term-8.csv"
           }
         ],
         "statement_count": 9211,
@@ -10234,7 +10261,7 @@
         "slug": "Representatives",
         "sources_directory": "data/Tajikistan/Representatives/sources",
         "popolo": "data/Tajikistan/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Tajikistan/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Tajikistan/Representatives/ep-popolo-v1.0.json",
         "names": "data/Tajikistan/Representatives/names.csv",
         "lastmod": "1528387224",
         "person_count": 62,
@@ -10246,7 +10273,7 @@
             "start_date": "2015-03-17",
             "slug": "2015",
             "csv": "data/Tajikistan/Representatives/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Tajikistan/Representatives/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Tajikistan/Representatives/term-2015.csv"
           }
         ],
         "statement_count": 986,
@@ -10265,49 +10292,49 @@
         "slug": "Assembly",
         "sources_directory": "data/Tanzania/Assembly/sources",
         "popolo": "data/Tanzania/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9fb18e99d698ac5773723a11ce133af1a998de32/data/Tanzania/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@99e6dd4407fa3e4cb13f5829fcb5ac469938a000/data/Tanzania/Assembly/ep-popolo-v1.0.json",
         "names": "data/Tanzania/Assembly/names.csv",
-        "lastmod": "1538739253",
+        "lastmod": "1539496479",
         "person_count": 906,
-        "sha": "9fb18e99d698ac5773723a11ce133af1a998de32",
+        "sha": "99e6dd4407fa3e4cb13f5829fcb5ac469938a000",
         "legislative_periods": [
           {
-            "id": "term/5",
-            "name": "5th Assembly",
+            "id": "term/11",
+            "name": "11th Parliament of Tanzania",
             "start_date": "2015-11-17",
-            "slug": "5",
-            "csv": "data/Tanzania/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a55691d8b8632243c031ada44898a273fa64d45b/data/Tanzania/Assembly/term-5.csv"
+            "slug": "11",
+            "csv": "data/Tanzania/Assembly/term-11.csv",
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e54e042b376aea0bb3777bbaab4a4d605ef387ef/data/Tanzania/Assembly/term-11.csv"
           },
           {
             "end_date": "2015-06-18",
-            "id": "term/4",
-            "name": "4th Assembly",
+            "id": "term/10",
+            "name": "10th Parliament of Tanzania",
             "start_date": "2010-10-31",
-            "slug": "4",
-            "csv": "data/Tanzania/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7d05049b9ae2cceff85a5e575a1d1ac612a4d001/data/Tanzania/Assembly/term-4.csv"
+            "slug": "10",
+            "csv": "data/Tanzania/Assembly/term-10.csv",
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e54e042b376aea0bb3777bbaab4a4d605ef387ef/data/Tanzania/Assembly/term-10.csv"
           },
           {
             "end_date": "2010-10-30",
-            "id": "term/3",
-            "name": "3rd Assembly",
+            "id": "term/9",
+            "name": "9th Parliament of Tanzania",
             "start_date": "2005-10-30",
-            "slug": "3",
-            "csv": "data/Tanzania/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7d05049b9ae2cceff85a5e575a1d1ac612a4d001/data/Tanzania/Assembly/term-3.csv"
+            "slug": "9",
+            "csv": "data/Tanzania/Assembly/term-9.csv",
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e54e042b376aea0bb3777bbaab4a4d605ef387ef/data/Tanzania/Assembly/term-9.csv"
           },
           {
             "end_date": "2005-10-29",
-            "id": "term/2",
-            "name": "2nd Assembly",
+            "id": "term/8",
+            "name": "8th Parliament of Tanzania",
             "start_date": "2000-10-29",
-            "slug": "2",
-            "csv": "data/Tanzania/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/7d05049b9ae2cceff85a5e575a1d1ac612a4d001/data/Tanzania/Assembly/term-2.csv"
+            "slug": "8",
+            "csv": "data/Tanzania/Assembly/term-8.csv",
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e54e042b376aea0bb3777bbaab4a4d605ef387ef/data/Tanzania/Assembly/term-8.csv"
           }
         ],
-        "statement_count": 30265,
+        "statement_count": 30271,
         "type": "unicameral legislature"
       }
     ]
@@ -10323,7 +10350,7 @@
         "slug": "National-Legislative-Assembly",
         "sources_directory": "data/Thailand/National_Legislative_Assembly/sources",
         "popolo": "data/Thailand/National_Legislative_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1fb6ebffc826ed2d8e3b714b8daadac3eb866efc/data/Thailand/National_Legislative_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1fb6ebffc826ed2d8e3b714b8daadac3eb866efc/data/Thailand/National_Legislative_Assembly/ep-popolo-v1.0.json",
         "names": "data/Thailand/National_Legislative_Assembly/names.csv",
         "lastmod": "1538946609",
         "person_count": 273,
@@ -10335,7 +10362,7 @@
             "start_date": "2014-08-07",
             "slug": "2557",
             "csv": "data/Thailand/National_Legislative_Assembly/term-2557.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f11baf26fe3a89ae121fc8d797301c2f7d64fe04/data/Thailand/National_Legislative_Assembly/term-2557.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f11baf26fe3a89ae121fc8d797301c2f7d64fe04/data/Thailand/National_Legislative_Assembly/term-2557.csv"
           }
         ],
         "statement_count": 4485,
@@ -10354,7 +10381,7 @@
         "slug": "Parlamento",
         "sources_directory": "data/Timor_Leste/Parlamento/sources",
         "popolo": "data/Timor_Leste/Parlamento/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Timor_Leste/Parlamento/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Timor_Leste/Parlamento/ep-popolo-v1.0.json",
         "names": "data/Timor_Leste/Parlamento/names.csv",
         "lastmod": "1528387224",
         "person_count": 65,
@@ -10366,7 +10393,7 @@
             "start_date": "2012-07-30",
             "slug": "2012",
             "csv": "data/Timor_Leste/Parlamento/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Timor_Leste/Parlamento/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Timor_Leste/Parlamento/term-2012.csv"
           }
         ],
         "statement_count": 1244,
@@ -10385,7 +10412,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Togo/Assembly/sources",
         "popolo": "data/Togo/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/677f72e91421e9bd035839a3c599429807634cc2/data/Togo/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@677f72e91421e9bd035839a3c599429807634cc2/data/Togo/Assembly/ep-popolo-v1.0.json",
         "names": "data/Togo/Assembly/names.csv",
         "lastmod": "1537402593",
         "person_count": 91,
@@ -10397,7 +10424,7 @@
             "start_date": "2013-08-20",
             "slug": "2013",
             "csv": "data/Togo/Assembly/term-2013.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Togo/Assembly/term-2013.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Togo/Assembly/term-2013.csv"
           }
         ],
         "statement_count": 2095,
@@ -10416,7 +10443,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Tonga/Assembly/sources",
         "popolo": "data/Tonga/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb9cdcac9208a55b422e5f838c0fdf9f26c9e3ff/data/Tonga/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@cb9cdcac9208a55b422e5f838c0fdf9f26c9e3ff/data/Tonga/Assembly/ep-popolo-v1.0.json",
         "names": "data/Tonga/Assembly/names.csv",
         "lastmod": "1537801566",
         "person_count": 27,
@@ -10428,7 +10455,7 @@
             "start_date": "2014-12-29",
             "slug": "2015",
             "csv": "data/Tonga/Assembly/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/cb9cdcac9208a55b422e5f838c0fdf9f26c9e3ff/data/Tonga/Assembly/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@cb9cdcac9208a55b422e5f838c0fdf9f26c9e3ff/data/Tonga/Assembly/term-2015.csv"
           }
         ],
         "statement_count": 796,
@@ -10447,7 +10474,7 @@
         "slug": "Supreme-Council",
         "sources_directory": "data/Transnistria/Supreme_Council/sources",
         "popolo": "data/Transnistria/Supreme_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Transnistria/Supreme_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Transnistria/Supreme_Council/ep-popolo-v1.0.json",
         "names": "data/Transnistria/Supreme_Council/names.csv",
         "lastmod": "1528387224",
         "person_count": 71,
@@ -10459,7 +10486,7 @@
             "start_date": "2015-12-23",
             "slug": "6",
             "csv": "data/Transnistria/Supreme_Council/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Transnistria/Supreme_Council/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Transnistria/Supreme_Council/term-6.csv"
           },
           {
             "end_date": "2015",
@@ -10468,7 +10495,7 @@
             "start_date": "2010",
             "slug": "5",
             "csv": "data/Transnistria/Supreme_Council/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Transnistria/Supreme_Council/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Transnistria/Supreme_Council/term-5.csv"
           }
         ],
         "statement_count": 1175,
@@ -10487,7 +10514,7 @@
         "slug": "Representatives",
         "sources_directory": "data/Trinidad_and_Tobago/Representatives/sources",
         "popolo": "data/Trinidad_and_Tobago/Representatives/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Trinidad_and_Tobago/Representatives/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Trinidad_and_Tobago/Representatives/ep-popolo-v1.0.json",
         "names": "data/Trinidad_and_Tobago/Representatives/names.csv",
         "lastmod": "1528387224",
         "person_count": 42,
@@ -10499,7 +10526,7 @@
             "start_date": "2015-09-23",
             "slug": "11",
             "csv": "data/Trinidad_and_Tobago/Representatives/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Trinidad_and_Tobago/Representatives/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Trinidad_and_Tobago/Representatives/term-11.csv"
           }
         ],
         "statement_count": 990,
@@ -10510,7 +10537,7 @@
         "slug": "Senate",
         "sources_directory": "data/Trinidad_and_Tobago/Senate/sources",
         "popolo": "data/Trinidad_and_Tobago/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Trinidad_and_Tobago/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Trinidad_and_Tobago/Senate/ep-popolo-v1.0.json",
         "names": "data/Trinidad_and_Tobago/Senate/names.csv",
         "lastmod": "1528387224",
         "person_count": 31,
@@ -10522,7 +10549,7 @@
             "start_date": "2015-09-23",
             "slug": "11",
             "csv": "data/Trinidad_and_Tobago/Senate/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Trinidad_and_Tobago/Senate/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Trinidad_and_Tobago/Senate/term-11.csv"
           }
         ],
         "statement_count": 556,
@@ -10541,7 +10568,7 @@
         "slug": "Majlis",
         "sources_directory": "data/Tunisia/Majlis/sources",
         "popolo": "data/Tunisia/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b06f8cbc91c8672149cd7e1432b8cef023ac509a/data/Tunisia/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b06f8cbc91c8672149cd7e1432b8cef023ac509a/data/Tunisia/Majlis/ep-popolo-v1.0.json",
         "names": "data/Tunisia/Majlis/names.csv",
         "lastmod": "1536854839",
         "person_count": 226,
@@ -10553,7 +10580,7 @@
             "start_date": "2014-12-02",
             "slug": "1",
             "csv": "data/Tunisia/Majlis/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1cbfc9c92a0c7b060b0c745aca3865b02fc07ec3/data/Tunisia/Majlis/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1cbfc9c92a0c7b060b0c745aca3865b02fc07ec3/data/Tunisia/Majlis/term-1.csv"
           }
         ],
         "statement_count": 4838,
@@ -10572,7 +10599,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Turkey/Assembly/sources",
         "popolo": "data/Turkey/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/ep-popolo-v1.0.json",
         "names": "data/Turkey/Assembly/names.csv",
         "lastmod": "1537883374",
         "person_count": 6899,
@@ -10584,7 +10611,7 @@
             "start_date": "2015-11-17",
             "slug": "26",
             "csv": "data/Turkey/Assembly/term-26.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-26.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-26.csv"
           },
           {
             "end_date": "2015-11-01",
@@ -10593,7 +10620,7 @@
             "start_date": "2015-06-23",
             "slug": "25",
             "csv": "data/Turkey/Assembly/term-25.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-25.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-25.csv"
           },
           {
             "end_date": "2015-06-23",
@@ -10602,7 +10629,7 @@
             "start_date": "2011-06-28",
             "slug": "24",
             "csv": "data/Turkey/Assembly/term-24.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-24.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-24.csv"
           },
           {
             "end_date": "2011-06-28",
@@ -10611,7 +10638,7 @@
             "start_date": "2007-07-23",
             "slug": "23",
             "csv": "data/Turkey/Assembly/term-23.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-23.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-23.csv"
           },
           {
             "end_date": "2007-07-23",
@@ -10620,7 +10647,7 @@
             "start_date": "2002-11-14",
             "slug": "22",
             "csv": "data/Turkey/Assembly/term-22.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-22.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-22.csv"
           },
           {
             "end_date": "2002-11-14",
@@ -10629,7 +10656,7 @@
             "start_date": "1999-04-18",
             "slug": "21",
             "csv": "data/Turkey/Assembly/term-21.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/084dde778a75575928852990466efa82f363d3f3/data/Turkey/Assembly/term-21.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@084dde778a75575928852990466efa82f363d3f3/data/Turkey/Assembly/term-21.csv"
           },
           {
             "end_date": "1999-04-18",
@@ -10638,7 +10665,7 @@
             "start_date": "1996-01-08",
             "slug": "20",
             "csv": "data/Turkey/Assembly/term-20.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-20.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-20.csv"
           },
           {
             "end_date": "1995-12-24",
@@ -10647,7 +10674,7 @@
             "start_date": "1991-11-06",
             "slug": "19",
             "csv": "data/Turkey/Assembly/term-19.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-19.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-19.csv"
           },
           {
             "end_date": "1991-10-20",
@@ -10656,7 +10683,7 @@
             "start_date": "1987-12-14",
             "slug": "18",
             "csv": "data/Turkey/Assembly/term-18.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-18.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-18.csv"
           },
           {
             "end_date": "1987-11-29",
@@ -10665,7 +10692,7 @@
             "start_date": "1983-11-24",
             "slug": "17",
             "csv": "data/Turkey/Assembly/term-17.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-17.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-17.csv"
           },
           {
             "end_date": "1980-09-12",
@@ -10674,7 +10701,7 @@
             "start_date": "1977-06-13",
             "slug": "16",
             "csv": "data/Turkey/Assembly/term-16.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-16.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-16.csv"
           },
           {
             "end_date": "1977-06-05",
@@ -10683,7 +10710,7 @@
             "start_date": "1973-10-24",
             "slug": "15",
             "csv": "data/Turkey/Assembly/term-15.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-15.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-15.csv"
           },
           {
             "end_date": "1973-10-14",
@@ -10692,7 +10719,7 @@
             "start_date": "1969-10-22",
             "slug": "14",
             "csv": "data/Turkey/Assembly/term-14.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-14.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-14.csv"
           },
           {
             "end_date": "1969-10-12",
@@ -10701,7 +10728,7 @@
             "start_date": "1965-10-22",
             "slug": "13",
             "csv": "data/Turkey/Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-13.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-13.csv"
           },
           {
             "end_date": "1965-10-01",
@@ -10710,7 +10737,7 @@
             "start_date": "1961-10-25",
             "slug": "12",
             "csv": "data/Turkey/Assembly/term-12.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-12.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-12.csv"
           },
           {
             "end_date": "1960-05-27",
@@ -10719,7 +10746,7 @@
             "start_date": "1957-11-01",
             "slug": "11",
             "csv": "data/Turkey/Assembly/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-11.csv"
           },
           {
             "end_date": "1957-11-01",
@@ -10728,7 +10755,7 @@
             "start_date": "1954-05-14",
             "slug": "10",
             "csv": "data/Turkey/Assembly/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-10.csv"
           },
           {
             "end_date": "1954-05-14",
@@ -10737,7 +10764,7 @@
             "start_date": "1950-05-22",
             "slug": "9",
             "csv": "data/Turkey/Assembly/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-9.csv"
           },
           {
             "end_date": "1950-05-22",
@@ -10746,7 +10773,7 @@
             "start_date": "1946-08-05",
             "slug": "8",
             "csv": "data/Turkey/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-8.csv"
           },
           {
             "end_date": "1946-08-05",
@@ -10755,7 +10782,7 @@
             "start_date": "1943-03-08",
             "slug": "7",
             "csv": "data/Turkey/Assembly/term-7.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-7.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-7.csv"
           },
           {
             "end_date": "1943-03-08",
@@ -10764,7 +10791,7 @@
             "start_date": "1939-04-03",
             "slug": "6",
             "csv": "data/Turkey/Assembly/term-6.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-6.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-6.csv"
           },
           {
             "end_date": "1939-04-03",
@@ -10773,7 +10800,7 @@
             "start_date": "1935-03-01",
             "slug": "5",
             "csv": "data/Turkey/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-5.csv"
           },
           {
             "end_date": "1935-03-01",
@@ -10782,7 +10809,7 @@
             "start_date": "1931-05-04",
             "slug": "4",
             "csv": "data/Turkey/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-4.csv"
           },
           {
             "end_date": "1931-05-04",
@@ -10791,7 +10818,7 @@
             "start_date": "1927-08-02",
             "slug": "3",
             "csv": "data/Turkey/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-3.csv"
           },
           {
             "end_date": "1927-08-02",
@@ -10800,7 +10827,7 @@
             "start_date": "1923-08-11",
             "slug": "2",
             "csv": "data/Turkey/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@65f97d1d9a83c0e2f48fb266fb2308958f1d61ad/data/Turkey/Assembly/term-2.csv"
           },
           {
             "end_date": "1923-08-11",
@@ -10809,7 +10836,7 @@
             "start_date": "1920-04-23",
             "slug": "1",
             "csv": "data/Turkey/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4a6cd4d0fd9b0ba949768f3d9062d4266346e3a0/data/Turkey/Assembly/term-1.csv"
           }
         ],
         "statement_count": 171632,
@@ -10828,7 +10855,7 @@
         "slug": "Mejlis",
         "sources_directory": "data/Turkmenistan/Mejlis/sources",
         "popolo": "data/Turkmenistan/Mejlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Turkmenistan/Mejlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Turkmenistan/Mejlis/ep-popolo-v1.0.json",
         "names": "data/Turkmenistan/Mejlis/names.csv",
         "lastmod": "1528387224",
         "person_count": 237,
@@ -10840,7 +10867,7 @@
             "start_date": "2014-01-07",
             "slug": "5",
             "csv": "data/Turkmenistan/Mejlis/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Turkmenistan/Mejlis/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Turkmenistan/Mejlis/term-5.csv"
           },
           {
             "end_date": "2013",
@@ -10849,7 +10876,7 @@
             "start_date": "2009",
             "slug": "4",
             "csv": "data/Turkmenistan/Mejlis/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Turkmenistan/Mejlis/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Turkmenistan/Mejlis/term-4.csv"
           }
         ],
         "statement_count": 4180,
@@ -10868,7 +10895,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Turks_and_Caicos_Islands/Assembly/sources",
         "popolo": "data/Turks_and_Caicos_Islands/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6029dc77b9c6eed036a59043aa877961eb113cad/data/Turks_and_Caicos_Islands/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6029dc77b9c6eed036a59043aa877961eb113cad/data/Turks_and_Caicos_Islands/Assembly/ep-popolo-v1.0.json",
         "names": "data/Turks_and_Caicos_Islands/Assembly/names.csv",
         "lastmod": "1533540549",
         "person_count": 22,
@@ -10880,7 +10907,7 @@
             "start_date": "2016-12-15",
             "slug": "2016",
             "csv": "data/Turks_and_Caicos_Islands/Assembly/term-2016.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Turks_and_Caicos_Islands/Assembly/term-2016.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Turks_and_Caicos_Islands/Assembly/term-2016.csv"
           },
           {
             "end_date": "2016-12-14",
@@ -10889,7 +10916,7 @@
             "start_date": "2012-11-09",
             "slug": "2012",
             "csv": "data/Turks_and_Caicos_Islands/Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Turks_and_Caicos_Islands/Assembly/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Turks_and_Caicos_Islands/Assembly/term-2012.csv"
           }
         ],
         "statement_count": 698,
@@ -10908,7 +10935,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Tuvalu/Parliament/sources",
         "popolo": "data/Tuvalu/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c902da243caf569157ba8e4f00711adc00b079c2/data/Tuvalu/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c902da243caf569157ba8e4f00711adc00b079c2/data/Tuvalu/Parliament/ep-popolo-v1.0.json",
         "names": "data/Tuvalu/Parliament/names.csv",
         "lastmod": "1534690915",
         "person_count": 27,
@@ -10920,7 +10947,7 @@
             "start_date": "2015-03-31",
             "slug": "11",
             "csv": "data/Tuvalu/Parliament/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Tuvalu/Parliament/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Tuvalu/Parliament/term-11.csv"
           },
           {
             "end_date": "2015-03-30",
@@ -10929,7 +10956,7 @@
             "start_date": "2010-09-16",
             "slug": "10",
             "csv": "data/Tuvalu/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Tuvalu/Parliament/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Tuvalu/Parliament/term-10.csv"
           },
           {
             "end_date": "2010-09-16",
@@ -10938,7 +10965,7 @@
             "start_date": "2006-08-03",
             "slug": "9",
             "csv": "data/Tuvalu/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/174ffa92fc072c779c63217dbfbbd55741b89e28/data/Tuvalu/Parliament/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@174ffa92fc072c779c63217dbfbbd55741b89e28/data/Tuvalu/Parliament/term-9.csv"
           }
         ],
         "statement_count": 1729,
@@ -10957,7 +10984,7 @@
         "slug": "Legislature",
         "sources_directory": "data/US_Virgin_Islands/Legislature/sources",
         "popolo": "data/US_Virgin_Islands/Legislature/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/US_Virgin_Islands/Legislature/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/US_Virgin_Islands/Legislature/ep-popolo-v1.0.json",
         "names": "data/US_Virgin_Islands/Legislature/names.csv",
         "lastmod": "1528387224",
         "person_count": 15,
@@ -10970,7 +10997,7 @@
             "start_date": "2015-01-12",
             "slug": "2014",
             "csv": "data/US_Virgin_Islands/Legislature/term-2014.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/US_Virgin_Islands/Legislature/term-2014.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/US_Virgin_Islands/Legislature/term-2014.csv"
           }
         ],
         "statement_count": 694,
@@ -10989,11 +11016,11 @@
         "slug": "Parliament",
         "sources_directory": "data/Uganda/Parliament/sources",
         "popolo": "data/Uganda/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/046517c3fc25b928b33b676cc9c84be8a9273595/data/Uganda/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@96ee1d72682f596abe6b0fa55dbc250c689def47/data/Uganda/Parliament/ep-popolo-v1.0.json",
         "names": "data/Uganda/Parliament/names.csv",
-        "lastmod": "1539076415",
+        "lastmod": "1539351954",
         "person_count": 651,
-        "sha": "046517c3fc25b928b33b676cc9c84be8a9273595",
+        "sha": "96ee1d72682f596abe6b0fa55dbc250c689def47",
         "legislative_periods": [
           {
             "id": "term/10",
@@ -11001,7 +11028,7 @@
             "start_date": "2016-05-16",
             "slug": "10",
             "csv": "data/Uganda/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8fe0eae2b1725df7bf14be16394672187336c7e3/data/Uganda/Parliament/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@8fe0eae2b1725df7bf14be16394672187336c7e3/data/Uganda/Parliament/term-10.csv"
           },
           {
             "end_date": "2016-05-13",
@@ -11010,10 +11037,10 @@
             "start_date": "2011-05-16",
             "slug": "9",
             "csv": "data/Uganda/Parliament/term-9.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5c6c00f8d9848ce88765df15f028599b744fd077/data/Uganda/Parliament/term-9.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@5c6c00f8d9848ce88765df15f028599b744fd077/data/Uganda/Parliament/term-9.csv"
           }
         ],
-        "statement_count": 17252,
+        "statement_count": 17254,
         "type": "unicameral legislature"
       }
     ]
@@ -11029,11 +11056,11 @@
         "slug": "Verkhovna-Rada",
         "sources_directory": "data/Ukraine/Verkhovna_Rada/sources",
         "popolo": "data/Ukraine/Verkhovna_Rada/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/5f2fc7e3f4587deda975272a5ce2f252e2327814/data/Ukraine/Verkhovna_Rada/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@69748923cbd4f3bfa43e16e9553352c0a2194ff3/data/Ukraine/Verkhovna_Rada/ep-popolo-v1.0.json",
         "names": "data/Ukraine/Verkhovna_Rada/names.csv",
-        "lastmod": "1539242489",
+        "lastmod": "1539608200",
         "person_count": 464,
-        "sha": "5f2fc7e3f4587deda975272a5ce2f252e2327814",
+        "sha": "69748923cbd4f3bfa43e16e9553352c0a2194ff3",
         "legislative_periods": [
           {
             "id": "term/8",
@@ -11041,10 +11068,10 @@
             "start_date": "2014-11-27",
             "slug": "8",
             "csv": "data/Ukraine/Verkhovna_Rada/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c466b2ead00da006feb36cb7da83820086e7d374/data/Ukraine/Verkhovna_Rada/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4847c8d347b7961285df20a494859dd61b27363b/data/Ukraine/Verkhovna_Rada/term-8.csv"
           }
         ],
-        "statement_count": 22643,
+        "statement_count": 22668,
         "type": "unicameral legislature"
       }
     ]
@@ -11060,7 +11087,7 @@
         "slug": "Federal-National-Council",
         "sources_directory": "data/United_Arab_Emirates/Federal_National_Council/sources",
         "popolo": "data/United_Arab_Emirates/Federal_National_Council/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f579b006c9b302a0da444a9d58cbda474cb84d89/data/United_Arab_Emirates/Federal_National_Council/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f579b006c9b302a0da444a9d58cbda474cb84d89/data/United_Arab_Emirates/Federal_National_Council/ep-popolo-v1.0.json",
         "names": "data/United_Arab_Emirates/Federal_National_Council/names.csv",
         "lastmod": "1537801675",
         "person_count": 40,
@@ -11073,7 +11100,7 @@
             "start_date": "2011-11-15",
             "slug": "2011",
             "csv": "data/United_Arab_Emirates/Federal_National_Council/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f579b006c9b302a0da444a9d58cbda474cb84d89/data/United_Arab_Emirates/Federal_National_Council/term-2011.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f579b006c9b302a0da444a9d58cbda474cb84d89/data/United_Arab_Emirates/Federal_National_Council/term-2011.csv"
           }
         ],
         "statement_count": 596,
@@ -11092,7 +11119,7 @@
         "slug": "Commons",
         "sources_directory": "data/UK/Commons/sources",
         "popolo": "data/UK/Commons/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/22db5d951f3765c4a42f406fbca687a9fc5954b6/data/UK/Commons/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@22db5d951f3765c4a42f406fbca687a9fc5954b6/data/UK/Commons/ep-popolo-v1.0.json",
         "names": "data/UK/Commons/names.csv",
         "lastmod": "1538045311",
         "person_count": 1436,
@@ -11104,7 +11131,7 @@
             "start_date": "2017-06-09",
             "slug": "57",
             "csv": "data/UK/Commons/term-57.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/f73b3431b912753b70fe5ab6c7aa305ffda5938b/data/UK/Commons/term-57.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@f73b3431b912753b70fe5ab6c7aa305ffda5938b/data/UK/Commons/term-57.csv"
           },
           {
             "end_date": "2017-05-03",
@@ -11113,7 +11140,7 @@
             "start_date": "2015-05-08",
             "slug": "56",
             "csv": "data/UK/Commons/term-56.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6de91f9c917723d5d2a53b74ef42eec57bcc6cb8/data/UK/Commons/term-56.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6de91f9c917723d5d2a53b74ef42eec57bcc6cb8/data/UK/Commons/term-56.csv"
           },
           {
             "end_date": "2015-03-30",
@@ -11122,7 +11149,7 @@
             "start_date": "2010-05-06",
             "slug": "55",
             "csv": "data/UK/Commons/term-55.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be39d1fb548df9c849213a2fa3eabcfecd8e8a96/data/UK/Commons/term-55.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@be39d1fb548df9c849213a2fa3eabcfecd8e8a96/data/UK/Commons/term-55.csv"
           },
           {
             "end_date": "2010-04-12",
@@ -11131,7 +11158,7 @@
             "start_date": "2005-05-05",
             "slug": "54",
             "csv": "data/UK/Commons/term-54.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be39d1fb548df9c849213a2fa3eabcfecd8e8a96/data/UK/Commons/term-54.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@be39d1fb548df9c849213a2fa3eabcfecd8e8a96/data/UK/Commons/term-54.csv"
           },
           {
             "end_date": "2005-04-11",
@@ -11140,7 +11167,7 @@
             "start_date": "2001-06-07",
             "slug": "53",
             "csv": "data/UK/Commons/term-53.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/be39d1fb548df9c849213a2fa3eabcfecd8e8a96/data/UK/Commons/term-53.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@be39d1fb548df9c849213a2fa3eabcfecd8e8a96/data/UK/Commons/term-53.csv"
           },
           {
             "end_date": "2001-05-14",
@@ -11149,7 +11176,7 @@
             "start_date": "1997-05-01",
             "slug": "52",
             "csv": "data/UK/Commons/term-52.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6de91f9c917723d5d2a53b74ef42eec57bcc6cb8/data/UK/Commons/term-52.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6de91f9c917723d5d2a53b74ef42eec57bcc6cb8/data/UK/Commons/term-52.csv"
           }
         ],
         "statement_count": 126358,
@@ -11168,7 +11195,7 @@
         "slug": "House",
         "sources_directory": "data/United_States_of_America/House/sources",
         "popolo": "data/United_States_of_America/House/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b39a02d466f2d18ca8998d35c4c92c8ce9367f28/data/United_States_of_America/House/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b39a02d466f2d18ca8998d35c4c92c8ce9367f28/data/United_States_of_America/House/ep-popolo-v1.0.json",
         "names": "data/United_States_of_America/House/names.csv",
         "lastmod": "1537882963",
         "person_count": 1648,
@@ -11180,7 +11207,7 @@
             "start_date": "2017-01-03",
             "slug": "115",
             "csv": "data/United_States_of_America/House/term-115.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/aed71d927f173fac7306593fbba0d7757e9b960e/data/United_States_of_America/House/term-115.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@aed71d927f173fac7306593fbba0d7757e9b960e/data/United_States_of_America/House/term-115.csv"
           },
           {
             "end_date": "2017-01-03",
@@ -11189,7 +11216,7 @@
             "start_date": "2015-01-06",
             "slug": "114",
             "csv": "data/United_States_of_America/House/term-114.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/70b1fd96910ff7f7b48d75f35f7a6b0d07c6afb6/data/United_States_of_America/House/term-114.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@70b1fd96910ff7f7b48d75f35f7a6b0d07c6afb6/data/United_States_of_America/House/term-114.csv"
           },
           {
             "end_date": "2015-01-03",
@@ -11198,7 +11225,7 @@
             "start_date": "2013-01-06",
             "slug": "113",
             "csv": "data/United_States_of_America/House/term-113.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-113.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-113.csv"
           },
           {
             "end_date": "2013-01-03",
@@ -11207,7 +11234,7 @@
             "start_date": "2011-01-06",
             "slug": "112",
             "csv": "data/United_States_of_America/House/term-112.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b39a02d466f2d18ca8998d35c4c92c8ce9367f28/data/United_States_of_America/House/term-112.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b39a02d466f2d18ca8998d35c4c92c8ce9367f28/data/United_States_of_America/House/term-112.csv"
           },
           {
             "end_date": "2011-01-03",
@@ -11216,7 +11243,7 @@
             "start_date": "2009-01-06",
             "slug": "111",
             "csv": "data/United_States_of_America/House/term-111.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b39a02d466f2d18ca8998d35c4c92c8ce9367f28/data/United_States_of_America/House/term-111.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b39a02d466f2d18ca8998d35c4c92c8ce9367f28/data/United_States_of_America/House/term-111.csv"
           },
           {
             "end_date": "2009-01-03",
@@ -11225,7 +11252,7 @@
             "start_date": "2007-01-06",
             "slug": "110",
             "csv": "data/United_States_of_America/House/term-110.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b39a02d466f2d18ca8998d35c4c92c8ce9367f28/data/United_States_of_America/House/term-110.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b39a02d466f2d18ca8998d35c4c92c8ce9367f28/data/United_States_of_America/House/term-110.csv"
           },
           {
             "end_date": "2007-01-03",
@@ -11234,7 +11261,7 @@
             "start_date": "2005-01-06",
             "slug": "109",
             "csv": "data/United_States_of_America/House/term-109.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/b39a02d466f2d18ca8998d35c4c92c8ce9367f28/data/United_States_of_America/House/term-109.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@b39a02d466f2d18ca8998d35c4c92c8ce9367f28/data/United_States_of_America/House/term-109.csv"
           },
           {
             "end_date": "2005-01-03",
@@ -11243,7 +11270,7 @@
             "start_date": "2003-01-06",
             "slug": "108",
             "csv": "data/United_States_of_America/House/term-108.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-108.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-108.csv"
           },
           {
             "end_date": "2003-01-03",
@@ -11252,7 +11279,7 @@
             "start_date": "2001-01-06",
             "slug": "107",
             "csv": "data/United_States_of_America/House/term-107.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-107.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-107.csv"
           },
           {
             "end_date": "2001-01-03",
@@ -11261,7 +11288,7 @@
             "start_date": "1999-01-06",
             "slug": "106",
             "csv": "data/United_States_of_America/House/term-106.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-106.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-106.csv"
           },
           {
             "end_date": "1999-01-03",
@@ -11270,7 +11297,7 @@
             "start_date": "1997-01-06",
             "slug": "105",
             "csv": "data/United_States_of_America/House/term-105.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-105.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-105.csv"
           },
           {
             "end_date": "1997-01-03",
@@ -11279,7 +11306,7 @@
             "start_date": "1995-01-06",
             "slug": "104",
             "csv": "data/United_States_of_America/House/term-104.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-104.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-104.csv"
           },
           {
             "end_date": "1995-01-03",
@@ -11288,7 +11315,7 @@
             "start_date": "1993-01-06",
             "slug": "103",
             "csv": "data/United_States_of_America/House/term-103.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-103.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-103.csv"
           },
           {
             "end_date": "1993-01-03",
@@ -11297,7 +11324,7 @@
             "start_date": "1991-01-06",
             "slug": "102",
             "csv": "data/United_States_of_America/House/term-102.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-102.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-102.csv"
           },
           {
             "end_date": "1991-01-03",
@@ -11306,7 +11333,7 @@
             "start_date": "1989-01-06",
             "slug": "101",
             "csv": "data/United_States_of_America/House/term-101.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-101.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-101.csv"
           },
           {
             "end_date": "1989-01-03",
@@ -11315,7 +11342,7 @@
             "start_date": "1987-01-06",
             "slug": "100",
             "csv": "data/United_States_of_America/House/term-100.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-100.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-100.csv"
           },
           {
             "end_date": "1987-01-03",
@@ -11324,7 +11351,7 @@
             "start_date": "1985-01-06",
             "slug": "99",
             "csv": "data/United_States_of_America/House/term-99.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-99.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-99.csv"
           },
           {
             "end_date": "1983-01-03",
@@ -11333,7 +11360,7 @@
             "start_date": "1983-01-06",
             "slug": "98",
             "csv": "data/United_States_of_America/House/term-98.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-98.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-98.csv"
           },
           {
             "end_date": "1983-01-03",
@@ -11342,7 +11369,7 @@
             "start_date": "1981-01-06",
             "slug": "97",
             "csv": "data/United_States_of_America/House/term-97.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-97.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@6b4ce5bd3d467b34e7225c96b5f6572af5890349/data/United_States_of_America/House/term-97.csv"
           }
         ],
         "statement_count": 189144,
@@ -11353,11 +11380,11 @@
         "slug": "Senate",
         "sources_directory": "data/United_States_of_America/Senate/sources",
         "popolo": "data/United_States_of_America/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/ep-popolo-v1.0.json",
         "names": "data/United_States_of_America/Senate/names.csv",
-        "lastmod": "1539152215",
+        "lastmod": "1539341213",
         "person_count": 321,
-        "sha": "dde537b7c1e161e65a51c40f4658ebd37cd3bea5",
+        "sha": "4de569cc1f98fab4e2f6d3710a39471c43631ec5",
         "legislative_periods": [
           {
             "id": "term/115",
@@ -11365,7 +11392,7 @@
             "start_date": "2017-01-03",
             "slug": "115",
             "csv": "data/United_States_of_America/Senate/term-115.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-115.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-115.csv"
           },
           {
             "end_date": "2017-01-03",
@@ -11374,7 +11401,7 @@
             "start_date": "2015-01-06",
             "slug": "114",
             "csv": "data/United_States_of_America/Senate/term-114.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-114.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-114.csv"
           },
           {
             "end_date": "2015-01-03",
@@ -11383,7 +11410,7 @@
             "start_date": "2013-01-06",
             "slug": "113",
             "csv": "data/United_States_of_America/Senate/term-113.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-113.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-113.csv"
           },
           {
             "end_date": "2013-01-03",
@@ -11392,7 +11419,7 @@
             "start_date": "2011-01-06",
             "slug": "112",
             "csv": "data/United_States_of_America/Senate/term-112.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-112.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-112.csv"
           },
           {
             "end_date": "2011-01-03",
@@ -11401,7 +11428,7 @@
             "start_date": "2009-01-06",
             "slug": "111",
             "csv": "data/United_States_of_America/Senate/term-111.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-111.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-111.csv"
           },
           {
             "end_date": "2009-01-03",
@@ -11410,7 +11437,7 @@
             "start_date": "2007-01-06",
             "slug": "110",
             "csv": "data/United_States_of_America/Senate/term-110.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-110.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-110.csv"
           },
           {
             "end_date": "2007-01-03",
@@ -11419,7 +11446,7 @@
             "start_date": "2005-01-06",
             "slug": "109",
             "csv": "data/United_States_of_America/Senate/term-109.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-109.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-109.csv"
           },
           {
             "end_date": "2005-01-03",
@@ -11428,7 +11455,7 @@
             "start_date": "2003-01-06",
             "slug": "108",
             "csv": "data/United_States_of_America/Senate/term-108.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-108.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-108.csv"
           },
           {
             "end_date": "2003-01-03",
@@ -11437,7 +11464,7 @@
             "start_date": "2001-01-06",
             "slug": "107",
             "csv": "data/United_States_of_America/Senate/term-107.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-107.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-107.csv"
           },
           {
             "end_date": "2001-01-03",
@@ -11446,7 +11473,7 @@
             "start_date": "1999-01-06",
             "slug": "106",
             "csv": "data/United_States_of_America/Senate/term-106.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-106.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-106.csv"
           },
           {
             "end_date": "1999-01-03",
@@ -11455,7 +11482,7 @@
             "start_date": "1997-01-06",
             "slug": "105",
             "csv": "data/United_States_of_America/Senate/term-105.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-105.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-105.csv"
           },
           {
             "end_date": "1997-01-03",
@@ -11464,7 +11491,7 @@
             "start_date": "1995-01-06",
             "slug": "104",
             "csv": "data/United_States_of_America/Senate/term-104.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-104.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-104.csv"
           },
           {
             "end_date": "1995-01-03",
@@ -11473,7 +11500,7 @@
             "start_date": "1993-01-06",
             "slug": "103",
             "csv": "data/United_States_of_America/Senate/term-103.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-103.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-103.csv"
           },
           {
             "end_date": "1993-01-03",
@@ -11482,7 +11509,7 @@
             "start_date": "1991-01-06",
             "slug": "102",
             "csv": "data/United_States_of_America/Senate/term-102.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-102.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-102.csv"
           },
           {
             "end_date": "1991-01-03",
@@ -11491,7 +11518,7 @@
             "start_date": "1989-01-06",
             "slug": "101",
             "csv": "data/United_States_of_America/Senate/term-101.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-101.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-101.csv"
           },
           {
             "end_date": "1989-01-03",
@@ -11500,7 +11527,7 @@
             "start_date": "1987-01-06",
             "slug": "100",
             "csv": "data/United_States_of_America/Senate/term-100.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-100.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-100.csv"
           },
           {
             "end_date": "1987-01-03",
@@ -11509,7 +11536,7 @@
             "start_date": "1985-01-06",
             "slug": "99",
             "csv": "data/United_States_of_America/Senate/term-99.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-99.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-99.csv"
           },
           {
             "end_date": "1983-01-03",
@@ -11518,7 +11545,7 @@
             "start_date": "1983-01-06",
             "slug": "98",
             "csv": "data/United_States_of_America/Senate/term-98.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-98.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-98.csv"
           },
           {
             "end_date": "1983-01-03",
@@ -11527,7 +11554,7 @@
             "start_date": "1981-01-06",
             "slug": "97",
             "csv": "data/United_States_of_America/Senate/term-97.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/dde537b7c1e161e65a51c40f4658ebd37cd3bea5/data/United_States_of_America/Senate/term-97.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@4de569cc1f98fab4e2f6d3710a39471c43631ec5/data/United_States_of_America/Senate/term-97.csv"
           }
         ],
         "statement_count": 76953,
@@ -11546,7 +11573,7 @@
         "slug": "Deputies",
         "sources_directory": "data/Uruguay/Deputies/sources",
         "popolo": "data/Uruguay/Deputies/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1d428a3ec7793b08ee425614ce271700c1e7d9d6/data/Uruguay/Deputies/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1d428a3ec7793b08ee425614ce271700c1e7d9d6/data/Uruguay/Deputies/ep-popolo-v1.0.json",
         "names": "data/Uruguay/Deputies/names.csv",
         "lastmod": "1536467003",
         "person_count": 125,
@@ -11558,7 +11585,7 @@
             "start_date": "2015-02-15",
             "slug": "48",
             "csv": "data/Uruguay/Deputies/term-48.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/1d428a3ec7793b08ee425614ce271700c1e7d9d6/data/Uruguay/Deputies/term-48.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@1d428a3ec7793b08ee425614ce271700c1e7d9d6/data/Uruguay/Deputies/term-48.csv"
           }
         ],
         "statement_count": 3744,
@@ -11577,7 +11604,7 @@
         "slug": "Legislative-Chamber",
         "sources_directory": "data/Uzbekistan/Legislative_Chamber/sources",
         "popolo": "data/Uzbekistan/Legislative_Chamber/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Uzbekistan/Legislative_Chamber/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Uzbekistan/Legislative_Chamber/ep-popolo-v1.0.json",
         "names": "data/Uzbekistan/Legislative_Chamber/names.csv",
         "lastmod": "1528387224",
         "person_count": 147,
@@ -11589,7 +11616,7 @@
             "start_date": "2015-01-12",
             "slug": "5",
             "csv": "data/Uzbekistan/Legislative_Chamber/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Uzbekistan/Legislative_Chamber/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Uzbekistan/Legislative_Chamber/term-5.csv"
           }
         ],
         "statement_count": 2530,
@@ -11608,7 +11635,7 @@
         "slug": "Parliament",
         "sources_directory": "data/Vanuatu/Parliament/sources",
         "popolo": "data/Vanuatu/Parliament/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/211c306be23f1c4cdecde4142f9b53bd6adf89e0/data/Vanuatu/Parliament/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@211c306be23f1c4cdecde4142f9b53bd6adf89e0/data/Vanuatu/Parliament/ep-popolo-v1.0.json",
         "names": "data/Vanuatu/Parliament/names.csv",
         "lastmod": "1538898946",
         "person_count": 96,
@@ -11620,7 +11647,7 @@
             "start_date": "2016-02-11",
             "slug": "11",
             "csv": "data/Vanuatu/Parliament/term-11.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71d16bcca418914c64f448cfbf027e65e86015f9/data/Vanuatu/Parliament/term-11.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@71d16bcca418914c64f448cfbf027e65e86015f9/data/Vanuatu/Parliament/term-11.csv"
           },
           {
             "end_date": "2015-11-24",
@@ -11629,7 +11656,7 @@
             "start_date": "2012-11-19",
             "slug": "10",
             "csv": "data/Vanuatu/Parliament/term-10.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/71d16bcca418914c64f448cfbf027e65e86015f9/data/Vanuatu/Parliament/term-10.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@71d16bcca418914c64f448cfbf027e65e86015f9/data/Vanuatu/Parliament/term-10.csv"
           }
         ],
         "statement_count": 2999,
@@ -11648,7 +11675,7 @@
         "slug": "Pontifical-Commission",
         "sources_directory": "data/Vatican_City/Pontifical_Commission/sources",
         "popolo": "data/Vatican_City/Pontifical_Commission/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/561ff6a4757ed51c996154319e801ac65d2bfde8/data/Vatican_City/Pontifical_Commission/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@561ff6a4757ed51c996154319e801ac65d2bfde8/data/Vatican_City/Pontifical_Commission/ep-popolo-v1.0.json",
         "names": "data/Vatican_City/Pontifical_Commission/names.csv",
         "lastmod": "1527529304",
         "person_count": 8,
@@ -11660,7 +11687,7 @@
             "start_date": "2016-06-11",
             "slug": "2016",
             "csv": "data/Vatican_City/Pontifical_Commission/term-2016.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Vatican_City/Pontifical_Commission/term-2016.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Vatican_City/Pontifical_Commission/term-2016.csv"
           },
           {
             "end_date": "2016-06-10",
@@ -11669,7 +11696,7 @@
             "start_date": "2011-10-01",
             "slug": "2011",
             "csv": "data/Vatican_City/Pontifical_Commission/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Vatican_City/Pontifical_Commission/term-2011.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Vatican_City/Pontifical_Commission/term-2011.csv"
           }
         ],
         "statement_count": 1342,
@@ -11688,7 +11715,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Venezuela/Assembly/sources",
         "popolo": "data/Venezuela/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a50a4bc37d6238363cf8ef7577aa0f62ebcf344e/data/Venezuela/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a50a4bc37d6238363cf8ef7577aa0f62ebcf344e/data/Venezuela/Assembly/ep-popolo-v1.0.json",
         "names": "data/Venezuela/Assembly/names.csv",
         "lastmod": "1539154961",
         "person_count": 279,
@@ -11700,7 +11727,7 @@
             "start_date": "2016-01-05",
             "slug": "4",
             "csv": "data/Venezuela/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a50a4bc37d6238363cf8ef7577aa0f62ebcf344e/data/Venezuela/Assembly/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a50a4bc37d6238363cf8ef7577aa0f62ebcf344e/data/Venezuela/Assembly/term-4.csv"
           },
           {
             "end_date": "2016-01-05",
@@ -11709,7 +11736,7 @@
             "start_date": "2011-01-05",
             "slug": "3",
             "csv": "data/Venezuela/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/a50a4bc37d6238363cf8ef7577aa0f62ebcf344e/data/Venezuela/Assembly/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@a50a4bc37d6238363cf8ef7577aa0f62ebcf344e/data/Venezuela/Assembly/term-3.csv"
           }
         ],
         "statement_count": 7281,
@@ -11728,11 +11755,11 @@
         "slug": "National-Assembly",
         "sources_directory": "data/Vietnam/National_Assembly/sources",
         "popolo": "data/Vietnam/National_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c6c7db6cd2efc137d2750c9391df02fb9e35b724/data/Vietnam/National_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@efbe2b1bd601059110bb2b70308db1d6341369d1/data/Vietnam/National_Assembly/ep-popolo-v1.0.json",
         "names": "data/Vietnam/National_Assembly/names.csv",
-        "lastmod": "1538976305",
+        "lastmod": "1539406931",
         "person_count": 500,
-        "sha": "c6c7db6cd2efc137d2750c9391df02fb9e35b724",
+        "sha": "efbe2b1bd601059110bb2b70308db1d6341369d1",
         "legislative_periods": [
           {
             "end_date": "2016-05-22",
@@ -11741,10 +11768,10 @@
             "start_date": "2011-07-25",
             "slug": "13",
             "csv": "data/Vietnam/National_Assembly/term-13.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/c6c7db6cd2efc137d2750c9391df02fb9e35b724/data/Vietnam/National_Assembly/term-13.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@c6c7db6cd2efc137d2750c9391df02fb9e35b724/data/Vietnam/National_Assembly/term-13.csv"
           }
         ],
-        "statement_count": 10540,
+        "statement_count": 10538,
         "type": "unicameral legislature"
       }
     ]
@@ -11760,11 +11787,11 @@
         "slug": "Assembly",
         "sources_directory": "data/Wales/Assembly/sources",
         "popolo": "data/Wales/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/24f3d358352cf6545c3f8e3576d7d5e30434d789/data/Wales/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@e33492d09c364874516d16919a2594059c1f6b94/data/Wales/Assembly/ep-popolo-v1.0.json",
         "names": "data/Wales/Assembly/names.csv",
-        "lastmod": "1538903232",
+        "lastmod": "1539608388",
         "person_count": 141,
-        "sha": "24f3d358352cf6545c3f8e3576d7d5e30434d789",
+        "sha": "e33492d09c364874516d16919a2594059c1f6b94",
         "legislative_periods": [
           {
             "id": "term/5",
@@ -11772,7 +11799,7 @@
             "start_date": "2016-05-06",
             "slug": "5",
             "csv": "data/Wales/Assembly/term-5.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/24f3d358352cf6545c3f8e3576d7d5e30434d789/data/Wales/Assembly/term-5.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@24f3d358352cf6545c3f8e3576d7d5e30434d789/data/Wales/Assembly/term-5.csv"
           },
           {
             "end_date": "2016-04-06",
@@ -11781,7 +11808,7 @@
             "start_date": "2011-09-15",
             "slug": "4",
             "csv": "data/Wales/Assembly/term-4.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/24f3d358352cf6545c3f8e3576d7d5e30434d789/data/Wales/Assembly/term-4.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@24f3d358352cf6545c3f8e3576d7d5e30434d789/data/Wales/Assembly/term-4.csv"
           },
           {
             "end_date": "2011-03-31",
@@ -11790,7 +11817,7 @@
             "start_date": "2007-05-04",
             "slug": "3",
             "csv": "data/Wales/Assembly/term-3.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/24f3d358352cf6545c3f8e3576d7d5e30434d789/data/Wales/Assembly/term-3.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@24f3d358352cf6545c3f8e3576d7d5e30434d789/data/Wales/Assembly/term-3.csv"
           },
           {
             "end_date": "2007-05-02",
@@ -11799,7 +11826,7 @@
             "start_date": "2003-05-02",
             "slug": "2",
             "csv": "data/Wales/Assembly/term-2.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/24f3d358352cf6545c3f8e3576d7d5e30434d789/data/Wales/Assembly/term-2.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@24f3d358352cf6545c3f8e3576d7d5e30434d789/data/Wales/Assembly/term-2.csv"
           },
           {
             "end_date": "2003-04-30",
@@ -11808,10 +11835,10 @@
             "start_date": "1999-05-07",
             "slug": "1",
             "csv": "data/Wales/Assembly/term-1.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/24f3d358352cf6545c3f8e3576d7d5e30434d789/data/Wales/Assembly/term-1.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@24f3d358352cf6545c3f8e3576d7d5e30434d789/data/Wales/Assembly/term-1.csv"
           }
         ],
-        "statement_count": 8444,
+        "statement_count": 8450,
         "type": "unicameral legislature"
       }
     ]
@@ -11827,7 +11854,7 @@
         "slug": "Territorial-Assembly",
         "sources_directory": "data/Wallis_and_Futuna/Territorial_Assembly/sources",
         "popolo": "data/Wallis_and_Futuna/Territorial_Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Wallis_and_Futuna/Territorial_Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Wallis_and_Futuna/Territorial_Assembly/ep-popolo-v1.0.json",
         "names": "data/Wallis_and_Futuna/Territorial_Assembly/names.csv",
         "lastmod": "1528387224",
         "person_count": 29,
@@ -11839,7 +11866,7 @@
             "start_date": "2017-03-26",
             "slug": "2017",
             "csv": "data/Wallis_and_Futuna/Territorial_Assembly/term-2017.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Wallis_and_Futuna/Territorial_Assembly/term-2017.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Wallis_and_Futuna/Territorial_Assembly/term-2017.csv"
           },
           {
             "end_date": "2017-03-25",
@@ -11848,7 +11875,7 @@
             "start_date": "2012-03-25",
             "slug": "2012",
             "csv": "data/Wallis_and_Futuna/Territorial_Assembly/term-2012.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Wallis_and_Futuna/Territorial_Assembly/term-2012.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Wallis_and_Futuna/Territorial_Assembly/term-2012.csv"
           }
         ],
         "statement_count": 603,
@@ -11867,7 +11894,7 @@
         "slug": "Majlis",
         "sources_directory": "data/Yemen/Majlis/sources",
         "popolo": "data/Yemen/Majlis/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Yemen/Majlis/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Yemen/Majlis/ep-popolo-v1.0.json",
         "names": "data/Yemen/Majlis/names.csv",
         "lastmod": "1528387224",
         "person_count": 302,
@@ -11879,7 +11906,7 @@
             "start_date": "2003-05-10",
             "slug": "2003",
             "csv": "data/Yemen/Majlis/term-2003.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Yemen/Majlis/term-2003.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@554a6cb306153130ac5558e4c015471d63e57cb7/data/Yemen/Majlis/term-2003.csv"
           }
         ],
         "statement_count": 5194,
@@ -11898,7 +11925,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Zambia/Assembly/sources",
         "popolo": "data/Zambia/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/41841a62685d6b8956de2c62d3c5336448f39b55/data/Zambia/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@41841a62685d6b8956de2c62d3c5336448f39b55/data/Zambia/Assembly/ep-popolo-v1.0.json",
         "names": "data/Zambia/Assembly/names.csv",
         "lastmod": "1538847372",
         "person_count": 260,
@@ -11910,7 +11937,7 @@
             "start_date": "2016-09-23",
             "slug": "2016",
             "csv": "data/Zambia/Assembly/term-2016.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/8b1cc7b3fe7617e89f1503937255d340cb282eed/data/Zambia/Assembly/term-2016.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@8b1cc7b3fe7617e89f1503937255d340cb282eed/data/Zambia/Assembly/term-2016.csv"
           },
           {
             "end_date": "2016-05-11",
@@ -11919,7 +11946,7 @@
             "start_date": "2011-10-06",
             "slug": "2011",
             "csv": "data/Zambia/Assembly/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/41841a62685d6b8956de2c62d3c5336448f39b55/data/Zambia/Assembly/term-2011.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@41841a62685d6b8956de2c62d3c5336448f39b55/data/Zambia/Assembly/term-2011.csv"
           }
         ],
         "statement_count": 6724,
@@ -11938,7 +11965,7 @@
         "slug": "Assembly",
         "sources_directory": "data/Zimbabwe/Assembly/sources",
         "popolo": "data/Zimbabwe/Assembly/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/81040f3e1cc373c1ff2da0b9282e3e6caab69153/data/Zimbabwe/Assembly/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@81040f3e1cc373c1ff2da0b9282e3e6caab69153/data/Zimbabwe/Assembly/ep-popolo-v1.0.json",
         "names": "data/Zimbabwe/Assembly/names.csv",
         "lastmod": "1538985395",
         "person_count": 229,
@@ -11950,7 +11977,7 @@
             "start_date": "2013-09-17",
             "slug": "8",
             "csv": "data/Zimbabwe/Assembly/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Zimbabwe/Assembly/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Zimbabwe/Assembly/term-8.csv"
           }
         ],
         "statement_count": 5858,
@@ -11961,7 +11988,7 @@
         "slug": "Senate",
         "sources_directory": "data/Zimbabwe/Senate/sources",
         "popolo": "data/Zimbabwe/Senate/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Zimbabwe/Senate/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Zimbabwe/Senate/ep-popolo-v1.0.json",
         "names": "data/Zimbabwe/Senate/names.csv",
         "lastmod": "1528387224",
         "person_count": 67,
@@ -11973,7 +12000,7 @@
             "start_date": "2013-09-17",
             "slug": "8",
             "csv": "data/Zimbabwe/Senate/term-8.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Zimbabwe/Senate/term-8.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@9a75c94fb3f01a45e5616242dec9743ba96f137f/data/Zimbabwe/Senate/term-8.csv"
           }
         ],
         "statement_count": 1338,
@@ -11992,11 +12019,11 @@
         "slug": "Lagting",
         "sources_directory": "data/Aland/Lagting/sources",
         "popolo": "data/Aland/Lagting/ep-popolo-v1.0.json",
-        "popolo_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/19351eb2ca9dd7ae3c19f22663ff23bcb73a7a64/data/Aland/Lagting/ep-popolo-v1.0.json",
+        "popolo_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@55e3ee76bf4ceabe9168f8b055cc18cac551c322/data/Aland/Lagting/ep-popolo-v1.0.json",
         "names": "data/Aland/Lagting/names.csv",
-        "lastmod": "1537800520",
+        "lastmod": "1539339458",
         "person_count": 60,
-        "sha": "19351eb2ca9dd7ae3c19f22663ff23bcb73a7a64",
+        "sha": "55e3ee76bf4ceabe9168f8b055cc18cac551c322",
         "legislative_periods": [
           {
             "id": "term/2015",
@@ -12004,7 +12031,7 @@
             "start_date": "2015-11-02",
             "slug": "2015",
             "csv": "data/Aland/Lagting/term-2015.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/554a6cb306153130ac5558e4c015471d63e57cb7/data/Aland/Lagting/term-2015.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@55e3ee76bf4ceabe9168f8b055cc18cac551c322/data/Aland/Lagting/term-2015.csv"
           },
           {
             "end_date": "2015",
@@ -12013,7 +12040,7 @@
             "start_date": "2011",
             "slug": "2011",
             "csv": "data/Aland/Lagting/term-2011.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/19351eb2ca9dd7ae3c19f22663ff23bcb73a7a64/data/Aland/Lagting/term-2011.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@19351eb2ca9dd7ae3c19f22663ff23bcb73a7a64/data/Aland/Lagting/term-2011.csv"
           },
           {
             "end_date": "2011",
@@ -12022,10 +12049,10 @@
             "start_date": "2007",
             "slug": "2007",
             "csv": "data/Aland/Lagting/term-2007.csv",
-            "csv_url": "https://cdn.rawgit.com/everypolitician/everypolitician-data/19351eb2ca9dd7ae3c19f22663ff23bcb73a7a64/data/Aland/Lagting/term-2007.csv"
+            "csv_url": "https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@19351eb2ca9dd7ae3c19f22663ff23bcb73a7a64/data/Aland/Lagting/term-2007.csv"
           }
         ],
-        "statement_count": 2639,
+        "statement_count": 2642,
         "type": "unicameral legislature"
       }
     ]

--- a/lib/country_data.rb
+++ b/lib/country_data.rb
@@ -89,7 +89,7 @@ module Everypolitician
       end
 
       def remote_source
-        'https://cdn.rawgit.com/everypolitician/everypolitician-data/%s/%s'
+        'https://cdn.jsdelivr.net/gh/everypolitician/everypolitician-data@%s/%s'
       end
 
       def terms


### PR DESCRIPTION
RawGit [is shutting down](https://twitter.com/rawgit/status/1049360165030567937), so we need to switch to another CDN provider. Luckily jsDelivr also supports GitHub URLs and is free, so it's a drop in replacement.

## Notes to reviewer

Looks like there are some unexpected changes to `countries.json` with SHAs and person counts changing, so I think that might need looking at before this is merged. Feel free to pick up this pull request and work on it/fix it/merge it etc 🙂 