### PR TITLE
report if Position Map still includes non-cabinet positions

### DIFF
--- a/lib/position/map.rb
+++ b/lib/position/map.rb
@@ -77,6 +77,12 @@ class PositionMap
       cabinet_positions.map { |r| r[:id] }
     end
 
+    # These shouldn't exist, but old files still include other types of
+    # positions, and we use this to warn about those
+    def non_cabinet_position_ids
+      non_cabinet_positions.map { |r| r[:id] }
+    end
+
     private
 
     attr_reader :pathname
@@ -87,6 +93,10 @@ class PositionMap
 
     def cabinet_positions
       map.select { |r| r[:type] == 'cabinet' }
+    end
+
+    def non_cabinet_positions
+      map.reject { |r| r[:type] == 'cabinet' }
     end
   end
 end

--- a/lib/position/map.rb
+++ b/lib/position/map.rb
@@ -64,3 +64,29 @@ class PositionMap
     end.to_h
   end
 end
+
+class PositionMap
+  class CSV
+    require 'csv'
+
+    def initialize(pathname)
+      @pathname = pathname
+    end
+
+    def cabinet_position_ids
+      cabinet_positions.map { |r| r[:id] }
+    end
+
+    private
+
+    attr_reader :pathname
+
+    def map
+      @map ||= ::CSV.table(pathname)
+    end
+
+    def cabinet_positions
+      map.select { |r| r[:type] == 'cabinet' }
+    end
+  end
+end

--- a/lib/source/cabinet.rb
+++ b/lib/source/cabinet.rb
@@ -5,8 +5,7 @@ require_relative 'plain_csv'
 module Source
   class Cabinet < PlainCSV
     def partitioned(position_map:)
-      map = ::CSV.table(position_map)
-      wanted = map.select { |r| r[:type] == 'cabinet' }.map { |r| r[:id] }
+      wanted = position_map.cabinet_position_ids
       as_table.partition { |r| wanted.include? r[:position] }
     end
   end

--- a/rake_build/generate_final_csvs.rb
+++ b/rake_build/generate_final_csvs.rb
@@ -69,7 +69,8 @@ namespace :term_csvs do
     src = @INSTRUCTIONS.sources_of_type('wikidata-cabinet').first or next
     source_warn "Creating #{POSITION_CSV}"
 
-    wanted, unwanted = src.partitioned(position_map: POSITION_FILTER_CSV)
+    pmap = PositionMap::CSV.new(POSITION_FILTER_CSV)
+    wanted, unwanted = src.partitioned(position_map: pmap)
     members = @popolo.persons.select(&:wikidata).group_by(&:wikidata)
 
     csv_headers = %w[id name position start_date end_date type].to_csv

--- a/rake_build/generate_final_csvs.rb
+++ b/rake_build/generate_final_csvs.rb
@@ -83,9 +83,13 @@ namespace :term_csvs do
     POSITION_CSV.dirname.mkpath
     POSITION_CSV.write(csv_headers + csv_data.join)
 
-    # Warn about uncategorised positions
-    skipped = unwanted.group_by { |r| r[:position] }.sort_by { |_r, rs| rs.count }.reverse
-    skipped.take(3).each do |posn, posns|
+    # Warn if the filter still contains non-cabinet positions
+    ncps = pmap.non_cabinet_position_ids.to_set
+    warn "  † position filter contains non-cabinet positions (#{ncps.count}) — run rake generate:cabinet" if ncps.any?
+
+    # Warn if people hold positions we're not expecting
+    skipped = unwanted.reject { |r| ncps.include? r[:position] }.group_by { |r| r[:position] }.sort_by { |_r, rs| rs.count }
+    skipped.reverse.take(3).each do |posn, posns|
       warn "  ⁕ skipped #{posns.count} x #{posn} (#{posns.first[:label]}) — e.g. #{posns.first[:id]}"
     end
   end


### PR DESCRIPTION
This usually means that we need to regenerate the map.

We should also skip those when reporting on unexpected positions actively
held by people (which might either need to be added to the map, or for the
scraper to be adjusted to not include them)