### PR TITLE
Explicitly require ruby 2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@
 
 source 'https://rubygems.org'
 
-abort 'Ruby should be >= 2.3' unless RUBY_VERSION.to_f >= 2.3
+ruby '~> 2.3.0'
+
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 gem 'close_old_pull_requests', github: 'everypolitician/close_old_pull_requests'


### PR DESCRIPTION
Since d4c001abeee we've explicitly required a ruby 2.3 or greater. But per https://github.com/everypolitician/everypolitician/issues/614 we can't yet handle ruby 2.4, so we should make that explicit too.