### PR TITLE
Add 'sourcetype' to each membership source

### DIFF
--- a/data/Abkhazia/Assembly/sources/instructions.json
+++ b/data/Abkhazia/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.parlamentra.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Afghanistan/Wolesi_Jirga/sources/instructions.json
+++ b/data/Afghanistan/Wolesi_Jirga/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://wolesi.website",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Aland/Lagting/sources/instructions.json
+++ b/data/Aland/Lagting/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-old.csv",
       "source": "http://www.lagtinget.ax",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official.csv",
@@ -18,7 +19,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official.csv"
-      }
+      },
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Albania/Assembly/sources/instructions.json
+++ b/data/Albania/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data WHERE term = '8' ORDER BY name"
       },
       "source": "https://en.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikipedia-7.csv",
@@ -23,7 +24,8 @@
         "existing_field": "name",
         "reconciliation_file": "reconciliation/wikipedia-7.csv"
       },
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/official-8.csv",

--- a/data/Alderney/States/sources/instructions.json
+++ b/data/Alderney/States/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-2014.csv",
       "source": "http://www.alderney.gov.gg",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official_2017.csv",
@@ -18,7 +19,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official_2017.csv"
-      }
+      },
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Algeria/Majlis/sources/instructions.json
+++ b/data/Algeria/Majlis/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.apn.dz",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/American_Samoa/House/sources/instructions.json
+++ b/data/American_Samoa/House/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org/wiki/American_Samoan_general_election,_2014",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Andorra/General_Council/sources/instructions.json
+++ b/data/Andorra/General_Council/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.consellgeneral.ad",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Angola/National_Assembly/sources/instructions.json
+++ b/data/Angola/National_Assembly/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-3.csv",
       "source": "http://www.parlamento.ao",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official.csv",
@@ -13,7 +14,8 @@
         "query": "SELECT id, name, party, constituency, homepage, photo, 4 AS term FROM data ORDER BY id"
       },
       "source": "http://www.parlamento.ao",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Anguilla/Assembly/sources/instructions.json
+++ b/data/Anguilla/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name, term DESC"
       },
       "source": "http://www.caribbeanelections.com/ai/election2015",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "election"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Antigua_and_Barbuda/Representatives/sources/instructions.json
+++ b/data/Antigua_and_Barbuda/Representatives/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name, term"
       },
       "source": "http://www.caribbeanelections.com",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "election"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Argentina/Diputados/sources/instructions.json
+++ b/data/Argentina/Diputados/sources/instructions.json
@@ -3,17 +3,20 @@
     {
       "file": "archive/official-2015.csv",
       "source": "http://www.hcdn.gob.ar",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-2016.csv",
       "source": "http://www.hcdn.gob.ar",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/vanished-2017.csv",
       "source": "http://www.hcdn.gob.ar",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official.csv",
@@ -23,7 +26,8 @@
         "query": "SELECT id,name,sort_name,district,mandate_start AS start_date,mandate_end AS end_date,party,source,image,phone,email,135 AS term FROM data ORDER BY id"
       },
       "source": "http://www.hcdn.gob.ar",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Argentina/Senado/sources/instructions.json
+++ b/data/Argentina/Senado/sources/instructions.json
@@ -8,12 +8,14 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.senado.gov.ar/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/vanished.csv",
       "source": "http://www.senado.gov.ar/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Armenia/Assembly/sources/instructions.json
+++ b/data/Armenia/Assembly/sources/instructions.json
@@ -8,12 +8,14 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://parliament.am/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-5.csv",
       "source": "http://parliament.am/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Aruba/Estates/sources/instructions.json
+++ b/data/Aruba/Estates/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, other_name AS name, name AS other_name FROM data ORDER BY id"
       },
       "source": "http://www.parlamento.aw",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Australia/Representatives/sources/instructions.json
+++ b/data/Australia/Representatives/sources/instructions.json
@@ -9,7 +9,8 @@
       },
       "corrections": "corrections/openaustralia.csv",
       "source": "http://data.openaustralia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/openaustralia-contact-details.csv",

--- a/data/Australia/Senate/sources/instructions.json
+++ b/data/Australia/Senate/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, id AS identifier__openaustralia, REPLACE(LOWER(party),' ','_') AS party_id, identifier__aph AS id FROM data ORDER BY id"
       },
       "source": "http://data.openaustralia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/contacts.csv",

--- a/data/Austria/Nationalrat/sources/instructions.json
+++ b/data/Austria/Nationalrat/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "amtsgeheimnis/members.csv",
       "source": "http://informationsfreiheit.at/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Azerbaijan/National_Assembly/sources/instructions.json
+++ b/data/Azerbaijan/National_Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name, term DESC"
       },
       "source": "https://az.wikipedia.org/wiki/Azərbaycan_Respublikası_Milli_Məclisinin_deputatlarının_siyahısı_(IV_çağırış)",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Bahamas/House_of_Assembly/sources/instructions.json
+++ b/data/Bahamas/House_of_Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org/wiki/Bahamian_general_election,_2012",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/official.csv",

--- a/data/Bahrain/Council_of_Representatives/sources/instructions.json
+++ b/data/Bahrain/Council_of_Representatives/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.nuwab.gov.bh/CouncilMembers/Pages/default.aspx",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Bangladesh/House/sources/instructions.json
+++ b/data/Bangladesh/House/sources/instructions.json
@@ -8,17 +8,20 @@
         "query": "SELECT * FROM data ORDER BY term DESC, id"
       },
       "source": "http://www.parliament.gov.bd",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-ceased.csv",
       "source": "http://www.parliament.gov.bd",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-10.csv",
       "source": "http://www.parliament.gov.bd",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Barbados/House_of_Assembly/sources/instructions.json
+++ b/data/Barbados/House_of_Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.barbadosparliament.com",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Belarus/Chamber/sources/instructions.json
+++ b/data/Belarus/Chamber/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-term-5.csv",
       "source": "http://house.gov.by/ru",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official.csv",
@@ -18,7 +19,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official.csv"
-      }
+      },
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Belgium/Representatives/sources/instructions.json
+++ b/data/Belgium/Representatives/sources/instructions.json
@@ -8,13 +8,15 @@
         "query": "SELECT * FROM data WHERE term = 54 ORDER BY id"
       },
       "source": "http://wikidata.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikidata"
     },
     {
       "file": "archive/wikipedia.csv",
       "source": "https://nl.wikipedia.org/",
       "type": "membership",
-      "note": "Not yet in P39s. Remove them from here as they start appearing in the P39s source"
+      "note": "Not yet in P39s. Remove them from here as they start appearing in the P39s source",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/official.csv",

--- a/data/Belize/Representatives/sources/instructions.json
+++ b/data/Belize/Representatives/sources/instructions.json
@@ -7,7 +7,9 @@
         "scraper": "everypolitician-scrapers/belize-representatives-p39s",
         "query": "SELECT * FROM data WHERE term >= 9 ORDER BY id"
       },
-      "type": "membership"
+      "source": "http://wikidata.org/",
+      "type": "membership",
+      "sourcetype": "wikidata"
     },
     {
       "file": "archive/official-2012-bio.csv",

--- a/data/Benin/National_Assembly/sources/instructions.json
+++ b/data/Benin/National_Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, 7 AS term FROM data"
       },
       "source": "http://www.assemblee-nationale.bj",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Bermuda/Assembly/sources/instructions.json
+++ b/data/Bermuda/Assembly/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-2012.csv",
       "source": "http://www.parliament.bm",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official.csv",
@@ -18,7 +19,8 @@
         "reconciliation_file": "reconciliation/official.csv"
       },
       "source": "http://www.parliament.bm",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/elections-2017.csv",

--- a/data/Bhutan/Assembly/sources/instructions.json
+++ b/data/Bhutan/Assembly/sources/instructions.json
@@ -8,12 +8,14 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.nab.gov.bt",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-ceased.csv",
       "source": "http://www.nab.gov.bt",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Bolivia/Deputies/sources/instructions.json
+++ b/data/Bolivia/Deputies/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data WHERE type = 'Titular' ORDER BY id"
       },
       "source": "http://www.diputados.bo/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Bosnia_and_Herzegovina/House_of_Representatives/sources/instructions.json
+++ b/data/Bosnia_and_Herzegovina/House_of_Representatives/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "https://www.parlament.ba",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Botswana/Assembly/sources/instructions.json
+++ b/data/Botswana/Assembly/sources/instructions.json
@@ -8,12 +8,14 @@
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id, 11 AS term FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "archive/wikipedia-ceased.csv",
       "source": "https://en.wikipedia.org",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/official.csv",

--- a/data/Brazil/Deputies/sources/instructions.json
+++ b/data/Brazil/Deputies/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, NULL as birth_date, NULL as death_date FROM data d JOIN membership m ON d.id = m.id WHERE term IN (54, 55) ORDER BY id, term DESC"
       },
       "source": "http://www.camara.gov.br",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-55.csv",

--- a/data/British_Virgin_Islands/Assembly/sources/instructions.json
+++ b/data/British_Virgin_Islands/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data WHERE term >= 2007 ORDER BY id"
       },
       "source": "https://en.wikipedia.org",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/British_Virgin_Islands/Council/sources/instructions.json
+++ b/data/British_Virgin_Islands/Council/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data WHERE term < 2007 ORDER BY term DESC, name"
       },
       "source": "https://en.wikipedia.org",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Brunei/Legislative_Council/sources/instructions.json
+++ b/data/Brunei/Legislative_Council/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://majlis-mesyuarat.gov.bn",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Bulgaria/National_Assembly/sources/instructions.json
+++ b/data/Bulgaria/National_Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, id AS identifier__parliament_bg FROM data ORDER BY id"
       },
       "source": "http://www.parliament.bg",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Burkina_Faso/Assembly/sources/instructions.json
+++ b/data/Burkina_Faso/Assembly/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-2012.csv",
       "source": "http://www.assembleenationale.bf",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-2015.csv",
@@ -18,7 +19,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official-2015.csv"
-      }
+      },
+      "sourcetype": "official"
     },
     {
       "file": "morph/historic-3.csv",
@@ -32,7 +34,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/historic-3.csv"
-      }
+      },
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/historic-2.csv",
@@ -46,7 +49,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/historic-2.csv"
-      }
+      },
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/historic-1.csv",
@@ -60,7 +64,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/historic-1.csv"
-      }
+      },
+      "sourcetype": "pmo"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Burundi/Assembly/sources/instructions.json
+++ b/data/Burundi/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.assemblee.bi",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-2015.csv",
@@ -18,7 +19,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.assemblee.bi",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Cabo_Verde/Assembly/sources/instructions.json
+++ b/data/Cabo_Verde/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data WHERE term = 8 ORDER BY id"
       },
       "source": "http://www.parlamento.cv",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/offical-9.csv",
@@ -23,12 +24,14 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official-9.csv"
-      }
+      },
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-8-vanished.csv",
       "source": "http://www.parlamento.cv",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Cambodia/National_Assembly/sources/instructions.json
+++ b/data/Cambodia/National_Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Cameroon/Assembly/sources/instructions.json
+++ b/data/Cameroon/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.assnat.cm",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Cameroon/Senate/sources/instructions.json
+++ b/data/Cameroon/Senate/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, 9 AS term FROM data ORDER BY name"
       },
       "source": "http://www.afroleadership.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Canada/Commons/sources/instructions.json
+++ b/data/Canada/Commons/sources/instructions.json
@@ -9,7 +9,8 @@
         "note": "fetch extra columns once this is Term 41 only"
       },
       "source": "https://en.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/parlinfo.csv",

--- a/data/Canada/Senate/sources/instructions.json
+++ b/data/Canada/Senate/sources/instructions.json
@@ -8,12 +8,14 @@
         "query": "SELECT *, 42 AS term, REPLACE(LOWER(party),' ','_') AS party_id FROM data ORDER BY id"
       },
       "source": "https://sencanada.ca",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-vanished.csv",
       "source": "https://sencanada.ca",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Cayman_Islands/Legislative_Assembly/sources/instructions.json
+++ b/data/Cayman_Islands/Legislative_Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.legislativeassembly.ky",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Chad/Assembly/sources/instructions.json
+++ b/data/Chad/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.assemblee-tchad.org",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Chile/Deputies/sources/instructions.json
+++ b/data/Chile/Deputies/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, CASE district WHEN '0' THEN '' ELSE district END AS area FROM data ORDER BY id"
       },
       "source": "http://opendata.congreso.cl",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/China/Congress/sources/instructions.json
+++ b/data/China/Congress/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "https://zh.wikipedia.org/wiki/第十二届全国人民代表大会代表名单",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Colombia/Representatives/sources/instructions.json
+++ b/data/Colombia/Representatives/sources/instructions.json
@@ -9,7 +9,8 @@
       },
       "corrections": "corrections/official.csv",
       "source": "http://www.camara.gov.co/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Colombia/Senate/sources/instructions.json
+++ b/data/Colombia/Senate/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.secretariasenado.gov.co/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/twitter.csv",

--- a/data/Comoros/Assembly/sources/instructions.json
+++ b/data/Comoros/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, 2015 as TERM FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org/wiki/Comorian_legislative_election,_2015",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Congo-Brazzaville/Assembly/sources/instructions.json
+++ b/data/Congo-Brazzaville/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.assemblee-nationale.cg",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Congo-Kinshasa/Assembly/sources/instructions.json
+++ b/data/Congo-Kinshasa/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.telema.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Cook_Islands/Parliament/sources/instructions.json
+++ b/data/Cook_Islands/Parliament/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Costa_Rica/Assembly/sources/instructions.json
+++ b/data/Costa_Rica/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.asamblea.go.cr/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/emails.csv",

--- a/data/Croatia/Sabor/sources/instructions.json
+++ b/data/Croatia/Sabor/sources/instructions.json
@@ -8,7 +8,8 @@
         "scraper": "tmtmtmtm/croatia-parliament",
         "query": "SELECT id, name, image, party, birth_date, constituency, term, start_date, end_date, source FROM data WHERE term = 7 ORDER BY id"
       },
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/sabor-8.csv",
@@ -23,7 +24,8 @@
         "existing_field": "name",
         "reconciliation_file": "reconciliation/sabor-8.csv"
       },
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/sabor-9.csv",
@@ -38,7 +40,8 @@
         "existing_field": "name",
         "reconciliation_file": "reconciliation/sabor-9.csv"
       },
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Curacao/Estates/sources/instructions.json
+++ b/data/Curacao/Estates/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data"
       },
       "source": "http://www.parlamento.cw",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Cyprus/House_of_Representatives/sources/instructions.json
+++ b/data/Cyprus/House_of_Representatives/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, NULL as wikipedia FROM data WHERE term IN ('10', '11') ORDER BY id"
       },
       "source": "https://github.com/openpatata/openpatata-data/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Czech_Republic/Deputies/sources/instructions.json
+++ b/data/Czech_Republic/Deputies/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id, term DESC"
       },
       "source": "http://api.parldata.eu/cz",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Denmark/Folketing/sources/instructions.json
+++ b/data/Denmark/Folketing/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-vanished.csv",
       "source": "http://www.thedanishparliament.dk",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official.csv",
@@ -13,7 +14,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.thedanishparliament.dk",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikipedia-historic.csv",
@@ -28,7 +30,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/wikipedia-historic.csv"
-      }
+      },
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Djibouti/Assembly/sources/instructions.json
+++ b/data/Djibouti/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.lughaya.com",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "press"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Dominica/House_of_Assembly/sources/instructions.json
+++ b/data/Dominica/House_of_Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data WHERE winner = 'yes' ORDER BY id"
       },
       "source": "http://electoraloffice.gov.dm/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "election"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Dominican_Republic/Diputados/sources/instructions.json
+++ b/data/Dominican_Republic/Diputados/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/term-2010.csv",
       "source": "http://www.camaradediputados.gob.do",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Ecuador/Asamblea/sources/instructions.json
+++ b/data/Ecuador/Asamblea/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, 2 AS term FROM data ORDER BY id"
       },
       "source": "http://www.asambleanacional.gob.ec/es/pleno-asambleistas",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Egypt/Parliament/sources/instructions.json
+++ b/data/Egypt/Parliament/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, cons AS area, 2015 AS term FROM data ORDER BY id"
       },
       "source": "http://www.parliament.gov.eg/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/El_Salvador/Legislative_Assembly/sources/instructions.json
+++ b/data/El_Salvador/Legislative_Assembly/sources/instructions.json
@@ -1,9 +1,10 @@
- {
+{
   "sources": [
     {
       "file": "morph/official.csv",
       "source": "http://asamblea.gob.sv/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Estonia/Riigikogu/sources/instructions.json
+++ b/data/Estonia/Riigikogu/sources/instructions.json
@@ -7,7 +7,9 @@
         "scraper": "everypolitician-scrapers/estonia-riigikogu-members-wikidata",
         "query": "SELECT * FROM data ORDER BY id"
       },
-      "type": "membership"
+      "source": "http://wikidata.org/",
+      "type": "membership",
+      "sourcetype": "wikidata"
     },
     {
       "file": "google/sheet-12.csv",
@@ -20,7 +22,8 @@
         "existing_field": "name",
         "reconciliation_file": "reconciliation/sheet-12.csv"
       },
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/official.csv",

--- a/data/Falkland_Islands/Assembly/sources/instructions.json
+++ b/data/Falkland_Islands/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/official.csv",

--- a/data/Faroe_Islands/Logting/sources/instructions.json
+++ b/data/Faroe_Islands/Logting/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY term DESC, name"
       },
       "source": "https://fo.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Fiji/Parliament/sources/instructions.json
+++ b/data/Fiji/Parliament/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.parliament.gov.fj",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Finland/Eduskunta/sources/instructions.json
+++ b/data/Finland/Eduskunta/sources/instructions.json
@@ -9,7 +9,8 @@
       },
       "corrections": "corrections/kansanmuisti.csv",
       "source": "http://kansanmuisti.fi/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/p39s.csv",
@@ -19,7 +20,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://wikidata.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikidata"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/France/National_Assembly/sources/instructions.json
+++ b/data/France/National_Assembly/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/nosdeputes14.csv",
       "source": "http://www.nosdeputes.fr/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/nosdeputes.csv",
@@ -18,7 +19,8 @@
         "reconciliation_file": "reconciliation/nosdeputes.csv"
       },
       "source": "http://www.nosdeputes.fr/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/sycomore.csv",
@@ -33,7 +35,8 @@
         "existing_field": "name",
         "reconciliation_file": "reconciliation/sycomore.csv"
       },
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/French_Polynesia/Assembly/sources/instructions.json
+++ b/data/French_Polynesia/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.assemblee.pf",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Gabon/Assembly/sources/instructions.json
+++ b/data/Gabon/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.assemblee-nationale.ga",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Gambia/National_Assembly/sources/instructions.json
+++ b/data/Gambia/National_Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.assembly.gov.gm/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Georgia/Parliament/sources/instructions.json
+++ b/data/Georgia/Parliament/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/chemiparlamenti-8.csv",
       "source": "http://www.chemiparlamenti.ge/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/chemiparlamenti.csv",
@@ -18,7 +19,8 @@
         "incoming_field": "id",
         "existing_field": "id",
         "reconciliation_file": "reconciliation/chemiparlamenti.csv"
-      }
+      },
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Germany/Bundestag/sources/instructions.json
+++ b/data/Germany/Bundestag/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id, term DESC"
       },
       "source": "https://de.wikipedia.org/wiki/Liste_der_Listen_der_Mitglieder_des_Deutschen_Bundestages",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/sparql.csv",
@@ -23,7 +24,8 @@
         "reconciliation_file": "reconciliation/sparql.csv"
       },
       "source": "http://wikidata.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikidata"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Ghana/Parliament/sources/instructions.json
+++ b/data/Ghana/Parliament/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-term-6.csv",
       "source": "http://www.parliament.gh",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-term-7.csv",
@@ -18,7 +19,8 @@
         "reconciliation_file": "reconciliation/official-term-7.csv"
       },
       "source": "http://www.parliament.gh",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Gibraltar/Parliament/sources/instructions.json
+++ b/data/Gibraltar/Parliament/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data"
       },
       "source": "http://www.parliament.gi/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikipedia.csv",

--- a/data/Greece/Parliament/sources/instructions.json
+++ b/data/Greece/Parliament/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, name_el AS name__el, id AS identifier__hellenic_parliament FROM data ORDER BY id, term DESC"
       },
       "source": "http://www.hellenicparliament.gr",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-bios.csv",

--- a/data/Greenland/Inatsisartut/sources/instructions.json
+++ b/data/Greenland/Inatsisartut/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY term DESC, name"
       },
       "source": "http://en.inatsisartut.gl/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Grenada/House_of_Representatives/sources/instructions.json
+++ b/data/Grenada/House_of_Representatives/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.gov.gd",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Guam/Parliament/sources/instructions.json
+++ b/data/Guam/Parliament/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name, term DESC"
       },
       "source": "http://www.guamlegislature.com",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Guatemala/Congress/sources/instructions.json
+++ b/data/Guatemala/Congress/sources/instructions.json
@@ -3,12 +3,14 @@
     {
       "file": "archive/official-term-7.csv",
       "source": "http://www.congreso.gob.gt/legislaturas.php",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-8-vanished.csv",
       "source": "http://www.congreso.gob.gt/legislaturas.php",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-8.csv",
@@ -19,7 +21,8 @@
       },
       "reuse_ids": false,
       "source": "http://www.congreso.gob.gt/legislaturas.php",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Guernsey/States/sources/instructions.json
+++ b/data/Guernsey/States/sources/instructions.json
@@ -3,12 +3,14 @@
     {
       "file": "archive/official-2012.csv",
       "source": "http://www.gov.gg/states_members",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-2016.csv",
       "source": "http://www.gov.gg/states_members",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official.csv",
@@ -23,7 +25,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/members.csv"
-      }
+      },
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Guinea-Bissau/Assembly/sources/instructions.json
+++ b/data/Guinea-Bissau/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, 2014 AS term FROM data ORDER BY id"
       },
       "source": "http://www.gbissau.com/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Guyana/National_Assembly/sources/instructions.json
+++ b/data/Guyana/National_Assembly/sources/instructions.json
@@ -8,12 +8,14 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://parliament.gov.gy/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-term-11.csv",
       "source": "http://parliament.gov.gy/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/gender.csv",

--- a/data/Haiti/Deputies/sources/instructions.json
+++ b/data/Haiti/Deputies/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.haiti-reference.com",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Honduras/Congreso_Nacional/sources/instructions.json
+++ b/data/Honduras/Congreso_Nacional/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, 8 AS term FROM data ORDER BY name"
       },
       "source": "https://es.wikipedia.org/wiki/Anexo:Diputados_del_Congreso_Nacional_de_Honduras_2014-2018",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Hong_Kong/Legislative_Council/sources/instructions.json
+++ b/data/Hong_Kong/Legislative_Council/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/term-5.csv",
       "source": "http://www.legco.gov.hk/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/term-6.csv",
@@ -13,12 +14,14 @@
         "query": "SELECT *, REPLACE(id,'yr16-20/','') AS id FROM data ORDER BY id"
       },
       "source": "http://www.legco.gov.hk/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/vanished-6.csv",
       "source": "http://www.legco.gov.hk/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Hungary/Assembly/sources/instructions.json
+++ b/data/Hungary/Assembly/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-40.csv",
       "source": "http://www.parlament.hu/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official.csv",
@@ -14,12 +15,14 @@
       },
       "source": "http://www.parlament.hu/",
       "reuse_ids": "true",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-41.csv",
       "source": "http://www.parlament.hu/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Iceland/Assembly/sources/instructions.json
+++ b/data/Iceland/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT REPLACE(LOWER(name),' ','_') AS id, REPLACE(LOWER(party),' ','_') AS party_id, * FROM data WHERE term NOT IN ('2013', '2016')"
       },
       "source": "https://is.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/p39s.csv",
@@ -23,7 +24,8 @@
         "reconciliation_file": "reconciliation/p39s.csv"
       },
       "source": "http://wikidata.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikidata"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/India/Lok_Sabha/sources/instructions.json
+++ b/data/India/Lok_Sabha/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://loksabha.nic.in/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Indonesia/Council/sources/instructions.json
+++ b/data/Indonesia/Council/sources/instructions.json
@@ -8,12 +8,14 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://dpr.go.id/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-vanished.csv",
       "source": "http://dpr.go.id/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Iran/Assembly/sources/instructions.json
+++ b/data/Iran/Assembly/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/term-9-sheet.csv",
       "source": "https://asl19.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "google/term-10-sheet.csv",
@@ -16,7 +17,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/term-10.csv"
-      }
+      },
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Iraq/Majlis/sources/instructions.json
+++ b/data/Iraq/Majlis/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.miqpm.com/new/Memberships_Index.php?ID=12",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Ireland/Dail/sources/instructions.json
+++ b/data/Ireland/Dail/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data WHERE term >= 20 ORDER BY id"
       },
       "source": "http://wikidata.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikidata"
     },
     {
       "file": "archive/kildare31.csv",

--- a/data/Isle_of_Man/House_of_Keys/sources/instructions.json
+++ b/data/Isle_of_Man/House_of_Keys/sources/instructions.json
@@ -8,12 +8,14 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "https://en.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "archive/vanished.csv",
       "source": "https://en.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/images.csv",

--- a/data/Israel/Knesset/sources/instructions.json
+++ b/data/Israel/Knesset/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id, term DESC"
       },
       "source": "http://www.knesset.gov.il",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Italy/House/sources/instructions.json
+++ b/data/Italy/House/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.camera.it/leg17/313",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/openpolis.csv",

--- a/data/Italy/Senate/sources/instructions.json
+++ b/data/Italy/Senate/sources/instructions.json
@@ -1,9 +1,10 @@
- {
+{
   "sources": [
     {
       "file": "archive/openpolis-17.csv",
       "source": "http://politici.openpolis.it",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/openpolis-18.csv",
@@ -14,7 +15,8 @@
       },
       "source": "http://politici.openpolis.it",
       "reuse_ids": "true",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Ivory_Coast/Assembly/sources/instructions.json
+++ b/data/Ivory_Coast/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://forums.abidjan.net",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "press"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Jamaica/House_of_Representatives/sources/instructions.json
+++ b/data/Jamaica/House_of_Representatives/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name, term"
       },
       "source": "https://en.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Japan/House_of_Representatives/sources/instructions.json
+++ b/data/Japan/House_of_Representatives/sources/instructions.json
@@ -8,20 +8,23 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.shugiin.go.jp",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-47.csv",
       "source": "http://www.shugiin.go.jp",
       "type": "membership",
-      "reuse-ids": "false"
+      "reuse-ids": "false",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-vanished.csv",
       "source": "http://www.shugiin.go.jp",
       "type": "membership",
       "reuse-ids": "false",
-      "note": "this should be merged with official-47.csv"
+      "note": "this should be merged with official-47.csv",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Jersey/States/sources/instructions.json
+++ b/data/Jersey/States/sources/instructions.json
@@ -8,13 +8,15 @@
         "query": "SELECT *, parish AS area FROM data ORDER BY id"
       },
       "source": "http://www.statesassembly.gov.je",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-11-vanished.csv",
       "source": "http://www.statesassembly.gov.je",
       "type": "membership",
-      "reuse_ids": false
+      "reuse_ids": false,
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Jordan/House_of_Representatives/sources/instructions.json
+++ b/data/Jordan/House_of_Representatives/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org/wiki/Jordanian_parliamentary_election_results,_2013",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Kazakhstan/Assembly/sources/instructions.json
+++ b/data/Kazakhstan/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, 5 AS term FROM data ORDER BY id"
       },
       "source": "http://www.parlam.kz",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",
@@ -31,11 +32,12 @@
       },
       "source": "http://www.parlam.kz",
       "merge": {
-          "incoming_field": "name",
-          "existing_field": "name",
-          "reconciliation_file": "reconciliation/official.csv"
+        "incoming_field": "name",
+        "existing_field": "name",
+        "reconciliation_file": "reconciliation/official.csv"
       },
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "wikidata/groups.json",

--- a/data/Kenya/Assembly/sources/instructions.json
+++ b/data/Kenya/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://info.mzalendo.com",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/official.csv",

--- a/data/Kiribati/Parliament/sources/instructions.json
+++ b/data/Kiribati/Parliament/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.parliament.gov.ki",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikipedia-9.csv",
@@ -23,7 +24,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/wikipedia-9.csv"
-      }
+      },
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Kosovo/Assembly/sources/instructions.json
+++ b/data/Kosovo/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id, term DESC"
       },
       "source": "http://api.parldata.eu/kv",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Kuwait/National_Assembly/sources/instructions.json
+++ b/data/Kuwait/National_Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.kna.kw/clt/erun.asp?id=1979",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Kyrgyzstan/Council/sources/instructions.json
+++ b/data/Kyrgyzstan/Council/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT id, name, name_ru AS name__ru, party, party_ru AS party__ru, image, term, source FROM data WHERE term = '5' ORDER BY id"
       },
       "source": "http://www.kenesh.kg",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official6.csv",
@@ -23,12 +24,14 @@
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official6.csv"
       },
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-6-vanished.csv",
       "source": "http://www.kenesh.kg",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Laos/Assembly/sources/instructions.json
+++ b/data/Laos/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data WHERE term = 2011 ORDER BY name"
       },
       "source": "http://na.gov.la/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-2016.csv",
@@ -23,7 +24,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official-2016.csv"
-      }
+      },
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Latvia/Saeima/sources/instructions.json
+++ b/data/Latvia/Saeima/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data WHERE term = 12 ORDER BY id"
       },
       "source": "http://www.saeima.lv/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-11.csv",
@@ -23,7 +24,8 @@
         "reconciliation_file": "reconciliation/official-11.csv"
       },
       "source": "http://www.saeima.lv/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-10.csv",
@@ -38,7 +40,8 @@
         "reconciliation_file": "reconciliation/official-10.csv"
       },
       "source": "http://www.saeima.lv/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Lebanon/Parliament/sources/instructions.json
+++ b/data/Lebanon/Parliament/sources/instructions.json
@@ -8,12 +8,14 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "archive/wikipedia-vanished.csv",
       "source": "https://en.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Lesotho/Assembly/sources/instructions.json
+++ b/data/Lesotho/Assembly/sources/instructions.json
@@ -2,8 +2,12 @@
   "sources": [
     {
       "file": "archive/official-9.csv",
-      "source": ["http://www.parliament.ls", "http://candidates.iec.org.ls"],
-      "type": "membership"
+      "source": [
+        "http://www.parliament.ls",
+        "http://candidates.iec.org.ls"
+      ],
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official.csv",
@@ -13,7 +17,8 @@
         "query": "SELECT *, 10 AS term FROM data ORDER BY name"
       },
       "source": "http://www.parliament.ls",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Liberia/House/sources/instructions.json
+++ b/data/Liberia/House/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://legislature.gov.lr",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Libya/House_of_Representatives/sources/instructions.json
+++ b/data/Libya/House_of_Representatives/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT name, area, image, party, term, end_date FROM data ORDER BY name"
       },
       "source": "https://www.temehu.com",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Liechtenstein/Landtag/sources/instructions.json
+++ b/data/Liechtenstein/Landtag/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.landtag.li",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Lithuania/Seimas/sources/instructions.json
+++ b/data/Lithuania/Seimas/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://manoseimas.lt",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Luxembourg/Chamber/sources/instructions.json
+++ b/data/Luxembourg/Chamber/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.chd.lu",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Macao/Assembly/sources/instructions.json
+++ b/data/Macao/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, name__en as name FROM data ORDER BY id"
       },
       "source": "http://www.al.gov.mo/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Macedonia/Sobranie/sources/instructions.json
+++ b/data/Macedonia/Sobranie/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://sobranie.mk/members-of-parliament.nspx",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Madagascar/Assembly/sources/instructions.json
+++ b/data/Madagascar/Assembly/sources/instructions.json
@@ -8,12 +8,14 @@
         "query": "SELECT *, term_id AS term, null AS term_id, district AS constituency FROM data ORDER BY name"
       },
       "source": "http://www.assemblee-nationale.mg/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-2013-vanished.csv",
       "source": "http://www.assemblee-nationale.mg/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Malawi/Assembly/sources/instructions.json
+++ b/data/Malawi/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT id,name,constituency,party,party_id,gender,tel,term,source FROM data ORDER BY id"
       },
       "source": "http://www.parliament.gov.mw",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Malaysia/Dewan_Rakyat/sources/instructions.json
+++ b/data/Malaysia/Dewan_Rakyat/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY term DESC, name"
       },
       "source": "https://en.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Maldives/Majlis/sources/instructions.json
+++ b/data/Maldives/Majlis/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://psephos.adam-carr.net/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "election"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Mali/Assembly/sources/instructions.json
+++ b/data/Mali/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://psephos.adam-carr.net/countries/m/mali/mali20131.txt",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "election"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Malta/Assembly/sources/instructions.json
+++ b/data/Malta/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.parlament.mt/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-13.csv",
@@ -23,9 +24,9 @@
         "reconciliation_file": "reconciliation/official-13.csv"
       },
       "source": "http://www.parlament.mt/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
-
     {
       "file": "morph/p39s.csv",
       "create": {
@@ -34,7 +35,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://wikidata.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikidata"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Marshall_Islands/Nitijela/sources/instructions.json
+++ b/data/Marshall_Islands/Nitijela/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.rmiparliament.org",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Mauritania/National_Assembly/sources/instructions.json
+++ b/data/Mauritania/National_Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.assembleenationale.mr",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Mauritius/National_Assembly/sources/instructions.json
+++ b/data/Mauritius/National_Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.lexpress.mu/resultats",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "press"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Mexico/Deputies/sources/instructions.json
+++ b/data/Mexico/Deputies/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://sitl.diputados.gob.mx/LXII_leg/listado_diputados_gpnp.php?tipot=TOTAL",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-LXIII.csv",
@@ -18,7 +19,8 @@
         "query": "SELECT *, '2015-' || id AS id, REPLACE(name, ' (LICENCIA)','') AS name FROM data ORDER BY id"
       },
       "source": "http://sitl.diputados.gob.mx/LXIII_leg/listado_diputados_gpnp.php?tipot=TOTAL",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Micronesia/Congress/sources/instructions.json
+++ b/data/Micronesia/Congress/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name, term DESC"
       },
       "source": "http://www.fsmcongress.fm",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Moldova/Parlamentul/sources/instructions.json
+++ b/data/Moldova/Parlamentul/sources/instructions.json
@@ -8,12 +8,14 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.parlament.md",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-vanished.csv",
       "source": "http://www.parlament.md",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Monaco/Council/sources/instructions.json
+++ b/data/Monaco/Council/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT id, name, party, area, image, email, term_id AS term, details_url AS source FROM data ORDER BY id"
       },
       "source": "http://www.conseil-national.mc/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-2018.csv",
@@ -23,7 +24,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official-2018.csv"
-      }
+      },
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Mongolia/Assembly/sources/instructions.json
+++ b/data/Mongolia/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, REPLACE(LOWER(constituency),' ','_') AS constituency_id FROM data"
       },
       "source": "https://en.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/official.csv",

--- a/data/Montenegro/Assembly/sources/instructions.json
+++ b/data/Montenegro/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id, term DESC"
       },
       "source": "http://api.parldata.eu/me",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Montserrat/Assembly/sources/instructions.json
+++ b/data/Montserrat/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.elections.ms",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Morocco/House/sources/instructions.json
+++ b/data/Morocco/House/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-term-9.csv",
       "type": "membership",
-      "source": "http://www.chambredesrepresentants.ma"
+      "source": "http://www.chambredesrepresentants.ma",
+      "sourcetype": "official"
     },
     {
       "file": "morph/term-10-nouabook.csv",
@@ -18,7 +19,8 @@
         "incoming_field": "name__ar",
         "existing_field": "name__ar",
         "reconciliation_file": "reconciliation/term_2016.csv"
-      }
+      },
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/official-10.csv",

--- a/data/Mozambique/Assembly/sources/instructions.json
+++ b/data/Mozambique/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.parlamento.mz",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Myanmar/House_of_Representatives/sources/instructions.json
+++ b/data/Myanmar/House_of_Representatives/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.pyithuhluttaw.gov.mm/?q=representatives",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Nagorno_Karabakh/Assembly/sources/instructions.json
+++ b/data/Nagorno_Karabakh/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT id, name, faction, faction, * FROM data ORDER BY id"
       },
       "source": "http://nankr.am/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Namibia/Assembly/sources/instructions.json
+++ b/data/Namibia/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT data.id, data.name, data.image, data.party, data.party AS party_id, terms.term_number AS term, data.email, data.area, data.details_url AS source from data JOIN terms ON data.term_id = terms.id WHERE chamber = 'National Assembly' ORDER BY data.id, term DESC"
       },
       "source": "http://www.parliament.gov.na",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Namibia/Council/sources/instructions.json
+++ b/data/Namibia/Council/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT data.id, data.name, data.image, data.party, data.party AS party_id, terms.term_number AS term, data.email, data.area, data.details_url AS source from data JOIN terms ON data.term_id = terms.id WHERE chamber = 'National Council' ORDER BY terms.term_number DESC, data.id"
       },
       "source": "http://www.parliament.na",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Nauru/Parliament/sources/instructions.json
+++ b/data/Nauru/Parliament/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, party as faction FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org/wiki/Parliament_of_Nauru",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/elections2016.csv",
@@ -23,7 +24,8 @@
         "existing_field": "name",
         "reconciliation_file": "reconciliation/elections2016.csv"
       },
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "election"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Nepal/Assembly/sources/instructions.json
+++ b/data/Nepal/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.leadnepal.com/contactyourleader",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Netherlands/House_of_Representatives/sources/instructions.json
+++ b/data/Netherlands/House_of_Representatives/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/wikipedia-2012.csv",
       "source": "http://nl.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikipedia-2017.csv",
@@ -18,7 +19,8 @@
         "reconciliation_file": "reconciliation/wikipedia-2017.csv"
       },
       "source": "http://nl.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/official.csv",

--- a/data/New_Caledonia/Congress/sources/instructions.json
+++ b/data/New_Caledonia/Congress/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, 4 AS term FROM data ORDER BY id"
       },
       "source": "http://www.congres.nc/assemblee/les-elus/?panel=5",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",
@@ -29,7 +30,8 @@
       "file": "archive/official-vanished.csv",
       "source": "http://www.congres.nc/assemblee/les-elus/?panel=5",
       "type": "membership",
-      "reuse_ids": false
+      "reuse_ids": false,
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/New_Zealand/House/sources/instructions.json
+++ b/data/New_Zealand/House/sources/instructions.json
@@ -3,12 +3,14 @@
     {
       "file": "archive/official-51.csv",
       "source": "http://www.parliament.nz",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-52-vanished.csv",
       "source": "http://www.parliament.nz",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-52.csv",
@@ -23,7 +25,8 @@
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official-52.csv"
       },
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikipedia.csv",
@@ -38,7 +41,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/wikipedia.csv"
-      }
+      },
+      "sourcetype": "wikidata"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Nicaragua/Asamblea/sources/instructions.json
+++ b/data/Nicaragua/Asamblea/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://apps.asamblea.gob.ni/Recursos/rpt3/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Niger/Assembly/sources/instructions.json
+++ b/data/Niger/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.assemblee.ne",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Nigeria/Representatives/sources/instructions.json
+++ b/data/Nigeria/Representatives/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, 8 AS term, name AS alternate_names, shorter_name AS name, id as identifier__nass FROM data WHERE js_position = 'Hon' AND area != '' AND NOT name LIKE '%Anonymous%Anonymous%' ORDER BY CAST(id AS int)"
       },
       "source": "http://www.nass.gov.ng/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Nigeria/Senate/sources/instructions.json
+++ b/data/Nigeria/Senate/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, 8 AS term, REPLACE(name, '(Deceased) ', '') AS alternate_names, REPLACE(shorter_name, '(Deceased) ', '') AS name, id as identifier__nass FROM data WHERE js_position = 'Sen' AND area != '' ORDER BY CAST(id AS int)"
       },
       "source": "http://www.nass.gov.ng/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/shineyoureye.csv",

--- a/data/Niue/Assembly/sources/instructions.json
+++ b/data/Niue/Assembly/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-15.csv",
       "source": "http://www.gov.nu/wb/pages/parliament/assembly.php",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-16.csv",
@@ -18,7 +19,8 @@
         "reconciliation_file": "reconciliation/official-16.csv"
       },
       "source": "http://www.gov.nu/wb/pages/parliament/assembly.php",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Norfolk_Island/Assembly/sources/instructions.json
+++ b/data/Norfolk_Island/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.norfolkisland.gov.nf/legislativeassembly/legislativeassembly.html",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/North_Korea/National_Assembly/sources/instructions.json
+++ b/data/North_Korea/National_Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org/wiki/North_Korean_parliamentary_election,_2014",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Northern_Cyprus/Assembly/sources/instructions.json
+++ b/data/Northern_Cyprus/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org/wiki/14th_Parliament_of_Northern_Cyprus",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/images.csv",

--- a/data/Northern_Ireland/Assembly/sources/instructions.json
+++ b/data/Northern_Ireland/Assembly/sources/instructions.json
@@ -7,7 +7,8 @@
         "instructions": "parlparse/instructions.json"
       },
       "source": "http://theyworkforyou.com/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/aims.csv",

--- a/data/Northern_Mariana_Islands/House/sources/instructions.json
+++ b/data/Northern_Mariana_Islands/House/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.cnmileg.gov.mp",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Norway/Storting/sources/instructions.json
+++ b/data/Norway/Storting/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id, term DESC"
       },
       "source": "http://data.stortinget.no/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Oman/Majlis/sources/instructions.json
+++ b/data/Oman/Majlis/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.khaleejtimes.com",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "press"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Pakistan/Assembly/sources/instructions.json
+++ b/data/Pakistan/Assembly/sources/instructions.json
@@ -8,12 +8,14 @@
         "query": "SELECT *, REPLACE(address, X'0D0A',' ') AS address FROM data ORDER BY id"
       },
       "source": "http://www.na.gov.pk",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-term-14.csv",
       "source": "http://www.na.gov.pk",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Palau/House_of_Delegates/sources/instructions.json
+++ b/data/Palau/House_of_Delegates/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data WHERE won = 'yes' ORDER BY name"
       },
       "source": "http://www.oceaniatv.net/republic-of-palau-2012-elections-candidates/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "press"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Panama/Assembly/sources/instructions.json
+++ b/data/Panama/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.asamblea.gob.pa/diputados/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Papua_New_Guinea/Parliament/sources/instructions.json
+++ b/data/Papua_New_Guinea/Parliament/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, province as area__province, region as area__region, area AS constituency, term_id AS term, null AS term_id FROM data ORDER BY id"
       },
       "source": "http://www.parliament.gov.pg/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Paraguay/Deputies/sources/instructions.json
+++ b/data/Paraguay/Deputies/sources/instructions.json
@@ -8,13 +8,15 @@
         "query": "SELECT *, 2018 AS term FROM data ORDER BY id"
       },
       "source": "http://www.diputados.gov.py",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-2013.csv",
       "source": "http://www.diputados.gov.py",
       "type": "membership",
-      "reuse_ids": false
+      "reuse_ids": false,
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Peru/Congreso/sources/instructions.json
+++ b/data/Peru/Congreso/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.congreso.gob.pe/members",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Philippines/House/sources/instructions.json
+++ b/data/Philippines/House/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-16.csv",
       "source": "http://www.congress.gov.ph",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/term-17.csv",
@@ -18,7 +19,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/term-17.csv"
-      }
+      },
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Pitcairn/Island_Council/sources/instructions.json
+++ b/data/Pitcairn/Island_Council/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Poland/Sejm/sources/instructions.json
+++ b/data/Poland/Sejm/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id, term DESC"
       },
       "source": "https://pl.wikipedia.org/wiki/Sejm_Rzeczypospolitej_Polskiej",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Portugal/Assembly/sources/instructions.json
+++ b/data/Portugal/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id, term"
       },
       "source": "https://github.com/centraldedados/parlamento-deputados",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/democratica.csv",

--- a/data/Puerto_Rico/House_of_Representatives/sources/instructions.json
+++ b/data/Puerto_Rico/House_of_Representatives/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "morph/official29.csv",
       "source": "http://www.tucamarapr.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official30.csv",
@@ -18,7 +19,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official30.csv"
-      }
+      },
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Romania/Deputies/sources/instructions.json
+++ b/data/Romania/Deputies/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-7.csv",
       "source": "http://www.cdep.ro/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-8.csv",
@@ -18,7 +19,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official-8.csv"
-      }
+      },
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Russia/Duma/sources/instructions.json
+++ b/data/Russia/Duma/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-6.csv",
       "source": "http://www.duma.gov.ru/structure/deputies/?letter=%D0%92%D1%81%D0%B5",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-7.csv",
@@ -18,7 +19,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official-7.csv"
-      }
+      },
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Rwanda/Deputies/sources/instructions.json
+++ b/data/Rwanda/Deputies/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.parliament.gov.rw/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Saint_Barthelemy/Council/sources/instructions.json
+++ b/data/Saint_Barthelemy/Council/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "https://fr.wikipedia.org/wiki/Conseil_territorial_de_Saint-Barthélemy",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Saint_Helena/Legislative_Council/sources/instructions.json
+++ b/data/Saint_Helena/Legislative_Council/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, REPLACE(LOWER(name),' ','_') AS id FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org/wiki/Saint_Helena_general_election,_2013",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/official.csv",

--- a/data/Saint_Kitts_and_Nevis/Assembly/sources/instructions.json
+++ b/data/Saint_Kitts_and_Nevis/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, election AS term FROM data WHERE election = '2015' ORDER BY id"
       },
       "source": "http://www.electionpassport.com/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "election"
     },
     {
       "file": "morph/electionpassport-2010.csv",
@@ -23,7 +24,8 @@
         "reconciliation_file": "reconciliation/electionpassport-2010.csv"
       },
       "source": "http://www.electionpassport.com/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "election"
     },
     {
       "file": "morph/electionpassport-2004.csv",
@@ -38,7 +40,8 @@
         "reconciliation_file": "reconciliation/electionpassport-2004.csv"
       },
       "source": "http://www.electionpassport.com/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "election"
     },
     {
       "file": "morph/electionpassport-2000.csv",
@@ -53,7 +56,8 @@
         "reconciliation_file": "reconciliation/electionpassport-2000.csv"
       },
       "source": "http://www.electionpassport.com/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "election"
     },
     {
       "file": "morph/electionpassport-1995.csv",
@@ -68,7 +72,8 @@
         "reconciliation_file": "reconciliation/electionpassport-1995.csv"
       },
       "source": "http://www.electionpassport.com/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "election"
     },
     {
       "file": "morph/electionpassport-1993.csv",
@@ -83,7 +88,8 @@
         "reconciliation_file": "reconciliation/electionpassport-1993.csv"
       },
       "source": "http://www.electionpassport.com/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "election"
     },
     {
       "file": "morph/electionpassport-1989.csv",
@@ -98,7 +104,8 @@
         "reconciliation_file": "reconciliation/electionpassport-1989.csv"
       },
       "source": "http://www.electionpassport.com/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "election"
     },
     {
       "file": "morph/electionpassport-1984.csv",
@@ -113,7 +120,8 @@
         "reconciliation_file": "reconciliation/electionpassport-1984.csv"
       },
       "source": "http://www.electionpassport.com/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "election"
     },
     {
       "file": "morph/wikipedia.csv",

--- a/data/Saint_Lucia/Assembly/sources/instructions.json
+++ b/data/Saint_Lucia/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, REPLACE(LOWER(name),' ','-') AS id FROM data ORDER BY id"
       },
       "source": "https://en.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/images.csv",

--- a/data/Saint_Martin/Council/sources/instructions.json
+++ b/data/Saint_Martin/Council/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "https://fr.wikipedia.org/wiki/Conseil_territorial_de_Saint-Martin",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Saint_Pierre_and_Miquelon/Territorial_Council/sources/instructions.json
+++ b/data/Saint_Pierre_and_Miquelon/Territorial_Council/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "https://fr.wikipedia.org/wiki/Conseil_territorial_de_Saint-Pierre-et-Miquelon",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Saint_Vincent_and_the_Grenadines/Assembly/sources/instructions.json
+++ b/data/Saint_Vincent_and_the_Grenadines/Assembly/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/elections-2010.csv",
       "source": "http://www.caribbeanelections.com/vc/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "election"
     },
     {
       "file": "morph/elections-2015.csv",
@@ -18,7 +19,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/elections-2015.csv"
-      }
+      },
+      "sourcetype": "election"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Samoa/Parliament/sources/instructions.json
+++ b/data/Samoa/Parliament/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org/wiki/15th_Samoan_Parliament",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/official-16.csv",
@@ -23,7 +24,8 @@
         "reconciliation_file": "reconciliation/official-16.csv"
       },
       "source": "http://www.parliament.gov.ws",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-15.csv",

--- a/data/San_Marino/Council/sources/instructions.json
+++ b/data/San_Marino/Council/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-2012.csv",
       "source": "http://www.consigliograndeegenerale.sm",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-2016.csv",
@@ -18,13 +19,15 @@
         "reconciliation_file": "reconciliation/official-2016.csv"
       },
       "source": "http://www.consigliograndeegenerale.sm",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-2016-vanished.csv",
       "source": "http://www.consigliograndeegenerale.sm",
       "type": "membership",
-      "reuse_ids": false
+      "reuse_ids": false,
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Sark/Chief_Pleas/sources/instructions.json
+++ b/data/Sark/Chief_Pleas/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, 'None' AS party FROM data ORDER BY name, term DESC"
       },
       "source": "https://en.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Saudi_Arabia/Shura/sources/instructions.json
+++ b/data/Saudi_Arabia/Shura/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://shura.gov.sa/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Scotland/Parliament/sources/instructions.json
+++ b/data/Scotland/Parliament/sources/instructions.json
@@ -7,7 +7,8 @@
         "instructions": "parlparse/instructions.json"
       },
       "source": "http://theyworkforyou.com/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Senegal/Assembly/sources/instructions.json
+++ b/data/Senegal/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "https://fr.wikipedia.org/wiki/Liste_des_d%C3%A9put%C3%A9s_du_S%C3%A9n%C3%A9gal_%C3%A9lus_en_2012",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Serbia/National_Assembly/sources/instructions.json
+++ b/data/Serbia/National_Assembly/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-10.csv",
       "source": "http://www.parlament.gov.rs/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-11.csv",
@@ -18,7 +19,8 @@
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official-11.csv"
       },
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Seychelles/Assembly/sources/instructions.json
+++ b/data/Seychelles/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.nationalassembly.sc/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Sierra_Leone/Parliament/sources/instructions.json
+++ b/data/Sierra_Leone/Parliament/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.parliament.gov.sl",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Singapore/Parliament/sources/instructions.json
+++ b/data/Singapore/Parliament/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id, term DESC"
       },
       "source": "http://www.parliament.gov.sg",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Sint_Maarten/Estates/sources/instructions.json
+++ b/data/Sint_Maarten/Estates/sources/instructions.json
@@ -3,12 +3,14 @@
     {
       "file": "archive/official_term2.csv",
       "source": "http://www.sxmparliament.org/organization/members-of-parliament.html",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official_term3.csv",
       "source": "http://www.sxmparliament.org/organization/members-of-parliament.html",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official_term4.csv",
@@ -18,12 +20,14 @@
         "query": "SELECT *, 4 AS term FROM data ORDER BY id"
       },
       "source": "http://www.sxmparliament.org/organization/members-of-parliament.html",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official_term4_vanished.csv",
       "source": "http://www.sxmparliament.org/organization/members-of-parliament.html",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Slovakia/National_Council/sources/instructions.json
+++ b/data/Slovakia/National_Council/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://api.parldata.eu/sk/nrsr/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/official.csv",
@@ -23,7 +24,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official.csv"
-      }
+      },
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Slovenia/National_Assembly/sources/instructions.json
+++ b/data/Slovenia/National_Assembly/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-7.csv",
       "source": "http://www.dz-rs.si/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-8.csv",
@@ -13,17 +14,20 @@
         "query": "SELECT *, 8 AS term FROM data"
       },
       "source": "http://www.dz-rs.si/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/vanished-8.csv",
       "source": "http://www.dz-rs.si/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/vanished-7.csv",
       "source": "http://www.dz-rs.si/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Solomon_Islands/Parliament/sources/instructions.json
+++ b/data/Solomon_Islands/Parliament/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.siec.gov.sb/index.php/journalist/127-2014-national-general-election-results",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "election"
     },
     {
       "file": "morph/official.csv",

--- a/data/Somalia/Lower/sources/instructions.json
+++ b/data/Somalia/Lower/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.parliament.somaligov.net/The%20Members.html",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Somaliland/Representatives/sources/instructions.json
+++ b/data/Somaliland/Representatives/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://somalilandparliament.net/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/South_Africa/Assembly/sources/instructions.json
+++ b/data/South_Africa/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://wikidata.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikidata"
     },
     {
       "file": "morph/peoplesassembly.csv",

--- a/data/South_Korea/National_Assembly/sources/instructions.json
+++ b/data/South_Korea/National_Assembly/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/popong-data-19.csv",
       "source": "https://github.com/teampopong/data-assembly",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/popong-data-20.csv",
@@ -18,12 +19,14 @@
         "incoming_field": "name__ko",
         "existing_field": "name__ko",
         "reconciliation_file": "reconciliation/popong-data-20.csv"
-      }
+      },
+      "sourcetype": "pmo"
     },
     {
       "file": "archive/popong-20-archive.csv",
       "source": "https://github.com/teampopong/data-assembly",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/South_Ossetia/Parliament/sources/instructions.json
+++ b/data/South_Ossetia/Parliament/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://cominf.org/node/1166502155",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "press"
     },
     {
       "file": "manual/terms.csv",

--- a/data/South_Sudan/Assembly/sources/instructions.json
+++ b/data/South_Sudan/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.goss.org",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Spain/Congress/sources/instructions.json
+++ b/data/Spain/Congress/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://proyectocolibri.es",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/official.csv",
@@ -34,7 +35,8 @@
         "reconciliation_file": "reconciliation/old-official-2015.csv"
       },
       "source": "http://www.congreso.es",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-2015.csv",

--- a/data/Sri_Lanka/Parliament/sources/instructions.json
+++ b/data/Sri_Lanka/Parliament/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, REPLACE(name, 'Hon. ', '') AS name FROM data ORDER BY id"
       },
       "source": "http://www.parliament.lk",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Suriname/Assembly/sources/instructions.json
+++ b/data/Suriname/Assembly/sources/instructions.json
@@ -4,7 +4,8 @@
       "file": "archive/official-2010.csv",
       "type": "membership",
       "source": "http://www.dna.sr",
-      "notes": "From old scraper output before site changed"
+      "notes": "From old scraper output before site changed",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official.csv",
@@ -19,7 +20,8 @@
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official.csv"
       },
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Swaziland/Assembly/sources/instructions.json
+++ b/data/Swaziland/Assembly/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-9.csv",
       "source": "http://www.observer.org.sz/index.php?news=54695",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Sweden/Riksdag/sources/instructions.json
+++ b/data/Sweden/Riksdag/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, id AS identifier__riksdagen FROM data ORDER BY term DESC, id"
       },
       "source": "http://data.riksdagen.se/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Switzerland/National_Council/sources/instructions.json
+++ b/data/Switzerland/National_Council/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data"
       },
       "source": "http://ws.parlament.ch",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Syria/Majlis/sources/instructions.json
+++ b/data/Syria/Majlis/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://parliament.gov.sy/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/term-2012-images.csv",

--- a/data/Taiwan/Legislative_Yuan/sources/instructions.json
+++ b/data/Taiwan/Legislative_Yuan/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "morph/official.csv",
       "source": "http://www.ly.gov.tw/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official9.csv",
@@ -18,7 +19,8 @@
         "incoming_field": "name__zh",
         "existing_field": "name__zh",
         "reconciliation_file": "reconciliation/official9.csv"
-      }
+      },
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Tajikistan/Representatives/sources/instructions.json
+++ b/data/Tajikistan/Representatives/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, 'Unknown' AS party, 2015 AS term FROM data ORDER BY id"
       },
       "source": "http://www.parlament.tj/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Tanzania/Assembly/sources/instructions.json
+++ b/data/Tanzania/Assembly/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-historic.csv",
       "source": "http://www.parliament.go.tz",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-11.csv",
@@ -19,12 +20,14 @@
         "reconciliation_file": "reconciliation/term5.csv"
       },
       "source": "http://www.parliament.go.tz",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-11-vanished.csv",
       "source": "http://www.parliament.go.tz",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Thailand/National_Legislative_Assembly/sources/instructions.json
+++ b/data/Thailand/National_Legislative_Assembly/sources/instructions.json
@@ -8,12 +8,14 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.senate.go.th/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/vanished.csv",
       "source": "http://www.senate.go.th/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Timor_Leste/Parlamento/sources/instructions.json
+++ b/data/Timor_Leste/Parlamento/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://parlamento.tl/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Togo/Assembly/sources/instructions.json
+++ b/data/Togo/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://www.assemblee-nationale.tg/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Tonga/Assembly/sources/instructions.json
+++ b/data/Tonga/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, 'unknown' AS party, 2015 AS term FROM data ORDER BY id"
       },
       "source": "http://parliament.gov.to/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/p39s.csv",
@@ -18,7 +19,8 @@
         "query": "SELECT *, 'unknown' AS party, 2015 AS term FROM data ORDER BY id"
       },
       "source": "http://wikidata.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikidata"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Transnistria/Supreme_Council/sources/instructions.json
+++ b/data/Transnistria/Supreme_Council/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://vspmr.org/structure/deputies/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Trinidad_and_Tobago/Representatives/sources/instructions.json
+++ b/data/Trinidad_and_Tobago/Representatives/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, 11 AS term FROM house_of_representatives ORDER BY id"
       },
       "source": "http://ttparliament.org",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Trinidad_and_Tobago/Senate/sources/instructions.json
+++ b/data/Trinidad_and_Tobago/Senate/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, 11 AS term FROM senate ORDER BY id"
       },
       "source": "http://ttparliament.org",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Tunisia/Majlis/sources/instructions.json
+++ b/data/Tunisia/Majlis/sources/instructions.json
@@ -8,13 +8,15 @@
         "query": "SELECT *, '1' as term FROM data WHERE term = '2014' ORDER BY id"
       },
       "source": "http://majles.marsad.tn",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-vanished.csv",
       "source": "http://majles.marsad.tn",
       "type": "membership",
-      "reuse_ids": false
+      "reuse_ids": false,
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Turkey/Assembly/sources/instructions.json
+++ b/data/Turkey/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER by term, name, party, area"
       },
       "source": "https://tr.wikipedia.org",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Turkmenistan/Mejlis/sources/instructions.json
+++ b/data/Turkmenistan/Mejlis/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id, term DESC"
       },
       "source": "http://mejlis2.bushluk.com/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Turks_and_Caicos_Islands/Assembly/sources/instructions.json
+++ b/data/Turks_and_Caicos_Islands/Assembly/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-2012-appointed-members.csv",
       "source": "http://www.gov.tc/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-2012-elected-members.csv",
@@ -28,7 +29,8 @@
         "reconciliation_file": "reconciliation/wikipedia.csv"
       },
       "source": "https://en.wikipedia.org/wiki/Turks_and_Caicos_Islands_general_election,_2012",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikipedia_2016.csv",
@@ -43,7 +45,8 @@
         "reconciliation_file": "reconciliation/wikipedia_2016.csv"
       },
       "source": "https://en.wikipedia.org/wiki/Turks_and_Caicos_Islands_general_election,_2016",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Tuvalu/Parliament/sources/instructions.json
+++ b/data/Tuvalu/Parliament/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "https://en.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/UK/Commons/sources/instructions.json
+++ b/data/UK/Commons/sources/instructions.json
@@ -7,7 +7,8 @@
         "from": "parlparse",
         "instructions": "parlparse/instructions.json"
       },
-      "source": "http://parser.theyworkforyou.com/"
+      "source": "http://parser.theyworkforyou.com/",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/parliament.csv",
@@ -38,7 +39,10 @@
         "existing_field": "name",
         "reconciliation_file": "reconciliation/twitter.csv",
         "patch": {
-          "ignore": [ "name", "image" ]
+          "ignore": [
+            "name",
+            "image"
+          ]
         }
       }
     },
@@ -138,7 +142,10 @@
         "existing_field": "name",
         "reconciliation_file": "reconciliation/twitter.csv",
         "patch": {
-          "ignore": [ "name", "twitter" ]
+          "ignore": [
+            "name",
+            "twitter"
+          ]
         }
       }
     },

--- a/data/US_Virgin_Islands/Legislature/sources/instructions.json
+++ b/data/US_Virgin_Islands/Legislature/sources/instructions.json
@@ -7,8 +7,9 @@
         "scraper": "tmtmtmtm/us-virgin-islands-legislature-wikipedia",
         "query": "SELECT * FROM data ORDER BY name"
       },
-      "source": "http://www.legvi.org/",
-      "type": "membership"
+      "source": "https://en.wikipedia.org",
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/official.csv",
@@ -17,6 +18,7 @@
         "scraper": "tmtmtmtm/us-virgin-islands-legislature",
         "query": "SELECT * FROM data ORDER BY id"
       },
+      "source": "http://www.legvi.org/",
       "type": "person",
       "merge": {
         "incoming_field": "name",

--- a/data/Uganda/Parliament/sources/instructions.json
+++ b/data/Uganda/Parliament/sources/instructions.json
@@ -8,12 +8,14 @@
         "query": "SELECT *, 9 AS term FROM data"
       },
       "source": "http://www.parliament.go.ug/mpdata/mps.hei",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-vanished.csv",
       "source": "http://www.parliament.go.ug/mpdata/mps.hei",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "google/sheet.csv",
@@ -26,7 +28,8 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/google-sheet-10.csv"
-      }
+      },
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Ukraine/Verkhovna_Rada/sources/instructions.json
+++ b/data/Ukraine/Verkhovna_Rada/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, COALESCE(faction, 'Позафракційні') AS faction, id AS identifier__verkhovna_rada FROM data ORDER BY id"
       },
       "source": "http://rada.gov.ua/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/United_Arab_Emirates/Federal_National_Council/sources/instructions.json
+++ b/data/United_Arab_Emirates/Federal_National_Council/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT id, name, name_ar AS name__ar, email, photo, 2011 AS term FROM data"
       },
       "source": "https://www.almajles.gov.ae",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/United_States_of_America/House/sources/instructions.json
+++ b/data/United_States_of_America/House/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, NULL AS district, CASE WHEN end_date > date('now') THEN '' ELSE end_date END AS end_date FROM data WHERE house = 'rep' ORDER BY id"
       },
       "source": "https://github.com/unitedstates/congress-legislators",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/socialmedia.csv",

--- a/data/United_States_of_America/Senate/sources/instructions.json
+++ b/data/United_States_of_America/Senate/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, CASE WHEN end_date > date('now') THEN '' ELSE end_date END AS end_date FROM data WHERE house = 'sen' ORDER BY id"
       },
       "source": "https://github.com/unitedstates/congress-legislators",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "morph/socialmedia.csv",

--- a/data/Uruguay/Deputies/sources/instructions.json
+++ b/data/Uruguay/Deputies/sources/instructions.json
@@ -8,12 +8,14 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.parlamento.gub.uy/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-vanished.csv",
       "source": "http://www.parlamento.gub.uy/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Uzbekistan/Legislative_Chamber/sources/instructions.json
+++ b/data/Uzbekistan/Legislative_Chamber/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.parliament.gov.uz/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Vanuatu/Parliament/sources/instructions.json
+++ b/data/Vanuatu/Parliament/sources/instructions.json
@@ -8,12 +8,14 @@
         "query": "SELECT * FROM data ORDER BY name"
       },
       "source": "http://parliament.gov.vu/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "archive/official-10.csv",
       "source": "http://parliament.gov.vu/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Vatican_City/Pontifical_Commission/sources/instructions.json
+++ b/data/Vatican_City/Pontifical_Commission/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/wikipedia-2011.csv",
       "source": "https://en.wikipedia.org/wiki/Pontifical_Commission_for_Vatican_City_State",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikipedia.csv",
@@ -15,10 +16,11 @@
       "source": "https://en.wikipedia.org/wiki/Pontifical_Commission_for_Vatican_City_State",
       "type": "membership",
       "merge": {
-      "incoming_field": "name",
-      "existing_field": "name",
-      "reconciliation_file": "reconciliation/members.csv"
-      }
+        "incoming_field": "name",
+        "existing_field": "name",
+        "reconciliation_file": "reconciliation/members.csv"
+      },
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Venezuela/Assembly/sources/instructions.json
+++ b/data/Venezuela/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT *, 3 AS term FROM data WHERE term = 2015 ORDER BY id"
       },
       "source": "http://asambleanacional.gob.ve/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official2016.csv",
@@ -23,7 +24,8 @@
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official2016.csv"
       },
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Vietnam/National_Assembly/sources/instructions.json
+++ b/data/Vietnam/National_Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://dbqh.na.gov.vn/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Wales/Assembly/sources/instructions.json
+++ b/data/Wales/Assembly/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://wikidata.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikidata"
     },
     {
       "file": "morph/official-5.csv",

--- a/data/Wallis_and_Futuna/Territorial_Assembly/sources/instructions.json
+++ b/data/Wallis_and_Futuna/Territorial_Assembly/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/wikipedia-2012.csv",
       "source": "https://fr.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/wikipedia-2017.csv",
@@ -18,7 +19,8 @@
         "reconciliation_file": "reconciliation/wikipedia-2017.csv"
       },
       "source": "https://fr.wikipedia.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "wikipedia"
     },
     {
       "file": "morph/official.csv",

--- a/data/Yemen/Majlis/sources/instructions.json
+++ b/data/Yemen/Majlis/sources/instructions.json
@@ -8,7 +8,8 @@
         "query": "SELECT * FROM data ORDER BY id"
       },
       "source": "http://www.ypwatch.org/",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Zambia/Assembly/sources/instructions.json
+++ b/data/Zambia/Assembly/sources/instructions.json
@@ -3,7 +3,8 @@
     {
       "file": "archive/official-2012.csv",
       "source": "http://www.parliament.gov.zm",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/official-2016.csv",
@@ -18,12 +19,14 @@
         "incoming_field": "name",
         "existing_field": "name",
         "reconciliation_file": "reconciliation/official-2016.csv"
-      }
+      },
+      "sourcetype": "official"
     },
     {
       "file": "archive/vanished-2016.csv",
       "source": "http://www.parliament.gov.zm",
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "official"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Zimbabwe/Assembly/sources/instructions.json
+++ b/data/Zimbabwe/Assembly/sources/instructions.json
@@ -11,7 +11,8 @@
           "term": "8"
         }
       },
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "google/people.csv",

--- a/data/Zimbabwe/Senate/sources/instructions.json
+++ b/data/Zimbabwe/Senate/sources/instructions.json
@@ -11,7 +11,8 @@
           "term": "8"
         }
       },
-      "type": "membership"
+      "type": "membership",
+      "sourcetype": "pmo"
     },
     {
       "file": "google/people.csv",


### PR DESCRIPTION
Categorise each membership source as one of

* official
* pmo
* wikipedia
* wikidata
* press
* election

This will allow us to more easily track the migration of each of these to being wikidata-driven, and produce other useful stats in the meanwhile.

Closes https://github.com/everypolitician/everypolitician/issues/444