### PR TITLE
Add office-based election lookups

### DIFF
--- a/data/Estonia/Riigikogu/sources/instructions.json
+++ b/data/Estonia/Riigikogu/sources/instructions.json
@@ -101,7 +101,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22160112"
+        "office": "Q21100241"
       }
     },
     {

--- a/data/Estonia/Riigikogu/sources/wikidata/elections.json
+++ b/data/Estonia/Riigikogu/sources/wikidata/elections.json
@@ -191,6 +191,7 @@
     "dates": [
       "1923-05-07"
     ],
+    "office": "member of the Estonian Riigikogu",
     "successful_candidates": [
       "Konstantin Päts"
     ]
@@ -570,6 +571,7 @@
     "dates": [
       "1926-05-17"
     ],
+    "office": "member of the Estonian Riigikogu",
     "successful_candidates": [
       "Jaan Teemant"
     ]
@@ -658,6 +660,7 @@
     "dates": [
       "1932-05-23"
     ],
+    "office": "member of the Estonian Riigikogu",
     "successful_candidates": [
       "Kaarel Eenpalu"
     ]
@@ -790,7 +793,7 @@
     ],
     "follows": "Estonian parliamentary election, 2011",
     "followed_by": "Estonian parliamentary election, 2019",
-    "office": "Prime Minister of Estonia",
+    "office": "Member of the 13th Riigikogu",
     "successful_candidates": [
       "Taavi Rõivas"
     ]
@@ -957,7 +960,8 @@
       "1940"
     ],
     "start_date": "1940-07-14",
-    "end_date": "1940-07-15"
+    "end_date": "1940-07-15",
+    "office": "member of the Estonian Riigikogu"
   },
   "Q2075093": {
     "identifiers": [
@@ -1026,7 +1030,8 @@
       "1938-02"
     ],
     "start_date": "1938-02-24",
-    "end_date": "1938-02-25"
+    "end_date": "1938-02-25",
+    "office": "member of the Estonian Riigikogu"
   },
   "Q254440": {
     "identifiers": [
@@ -1391,6 +1396,7 @@
     "dates": [
       "1929-05-13"
     ],
+    "office": "member of the Estonian Riigikogu",
     "successful_candidates": [
       "Otto Strandman"
     ]

--- a/lib/wikidata_lookup.rb
+++ b/lib/wikidata_lookup.rb
@@ -140,15 +140,7 @@ class ElectionLookup < WikidataLookup
   # We don't have the normal id => uuid Hash here,
   # but rather instructions for a Wikidata SPARQL lookup
   def initialize(instructions)
-    query = <<~EOSPARQL
-      SELECT ?item WHERE {
-        ?item wdt:P31 wd:#{instructions[:base]}
-        FILTER NOT EXISTS { ?item wdt:P361/wdt:P31 wd:#{instructions[:base]} }
-      }
-      ORDER BY ?item
-    EOSPARQL
-    ids = wikidata_sparql(query)
-    @wikidata_id_lookup = Hash[ids.map { |id| [id, id] }]
+    @instructions = instructions
   end
 
   def other_fields_for(result)
@@ -169,6 +161,8 @@ class ElectionLookup < WikidataLookup
 
   private
 
+  attr_reader :instructions
+
   WIKIDATA_SPARQL_URL = 'https://query.wikidata.org/sparql'
 
   def wikidata_sparql(query)
@@ -177,5 +171,23 @@ class ElectionLookup < WikidataLookup
     json[:results][:bindings].map { |res| res[:item][:value].split('/').last }
   rescue RestClient::Exception => e
     abort "Wikidata query #{query.inspect} failed: #{e.message}"
+  end
+
+  def query
+    <<~EOSPARQL
+      SELECT ?item WHERE {
+        ?item wdt:P31 wd:#{instructions[:base]}
+        FILTER NOT EXISTS { ?item wdt:P361/wdt:P31 wd:#{instructions[:base]} }
+      }
+      ORDER BY ?item
+    EOSPARQL
+  end
+
+  def ids
+    wikidata_sparql(query)
+  end
+
+  def wikidata_id_lookup
+    Hash[ids.map { |id| [id, id] }]
   end
 end

--- a/lib/wikidata_lookup.rb
+++ b/lib/wikidata_lookup.rb
@@ -165,7 +165,7 @@ class ElectionLookup < WikidataLookup
 
   WIKIDATA_SPARQL_URL = 'https://query.wikidata.org/sparql'
 
-  def wikidata_sparql(query)
+  def raw_results
     result = RestClient.get WIKIDATA_SPARQL_URL, params: { query: query, format: 'json' }
     json = JSON.parse(result, symbolize_names: true)
     json[:results][:bindings].map { |res| res[:item][:value].split('/').last }
@@ -174,20 +174,34 @@ class ElectionLookup < WikidataLookup
   end
 
   def query
-    <<~EOSPARQL
+    instructions.key?(:office) ? office_held_query : base_item_query
+  end
+
+  def base_item_query
+    warn "\t♦ using old-style election lookup"
+    <<~SPARQL
       SELECT ?item WHERE {
         ?item wdt:P31 wd:#{instructions[:base]}
         FILTER NOT EXISTS { ?item wdt:P361/wdt:P31 wd:#{instructions[:base]} }
       }
       ORDER BY ?item
-    EOSPARQL
+    SPARQL
+  end
+
+  def office_held_query
+    <<~SPARQL
+      SELECT ?item WHERE {
+        ?item wdt:P31/wdt:P279* wd:Q40231 ; wdt:P541/wdt:P279* wd:#{instructions[:office]}
+      }
+      ORDER BY ?item
+    SPARQL
   end
 
   def ids
-    wikidata_sparql(query)
+    @ids ||= raw_results
   end
 
   def wikidata_id_lookup
-    Hash[ids.map { |id| [id, id] }]
+    ids.zip(ids).to_h
   end
 end


### PR DESCRIPTION
Rather of supplying a base Item each relevant election should be an
instance of, we should instead be checking that an election has an
'Office contested' of a relevant Item (usually the "Member of X
legislature" one)

We'll need to migrate these all one by one, so in the mean time, warn if
anything is using the old approach.