### PR TITLE
Remove 'indent heredocs' warnings from rubocop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,13 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: auto_detection, squiggly, active_support, powerpack, unindent
-Layout/IndentHeredoc:
-  Exclude:
-    - 'bin/wikidata_info.rb'
 
 # Offense count: 4
 Lint/AmbiguousBlockAssociation:

--- a/bin/wikidata_info.rb
+++ b/bin/wikidata_info.rb
@@ -17,11 +17,11 @@ end
 
 EveryPolitician.countries_json = 'countries.json'
 
-puts <<'TABLEHEADER'
-{| class="wikitable sortable"
-|-
-! Country !! Legislature !! Total Members !! Matched to Wikidata !! Percentage !! Parties !! Matched !! Pct
-|-
+puts <<~'TABLEHEADER'
+  {| class="wikitable sortable"
+  |-
+  ! Country !! Legislature !! Total Members !! Matched to Wikidata !! Percentage !! Parties !! Matched !! Pct
+  |-
 TABLEHEADER
 
 total = { persons: 0, matched: 0 }


### PR DESCRIPTION
We only have one of them, so it's easily fixed.