### PR TITLE
Fix rubocop RegexpLiteral warnings

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,7 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-
 # Offense count: 4
 Lint/AmbiguousBlockAssociation:
   Exclude:
@@ -113,12 +112,4 @@ Style/MultilineBlockChain:
 Style/MultilineTernaryOperator:
   Exclude:
     - 'lib/source/elections.rb'
-    - 'lib/source/term.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, AllowInnerSlashes.
-# SupportedStyles: slashes, percent_r, mixed
-Style/RegexpLiteral:
-  Exclude:
     - 'lib/source/term.rb'

--- a/lib/source/term.rb
+++ b/lib/source/term.rb
@@ -24,7 +24,7 @@ module Source
     def events
       @events ||= as_table.map do |row|
         {
-          id:             row[:id][/\//] ? row[:id] : "term/#{row[:id]}",
+          id:             row[:id][%r{/}] ? row[:id] : "term/#{row[:id]}",
           name:           row[:name],
           start_date:     row[:start_date],
           end_date:       row[:end_date],


### PR DESCRIPTION
Especially easy as these are autocorrect-able