### PR TITLE
Remove obsolete code from Rakefile

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -1,26 +1,9 @@
 # frozen_string_literal: true
 
-require 'everypolitician'
 require 'fileutils'
-require 'pathname'
-require 'pry'
 require 'require_all'
-require 'tmpdir'
-require 'json'
 
 require_rel 'lib'
-
-@HOUSES = FileList['data/*/*/Rakefile.rb'].map { |f| f.pathmap '%d' }.reject { |p| File.exist? "#{p}/WIP" }
-
-def json_load(file)
-  raise "No such file #{file}" unless File.exist? file
-
-  JSON.parse(File.read(file), symbolize_names: true)
-end
-
-def json_write(file, json)
-  File.write(file, JSON.pretty_generate(json))
-end
 
 desc 'Install country-list locally'
 task 'countries.json' do
@@ -31,7 +14,6 @@ task 'countries.json' do
 end
 
 require 'rake/testtask'
-
 Rake::TestTask.new do |t|
   t.libs << 'test'
   t.test_files = FileList['test/*_test.rb']


### PR DESCRIPTION
Most of this hasn't been needed since 1b659301a30f76ab159cc536dde4cb9e02950adf
but it's left behind, slowing things down, and making the code uglier,
since then.