### PR TITLE
Refactor matcher.rb

### DIFF
--- a/lib/matcher.rb
+++ b/lib/matcher.rb
@@ -1,41 +1,56 @@
 # frozen_string_literal: true
 
+# TODO: rename as non -er class
 class Matcher
-  def initialize(existing_rows, instructions, reconciled_csv = nil)
-    @_existing_rows = existing_rows
-    @_instructions  = instructions
-    warn "Deprecated use of 'overrides'".cyan if @_instructions.include? :overrides
-    @_existing_field = instructions[:existing_field].to_sym rescue raise('Need an `existing_field` to match on')
-    @_incoming_field = instructions[:incoming_field].to_sym rescue raise('Need an `incoming_field` to match on')
-    @_reconciled = reconciled_csv ? Hash[reconciled_csv.map { |r| [r.to_hash.values[0].to_s, r.to_hash] }] : {}
+  def initialize(existing_rows, instructions, reconciliation_csv = nil)
+    @existing_rows = existing_rows
+    @instructions  = instructions
+    @reconciliation_csv = reconciliation_csv
   end
 
-  def existing
-    @existing ||= @_existing_rows.group_by { |r| r[@_existing_field].to_s.downcase }
+  private
+
+  attr_reader :existing_rows, :instructions, :reconciliation_csv
+
+  def existing_field
+    instructions[:existing_field].to_sym rescue raise('Need an `existing_field` to match on')
   end
 
-  def existing_by_uuid
-    @existing_by_uuid ||= @_existing_rows.group_by { |r| r[:uuid].to_s }
+  def incoming_field
+    instructions[:incoming_field].to_sym rescue raise('Need an `incoming_field` to match on')
   end
 end
 
 class Matcher::Reconciled < Matcher
   def find_all(incoming_row)
-    if match = @_reconciled[incoming_row[:id].to_s]
-      return existing_by_uuid[match[:uuid].to_s] if match[:uuid]
-    end
-    []
+    match = prereconciled[incoming_row[:id].to_s] or return []
+    existing[match]
+  end
+
+  private
+
+  def existing
+    @existing ||= existing_rows.group_by { |row| row[:uuid].to_s }
+  end
+
+  def prereconciled
+    return {} unless reconciliation_csv
+
+    @prereconciled ||= reconciliation_csv.map { |row| row.values_at(:id, :uuid) }.to_h
   end
 end
 
 class Matcher::Exact < Matcher
   def find_all(incoming_row)
-    return [] if incoming_row[@_incoming_field].to_s.empty?
+    incoming = incoming_row[incoming_field]
+    return [] if incoming.to_s.empty?
 
-    if exact_match = existing[incoming_row[@_incoming_field].downcase]
-      return exact_match
-    end
+    existing[incoming.downcase] || []
+  end
 
-    []
+  private
+
+  def existing
+    @existing ||= existing_rows.group_by { |row| row[existing_field].to_s.downcase }
   end
 end


### PR DESCRIPTION
This makes it reek-clean as well as rubocop-clean.

I've tested that every legislature still builds cleanly with this
applied.

Previously the warnings were:

```
lib/matcher.rb -- 9 warnings:
  [10, 10]:DuplicateMethodCall: Matcher#initialize calls 'r.to_hash' 2 times [https://github.com/troessner/reek/blob/v5.3.1/docs/Duplicate-Method-Call.md]
  [33, 35]:DuplicateMethodCall: Matcher::Exact#find_all calls 'incoming_row[@_incoming_field]' 2 times [https://github.com/troessner/reek/blob/v5.3.1/docs/Duplicate-Method-Call.md]
  [25, 25]:DuplicateMethodCall: Matcher::Reconciled#find_all calls 'match[:uuid]' 2 times [https://github.com/troessner/reek/blob/v5.3.1/docs/Duplicate-Method-Call.md]
  [31]:InstanceVariableAssumption: Matcher::Exact assumes too much for instance variable '@_incoming_field' [https://github.com/troessner/reek/blob/v5.3.1/docs/Instance-Variable-Assumption.md]
  [22]:InstanceVariableAssumption: Matcher::Reconciled assumes too much for instance variable '@_reconciled' [https://github.com/troessner/reek/blob/v5.3.1/docs/Instance-Variable-Assumption.md]
  [3]:TooManyInstanceVariables: Matcher has at least 5 instance variables [https://github.com/troessner/reek/blob/v5.3.1/docs/Too-Many-Instance-Variables.md]
  [14]:UncommunicativeVariableName: Matcher#existing has the variable name 'r' [https://github.com/troessner/reek/blob/v5.3.1/docs/Uncommunicative-Variable-Name.md]
  [18]:UncommunicativeVariableName: Matcher#existing_by_uuid has the variable name 'r' [https://github.com/troessner/reek/blob/v5.3.1/docs/Uncommunicative-Variable-Name.md]
  [10]:UncommunicativeVariableName: Matcher#initialize has the variable name 'r' [https://github.com/troessner/reek/blob/v5.3.1/docs/Uncommunicative-Variable-Name.md]
```