### PR TITLE
Migrate remaining legislatures to office-based elections

### DIFF
--- a/data/Abkhazia/Assembly/sources/instructions.json
+++ b/data/Abkhazia/Assembly/sources/instructions.json
@@ -57,7 +57,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24451601"
+        "office": "Q20110697"
       }
     }
   ]

--- a/data/Afghanistan/Wolesi_Jirga/sources/instructions.json
+++ b/data/Afghanistan/Wolesi_Jirga/sources/instructions.json
@@ -58,7 +58,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22696414"
+        "office": "Q19853383"
       }
     }
   ]

--- a/data/Albania/Assembly/sources/instructions.json
+++ b/data/Albania/Assembly/sources/instructions.json
@@ -103,7 +103,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22276264"
+        "office": "Q20177772"
       }
     },
     {

--- a/data/Andorra/General_Council/sources/instructions.json
+++ b/data/Andorra/General_Council/sources/instructions.json
@@ -65,7 +65,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22276316"
+        "office": "Q20177831"
       }
     }
   ]

--- a/data/Angola/National_Assembly/sources/instructions.json
+++ b/data/Angola/National_Assembly/sources/instructions.json
@@ -62,7 +62,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22342180"
+        "office": "Q20179557"
       }
     }
   ]

--- a/data/Antigua_and_Barbuda/Representatives/sources/instructions.json
+++ b/data/Antigua_and_Barbuda/Representatives/sources/instructions.json
@@ -65,7 +65,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24715089"
+        "office": "Q21290853"
       }
     }
   ]

--- a/data/Argentina/Diputados/sources/instructions.json
+++ b/data/Argentina/Diputados/sources/instructions.json
@@ -111,7 +111,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22266213"
+        "office": "Q18229570"
       }
     }
   ]

--- a/data/Aruba/Estates/sources/instructions.json
+++ b/data/Aruba/Estates/sources/instructions.json
@@ -51,7 +51,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25367878"
+        "office": "Q52802973"
       }
     }
   ]

--- a/data/Australia/Representatives/sources/instructions.json
+++ b/data/Australia/Representatives/sources/instructions.json
@@ -109,7 +109,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22284407"
+        "office": "Q18912794"
       }
     }
   ]

--- a/data/Austria/Nationalrat/sources/instructions.json
+++ b/data/Austria/Nationalrat/sources/instructions.json
@@ -54,7 +54,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22268901"
+        "office": "Q17535155"
       }
     },
     {

--- a/data/Azerbaijan/National_Assembly/sources/instructions.json
+++ b/data/Azerbaijan/National_Assembly/sources/instructions.json
@@ -70,7 +70,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22160593"
+        "office": "Q21269547"
       }
     }
   ]

--- a/data/Bahamas/House_of_Assembly/sources/instructions.json
+++ b/data/Bahamas/House_of_Assembly/sources/instructions.json
@@ -79,7 +79,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25449075"
+        "office": "Q17601986"
       }
     }
   ]

--- a/data/Bahrain/Council_of_Representatives/sources/instructions.json
+++ b/data/Bahrain/Council_of_Representatives/sources/instructions.json
@@ -28,7 +28,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25468000"
+        "office": "Q21328582"
       }
     }
   ]

--- a/data/Barbados/House_of_Assembly/sources/instructions.json
+++ b/data/Barbados/House_of_Assembly/sources/instructions.json
@@ -51,7 +51,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25477438"
+        "office": "Q21296440"
       }
     }
   ]

--- a/data/Belgium/Representatives/sources/instructions.json
+++ b/data/Belgium/Representatives/sources/instructions.json
@@ -96,7 +96,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22266255"
+        "office": "Q15705021"
       }
     },
     {

--- a/data/Benin/National_Assembly/sources/instructions.json
+++ b/data/Benin/National_Assembly/sources/instructions.json
@@ -43,7 +43,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669513"
+        "office": "Q21290849"
       }
     },
     {

--- a/data/Bermuda/Assembly/sources/instructions.json
+++ b/data/Bermuda/Assembly/sources/instructions.json
@@ -83,7 +83,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25546358"
+        "office": "Q33487629"
       }
     }
   ]

--- a/data/Bhutan/Assembly/sources/instructions.json
+++ b/data/Bhutan/Assembly/sources/instructions.json
@@ -63,7 +63,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25367811"
+        "office": "Q21295972"
       }
     }
   ]

--- a/data/Bolivia/Deputies/sources/instructions.json
+++ b/data/Bolivia/Deputies/sources/instructions.json
@@ -59,7 +59,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22696329"
+        "office": "Q20081432"
       }
     }
   ]

--- a/data/Bosnia_and_Herzegovina/House_of_Representatives/sources/instructions.json
+++ b/data/Bosnia_and_Herzegovina/House_of_Representatives/sources/instructions.json
@@ -43,7 +43,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22276155"
+        "office": "Q21290855"
       }
     },
     {

--- a/data/Botswana/Assembly/sources/instructions.json
+++ b/data/Botswana/Assembly/sources/instructions.json
@@ -91,7 +91,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669582"
+        "office": "Q21290847"
       }
     }
   ]

--- a/data/Brazil/Deputies/sources/instructions.json
+++ b/data/Brazil/Deputies/sources/instructions.json
@@ -98,7 +98,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22338585"
+        "office": "Q20058725"
       }
     }
   ]

--- a/data/British_Virgin_Islands/Assembly/sources/instructions.json
+++ b/data/British_Virgin_Islands/Assembly/sources/instructions.json
@@ -65,7 +65,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22703997"
+        "office": "Q61685280"
       }
     }
   ]

--- a/data/Bulgaria/National_Assembly/sources/instructions.json
+++ b/data/Bulgaria/National_Assembly/sources/instructions.json
@@ -66,7 +66,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22275982"
+        "office": "Q18924508"
       }
     }
   ]

--- a/data/Burkina_Faso/Assembly/sources/instructions.json
+++ b/data/Burkina_Faso/Assembly/sources/instructions.json
@@ -99,7 +99,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22342947"
+        "office": "Q18339650"
       }
     },
     {

--- a/data/Cabo_Verde/Assembly/sources/instructions.json
+++ b/data/Cabo_Verde/Assembly/sources/instructions.json
@@ -73,7 +73,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669625"
+        "office": "Q21295976"
       }
     }
   ]

--- a/data/Cambodia/National_Assembly/sources/instructions.json
+++ b/data/Cambodia/National_Assembly/sources/instructions.json
@@ -65,7 +65,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24714562"
+        "office": "Q21295974"
       }
     }
   ]

--- a/data/Cameroon/Assembly/sources/instructions.json
+++ b/data/Cameroon/Assembly/sources/instructions.json
@@ -57,7 +57,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22342918"
+        "office": "Q21295975"
       }
     }
   ]

--- a/data/Chad/Assembly/sources/instructions.json
+++ b/data/Chad/Assembly/sources/instructions.json
@@ -56,7 +56,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22442774"
+        "office": "Q21295978"
       }
     }
   ]

--- a/data/Chile/Deputies/sources/instructions.json
+++ b/data/Chile/Deputies/sources/instructions.json
@@ -66,7 +66,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24566674"
+        "office": "Q18067639"
       }
     }
   ]

--- a/data/Colombia/Representatives/sources/instructions.json
+++ b/data/Colombia/Representatives/sources/instructions.json
@@ -81,7 +81,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q18248981"
+        "office": "Q18960607"
       }
     }
   ]

--- a/data/Comoros/Assembly/sources/instructions.json
+++ b/data/Comoros/Assembly/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669621"
+        "office": "Q21328589"
       }
     }
   ]

--- a/data/Congo-Brazzaville/Assembly/sources/instructions.json
+++ b/data/Congo-Brazzaville/Assembly/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669531"
+        "office": "Q21295980"
       }
     }
   ]

--- a/data/Congo-Kinshasa/Assembly/sources/instructions.json
+++ b/data/Congo-Kinshasa/Assembly/sources/instructions.json
@@ -51,7 +51,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22341298"
+        "office": "Q21295979"
       }
     }
   ]

--- a/data/Cook_Islands/Parliament/sources/instructions.json
+++ b/data/Cook_Islands/Parliament/sources/instructions.json
@@ -65,7 +65,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24178659"
+        "office": "Q19247218"
       }
     }
   ]

--- a/data/Costa_Rica/Assembly/sources/instructions.json
+++ b/data/Costa_Rica/Assembly/sources/instructions.json
@@ -96,7 +96,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25343628"
+        "office": "Q21328617"
       }
     }
   ]

--- a/data/Cyprus/House_of_Representatives/sources/instructions.json
+++ b/data/Cyprus/House_of_Representatives/sources/instructions.json
@@ -71,7 +71,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22275878"
+        "office": "Q19801674"
       }
     }
   ]

--- a/data/Denmark/Folketing/sources/instructions.json
+++ b/data/Denmark/Folketing/sources/instructions.json
@@ -81,7 +81,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q12311825"
+        "office": "Q12311817"
       }
     },
     {

--- a/data/Djibouti/Assembly/sources/instructions.json
+++ b/data/Djibouti/Assembly/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669618"
+        "office": "Q19252823"
       }
     }
   ]

--- a/data/Dominica/House_of_Assembly/sources/instructions.json
+++ b/data/Dominica/House_of_Assembly/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25548020"
+        "office": "Q21296441"
       }
     }
   ]

--- a/data/Dominican_Republic/Diputados/sources/instructions.json
+++ b/data/Dominican_Republic/Diputados/sources/instructions.json
@@ -60,7 +60,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25343622"
+        "office": "Q21328590"
       }
     }
   ]

--- a/data/Ecuador/Asamblea/sources/instructions.json
+++ b/data/Ecuador/Asamblea/sources/instructions.json
@@ -70,7 +70,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24618255"
+        "office": "Q21295982"
       }
     }
   ]

--- a/data/El_Salvador/Legislative_Assembly/sources/instructions.json
+++ b/data/El_Salvador/Legislative_Assembly/sources/instructions.json
@@ -31,7 +31,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25343631"
+        "office": "Q21328618"
       }
     },
     {

--- a/data/Falkland_Islands/Assembly/sources/instructions.json
+++ b/data/Falkland_Islands/Assembly/sources/instructions.json
@@ -73,7 +73,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24715318"
+        "office": "Q24232020"
       }
     }
   ]

--- a/data/Faroe_Islands/Logting/sources/instructions.json
+++ b/data/Faroe_Islands/Logting/sources/instructions.json
@@ -51,7 +51,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22280976"
+        "office": "Q48474540"
       }
     },
     {

--- a/data/France/National_Assembly/sources/instructions.json
+++ b/data/France/National_Assembly/sources/instructions.json
@@ -105,7 +105,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q3587148"
+        "office": "Q3044918"
       }
     }
   ]

--- a/data/French_Polynesia/Assembly/sources/instructions.json
+++ b/data/French_Polynesia/Assembly/sources/instructions.json
@@ -65,7 +65,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25532583"
+        "office": "Q28332780"
       }
     }
   ]

--- a/data/Gabon/Assembly/sources/instructions.json
+++ b/data/Gabon/Assembly/sources/instructions.json
@@ -59,7 +59,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669601"
+        "office": "Q19798976"
       }
     }
   ]

--- a/data/Gambia/National_Assembly/sources/instructions.json
+++ b/data/Gambia/National_Assembly/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669585"
+        "office": "Q21295984"
       }
     }
   ]

--- a/data/Georgia/Parliament/sources/instructions.json
+++ b/data/Georgia/Parliament/sources/instructions.json
@@ -73,7 +73,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22330752"
+        "office": "Q21290878"
       }
     },
     {

--- a/data/Germany/Bundestag/sources/instructions.json
+++ b/data/Germany/Bundestag/sources/instructions.json
@@ -68,7 +68,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q1007356"
+        "office": "Q1939555"
       }
     },
     {

--- a/data/Gibraltar/Parliament/sources/instructions.json
+++ b/data/Gibraltar/Parliament/sources/instructions.json
@@ -77,7 +77,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22704005"
+        "office": "Q28331905"
       }
     }
   ]

--- a/data/Grenada/House_of_Representatives/sources/instructions.json
+++ b/data/Grenada/House_of_Representatives/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25534840"
+        "office": "Q21290858"
       }
     }
   ]

--- a/data/Guam/Parliament/sources/instructions.json
+++ b/data/Guam/Parliament/sources/instructions.json
@@ -65,7 +65,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25467156"
+        "office": "Q19420755"
       }
     }
   ]

--- a/data/Guatemala/Congress/sources/instructions.json
+++ b/data/Guatemala/Congress/sources/instructions.json
@@ -74,7 +74,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24713572"
+        "office": "Q18277108"
       }
     }
   ]

--- a/data/Guinea-Bissau/Assembly/sources/instructions.json
+++ b/data/Guinea-Bissau/Assembly/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669603"
+        "office": "Q21328631"
       }
     }
   ]

--- a/data/Guyana/National_Assembly/sources/instructions.json
+++ b/data/Guyana/National_Assembly/sources/instructions.json
@@ -60,7 +60,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25369324"
+        "office": "Q18654760"
       }
     }
   ]

--- a/data/Honduras/Congreso_Nacional/sources/instructions.json
+++ b/data/Honduras/Congreso_Nacional/sources/instructions.json
@@ -65,7 +65,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25448839"
+        "office": "Q19300340"
       }
     }
   ]

--- a/data/Hungary/Assembly/sources/instructions.json
+++ b/data/Hungary/Assembly/sources/instructions.json
@@ -80,7 +80,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q716176"
+        "office": "Q17590876"
       }
     }
   ]

--- a/data/India/Lok_Sabha/sources/instructions.json
+++ b/data/India/Lok_Sabha/sources/instructions.json
@@ -76,7 +76,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22696407"
+        "office": "Q16556694"
       }
     },
     {

--- a/data/Indonesia/Council/sources/instructions.json
+++ b/data/Indonesia/Council/sources/instructions.json
@@ -72,7 +72,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24567296"
+        "office": "Q21328632"
       }
     }
   ]

--- a/data/Iran/Assembly/sources/instructions.json
+++ b/data/Iran/Assembly/sources/instructions.json
@@ -60,7 +60,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22703240"
+        "office": "Q17525449"
       }
     }
   ]

--- a/data/Iraq/Majlis/sources/instructions.json
+++ b/data/Iraq/Majlis/sources/instructions.json
@@ -28,7 +28,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22703992"
+        "office": "Q21328603"
       }
     }
   ]

--- a/data/Isle_of_Man/House_of_Keys/sources/instructions.json
+++ b/data/Isle_of_Man/House_of_Keys/sources/instructions.json
@@ -102,7 +102,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25343640"
+        "office": "Q2734582"
       }
     }
   ]

--- a/data/Israel/Knesset/sources/instructions.json
+++ b/data/Israel/Knesset/sources/instructions.json
@@ -80,7 +80,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24659965"
+        "office": "Q4047513"
       }
     },
     {

--- a/data/Italy/House/sources/instructions.json
+++ b/data/Italy/House/sources/instructions.json
@@ -99,7 +99,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q3722420"
+        "office": "Q18558478"
       }
     },
     {

--- a/data/Ivory_Coast/Assembly/sources/instructions.json
+++ b/data/Ivory_Coast/Assembly/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22342211"
+        "office": "Q21295981"
       }
     }
   ]

--- a/data/Jamaica/House_of_Representatives/sources/instructions.json
+++ b/data/Jamaica/House_of_Representatives/sources/instructions.json
@@ -82,7 +82,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25343648"
+        "office": "Q21290859"
       }
     }
   ]

--- a/data/Jersey/States/sources/instructions.json
+++ b/data/Jersey/States/sources/instructions.json
@@ -43,7 +43,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25343642"
+        "office": "Q62033092"
       }
     }
   ]

--- a/data/Jordan/House_of_Representatives/sources/instructions.json
+++ b/data/Jordan/House_of_Representatives/sources/instructions.json
@@ -51,7 +51,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25367968"
+        "office": "Q17524418"
       }
     }
   ]

--- a/data/Kenya/Assembly/sources/instructions.json
+++ b/data/Kenya/Assembly/sources/instructions.json
@@ -80,7 +80,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22281036"
+        "office": "Q17510786"
       }
     }
   ]

--- a/data/Kiribati/Parliament/sources/instructions.json
+++ b/data/Kiribati/Parliament/sources/instructions.json
@@ -75,7 +75,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24176345"
+        "office": "Q21296447"
       }
     }
   ]

--- a/data/Kosovo/Assembly/sources/instructions.json
+++ b/data/Kosovo/Assembly/sources/instructions.json
@@ -43,7 +43,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22276226"
+        "office": "Q22262242"
       }
     },
     {

--- a/data/Kuwait/National_Assembly/sources/instructions.json
+++ b/data/Kuwait/National_Assembly/sources/instructions.json
@@ -59,7 +59,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25548021"
+        "office": "Q21295986"
       }
     }
   ]

--- a/data/Laos/Assembly/sources/instructions.json
+++ b/data/Laos/Assembly/sources/instructions.json
@@ -59,7 +59,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25343650"
+        "office": "Q21295987"
       }
     }
   ]

--- a/data/Lesotho/Assembly/sources/instructions.json
+++ b/data/Lesotho/Assembly/sources/instructions.json
@@ -66,7 +66,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669594"
+        "office": "Q21295988"
       }
     }
   ]

--- a/data/Liberia/House/sources/instructions.json
+++ b/data/Liberia/House/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669535"
+        "office": "Q21290860"
       }
     }
   ]

--- a/data/Libya/House_of_Representatives/sources/instructions.json
+++ b/data/Libya/House_of_Representatives/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669526"
+        "office": "Q21328602"
       }
     }
   ]

--- a/data/Lithuania/Seimas/sources/instructions.json
+++ b/data/Lithuania/Seimas/sources/instructions.json
@@ -66,7 +66,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22269349"
+        "office": "Q18507240"
       }
     }
   ]

--- a/data/Luxembourg/Chamber/sources/instructions.json
+++ b/data/Luxembourg/Chamber/sources/instructions.json
@@ -83,7 +83,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22266624"
+        "office": "Q21328592"
       }
     }
   ]

--- a/data/Macao/Assembly/sources/instructions.json
+++ b/data/Macao/Assembly/sources/instructions.json
@@ -57,7 +57,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25455090"
+        "office": "Q28941940"
       }
     }
   ]

--- a/data/Madagascar/Assembly/sources/instructions.json
+++ b/data/Madagascar/Assembly/sources/instructions.json
@@ -71,7 +71,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22342312"
+        "office": "Q21295989"
       }
     }
   ]

--- a/data/Mali/Assembly/sources/instructions.json
+++ b/data/Mali/Assembly/sources/instructions.json
@@ -56,7 +56,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22342957"
+        "office": "Q21295991"
       }
     }
   ]

--- a/data/Malta/Assembly/sources/instructions.json
+++ b/data/Malta/Assembly/sources/instructions.json
@@ -98,7 +98,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q16939528"
+        "office": "Q19367406"
       }
     }
   ]

--- a/data/Mauritania/National_Assembly/sources/instructions.json
+++ b/data/Mauritania/National_Assembly/sources/instructions.json
@@ -28,7 +28,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669547"
+        "office": "Q21295992"
       }
     }
   ]

--- a/data/Mauritius/National_Assembly/sources/instructions.json
+++ b/data/Mauritius/National_Assembly/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669606"
+        "office": "Q21295993"
       }
     }
   ]

--- a/data/Mexico/Deputies/sources/instructions.json
+++ b/data/Mexico/Deputies/sources/instructions.json
@@ -82,7 +82,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24558942"
+        "office": "Q18534310"
       }
     }
   ]

--- a/data/Micronesia/Congress/sources/instructions.json
+++ b/data/Micronesia/Congress/sources/instructions.json
@@ -59,7 +59,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24177311"
+        "office": "Q21328596"
       }
     }
   ]

--- a/data/Moldova/Parlamentul/sources/instructions.json
+++ b/data/Moldova/Parlamentul/sources/instructions.json
@@ -72,7 +72,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22276298"
+        "office": "Q18390049"
       }
     }
   ]

--- a/data/Monaco/Council/sources/instructions.json
+++ b/data/Monaco/Council/sources/instructions.json
@@ -67,7 +67,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22695898"
+        "office": "Q21328626"
       }
     }
   ]

--- a/data/Mongolia/Assembly/sources/instructions.json
+++ b/data/Mongolia/Assembly/sources/instructions.json
@@ -80,7 +80,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24566658"
+        "office": "Q21328637"
       }
     }
   ]

--- a/data/Montenegro/Assembly/sources/instructions.json
+++ b/data/Montenegro/Assembly/sources/instructions.json
@@ -65,7 +65,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22276186"
+        "office": "Q21328576"
       }
     }
   ]

--- a/data/Mozambique/Assembly/sources/instructions.json
+++ b/data/Mozambique/Assembly/sources/instructions.json
@@ -51,7 +51,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22342178"
+        "office": "Q19953712"
       }
     }
   ]

--- a/data/Myanmar/House_of_Representatives/sources/instructions.json
+++ b/data/Myanmar/House_of_Representatives/sources/instructions.json
@@ -28,7 +28,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24332812"
+        "office": "Q21290856"
       }
     }
   ]

--- a/data/Nauru/Parliament/sources/instructions.json
+++ b/data/Nauru/Parliament/sources/instructions.json
@@ -75,7 +75,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24181434"
+        "office": "Q21290882"
       }
     }
   ]

--- a/data/Nepal/Assembly/sources/instructions.json
+++ b/data/Nepal/Assembly/sources/instructions.json
@@ -49,7 +49,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24568879"
+        "office": "Q21328597"
       }
     },
     {

--- a/data/Nicaragua/Asamblea/sources/instructions.json
+++ b/data/Nicaragua/Asamblea/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24713744"
+        "office": "Q18616113"
       }
     }
   ]

--- a/data/Niger/Assembly/sources/instructions.json
+++ b/data/Niger/Assembly/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22342927"
+        "office": "Q21295995"
       }
     }
   ]

--- a/data/Nigeria/Representatives/sources/instructions.json
+++ b/data/Nigeria/Representatives/sources/instructions.json
@@ -61,7 +61,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22283753"
+        "office": "Q21290864"
       }
     },
     {

--- a/data/Niue/Assembly/sources/instructions.json
+++ b/data/Niue/Assembly/sources/instructions.json
@@ -76,7 +76,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24179666"
+        "office": "Q40011889"
       }
     }
   ]

--- a/data/Northern_Mariana_Islands/House/sources/instructions.json
+++ b/data/Northern_Mariana_Islands/House/sources/instructions.json
@@ -51,7 +51,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24180038"
+        "office": "Q61911728"
       }
     },
     {

--- a/data/Norway/Storting/sources/instructions.json
+++ b/data/Norway/Storting/sources/instructions.json
@@ -71,7 +71,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22276038"
+        "office": "Q9045502"
       }
     }
   ]

--- a/data/Oman/Majlis/sources/instructions.json
+++ b/data/Oman/Majlis/sources/instructions.json
@@ -56,7 +56,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25438796"
+        "office": "Q21328587"
       }
     }
   ]

--- a/data/Palau/House_of_Delegates/sources/instructions.json
+++ b/data/Palau/House_of_Delegates/sources/instructions.json
@@ -51,7 +51,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24182685"
+        "office": "Q21328610"
       }
     }
   ]

--- a/data/Panama/Assembly/sources/instructions.json
+++ b/data/Panama/Assembly/sources/instructions.json
@@ -56,7 +56,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24713353"
+        "office": "Q21295996"
       }
     }
   ]

--- a/data/Papua_New_Guinea/Parliament/sources/instructions.json
+++ b/data/Papua_New_Guinea/Parliament/sources/instructions.json
@@ -49,7 +49,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24183035"
+        "office": "Q21294916"
       }
     },
     {

--- a/data/Paraguay/Deputies/sources/instructions.json
+++ b/data/Paraguay/Deputies/sources/instructions.json
@@ -63,7 +63,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25363518"
+        "office": "Q20058561"
       }
     }
   ]

--- a/data/Peru/Congreso/sources/instructions.json
+++ b/data/Peru/Congreso/sources/instructions.json
@@ -65,7 +65,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24713657"
+        "office": "Q18812470"
       }
     },
     {

--- a/data/Poland/Sejm/sources/instructions.json
+++ b/data/Poland/Sejm/sources/instructions.json
@@ -64,7 +64,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22269206"
+        "office": "Q19269361"
       }
     },
     {

--- a/data/Portugal/Assembly/sources/instructions.json
+++ b/data/Portugal/Assembly/sources/instructions.json
@@ -97,7 +97,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q7232773"
+        "office": "Q19953703"
       }
     }
   ]

--- a/data/Romania/Deputies/sources/instructions.json
+++ b/data/Romania/Deputies/sources/instructions.json
@@ -94,7 +94,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22275938"
+        "office": "Q17556530"
       }
     }
   ]

--- a/data/Rwanda/Deputies/sources/instructions.json
+++ b/data/Rwanda/Deputies/sources/instructions.json
@@ -28,7 +28,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669381"
+        "office": "Q21328594"
       }
     },
     {

--- a/data/Saint_Barthelemy/Council/sources/instructions.json
+++ b/data/Saint_Barthelemy/Council/sources/instructions.json
@@ -58,7 +58,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25476949"
+        "office": "Q61897978"
       }
     }
   ]

--- a/data/Saint_Kitts_and_Nevis/Assembly/sources/instructions.json
+++ b/data/Saint_Kitts_and_Nevis/Assembly/sources/instructions.json
@@ -186,7 +186,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25546854"
+        "office": "Q21295997"
       }
     }
   ]

--- a/data/Saint_Lucia/Assembly/sources/instructions.json
+++ b/data/Saint_Lucia/Assembly/sources/instructions.json
@@ -84,7 +84,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25532438"
+        "office": "Q21296449"
       }
     }
   ]

--- a/data/Saint_Pierre_and_Miquelon/Territorial_Council/sources/instructions.json
+++ b/data/Saint_Pierre_and_Miquelon/Territorial_Council/sources/instructions.json
@@ -59,7 +59,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25535282"
+        "office": "Q29110604"
       }
     }
   ]

--- a/data/Saint_Vincent_and_the_Grenadines/Assembly/sources/instructions.json
+++ b/data/Saint_Vincent_and_the_Grenadines/Assembly/sources/instructions.json
@@ -47,7 +47,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24576690"
+        "office": "Q21296452"
       }
     }
   ]

--- a/data/San_Marino/Council/sources/instructions.json
+++ b/data/San_Marino/Council/sources/instructions.json
@@ -76,7 +76,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22695896"
+        "office": "Q20968670"
       }
     },
     {

--- a/data/Sark/Chief_Pleas/sources/instructions.json
+++ b/data/Sark/Chief_Pleas/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25531065"
+        "office": "Q61905214"
       }
     }
   ]

--- a/data/Senegal/Assembly/sources/instructions.json
+++ b/data/Senegal/Assembly/sources/instructions.json
@@ -56,7 +56,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22343980"
+        "office": "Q20757571"
       }
     },
     {

--- a/data/Seychelles/Assembly/sources/instructions.json
+++ b/data/Seychelles/Assembly/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669642"
+        "office": "Q21296000"
       }
     }
   ]

--- a/data/Sierra_Leone/Parliament/sources/instructions.json
+++ b/data/Sierra_Leone/Parliament/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669525"
+        "office": "Q19694740"
       }
     }
   ]

--- a/data/Slovakia/National_Council/sources/instructions.json
+++ b/data/Slovakia/National_Council/sources/instructions.json
@@ -79,7 +79,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22269256"
+        "office": "Q19967563"
       }
     },
     {

--- a/data/Solomon_Islands/Parliament/sources/instructions.json
+++ b/data/Solomon_Islands/Parliament/sources/instructions.json
@@ -90,7 +90,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24180344"
+        "office": "Q17633943"
       }
     },
     {

--- a/data/Somalia/Lower/sources/instructions.json
+++ b/data/Somalia/Lower/sources/instructions.json
@@ -48,7 +48,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669427"
+        "office": "Q21328615"
       }
     }
   ]

--- a/data/Somaliland/Representatives/sources/instructions.json
+++ b/data/Somaliland/Representatives/sources/instructions.json
@@ -28,7 +28,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25544724"
+        "office": "Q28941952"
       }
     }
   ]

--- a/data/South_Africa/Assembly/sources/instructions.json
+++ b/data/South_Africa/Assembly/sources/instructions.json
@@ -86,7 +86,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q17317625"
+        "office": "Q16744266"
       }
     }
   ]

--- a/data/South_Korea/National_Assembly/sources/instructions.json
+++ b/data/South_Korea/National_Assembly/sources/instructions.json
@@ -89,7 +89,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q5518656"
+        "office": "Q14850694"
       }
     },
     {

--- a/data/South_Sudan/Assembly/sources/instructions.json
+++ b/data/South_Sudan/Assembly/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22442788"
+        "office": "Q21328629"
       }
     }
   ]

--- a/data/Spain/Congress/sources/instructions.json
+++ b/data/Spain/Congress/sources/instructions.json
@@ -114,7 +114,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q17317594"
+        "office": "Q18171345"
       }
     },
     {

--- a/data/Swaziland/Assembly/sources/instructions.json
+++ b/data/Swaziland/Assembly/sources/instructions.json
@@ -23,7 +23,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22669611"
+        "office": "Q21296436"
       }
     }
   ]

--- a/data/Switzerland/National_Council/sources/instructions.json
+++ b/data/Switzerland/National_Council/sources/instructions.json
@@ -63,7 +63,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22160401"
+        "office": "Q18510612"
       }
     },
     {

--- a/data/Syria/Majlis/sources/instructions.json
+++ b/data/Syria/Majlis/sources/instructions.json
@@ -62,7 +62,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24718981"
+        "office": "Q20489786"
       }
     }
   ]

--- a/data/Taiwan/Legislative_Yuan/sources/instructions.json
+++ b/data/Taiwan/Legislative_Yuan/sources/instructions.json
@@ -71,7 +71,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24410897"
+        "office": "Q6310593"
       }
     }
   ]

--- a/data/Tajikistan/Representatives/sources/instructions.json
+++ b/data/Tajikistan/Representatives/sources/instructions.json
@@ -28,7 +28,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22333685"
+        "office": "Q21328584"
       }
     }
   ]

--- a/data/Timor_Leste/Parlamento/sources/instructions.json
+++ b/data/Timor_Leste/Parlamento/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25369733"
+        "office": "Q19966812"
       }
     }
   ]

--- a/data/Tonga/Assembly/sources/instructions.json
+++ b/data/Tonga/Assembly/sources/instructions.json
@@ -59,7 +59,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22696370"
+        "office": "Q21328621"
       }
     }
   ]

--- a/data/Transnistria/Supreme_Council/sources/instructions.json
+++ b/data/Transnistria/Supreme_Council/sources/instructions.json
@@ -28,7 +28,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22703975"
+        "office": "Q34925040"
       }
     }
   ]

--- a/data/Trinidad_and_Tobago/Representatives/sources/instructions.json
+++ b/data/Trinidad_and_Tobago/Representatives/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25363097"
+        "office": "Q18719159"
       }
     }
   ]

--- a/data/Tunisia/Majlis/sources/instructions.json
+++ b/data/Tunisia/Majlis/sources/instructions.json
@@ -71,7 +71,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q3587147"
+        "office": "Q29169698"
       }
     }
   ]

--- a/data/Turkmenistan/Mejlis/sources/instructions.json
+++ b/data/Turkmenistan/Mejlis/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24452127"
+        "office": "Q21328577"
       }
     }
   ]

--- a/data/Tuvalu/Parliament/sources/instructions.json
+++ b/data/Tuvalu/Parliament/sources/instructions.json
@@ -58,7 +58,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24178042"
+        "office": "Q21294919"
       }
     }
   ]

--- a/data/UK/Commons/sources/instructions.json
+++ b/data/UK/Commons/sources/instructions.json
@@ -117,7 +117,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q15283424"
+        "office": "Q16707842"
       }
     },
     {

--- a/data/US_Virgin_Islands/Legislature/sources/instructions.json
+++ b/data/US_Virgin_Islands/Legislature/sources/instructions.json
@@ -65,7 +65,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24292618"
+        "office": "Q20846080"
       }
     }
   ]

--- a/data/United_Arab_Emirates/Federal_National_Council/sources/instructions.json
+++ b/data/United_Arab_Emirates/Federal_National_Council/sources/instructions.json
@@ -28,7 +28,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24718538"
+        "office": "Q21328608"
       }
     }
   ]

--- a/data/United_States_of_America/Senate/sources/instructions.json
+++ b/data/United_States_of_America/Senate/sources/instructions.json
@@ -93,7 +93,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24333627"
+        "office": "Q13217683"
       }
     }
   ]

--- a/data/Uruguay/Deputies/sources/instructions.json
+++ b/data/Uruguay/Deputies/sources/instructions.json
@@ -71,7 +71,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22338592"
+        "office": "Q19930720"
       }
     }
   ]

--- a/data/Uzbekistan/Legislative_Chamber/sources/instructions.json
+++ b/data/Uzbekistan/Legislative_Chamber/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22333339"
+        "office": "Q21328622"
       }
     }
   ]

--- a/data/Venezuela/Assembly/sources/instructions.json
+++ b/data/Venezuela/Assembly/sources/instructions.json
@@ -86,7 +86,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24713040"
+        "office": "Q20011182"
       }
     }
   ]

--- a/data/Vietnam/National_Assembly/sources/instructions.json
+++ b/data/Vietnam/National_Assembly/sources/instructions.json
@@ -52,7 +52,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25448932"
+        "office": "Q17593571"
       }
     }
   ]

--- a/data/Wallis_and_Futuna/Territorial_Assembly/sources/instructions.json
+++ b/data/Wallis_and_Futuna/Territorial_Assembly/sources/instructions.json
@@ -83,7 +83,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24183631"
+        "office": "Q61914089"
       }
     }
   ]

--- a/data/Yemen/Majlis/sources/instructions.json
+++ b/data/Yemen/Majlis/sources/instructions.json
@@ -43,7 +43,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24659969"
+        "office": "Q24810806"
       }
     }
   ]


### PR DESCRIPTION
`bin/run_command_for_each_legislature bundle exec rake generate:electionoffice`

with a whipped up rake task of:

```ruby
namespace :generate do
  desc 'Switch instructions file to office-based elections'
  task :electionoffice do
    # Can't use the pre-existing @INSTRUCTIONS as it's already remapped the files
    instructions = Instructions.new(@INSTRUCTIONS_FILE)
    raw = instructions.send(:data)
    unless stanza = raw[:sources].find { |src| src[:type] == 'wikidata-elections' }
      warn "No election stanza"
      next
    end

    if stanza[:create][:office]
      warn "Already migrated to office-based"
      next
    end

    unless stanza[:create][:base]
      warn "No base election"
      next
    end

    linfo = json_load(LEGISLATURE_META)
    unless linfo[:member]
      warn "No membership item set in #{LEGISLATURE_META}"
      next
    end

    stanza[:create].delete(:base)
    stanza[:create][:office] = linfo[:member]
    instructions.write(raw)
  end
end
```