### PR TITLE
Make sure all legislatures know their membership ID

### DIFF
--- a/data/Aland/Lagting/meta.json
+++ b/data/Aland/Lagting/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1091494",
   "seats": 30,
   "uuid": "f20e26e8-713b-4cff-91c5-baaedb2d0253",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q23256979"
 }

--- a/data/Aland/Lagting/sources/instructions.json
+++ b/data/Aland/Lagting/sources/instructions.json
@@ -70,7 +70,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24529773"
+        "office": "Q23256979"
       }
     }
   ]

--- a/data/Alderney/States/meta.json
+++ b/data/Alderney/States/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q7604031",
   "seats": 10,
   "uuid": "a458ad55-58ef-47d7-9f15-4a5558df7006",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q62060513"
 }

--- a/data/Alderney/States/sources/instructions.json
+++ b/data/Alderney/States/sources/instructions.json
@@ -47,7 +47,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24715377"
+        "office": "Q62060513"
       }
     }
   ]

--- a/data/British_Virgin_Islands/Council/meta.json
+++ b/data/British_Virgin_Islands/Council/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q21097717",
   "seats": 13,
   "uuid": "b3e370b7-4a05-4ec7-a065-845001cf65cd",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q62060557"
 }

--- a/data/Cayman_Islands/Legislative_Assembly/meta.json
+++ b/data/Cayman_Islands/Legislative_Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 18,
   "wikidata": "Q3625554",
   "uuid": "8d011df3-c2fc-44b3-940d-564d20880b36",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q62060517"
 }

--- a/data/Cayman_Islands/Legislative_Assembly/sources/instructions.json
+++ b/data/Cayman_Islands/Legislative_Assembly/sources/instructions.json
@@ -50,7 +50,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25544454"
+        "office": "Q62060517"
       }
     }
   ]

--- a/data/Egypt/Parliament/meta.json
+++ b/data/Egypt/Parliament/meta.json
@@ -3,5 +3,6 @@
   "seats": 596,
   "wikidata": "Q2584535",
   "uuid": "c12bfd70-76b4-476b-98a4-0e16a6499688",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q21290857"
 }

--- a/data/Egypt/Parliament/sources/instructions.json
+++ b/data/Egypt/Parliament/sources/instructions.json
@@ -49,7 +49,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q22341286"
+        "office": "Q21290857"
       }
     }
   ]

--- a/data/Montserrat/Assembly/meta.json
+++ b/data/Montserrat/Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q21029427",
   "seats": 9,
   "uuid": "84a76356-d0c5-41de-b64b-457723b88aa4",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q62060523"
 }

--- a/data/Montserrat/Assembly/sources/instructions.json
+++ b/data/Montserrat/Assembly/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25548647"
+        "office": "Q62060523"
       }
     }
   ]

--- a/data/Nagorno_Karabakh/Assembly/meta.json
+++ b/data/Nagorno_Karabakh/Assembly/meta.json
@@ -3,5 +3,6 @@
   "seats": 33,
   "wikidata": "Q166619",
   "uuid": "decd5761-419d-4026-aa5c-b79b12f7df31",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q62060527"
 }

--- a/data/Nagorno_Karabakh/Assembly/sources/instructions.json
+++ b/data/Nagorno_Karabakh/Assembly/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25531251"
+        "office": "Q62060527"
       }
     }
   ]

--- a/data/Norfolk_Island/Assembly/meta.json
+++ b/data/Norfolk_Island/Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q7051064",
   "seats": 9,
   "uuid": "0ad052e9-585a-4697-ae89-fea9085a23c4",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q62060530"
 }

--- a/data/Norfolk_Island/Assembly/sources/instructions.json
+++ b/data/Norfolk_Island/Assembly/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25541728"
+        "office": "Q62060530"
       }
     }
   ]

--- a/data/Puerto_Rico/House_of_Representatives/meta.json
+++ b/data/Puerto_Rico/House_of_Representatives/meta.json
@@ -3,5 +3,6 @@
   "seats": 51,
   "wikidata": "Q169652",
   "uuid": "d82e59cc-6c1f-4cb0-bc75-49e69a785ac7",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q28332105"
 }

--- a/data/Puerto_Rico/House_of_Representatives/sources/instructions.json
+++ b/data/Puerto_Rico/House_of_Representatives/sources/instructions.json
@@ -76,7 +76,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24714393"
+        "office": "Q28332105"
       }
     }
   ]

--- a/data/Saint_Helena/Legislative_Council/meta.json
+++ b/data/Saint_Helena/Legislative_Council/meta.json
@@ -3,5 +3,6 @@
   "seats": 15,
   "wikidata": "Q6518247",
   "uuid": "6e770a74-4032-47d7-afe5-3502c239521b",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q62060536"
 }

--- a/data/Saint_Helena/Legislative_Council/sources/instructions.json
+++ b/data/Saint_Helena/Legislative_Council/sources/instructions.json
@@ -51,7 +51,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25547854"
+        "office": "Q62060536"
       }
     }
   ]

--- a/data/Saint_Martin/Council/meta.json
+++ b/data/Saint_Martin/Council/meta.json
@@ -3,5 +3,6 @@
   "seats": 23,
   "wikidata": "Q2994334",
   "uuid": "67dbc987-d69d-4287-a71a-86e0ab000858",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q61898162"
 }

--- a/data/Saint_Martin/Council/sources/instructions.json
+++ b/data/Saint_Martin/Council/sources/instructions.json
@@ -58,7 +58,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25534427"
+        "office": "Q61898162"
       }
     }
   ]

--- a/data/Sint_Maarten/Estates/meta.json
+++ b/data/Sint_Maarten/Estates/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q388526",
   "seats": 15,
   "uuid": "9501bf4e-e6e6-4c06-811f-e7277c4f7c60",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q28778417"
 }

--- a/data/Sint_Maarten/Estates/sources/instructions.json
+++ b/data/Sint_Maarten/Estates/sources/instructions.json
@@ -54,7 +54,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q25534775"
+        "office": "Q28778417"
       }
     }
   ]

--- a/data/South_Ossetia/Parliament/meta.json
+++ b/data/South_Ossetia/Parliament/meta.json
@@ -3,5 +3,6 @@
   "seats": 34,
   "wikidata": "Q2063555",
   "uuid": "6ace9785-8aad-4bca-88b5-418640558929",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q62060547"
 }

--- a/data/South_Ossetia/Parliament/sources/instructions.json
+++ b/data/South_Ossetia/Parliament/sources/instructions.json
@@ -36,7 +36,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24715411"
+        "office": "Q62060547"
       }
     }
   ]

--- a/data/Thailand/National_Legislative_Assembly/meta.json
+++ b/data/Thailand/National_Legislative_Assembly/meta.json
@@ -3,5 +3,6 @@
   "wikidata": "Q1368318",
   "seats": 250,
   "uuid": "e441ca10-6c4b-4991-8f1d-4a4ea0dae3d0",
-  "type": "unicameral legislature"
+  "type": "unicameral legislature",
+  "member": "Q62060564"
 }

--- a/data/United_States_of_America/House/meta.json
+++ b/data/United_States_of_America/House/meta.json
@@ -3,5 +3,6 @@
   "seats": 435,
   "wikidata": "Q11701",
   "uuid": "d56acebe-8fdc-47bc-8b53-20170a3214bc",
-  "type": "lower house"
+  "type": "lower house",
+  "member": "Q13218630"
 }

--- a/data/United_States_of_America/House/sources/instructions.json
+++ b/data/United_States_of_America/House/sources/instructions.json
@@ -93,7 +93,7 @@
       "type": "wikidata-elections",
       "create": {
         "from": "election-wikidata",
-        "base": "Q24397514"
+        "office": "Q13218630"
       }
     }
   ]


### PR DESCRIPTION
Find the final stragglers with no wikidata membership ID (creating the item in many cases), and then tie those to elections where necessary.

Both of these commands now return no results:
```
 > fgrep -L member data/*/*/meta.json
 > fgrep base data/**/instructions.json
```