### PR TITLE
Remove code to handle Executive positions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,9 +65,9 @@ GIT
 
 GIT
   remote: https://github.com/tmtmtmtm/csv_to_popolo.git
-  revision: 0711094f7e62ea2c4c67d0017fdb112572c0ced6
+  revision: 5a53ef493865eca612a8c17f1e4ebb62bcce73fe
   specs:
-    csv_to_popolo (0.29.0)
+    csv_to_popolo (0.30.0)
       facebook_username_extractor
       json
       rcsv
@@ -133,7 +133,7 @@ GEM
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     jaro_winkler (1.5.2)
-    json (2.1.0)
+    json (2.2.0)
     json5 (0.0.1)
     kwalify (0.7.2)
     method_source (0.9.2)

--- a/data/Abkhazia/Assembly/unstable/stats.json
+++ b/data/Abkhazia/Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/abkhazia-peoples-assmebly-wikidata",
-      "lastmod": "2019-03-14"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -65,7 +65,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-14"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Afghanistan/Wolesi_Jirga/unstable/stats.json
+++ b/data/Afghanistan/Wolesi_Jirga/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/afghanistan-assembly-wikidata",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -66,7 +66,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Aland/Lagting/unstable/stats.json
+++ b/data/Aland/Lagting/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/aland-lagting-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "manual/terms.csv",
@@ -59,7 +59,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "gender-balance/results.csv",
@@ -74,7 +74,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-07"
     }
   ]
 }

--- a/data/Albania/Assembly/unstable/stats.json
+++ b/data/Albania/Assembly/unstable/stats.json
@@ -61,7 +61,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/albania-assembly-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "morph/terms.csv",

--- a/data/Alderney/States/unstable/stats.json
+++ b/data/Alderney/States/unstable/stats.json
@@ -63,7 +63,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-03"
     }
   ]
 }

--- a/data/Algeria/Majlis/unstable/stats.json
+++ b/data/Algeria/Majlis/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/algeria-national-assembly-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",
@@ -59,7 +59,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "wikidata/elections.json",

--- a/data/American_Samoa/House/unstable/stats.json
+++ b/data/American_Samoa/House/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/american-samoa-representatives",
-      "lastmod": "2019-02-26"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -64,12 +64,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-11"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-26"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Andorra/General_Council/unstable/stats.json
+++ b/data/Andorra/General_Council/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/andorra-consell-general-wikidata",
-      "lastmod": "2019-02-22"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -60,17 +60,17 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-01-14"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2018-05-31"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-22"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Angola/National_Assembly/unstable/stats.json
+++ b/data/Angola/National_Assembly/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/angola-national-assembly-wikidata",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-03-28"
     },
     {
       "file": "manual/terms.csv",
@@ -70,7 +70,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-03-28"
     }
   ]
 }

--- a/data/Anguilla/Assembly/unstable/stats.json
+++ b/data/Anguilla/Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/anguilla-assembly-wikidata",
-      "lastmod": "2019-03-04"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -60,7 +60,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-12"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "gender-balance/results.csv",
@@ -70,7 +70,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-04"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Antigua_and_Barbuda/Representatives/unstable/stats.json
+++ b/data/Antigua_and_Barbuda/Representatives/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/antigua-barbuda-representatives-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -65,12 +65,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Argentina/Senado/unstable/stats.json
+++ b/data/Argentina/Senado/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/argentina-senators-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Armenia/Assembly/unstable/stats.json
+++ b/data/Armenia/Assembly/unstable/stats.json
@@ -54,7 +54,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/armenia-assembly-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/terms.csv",
@@ -65,7 +65,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -82,7 +82,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Aruba/Estates/unstable/stats.json
+++ b/data/Aruba/Estates/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/aruba-estates-members-wikidata",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -64,7 +64,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Australia/Representatives/unstable/stats.json
+++ b/data/Australia/Representatives/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/australia-house-of-representatives-wikidata",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/emails.csv",
@@ -76,7 +76,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -93,7 +93,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Australia/Senate/unstable/stats.json
+++ b/data/Australia/Senate/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/australia-senators-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",
@@ -71,7 +71,7 @@
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "morph/areas.csv",

--- a/data/Austria/Nationalrat/unstable/stats.json
+++ b/data/Austria/Nationalrat/unstable/stats.json
@@ -43,7 +43,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/austria-nationalrat-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "manual/terms.csv",
@@ -65,12 +65,12 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "morph/twitter.csv",

--- a/data/Bahamas/House_of_Assembly/unstable/stats.json
+++ b/data/Bahamas/House_of_Assembly/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/bahamas-assembly-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -66,7 +66,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/positions.json",
@@ -76,7 +76,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Bahrain/Council_of_Representatives/unstable/stats.json
+++ b/data/Bahrain/Council_of_Representatives/unstable/stats.json
@@ -43,19 +43,16 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2017-01-11"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
-      "lastmod": "2016-09-17"
+      "lastmod": "2019-02-02"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
       "lastmod": "2017-10-07"
     }
   ]

--- a/data/Bangladesh/House/unstable/stats.json
+++ b/data/Bangladesh/House/unstable/stats.json
@@ -54,7 +54,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/bangladesh-parliament-wikidata",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -70,7 +70,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-27"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/cabinet.csv",
@@ -81,7 +81,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-27"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Barbados/House_of_Assembly/unstable/stats.json
+++ b/data/Barbados/House_of_Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/barbados-house-of-assembly-members-wikidata",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-05"
     },
     {
       "file": "manual/terms.csv",
@@ -59,12 +59,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-05"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-05"
     }
   ]
 }

--- a/data/Belarus/Chamber/unstable/stats.json
+++ b/data/Belarus/Chamber/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/belarus-house-of-representatives-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -71,12 +71,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2018-08-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Belgium/Representatives/unstable/stats.json
+++ b/data/Belgium/Representatives/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/official.csv",
       "type": "person",
       "scraper": "tmtmtmtm/belgium-lachambre",
-      "lastmod": "2019-01-24"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Belize/Representatives/unstable/stats.json
+++ b/data/Belize/Representatives/unstable/stats.json
@@ -55,7 +55,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/belize-national-assembly-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/terms.csv",
@@ -77,7 +77,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-13"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/areas.csv",
@@ -88,7 +88,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Benin/National_Assembly/unstable/stats.json
+++ b/data/Benin/National_Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/benin-deputies-wikidata",
-      "lastmod": "2019-02-24"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -59,12 +59,12 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-24"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-22"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Bermuda/Assembly/unstable/stats.json
+++ b/data/Bermuda/Assembly/unstable/stats.json
@@ -55,7 +55,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/bermuda-wikidata",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -71,12 +71,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Bhutan/Assembly/unstable/stats.json
+++ b/data/Bhutan/Assembly/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/bhutan-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Bolivia/Deputies/unstable/stats.json
+++ b/data/Bolivia/Deputies/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/bolivia-diputados-wikidata",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -69,7 +69,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Bosnia_and_Herzegovina/House_of_Representatives/unstable/stats.json
+++ b/data/Bosnia_and_Herzegovina/House_of_Representatives/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/bosnia-herzegovina-deputies-wikidata",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -59,12 +59,12 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Botswana/Assembly/unstable/stats.json
+++ b/data/Botswana/Assembly/unstable/stats.json
@@ -55,7 +55,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/botswana-national-assembly-wikidata",
-      "lastmod": "2019-02-28"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "morph/terms.csv",
@@ -82,7 +82,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-28"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Brazil/Deputies/unstable/stats.json
+++ b/data/Brazil/Deputies/unstable/stats.json
@@ -62,7 +62,7 @@
       "file": "morph/areas.csv",
       "type": "area-wikidata",
       "scraper": "everypolitician-scrapers/brazil-states",
-      "lastmod": "2019-02-06"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "morph/genderbalance.csv",

--- a/data/British_Virgin_Islands/Assembly/unstable/stats.json
+++ b/data/British_Virgin_Islands/Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/british-virgin-islands-assembly-wikidata",
-      "lastmod": "2019-03-28"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "manual/terms.csv",
@@ -54,7 +54,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-28"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -65,12 +65,12 @@
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-29"
+      "lastmod": "2019-04-07"
     }
   ]
 }

--- a/data/British_Virgin_Islands/Council/unstable/stats.json
+++ b/data/British_Virgin_Islands/Council/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/british-virgin-islands-assembly-wikidata",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -64,12 +64,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-29"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Brunei/Legislative_Council/unstable/stats.json
+++ b/data/Brunei/Legislative_Council/unstable/stats.json
@@ -43,7 +43,8 @@
     {
       "file": "morph/wikidata.csv",
       "type": "wikidata",
-      "scraper": "everypolitician-scrapers/brunei-legislative-council-members-wikidata"
+      "scraper": "everypolitician-scrapers/brunei-legislative-council-members-wikidata",
+      "lastmod": "2019-03-12"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Bulgaria/National_Assembly/unstable/stats.json
+++ b/data/Bulgaria/National_Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/bulgaria-parliament-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -54,7 +54,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -71,7 +71,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Burkina_Faso/Assembly/unstable/stats.json
+++ b/data/Burkina_Faso/Assembly/unstable/stats.json
@@ -67,7 +67,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/burkina-faso-deputies-wikidata",
-      "lastmod": "2019-03-07"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -82,12 +82,12 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-07"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-22"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Burundi/Assembly/unstable/stats.json
+++ b/data/Burundi/Assembly/unstable/stats.json
@@ -64,7 +64,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-13"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Cabo_Verde/Assembly/unstable/stats.json
+++ b/data/Cabo_Verde/Assembly/unstable/stats.json
@@ -55,7 +55,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/cabo-verde-wikidata",
-      "lastmod": "2019-01-18"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",
@@ -75,7 +75,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-01-18"
+      "lastmod": "2019-04-03"
     }
   ]
 }

--- a/data/Cambodia/National_Assembly/unstable/stats.json
+++ b/data/Cambodia/National_Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/cambodia-national-assembly-wikidata",
-      "lastmod": "2019-03-07"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",
@@ -60,7 +60,7 @@
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2019-01-15"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "wikidata/groups.json",
@@ -70,7 +70,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-07"
+      "lastmod": "2019-04-03"
     }
   ]
 }

--- a/data/Cameroon/Assembly/unstable/stats.json
+++ b/data/Cameroon/Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/cameroon-assembly-wikidata",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -65,7 +65,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Cameroon/Senate/unstable/stats.json
+++ b/data/Cameroon/Senate/unstable/stats.json
@@ -43,20 +43,17 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2015-10-15"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
       "lastmod": "2015-12-22"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
-      "lastmod": "2017-08-17"
+      "lastmod": "2019-01-31"
     }
   ]
 }

--- a/data/Canada/Commons/unstable/stats.json
+++ b/data/Canada/Commons/unstable/stats.json
@@ -61,7 +61,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/canada-house-of-commons-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "manual/twitter.csv",
@@ -95,7 +95,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -112,7 +112,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-04"
     }
   ]
 }

--- a/data/Canada/Senate/unstable/stats.json
+++ b/data/Canada/Senate/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/canada-senate-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -59,7 +59,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-27"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Cayman_Islands/Legislative_Assembly/unstable/stats.json
+++ b/data/Cayman_Islands/Legislative_Assembly/unstable/stats.json
@@ -44,12 +44,12 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/cayman-islands-assembly-wikidata",
-      "lastmod": "2019-02-07"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "lastmod": "2015-07-15"
+      "lastmod": "2015-07-16"
     },
     {
       "file": "gender-balance/results.csv",
@@ -59,12 +59,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-08"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2018-07-16"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Chad/Assembly/unstable/stats.json
+++ b/data/Chad/Assembly/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/chad-assembly-wikidata",
-      "lastmod": "2019-02-04"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -65,7 +65,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-04"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/China/Congress/unstable/stats.json
+++ b/data/China/Congress/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/china-congress-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Colombia/Representatives/unstable/stats.json
+++ b/data/Colombia/Representatives/unstable/stats.json
@@ -43,7 +43,7 @@
       "file": "morph/official-2018.csv",
       "type": "membership",
       "scraper": "tmtmtmtm/colombia-representantes",
-      "lastmod": "2019-01-29"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Colombia/Senate/unstable/stats.json
+++ b/data/Colombia/Senate/unstable/stats.json
@@ -55,7 +55,6 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2018-04-25"
     },
     {

--- a/data/Comoros/Assembly/unstable/stats.json
+++ b/data/Comoros/Assembly/unstable/stats.json
@@ -32,5 +32,33 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/wikipedia.csv",
+      "type": "membership",
+      "scraper": "tmtmtmtm/comoros-legislative-election-2015",
+      "lastmod": "2017-03-27"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2017-01-11"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2016-09-17"
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "lastmod": "2017-08-17"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2017-10-07"
+    }
+  ]
 }

--- a/data/Congo-Brazzaville/Assembly/unstable/stats.json
+++ b/data/Congo-Brazzaville/Assembly/unstable/stats.json
@@ -53,12 +53,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-11"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-11"
+      "lastmod": "2019-04-03"
     }
   ]
 }

--- a/data/Congo-Kinshasa/Assembly/unstable/stats.json
+++ b/data/Congo-Kinshasa/Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/drc-national-assembly-members-wikidata",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",
@@ -59,12 +59,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-03"
     }
   ]
 }

--- a/data/Cook_Islands/Parliament/unstable/stats.json
+++ b/data/Cook_Islands/Parliament/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/cook-islands-representatives-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -65,12 +65,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Costa_Rica/Assembly/unstable/stats.json
+++ b/data/Costa_Rica/Assembly/unstable/stats.json
@@ -56,7 +56,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/costa-rica-asamblea-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "morph/terms.csv",
@@ -83,7 +83,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-07"
     }
   ]
 }

--- a/data/Croatia/Sabor/unstable/stats.json
+++ b/data/Croatia/Sabor/unstable/stats.json
@@ -56,7 +56,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/croatian-parliament-wikidata",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "morph/terms.csv",

--- a/data/Curacao/Estates/unstable/stats.json
+++ b/data/Curacao/Estates/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/curacao-estates-members-wikidata",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "manual/terms.csv",
@@ -54,7 +54,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -65,7 +65,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-07"
     }
   ]
 }

--- a/data/Cyprus/House_of_Representatives/unstable/stats.json
+++ b/data/Cyprus/House_of_Representatives/unstable/stats.json
@@ -44,12 +44,12 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/cyprus-parliament-wikidata",
-      "lastmod": "2019-03-04"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-12"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",
@@ -70,12 +70,12 @@
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2019-01-29"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-04"
+      "lastmod": "2019-04-03"
     }
   ]
 }

--- a/data/Czech_Republic/Deputies/unstable/stats.json
+++ b/data/Czech_Republic/Deputies/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/czech-chamber-of-deputies-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Denmark/Folketing/unstable/stats.json
+++ b/data/Denmark/Folketing/unstable/stats.json
@@ -55,7 +55,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/denmark-folketing-wikidata",
-      "lastmod": "2019-02-25"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -72,17 +72,17 @@
       "file": "morph/cabinet.csv",
       "type": "wikidata-cabinet",
       "scraper": "everypolitician-scrapers/denmark-positions",
-      "lastmod": "2019-03-07"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-25"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-12"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Djibouti/Assembly/unstable/stats.json
+++ b/data/Djibouti/Assembly/unstable/stats.json
@@ -32,5 +32,33 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/election.csv",
+      "type": "membership",
+      "scraper": "tmtmtmtm/djibouti-election-2013",
+      "lastmod": "2017-03-24"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2017-01-11"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2017-07-14"
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "lastmod": "2017-08-30"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2017-08-30"
+    }
+  ]
 }

--- a/data/Dominica/House_of_Assembly/unstable/stats.json
+++ b/data/Dominica/House_of_Assembly/unstable/stats.json
@@ -58,7 +58,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-03"
     }
   ]
 }

--- a/data/Dominican_Republic/Diputados/unstable/stats.json
+++ b/data/Dominican_Republic/Diputados/unstable/stats.json
@@ -43,7 +43,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/dominican-republic-deputies-wikidata",
-      "lastmod": "2019-03-13"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -69,7 +69,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-13"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Ecuador/Asamblea/unstable/stats.json
+++ b/data/Ecuador/Asamblea/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/ecuador_national_assembly_wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/terms.csv",
@@ -61,7 +61,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/positions.json",
@@ -71,7 +71,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Egypt/Parliament/unstable/stats.json
+++ b/data/Egypt/Parliament/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/egypt-parliament-wikidata",
-      "lastmod": "2019-03-13"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -60,7 +60,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-13"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/El_Salvador/Legislative_Assembly/unstable/stats.json
+++ b/data/El_Salvador/Legislative_Assembly/unstable/stats.json
@@ -37,31 +37,26 @@
     {
       "file": "archive/official-2015.csv",
       "type": "membership",
-      "scraper": null,
       "lastmod": "2019-01-31"
     },
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2019-01-31"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
       "lastmod": "2016-06-13"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
       "lastmod": "2018-05-31"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
       "lastmod": "2017-10-07"
     },
     {

--- a/data/Estonia/Riigikogu/unstable/stats.json
+++ b/data/Estonia/Riigikogu/unstable/stats.json
@@ -56,7 +56,7 @@
       "file": "morph/terms.csv",
       "type": "term",
       "scraper": "everypolitician-scrapers/estonia-riigikogu-terms",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/groups.json",

--- a/data/Falkland_Islands/Assembly/unstable/stats.json
+++ b/data/Falkland_Islands/Assembly/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/falkland-islands-representatives-wikidata",
-      "lastmod": "2019-03-07"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",
@@ -70,12 +70,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-27"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-07"
+      "lastmod": "2019-04-03"
     }
   ]
 }

--- a/data/Faroe_Islands/Logting/unstable/stats.json
+++ b/data/Faroe_Islands/Logting/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/faroes-logting-wikidata",
-      "lastmod": "2019-02-26"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -59,12 +59,12 @@
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2019-02-26"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-26"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/groups.json",

--- a/data/Fiji/Parliament/unstable/stats.json
+++ b/data/Fiji/Parliament/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/fiji-parliament-wikidata",
-      "lastmod": "2019-03-13"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -60,7 +60,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-07"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/positions.json",
@@ -70,7 +70,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-13"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Finland/Eduskunta/unstable/stats.json
+++ b/data/Finland/Eduskunta/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/finland-eduskunta-wikidata",
-      "lastmod": "2019-04-05"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "morph/twitter.csv",

--- a/data/French_Polynesia/Assembly/unstable/stats.json
+++ b/data/French_Polynesia/Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/french-polynesia-assembly-wikidata",
-      "lastmod": "2019-01-25"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",
@@ -65,12 +65,12 @@
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2019-01-16"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-01-16"
+      "lastmod": "2019-04-03"
     }
   ]
 }

--- a/data/Gabon/Assembly/unstable/stats.json
+++ b/data/Gabon/Assembly/unstable/stats.json
@@ -44,36 +44,31 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/gabon-deputes-wikidata",
-      "lastmod": "2019-01-17"
+      "lastmod": "2019-01-21"
     },
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2016-06-13"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
       "lastmod": "2017-12-18"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
       "lastmod": "2019-01-17"
     },
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "scraper": null,
-      "lastmod": "2019-01-17"
+      "lastmod": "2019-01-21"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
       "lastmod": "2019-01-17"
     }
   ]

--- a/data/Gambia/National_Assembly/unstable/stats.json
+++ b/data/Gambia/National_Assembly/unstable/stats.json
@@ -32,5 +32,33 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/official.csv",
+      "type": "membership",
+      "scraper": "tmtmtmtm/gambia-parliament",
+      "lastmod": "2017-03-27"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2016-06-13"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2016-09-17"
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "lastmod": "2017-01-13"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2017-10-07"
+    }
+  ]
 }

--- a/data/Georgia/Parliament/unstable/stats.json
+++ b/data/Georgia/Parliament/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/georgia-parliament-wikidata",
-      "lastmod": "2019-02-12"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "morph/terms.csv",
@@ -71,12 +71,12 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-06"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-09"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Ghana/Parliament/unstable/stats.json
+++ b/data/Ghana/Parliament/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/ghana-parliament-wikidata",
-      "lastmod": "2019-03-14"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -59,7 +59,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-14"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -70,12 +70,12 @@
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2019-03-14"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Greenland/Inatsisartut/unstable/stats.json
+++ b/data/Greenland/Inatsisartut/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/greenland-inatsisartut-members-wikidata",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "morph/terms.csv",
@@ -66,12 +66,12 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-12"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Grenada/House_of_Representatives/unstable/stats.json
+++ b/data/Grenada/House_of_Representatives/unstable/stats.json
@@ -58,7 +58,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-01-16"
+      "lastmod": "2019-04-03"
     }
   ]
 }

--- a/data/Guam/Parliament/unstable/stats.json
+++ b/data/Guam/Parliament/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/guam-legislature-members",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-05"
     },
     {
       "file": "manual/terms.csv",
@@ -54,7 +54,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-01-20"
+      "lastmod": "2019-04-05"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -70,7 +70,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-05"
     }
   ]
 }

--- a/data/Guatemala/Congress/unstable/stats.json
+++ b/data/Guatemala/Congress/unstable/stats.json
@@ -54,7 +54,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/guatemala-congress-members-wikidata",
-      "lastmod": "2019-02-25"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "morph/terms.csv",
@@ -76,7 +76,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-25"
+      "lastmod": "2019-04-03"
     }
   ]
 }

--- a/data/Guernsey/States/unstable/stats.json
+++ b/data/Guernsey/States/unstable/stats.json
@@ -54,7 +54,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/guernsey-states-wikidata",
-      "lastmod": "2019-02-15"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -69,7 +69,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-15"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/positions.json",
@@ -79,7 +79,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-15"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Guinea-Bissau/Assembly/unstable/stats.json
+++ b/data/Guinea-Bissau/Assembly/unstable/stats.json
@@ -32,5 +32,33 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/official.csv",
+      "type": "membership",
+      "scraper": "chrismytton/guinea-bissau-national-peoples-assembly",
+      "lastmod": "2017-03-27"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2017-01-11"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2016-04-03"
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "lastmod": "2017-01-13"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2017-10-07"
+    }
+  ]
 }

--- a/data/Guyana/National_Assembly/unstable/stats.json
+++ b/data/Guyana/National_Assembly/unstable/stats.json
@@ -65,7 +65,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/guyana-assembly-members-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -86,12 +86,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Haiti/Deputies/unstable/stats.json
+++ b/data/Haiti/Deputies/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/haiti-deputies-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -60,12 +60,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Honduras/Congreso_Nacional/unstable/stats.json
+++ b/data/Honduras/Congreso_Nacional/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/honduras-national-congress-wikidata",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -70,7 +70,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Hong_Kong/Legislative_Council/unstable/stats.json
+++ b/data/Hong_Kong/Legislative_Council/unstable/stats.json
@@ -54,7 +54,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/hong-kong-legislative-council-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -82,12 +82,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-28"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-28"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Hungary/Assembly/unstable/stats.json
+++ b/data/Hungary/Assembly/unstable/stats.json
@@ -54,7 +54,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/hungary-parliament-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -70,7 +70,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/cabinet.csv",
@@ -81,7 +81,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Iceland/Assembly/unstable/stats.json
+++ b/data/Iceland/Assembly/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/iceland-althingismenn-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/terms.csv",
@@ -78,7 +78,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/India/Lok_Sabha/unstable/stats.json
+++ b/data/India/Lok_Sabha/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/india-lok-sabha-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/terms.csv",
@@ -73,12 +73,12 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Indonesia/Council/unstable/stats.json
+++ b/data/Indonesia/Council/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/indonesian-mps",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -76,7 +76,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Iran/Assembly/unstable/stats.json
+++ b/data/Iran/Assembly/unstable/stats.json
@@ -48,7 +48,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/iran-assembly-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "manual/terms.csv",
@@ -68,7 +68,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-04"
     }
   ]
 }

--- a/data/Iraq/Majlis/unstable/stats.json
+++ b/data/Iraq/Majlis/unstable/stats.json
@@ -32,5 +32,28 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/madarik-foundation.csv",
+      "type": "membership",
+      "scraper": "tmtmtmtm/iraq-majilis",
+      "lastmod": "2017-03-24"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2016-06-13"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2016-04-17"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2017-10-07"
+    }
+  ]
 }

--- a/data/Ireland/Dail/unstable/stats.json
+++ b/data/Ireland/Dail/unstable/stats.json
@@ -61,7 +61,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/ireland-dail-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "morph/terms.csv",
@@ -78,7 +78,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -95,7 +95,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-04"
     }
   ]
 }

--- a/data/Isle_of_Man/House_of_Keys/unstable/stats.json
+++ b/data/Isle_of_Man/House_of_Keys/unstable/stats.json
@@ -61,7 +61,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/isle-of-man-house-of-keys-wikidata",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -77,17 +77,17 @@
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Israel/Knesset/unstable/stats.json
+++ b/data/Israel/Knesset/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/israel-knesset-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "morph/twitter.csv",
@@ -73,7 +73,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "wikidata/groups.json",

--- a/data/Italy/House/unstable/stats.json
+++ b/data/Italy/House/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/italy-legislature-XVII-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "morph/cabinet.csv",

--- a/data/Ivory_Coast/Assembly/unstable/stats.json
+++ b/data/Ivory_Coast/Assembly/unstable/stats.json
@@ -32,5 +32,33 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/abidjan-forums.csv",
+      "type": "membership",
+      "scraper": "tmtmtmtm/ivory-coast-election-results-2011",
+      "lastmod": "2017-03-24"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2016-12-15"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2016-03-05"
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "lastmod": "2018-05-31"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2018-05-31"
+    }
+  ]
 }

--- a/data/Jamaica/House_of_Representatives/unstable/stats.json
+++ b/data/Jamaica/House_of_Representatives/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/jamaica-representatives-wikidata",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "morph/jmelections.csv",
@@ -77,7 +77,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Japan/House_of_Representatives/unstable/stats.json
+++ b/data/Japan/House_of_Representatives/unstable/stats.json
@@ -54,7 +54,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/japan-house-of-representatives-wikidata",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/terms.csv",
@@ -83,12 +83,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Jersey/States/unstable/stats.json
+++ b/data/Jersey/States/unstable/stats.json
@@ -43,31 +43,26 @@
     {
       "file": "archive/official-11-vanished.csv",
       "type": "membership",
-      "scraper": null,
       "lastmod": "2018-11-09"
     },
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2016-07-06"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
-      "lastmod": "2017-01-13"
+      "lastmod": "2019-02-02"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
       "lastmod": "2017-01-13"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
       "lastmod": "2017-10-07"
     }
   ]

--- a/data/Jordan/House_of_Representatives/unstable/stats.json
+++ b/data/Jordan/House_of_Representatives/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/jordan-house-of-representatives-wikidata",
-      "lastmod": "2019-01-23"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -59,12 +59,12 @@
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2018-08-10"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2018-08-10"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Kazakhstan/Assembly/unstable/stats.json
+++ b/data/Kazakhstan/Assembly/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/kazakhstan-deputies-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",
@@ -65,7 +65,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "wikidata/elections.json",

--- a/data/Kenya/Assembly/unstable/stats.json
+++ b/data/Kenya/Assembly/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/kenya-house-of-representatives-wikidata",
-      "lastmod": "2019-04-07"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -66,7 +66,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-07"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/positions.json",

--- a/data/Kiribati/Parliament/unstable/stats.json
+++ b/data/Kiribati/Parliament/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/kiribati-parliament-wikidata",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -70,12 +70,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-25"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Kosovo/Assembly/unstable/stats.json
+++ b/data/Kosovo/Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/kosovan-parliament-wikidata",
-      "lastmod": "2019-02-28"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -59,7 +59,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-28"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/groups.json",

--- a/data/Kuwait/National_Assembly/unstable/stats.json
+++ b/data/Kuwait/National_Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/kuwait-national-assembly-wikidata",
-      "lastmod": "2019-03-14"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -64,12 +64,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-10"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-14"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Kyrgyzstan/Council/unstable/stats.json
+++ b/data/Kyrgyzstan/Council/unstable/stats.json
@@ -55,7 +55,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/kyrgyzstan-supreme-council-wikidata",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -71,17 +71,17 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-28"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Laos/Assembly/unstable/stats.json
+++ b/data/Laos/Assembly/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/laos-national-assembly-wikidata",
-      "lastmod": "2018-03-06"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -65,7 +65,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2017-08-27"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Latvia/Saeima/unstable/stats.json
+++ b/data/Latvia/Saeima/unstable/stats.json
@@ -56,7 +56,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/latvia-saeima-wikidata",
-      "lastmod": "2019-03-28"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "morph/terms.csv",

--- a/data/Lebanon/Parliament/unstable/stats.json
+++ b/data/Lebanon/Parliament/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/lebanese-parliament-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "manual/terms.csv",
@@ -70,12 +70,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-04"
     }
   ]
 }

--- a/data/Lesotho/Assembly/unstable/stats.json
+++ b/data/Lesotho/Assembly/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/lesotho-national-assembly-wikidata",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -70,7 +70,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Liberia/House/unstable/stats.json
+++ b/data/Liberia/House/unstable/stats.json
@@ -43,25 +43,21 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2016-06-13"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
       "lastmod": "2017-01-13"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
-      "lastmod": "2016-09-17"
+      "lastmod": "2019-02-02"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
       "lastmod": "2017-10-07"
     }
   ]

--- a/data/Libya/House_of_Representatives/unstable/stats.json
+++ b/data/Libya/House_of_Representatives/unstable/stats.json
@@ -32,5 +32,33 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/temehu.csv",
+      "type": "membership",
+      "scraper": "tmtmtmtm/libya-house-of-representatives",
+      "lastmod": "2017-03-22"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2016-12-15"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2016-10-18"
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "lastmod": "2017-04-02"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2017-10-07"
+    }
+  ]
 }

--- a/data/Liechtenstein/Landtag/unstable/stats.json
+++ b/data/Liechtenstein/Landtag/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/liechtenstein-landtag-wikidata",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -60,7 +60,7 @@
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2018-08-01"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/groups.json",
@@ -70,7 +70,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Lithuania/Seimas/unstable/stats.json
+++ b/data/Lithuania/Seimas/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/lithuania-manoseimas-wikidata",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -54,7 +54,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-01-30"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -71,7 +71,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Luxembourg/Chamber/unstable/stats.json
+++ b/data/Luxembourg/Chamber/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/luxembourg-chamber-of-deputies-wikidata",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "morph/terms.csv",
@@ -77,7 +77,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Macao/Assembly/unstable/stats.json
+++ b/data/Macao/Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/macau-legislative-assembly-wikidata",
-      "lastmod": "2019-03-27"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Macedonia/Sobranie/unstable/stats.json
+++ b/data/Macedonia/Sobranie/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/macedonia-sobranie-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "morph/terms.csv",
@@ -61,7 +61,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -78,7 +78,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-07"
     }
   ]
 }

--- a/data/Madagascar/Assembly/unstable/stats.json
+++ b/data/Madagascar/Assembly/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/madagascar-national-assembly-members-wikidata",
-      "lastmod": "2019-02-10"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -70,12 +70,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-10"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-08"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Malawi/Assembly/unstable/stats.json
+++ b/data/Malawi/Assembly/unstable/stats.json
@@ -54,7 +54,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/malawi-national-assembly-wikidata",
-      "lastmod": "2019-03-08"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -69,12 +69,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-27"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-08"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Maldives/Majlis/unstable/stats.json
+++ b/data/Maldives/Majlis/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/maldives-representatives-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "manual/terms.csv",
@@ -59,12 +59,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-04"
     }
   ]
 }

--- a/data/Mali/Assembly/unstable/stats.json
+++ b/data/Mali/Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/mali-representatives-wikidata",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -60,12 +60,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Malta/Assembly/unstable/stats.json
+++ b/data/Malta/Assembly/unstable/stats.json
@@ -56,7 +56,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/malta-parliament-wikidata",
-      "lastmod": "2019-03-08"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "morph/terms.csv",
@@ -73,7 +73,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-07"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "morph/cabinet.csv",
@@ -84,7 +84,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-08"
+      "lastmod": "2019-04-04"
     }
   ]
 }

--- a/data/Marshall_Islands/Nitijela/unstable/stats.json
+++ b/data/Marshall_Islands/Nitijela/unstable/stats.json
@@ -64,7 +64,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Mauritania/National_Assembly/unstable/stats.json
+++ b/data/Mauritania/National_Assembly/unstable/stats.json
@@ -32,5 +32,28 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/official.csv",
+      "type": "membership",
+      "scraper": "tmtmtmtm/mauritania-assembly",
+      "lastmod": "2017-03-24"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2016-12-15"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2016-09-17"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2017-10-07"
+    }
+  ]
 }

--- a/data/Mauritius/National_Assembly/unstable/stats.json
+++ b/data/Mauritius/National_Assembly/unstable/stats.json
@@ -32,5 +32,33 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/elections.csv",
+      "type": "membership",
+      "scraper": "tmtmtmtm/mauritius-election-2014",
+      "lastmod": "2017-03-27"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2015-09-18"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2015-12-22"
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "lastmod": "2016-09-17"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2017-10-07"
+    }
+  ]
 }

--- a/data/Mexico/Deputies/unstable/stats.json
+++ b/data/Mexico/Deputies/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/mexico-deputies-wikidata",
-      "lastmod": "2019-02-27"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "morph/terms.csv",
@@ -67,7 +67,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-27"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "morph/cabinet.csv",
@@ -78,7 +78,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-27"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Micronesia/Congress/unstable/stats.json
+++ b/data/Micronesia/Congress/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/micronesia-congress-wikidata",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",
@@ -59,7 +59,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-11"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "wikidata/positions.json",
@@ -69,7 +69,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-03"
     }
   ]
 }

--- a/data/Moldova/Parlamentul/unstable/stats.json
+++ b/data/Moldova/Parlamentul/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/moldova-parlament-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-05"
     },
     {
       "file": "manual/terms.csv",
@@ -65,7 +65,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-05"
     },
     {
       "file": "morph/cabinet.csv",
@@ -76,7 +76,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-05"
     }
   ]
 }

--- a/data/Monaco/Council/unstable/stats.json
+++ b/data/Monaco/Council/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/monaco-council-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -70,7 +70,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Mongolia/Assembly/unstable/stats.json
+++ b/data/Mongolia/Assembly/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/mongolia-khurai-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-05"
     },
     {
       "file": "manual/terms.csv",
@@ -76,7 +76,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-05"
     }
   ]
 }

--- a/data/Montenegro/Assembly/unstable/stats.json
+++ b/data/Montenegro/Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/montenegro-politicians-wikidata",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -60,7 +60,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-06"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/positions.json",
@@ -70,7 +70,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Montserrat/Assembly/unstable/stats.json
+++ b/data/Montserrat/Assembly/unstable/stats.json
@@ -43,25 +43,21 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2016-12-15"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
-      "lastmod": "2016-09-17"
+      "lastmod": "2019-02-02"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
       "lastmod": "2016-07-07"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
       "lastmod": "2017-10-07"
     }
   ]

--- a/data/Morocco/House/unstable/stats.json
+++ b/data/Morocco/House/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/official-10.csv",
       "type": "person",
       "scraper": "everypolitician-scrapers/morocco-house-of-representatives",
-      "lastmod": "2018-09-26"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/Myanmar/House_of_Representatives/unstable/stats.json
+++ b/data/Myanmar/House_of_Representatives/unstable/stats.json
@@ -53,7 +53,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-04"
     }
   ]
 }

--- a/data/Nagorno_Karabakh/Assembly/unstable/stats.json
+++ b/data/Nagorno_Karabakh/Assembly/unstable/stats.json
@@ -32,5 +32,33 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/official.csv",
+      "type": "membership",
+      "scraper": "tmtmtmtm/nagorno-karabakh-national-assembly",
+      "lastmod": "2017-03-27"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2015-10-02"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2016-10-21"
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "lastmod": "2016-10-21"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2017-10-07"
+    }
+  ]
 }

--- a/data/Namibia/Assembly/unstable/stats.json
+++ b/data/Namibia/Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/namibia-national-assembly-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "manual/terms.csv",
@@ -60,7 +60,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-01"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "wikidata/positions.json",
@@ -70,7 +70,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-04"
     }
   ]
 }

--- a/data/Namibia/Council/unstable/stats.json
+++ b/data/Namibia/Council/unstable/stats.json
@@ -32,5 +32,28 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/official.csv",
+      "type": "membership",
+      "scraper": "duncanparkes/namibia",
+      "lastmod": "2017-03-24"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2016-06-12"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2016-10-24"
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "lastmod": "2016-06-12"
+    }
+  ]
 }

--- a/data/Nauru/Parliament/unstable/stats.json
+++ b/data/Nauru/Parliament/unstable/stats.json
@@ -75,7 +75,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-03"
     }
   ]
 }

--- a/data/Nepal/Assembly/unstable/stats.json
+++ b/data/Nepal/Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/nepalese-constituent-assembly-members",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "manual/terms.csv",
@@ -60,12 +60,12 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-07"
     }
   ]
 }

--- a/data/Netherlands/House_of_Representatives/unstable/stats.json
+++ b/data/Netherlands/House_of_Representatives/unstable/stats.json
@@ -55,7 +55,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/netherlands-tweede-kamer-wikidata",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "manual/terms.csv",
@@ -77,12 +77,12 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-28"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "morph/twitter.csv",

--- a/data/New_Caledonia/Congress/unstable/stats.json
+++ b/data/New_Caledonia/Congress/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/new-caledonia-mps-wp",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "archive/official-vanished.csv",
@@ -64,17 +64,17 @@
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2018-09-28"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/New_Zealand/House/unstable/stats.json
+++ b/data/New_Zealand/House/unstable/stats.json
@@ -60,7 +60,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/new-zealand-parliament-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/terms.csv",
@@ -71,7 +71,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/areas.csv",
@@ -94,7 +94,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Nicaragua/Asamblea/unstable/stats.json
+++ b/data/Nicaragua/Asamblea/unstable/stats.json
@@ -43,26 +43,22 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2016-06-13"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
-      "lastmod": "2016-06-13"
+      "lastmod": "2019-01-31"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
-      "lastmod": "2017-01-13"
+      "lastmod": "2019-01-31"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
-      "lastmod": "2017-10-07"
+      "lastmod": "2019-01-31"
     }
   ]
 }

--- a/data/Niger/Assembly/unstable/stats.json
+++ b/data/Niger/Assembly/unstable/stats.json
@@ -32,5 +32,33 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/official.csv",
+      "type": "membership",
+      "scraper": "tmtmtmtm/niger-assemblee",
+      "lastmod": "2017-03-24"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2016-11-14"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2015-12-22"
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "lastmod": "2016-04-03"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2017-10-07"
+    }
+  ]
 }

--- a/data/Nigeria/Representatives/unstable/stats.json
+++ b/data/Nigeria/Representatives/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/nigeria-representatives-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "morph/terms.csv",
@@ -66,7 +66,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "morph/shineyoureye.csv",

--- a/data/Nigeria/Senate/unstable/stats.json
+++ b/data/Nigeria/Senate/unstable/stats.json
@@ -38,7 +38,7 @@
       "file": "morph/official.csv",
       "type": "membership",
       "scraper": "everypolitician-scrapers/nigeria-national-assembly",
-      "lastmod": "2018-11-20"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "morph/shineyoureye.csv",

--- a/data/Niue/Assembly/unstable/stats.json
+++ b/data/Niue/Assembly/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/niue-election-2014",
-      "lastmod": "2019-03-28"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -70,12 +70,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-28"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-28"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Norfolk_Island/Assembly/unstable/stats.json
+++ b/data/Norfolk_Island/Assembly/unstable/stats.json
@@ -32,5 +32,33 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/official.csv",
+      "type": "membership",
+      "scraper": "tmtmtmtm/norfolk-island-assembly",
+      "lastmod": "2017-03-27"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2016-07-07"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2017-01-14"
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "lastmod": "2017-01-14"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2017-10-07"
+    }
+  ]
 }

--- a/data/North_Korea/National_Assembly/unstable/stats.json
+++ b/data/North_Korea/National_Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/north-korea-assembly-wikidata",
-      "lastmod": "2019-03-13"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -65,7 +65,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-28"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Northern_Cyprus/Assembly/unstable/stats.json
+++ b/data/Northern_Cyprus/Assembly/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/northern_cyprus_parliament_wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "manual/terms.csv",
@@ -60,7 +60,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-26"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "gender-balance/results.csv",
@@ -75,7 +75,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-07"
     }
   ]
 }

--- a/data/Northern_Ireland/Assembly/unstable/stats.json
+++ b/data/Northern_Ireland/Assembly/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/ni-assembly-wikidata",
-      "lastmod": "2019-04-07"
+      "lastmod": "2019-04-09"
     },
     {
       "file": "manual/terms.csv",
@@ -59,7 +59,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-07"
+      "lastmod": "2019-04-09"
     },
     {
       "file": "morph/genderbalance.csv",

--- a/data/Northern_Mariana_Islands/House/unstable/stats.json
+++ b/data/Northern_Mariana_Islands/House/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/northern-marianas-legislature-wikidata",
-      "lastmod": "2019-03-07"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "manual/terms.csv",
@@ -59,17 +59,17 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-11"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-07"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2019-03-07"
+      "lastmod": "2019-04-04"
     }
   ]
 }

--- a/data/Norway/Storting/unstable/stats.json
+++ b/data/Norway/Storting/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/norway-stortingsrepresentanter-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "morph/terms.csv",

--- a/data/Oman/Majlis/unstable/stats.json
+++ b/data/Oman/Majlis/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/oman-representatives-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -60,12 +60,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Pakistan/Assembly/unstable/stats.json
+++ b/data/Pakistan/Assembly/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/pakistan-national-assembly-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "morph/terms.csv",

--- a/data/Palau/House_of_Delegates/unstable/stats.json
+++ b/data/Palau/House_of_Delegates/unstable/stats.json
@@ -59,12 +59,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-18"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Panama/Assembly/unstable/stats.json
+++ b/data/Panama/Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/panama-representatives-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "manual/terms.csv",
@@ -60,12 +60,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-07"
     }
   ]
 }

--- a/data/Papua_New_Guinea/Parliament/unstable/stats.json
+++ b/data/Papua_New_Guinea/Parliament/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/png-parliament-wikidata",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -60,12 +60,12 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-08"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Paraguay/Deputies/unstable/stats.json
+++ b/data/Paraguay/Deputies/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/paraguay-deputies-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "manual/terms.csv",
@@ -65,12 +65,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-07"
     }
   ]
 }

--- a/data/Peru/Congreso/unstable/stats.json
+++ b/data/Peru/Congreso/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/peru-congreso-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -60,7 +60,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/positions.json",
@@ -70,7 +70,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/twitter.csv",

--- a/data/Philippines/House/unstable/stats.json
+++ b/data/Philippines/House/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/philippines-house-of-representatives-wikidata",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "morph/terms.csv",
@@ -77,7 +77,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Pitcairn/Island_Council/unstable/stats.json
+++ b/data/Pitcairn/Island_Council/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/pitcairn-island-council-wikidata",
-      "lastmod": "2019-01-22"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -59,12 +59,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-22"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-22"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Poland/Sejm/unstable/stats.json
+++ b/data/Poland/Sejm/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/poland-sejm-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "morph/terms.csv",
@@ -72,7 +72,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-07"
     }
   ]
 }

--- a/data/Portugal/Assembly/unstable/stats.json
+++ b/data/Portugal/Assembly/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/portugal-deputados-wikidata",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/terms.csv",
@@ -73,7 +73,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -84,7 +84,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Puerto_Rico/House_of_Representatives/unstable/stats.json
+++ b/data/Puerto_Rico/House_of_Representatives/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/puerto-rico-house-of-representatives-wikidata",
-      "lastmod": "2019-03-10"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -70,12 +70,12 @@
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2019-01-15"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-10"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Romania/Deputies/unstable/stats.json
+++ b/data/Romania/Deputies/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/romanian-parliament-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "morph/terms.csv",
@@ -83,7 +83,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-07"
     }
   ]
 }

--- a/data/Russia/Duma/unstable/stats.json
+++ b/data/Russia/Duma/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/russian-duma-wikidata",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "morph/terms.csv",
@@ -60,7 +60,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -77,7 +77,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-04"
     }
   ]
 }

--- a/data/Rwanda/Deputies/unstable/stats.json
+++ b/data/Rwanda/Deputies/unstable/stats.json
@@ -43,25 +43,21 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2016-06-13"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
-      "lastmod": "2017-01-13"
+      "lastmod": "2019-02-02"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
       "lastmod": "2017-10-07"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
       "lastmod": "2017-01-13"
     }
   ]

--- a/data/Saint_Barthelemy/Council/unstable/stats.json
+++ b/data/Saint_Barthelemy/Council/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/saint-barthelemy-council-wikidata",
-      "lastmod": "2019-01-23"
+      "lastmod": "2019-03-25"
     },
     {
       "file": "manual/terms.csv",
@@ -69,7 +69,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-01-23"
+      "lastmod": "2019-03-25"
     }
   ]
 }

--- a/data/Saint_Helena/Legislative_Council/unstable/stats.json
+++ b/data/Saint_Helena/Legislative_Council/unstable/stats.json
@@ -49,25 +49,21 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2017-01-11"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
-      "lastmod": "2017-01-14"
+      "lastmod": "2019-02-02"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
       "lastmod": "2017-01-14"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
       "lastmod": "2017-10-07"
     }
   ]

--- a/data/Saint_Kitts_and_Nevis/Assembly/unstable/stats.json
+++ b/data/Saint_Kitts_and_Nevis/Assembly/unstable/stats.json
@@ -97,31 +97,26 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2016-06-14"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
       "lastmod": "2017-07-27"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
-      "lastmod": "2019-01-14"
+      "lastmod": "2019-01-31"
     },
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "scraper": null,
       "lastmod": "2018-09-09"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
       "lastmod": "2019-01-14"
     }
   ]

--- a/data/Saint_Lucia/Assembly/unstable/stats.json
+++ b/data/Saint_Lucia/Assembly/unstable/stats.json
@@ -55,7 +55,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/saint-lucia-assembly-wikidata",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -75,12 +75,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-11"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Saint_Martin/Council/unstable/stats.json
+++ b/data/Saint_Martin/Council/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/saint-martin-territorial-council-wikidata",
-      "lastmod": "2019-03-04"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -69,7 +69,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-04"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Saint_Pierre_and_Miquelon/Territorial_Council/unstable/stats.json
+++ b/data/Saint_Pierre_and_Miquelon/Territorial_Council/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/saint-pierre-and-miquelon-territorial-council-wikidata",
-      "lastmod": "2019-01-21"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -69,7 +69,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2017-08-30"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Saint_Vincent_and_the_Grenadines/Assembly/unstable/stats.json
+++ b/data/Saint_Vincent_and_the_Grenadines/Assembly/unstable/stats.json
@@ -63,7 +63,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-01-27"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Samoa/Parliament/unstable/stats.json
+++ b/data/Samoa/Parliament/unstable/stats.json
@@ -81,7 +81,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-28"
+      "lastmod": "2019-03-29"
     }
   ]
 }

--- a/data/San_Marino/Council/unstable/stats.json
+++ b/data/San_Marino/Council/unstable/stats.json
@@ -54,7 +54,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/san_marino_council-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "manual/terms.csv",
@@ -76,7 +76,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-07"
     },
     {
       "file": "wikidata/groups.json",

--- a/data/Saudi_Arabia/Shura/unstable/stats.json
+++ b/data/Saudi_Arabia/Shura/unstable/stats.json
@@ -43,19 +43,16 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2015-09-13"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
-      "lastmod": "2017-01-14"
+      "lastmod": "2019-02-02"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
       "lastmod": "2017-01-14"
     }
   ]

--- a/data/Scotland/Parliament/unstable/stats.json
+++ b/data/Scotland/Parliament/unstable/stats.json
@@ -43,7 +43,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/scottish-parliament-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Senegal/Assembly/unstable/stats.json
+++ b/data/Senegal/Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/senegal-national-assembly-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -65,12 +65,12 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-07"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Seychelles/Assembly/unstable/stats.json
+++ b/data/Seychelles/Assembly/unstable/stats.json
@@ -32,5 +32,33 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/official.csv",
+      "type": "membership",
+      "scraper": "tmtmtmtm/seychelles_national_assembly",
+      "lastmod": "2017-03-27"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2016-06-13"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2016-03-05"
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "lastmod": "2017-01-13"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2017-10-07"
+    }
+  ]
 }

--- a/data/Sierra_Leone/Parliament/unstable/stats.json
+++ b/data/Sierra_Leone/Parliament/unstable/stats.json
@@ -32,5 +32,33 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/official.csv",
+      "type": "membership",
+      "scraper": "everypolitician-scrapers/sierra-leone-parliament",
+      "lastmod": "2017-03-24"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2017-01-11"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2016-11-07"
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "lastmod": "2018-04-05"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2018-04-05"
+    }
+  ]
 }

--- a/data/Singapore/Parliament/unstable/stats.json
+++ b/data/Singapore/Parliament/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/singapore-parliament-wikidata",
-      "lastmod": "2019-03-25"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "morph/terms.csv",
@@ -67,7 +67,7 @@
       "file": "morph/cabinet.csv",
       "type": "wikidata-cabinet",
       "scraper": "everypolitician-scrapers/singapore-positions",
-      "lastmod": "2019-03-01"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/elections.json",

--- a/data/Sint_Maarten/Estates/unstable/stats.json
+++ b/data/Sint_Maarten/Estates/unstable/stats.json
@@ -68,12 +68,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-22"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-07"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Slovakia/National_Council/unstable/stats.json
+++ b/data/Slovakia/National_Council/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/slovakia-national-council-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/terms.csv",
@@ -78,7 +78,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Slovenia/National_Assembly/unstable/stats.json
+++ b/data/Slovenia/National_Assembly/unstable/stats.json
@@ -59,7 +59,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/slovenia-national-assembly-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/terms.csv",
@@ -76,7 +76,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/cabinet.csv",
@@ -87,7 +87,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-28"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/facebook.csv",

--- a/data/Solomon_Islands/Parliament/unstable/stats.json
+++ b/data/Solomon_Islands/Parliament/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/solomon-islands-parliament-wikidata",
-      "lastmod": "2019-02-22"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "morph/terms.csv",
@@ -78,12 +78,12 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-22"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-13"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Somalia/Lower/unstable/stats.json
+++ b/data/Somalia/Lower/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/somalian-politicians-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -60,7 +60,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Somaliland/Representatives/unstable/stats.json
+++ b/data/Somaliland/Representatives/unstable/stats.json
@@ -32,5 +32,28 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/official.csv",
+      "type": "membership",
+      "scraper": "tmtmtmtm/somaliland-parliament",
+      "lastmod": "2017-03-27"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2017-01-11"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2016-09-17"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2017-10-07"
+    }
+  ]
 }

--- a/data/South_Africa/Assembly/unstable/stats.json
+++ b/data/South_Africa/Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/peoplesassembly.csv",
       "type": "person",
       "scraper": "everypolitician-scrapers/south-africa-national-assembly",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-03-19"
     },
     {
       "file": "morph/wikidata.csv",

--- a/data/South_Korea/National_Assembly/unstable/stats.json
+++ b/data/South_Korea/National_Assembly/unstable/stats.json
@@ -54,7 +54,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/korean-assembly-members-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "morph/terms.csv",
@@ -65,7 +65,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -82,7 +82,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "morph/twitter.csv",

--- a/data/South_Ossetia/Parliament/unstable/stats.json
+++ b/data/South_Ossetia/Parliament/unstable/stats.json
@@ -43,26 +43,22 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2017-01-11"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
-      "lastmod": "2015-12-22"
+      "lastmod": "2019-01-31"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
-      "lastmod": "2016-04-02"
+      "lastmod": "2019-01-31"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
-      "lastmod": "2017-10-07"
+      "lastmod": "2019-01-31"
     }
   ]
 }

--- a/data/South_Sudan/Assembly/unstable/stats.json
+++ b/data/South_Sudan/Assembly/unstable/stats.json
@@ -32,5 +32,33 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/official.csv",
+      "type": "membership",
+      "scraper": "tmtmtmtm/south-sudan-legislative-assembly",
+      "lastmod": "2017-03-24"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2016-12-15"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2017-01-13"
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "lastmod": "2018-04-05"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2017-10-07"
+    }
+  ]
 }

--- a/data/Spain/Congress/unstable/stats.json
+++ b/data/Spain/Congress/unstable/stats.json
@@ -61,7 +61,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/spain-diputados-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "morph/terms.csv",
@@ -89,7 +89,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "morph/twitter.csv",

--- a/data/Sri_Lanka/Parliament/unstable/stats.json
+++ b/data/Sri_Lanka/Parliament/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/sri-lanka-parliament-wikidata",
-      "lastmod": "2019-02-28"
+      "lastmod": "2019-03-28"
     },
     {
       "file": "morph/terms.csv",
@@ -72,7 +72,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-28"
+      "lastmod": "2019-03-28"
     }
   ]
 }

--- a/data/Suriname/Assembly/unstable/stats.json
+++ b/data/Suriname/Assembly/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/suriname-assembly-members",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",
@@ -70,7 +70,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-03"
     }
   ]
 }

--- a/data/Swaziland/Assembly/unstable/stats.json
+++ b/data/Swaziland/Assembly/unstable/stats.json
@@ -37,25 +37,21 @@
     {
       "file": "archive/official-9.csv",
       "type": "membership",
-      "scraper": null,
       "lastmod": "2018-11-09"
     },
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2017-03-16"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
       "lastmod": "2015-12-22"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
       "lastmod": "2017-10-07"
     }
   ]

--- a/data/Switzerland/National_Council/unstable/stats.json
+++ b/data/Switzerland/National_Council/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/switzerland-national-assembly-wikidata",
-      "lastmod": "2019-04-04"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/terms.csv",

--- a/data/Syria/Majlis/unstable/stats.json
+++ b/data/Syria/Majlis/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/syria-council-wikidata",
-      "lastmod": "2019-03-06"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "morph/terms.csv",
@@ -66,7 +66,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-06"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Taiwan/Legislative_Yuan/unstable/stats.json
+++ b/data/Taiwan/Legislative_Yuan/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/taiwan-legislative-yuan-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Tajikistan/Representatives/unstable/stats.json
+++ b/data/Tajikistan/Representatives/unstable/stats.json
@@ -32,5 +32,28 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/official.csv",
+      "type": "membership",
+      "scraper": "tmtmtmtm/tajikistan-parlament",
+      "lastmod": "2017-03-27"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2017-01-11"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2016-10-18"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2017-10-07"
+    }
+  ]
 }

--- a/data/Tanzania/Assembly/unstable/stats.json
+++ b/data/Tanzania/Assembly/unstable/stats.json
@@ -54,7 +54,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/tanzania-parliament-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/terms.csv",
@@ -77,12 +77,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-01-15"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Thailand/National_Legislative_Assembly/unstable/stats.json
+++ b/data/Thailand/National_Legislative_Assembly/unstable/stats.json
@@ -76,7 +76,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Timor_Leste/Parlamento/unstable/stats.json
+++ b/data/Timor_Leste/Parlamento/unstable/stats.json
@@ -43,26 +43,22 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2016-06-14"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
-      "lastmod": "2017-01-13"
+      "lastmod": "2019-01-31"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
-      "lastmod": "2017-01-13"
+      "lastmod": "2019-01-31"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
-      "lastmod": "2017-10-07"
+      "lastmod": "2019-01-31"
     }
   ]
 }

--- a/data/Togo/Assembly/unstable/stats.json
+++ b/data/Togo/Assembly/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/togo-national-assembly-wikidata",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-03-28"
     },
     {
       "file": "manual/terms.csv",
@@ -70,12 +70,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-22"
+      "lastmod": "2019-03-28"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-03"
+      "lastmod": "2019-03-28"
     }
   ]
 }

--- a/data/Tonga/Assembly/unstable/stats.json
+++ b/data/Tonga/Assembly/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/tonga-assembly-members-wikidata",
-      "lastmod": "2019-01-25"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",
@@ -66,7 +66,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2017-10-07"
+      "lastmod": "2019-04-03"
     }
   ]
 }

--- a/data/Transnistria/Supreme_Council/unstable/stats.json
+++ b/data/Transnistria/Supreme_Council/unstable/stats.json
@@ -38,7 +38,7 @@
       "file": "morph/official.csv",
       "type": "membership",
       "scraper": "tmtmtmtm/transnistrian-supreme-council",
-      "lastmod": "2018-03-20"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -53,7 +53,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2017-10-07"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Trinidad_and_Tobago/Representatives/unstable/stats.json
+++ b/data/Trinidad_and_Tobago/Representatives/unstable/stats.json
@@ -43,25 +43,21 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2015-10-26"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
       "lastmod": "2016-09-18"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
-      "lastmod": "2016-07-05"
+      "lastmod": "2019-02-02"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
       "lastmod": "2017-10-07"
     }
   ]

--- a/data/Trinidad_and_Tobago/Senate/unstable/stats.json
+++ b/data/Trinidad_and_Tobago/Senate/unstable/stats.json
@@ -43,20 +43,17 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2015-10-26"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
       "lastmod": "2016-09-18"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
-      "lastmod": "2016-09-18"
+      "lastmod": "2019-02-02"
     }
   ]
 }

--- a/data/Tunisia/Majlis/unstable/stats.json
+++ b/data/Tunisia/Majlis/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/tunisia-marsad-wikidata",
-      "lastmod": "2019-03-07"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "morph/terms.csv",
@@ -65,17 +65,17 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-07"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2019-03-07"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-07"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Turkey/Assembly/unstable/stats.json
+++ b/data/Turkey/Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/turkey-tbmm-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "manual/terms.csv",
@@ -66,12 +66,12 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-04"
     }
   ]
 }

--- a/data/Turkmenistan/Mejlis/unstable/stats.json
+++ b/data/Turkmenistan/Mejlis/unstable/stats.json
@@ -32,5 +32,33 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "morph/official.csv",
+      "type": "membership",
+      "scraper": "tmtmtmtm/turkmenistan-majilis",
+      "lastmod": "2017-03-22"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2017-01-11"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2016-11-08"
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "lastmod": "2016-06-05"
+    },
+    {
+      "file": "wikidata/elections.json",
+      "type": "wikidata-elections",
+      "lastmod": "2017-10-07"
+    }
+  ]
 }

--- a/data/Turks_and_Caicos_Islands/Assembly/unstable/stats.json
+++ b/data/Turks_and_Caicos_Islands/Assembly/unstable/stats.json
@@ -60,7 +60,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/turks-and-caicos-assembly-wikidata",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -85,7 +85,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-25"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Tuvalu/Parliament/unstable/stats.json
+++ b/data/Tuvalu/Parliament/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/tuvalu-parliament-wikidata",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "manual/terms.csv",
@@ -64,12 +64,12 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-04"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-03"
+      "lastmod": "2019-04-04"
     }
   ]
 }

--- a/data/US_Virgin_Islands/Legislature/unstable/stats.json
+++ b/data/US_Virgin_Islands/Legislature/unstable/stats.json
@@ -55,25 +55,21 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2016-07-04"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
       "lastmod": "2016-07-04"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
       "lastmod": "2019-01-31"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
       "lastmod": "2017-10-07"
     }
   ]

--- a/data/Uganda/Parliament/unstable/stats.json
+++ b/data/Uganda/Parliament/unstable/stats.json
@@ -54,7 +54,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/uganda-parliament-wikidata",
-      "lastmod": "2019-04-02"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -70,7 +70,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-03-28"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/cabinet.csv",
@@ -81,7 +81,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-28"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Ukraine/Verkhovna_Rada/unstable/stats.json
+++ b/data/Ukraine/Verkhovna_Rada/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/ukraine-deputies-wikidata",
-      "lastmod": "2019-04-05"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/terms.csv",
@@ -61,7 +61,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-05"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/cabinet.csv",

--- a/data/United_Arab_Emirates/Federal_National_Council/unstable/stats.json
+++ b/data/United_Arab_Emirates/Federal_National_Council/unstable/stats.json
@@ -43,19 +43,16 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2016-06-22"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
-      "lastmod": "2016-11-14"
+      "lastmod": "2019-02-02"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
       "lastmod": "2017-10-07"
     }
   ]

--- a/data/United_States_of_America/House/unstable/stats.json
+++ b/data/United_States_of_America/House/unstable/stats.json
@@ -61,7 +61,7 @@
       "file": "morph/areas.csv",
       "type": "area-wikidata",
       "scraper": "everypolitician-scrapers/us-house-constituencies-wikidata",
-      "lastmod": "2019-03-11"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -78,7 +78,7 @@
       "file": "morph/cabinet.csv",
       "type": "wikidata-cabinet",
       "scraper": "everypolitician-scrapers/us-representatives-positions",
-      "lastmod": "2019-02-28"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/elections.json",

--- a/data/United_States_of_America/Senate/unstable/stats.json
+++ b/data/United_States_of_America/Senate/unstable/stats.json
@@ -38,7 +38,7 @@
       "file": "morph/unitedstates-project.csv",
       "type": "membership",
       "scraper": "tmtmtmtm/us-congress-members",
-      "lastmod": "2019-03-01"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "morph/socialmedia.csv",
@@ -61,7 +61,7 @@
       "file": "morph/areas.csv",
       "type": "area-wikidata",
       "scraper": "everypolitician-scrapers/us-states-wikidata",
-      "lastmod": "2019-03-14"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Uruguay/Deputies/unstable/stats.json
+++ b/data/Uruguay/Deputies/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/uruguay-parlamento-wikidata",
-      "lastmod": "2019-02-25"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -59,7 +59,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-02"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -70,12 +70,12 @@
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2019-01-18"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-25"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Uzbekistan/Legislative_Chamber/unstable/stats.json
+++ b/data/Uzbekistan/Legislative_Chamber/unstable/stats.json
@@ -43,26 +43,22 @@
     {
       "file": "manual/terms.csv",
       "type": "term",
-      "scraper": null,
       "lastmod": "2017-01-11"
     },
     {
       "file": "gender-balance/results.csv",
       "type": "gender",
-      "scraper": null,
-      "lastmod": "2016-11-07"
+      "lastmod": "2019-01-31"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "scraper": null,
-      "lastmod": "2017-01-14"
+      "lastmod": "2019-01-31"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "scraper": null,
-      "lastmod": "2017-10-07"
+      "lastmod": "2019-01-31"
     }
   ]
 }

--- a/data/Vanuatu/Parliament/unstable/stats.json
+++ b/data/Vanuatu/Parliament/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "everypolitician-scrapers/vanuatau-parliament-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "manual/terms.csv",
@@ -65,7 +65,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "wikidata/positions.json",
@@ -75,7 +75,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-08"
     }
   ]
 }

--- a/data/Vatican_City/Pontifical_Commission/unstable/stats.json
+++ b/data/Vatican_City/Pontifical_Commission/unstable/stats.json
@@ -49,7 +49,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/pontifical-commission-for-vatican-state-wikidata",
-      "lastmod": "2019-02-03"
+      "lastmod": "2019-03-08"
     },
     {
       "file": "manual/terms.csv",
@@ -69,7 +69,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-03"
+      "lastmod": "2019-03-08"
     }
   ]
 }

--- a/data/Venezuela/Assembly/unstable/stats.json
+++ b/data/Venezuela/Assembly/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/venezuela-asamblea-wikidata",
-      "lastmod": "2019-02-28"
+      "lastmod": "2019-03-11"
     },
     {
       "file": "morph/terms.csv",
@@ -67,17 +67,17 @@
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2019-02-09"
+      "lastmod": "2019-03-11"
     },
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-09"
+      "lastmod": "2019-03-11"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-28"
+      "lastmod": "2019-03-11"
     }
   ]
 }

--- a/data/Vietnam/National_Assembly/unstable/stats.json
+++ b/data/Vietnam/National_Assembly/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/vietnam-national-assembly-wikidata",
-      "lastmod": "2019-04-01"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Wales/Assembly/unstable/stats.json
+++ b/data/Wales/Assembly/unstable/stats.json
@@ -50,7 +50,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/wales-AMs-wikidata",
-      "lastmod": "2019-04-07"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "archive/official-4.csv",
@@ -60,7 +60,7 @@
     {
       "file": "wikidata/parties.json",
       "type": "group",
-      "lastmod": "2019-04-07"
+      "lastmod": "2019-04-08"
     },
     {
       "file": "morph/terms.csv",

--- a/data/Wallis_and_Futuna/Territorial_Assembly/unstable/stats.json
+++ b/data/Wallis_and_Futuna/Territorial_Assembly/unstable/stats.json
@@ -55,7 +55,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/wallis-and-futuna-territorial-assembly-wikidata",
-      "lastmod": "2019-02-12"
+      "lastmod": "2019-03-27"
     },
     {
       "file": "manual/terms.csv",
@@ -76,7 +76,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-02-12"
+      "lastmod": "2019-03-27"
     }
   ]
 }

--- a/data/Yemen/Majlis/unstable/stats.json
+++ b/data/Yemen/Majlis/unstable/stats.json
@@ -44,7 +44,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/yemen-deputies-wikidata",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-02"
     },
     {
       "file": "manual/terms.csv",
@@ -59,7 +59,7 @@
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-12"
+      "lastmod": "2019-04-02"
     }
   ]
 }

--- a/data/Zambia/Assembly/unstable/stats.json
+++ b/data/Zambia/Assembly/unstable/stats.json
@@ -54,7 +54,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/zambia-national-assembly-wikidata",
-      "lastmod": "2019-03-28"
+      "lastmod": "2019-04-03"
     },
     {
       "file": "manual/terms.csv",

--- a/data/Zimbabwe/Assembly/unstable/stats.json
+++ b/data/Zimbabwe/Assembly/unstable/stats.json
@@ -54,7 +54,7 @@
       "file": "morph/wikidata.csv",
       "type": "wikidata",
       "scraper": "tmtmtmtm/zimbabwe-representatives-wikidata",
-      "lastmod": "2019-03-03"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "manual/terms.csv",
@@ -64,7 +64,7 @@
     {
       "file": "wikidata/groups.json",
       "type": "group",
-      "lastmod": "2019-02-13"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "morph/genderbalance.csv",
@@ -75,12 +75,12 @@
     {
       "file": "wikidata/positions.json",
       "type": "wikidata-positions",
-      "lastmod": "2018-11-19"
+      "lastmod": "2019-04-01"
     },
     {
       "file": "wikidata/elections.json",
       "type": "wikidata-elections",
-      "lastmod": "2019-03-04"
+      "lastmod": "2019-04-01"
     }
   ]
 }

--- a/data/Zimbabwe/Senate/unstable/stats.json
+++ b/data/Zimbabwe/Senate/unstable/stats.json
@@ -32,5 +32,38 @@
   },
   "positions": {
     "cabinet": 0
-  }
+  },
+  "sources": [
+    {
+      "file": "google/memberships.csv",
+      "type": "membership",
+      "lastmod": "2015-12-11"
+    },
+    {
+      "file": "google/people.csv",
+      "type": "person",
+      "lastmod": "2016-06-03"
+    },
+    {
+      "file": "morph/official.csv",
+      "type": "person",
+      "scraper": "tmtmtmtm/zimbabwe-parliament",
+      "lastmod": "2017-02-22"
+    },
+    {
+      "file": "manual/terms.csv",
+      "type": "term",
+      "lastmod": "2016-06-12"
+    },
+    {
+      "file": "wikidata/groups.json",
+      "type": "group",
+      "lastmod": "2016-09-18"
+    },
+    {
+      "file": "gender-balance/results.csv",
+      "type": "gender",
+      "lastmod": "2016-09-18"
+    }
+  ]
 }

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -62,7 +62,6 @@ module Source
       chamber:         %w[house],
       death_date:      %w[dod date_of_death],
       end_date:        %w[end ended until to],
-      executive:       %w[post],
       family_name:     %w[last_name surname lastname],
       fax:             %w[facsimile],
       gender:          %w[sex],

--- a/rake_build/generate_ep_popolo.rb
+++ b/rake_build/generate_ep_popolo.rb
@@ -5,7 +5,6 @@ require 'deep_merge'
 #-----------------------------------------------------------------------
 # Transform the results from generic CSV-to-Popolo into EP-Popolo
 #
-#   - remove all Executive Memberships
 #   - remove duplicated names
 #   - merge legislature data from meta.json
 #     - ensure all legislative memberships are on that
@@ -28,10 +27,6 @@ namespace :transform do
   #---------------------------------------------------------------------
   task write: :ensure_legislature
   task ensure_legislature: :load do
-    # Clean out legislative memberships
-    @json[:memberships].delete_if { |m| m[:organization_id] == 'executive' }
-    @json[:organizations].delete_if { |h| h[:classification] == 'executive' }
-
     legis = @json[:organizations].select { |h| h[:classification] == 'legislature' }
     raise "Legislature count = #{legis.count}" unless legis.count == 1
 


### PR DESCRIPTION
If we update csv-to-popolo to 0.30, which no longer creates these, we don't need to then clean them up afterwards.