### PR TITLE
Remove 'chamber' handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,9 +65,9 @@ GIT
 
 GIT
   remote: https://github.com/tmtmtmtm/csv_to_popolo.git
-  revision: 5a53ef493865eca612a8c17f1e4ebb62bcce73fe
+  revision: 257f65f516120f29b24c79f8df7058ce80c05252
   specs:
-    csv_to_popolo (0.30.0)
+    csv_to_popolo (0.31.0)
       facebook_username_extractor
       json
       rcsv

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -59,7 +59,6 @@ module Source
       birth_date:      %w[dob date_of_birth],
       blog:            %w[weblog],
       cell:            %w[mob mobile cellphone],
-      chamber:         %w[house],
       death_date:      %w[dod date_of_death],
       end_date:        %w[end ended until to],
       family_name:     %w[last_name surname lastname],

--- a/rake_build/generate_ep_popolo.rb
+++ b/rake_build/generate_ep_popolo.rb
@@ -31,14 +31,6 @@ namespace :transform do
     raise "Legislature count = #{legis.count}" unless legis.count == 1
 
     @legislature = legis.first
-
-    # Remake 'chamber' memberships to the full legislature
-    @json[:organizations].select { |h| h[:classification] == 'chamber' }.each do |c|
-      @json[:memberships].select { |m| m[:organization_id] == c[:id] }.each do |m|
-        m[:organization_id] = @legislature[:id]
-      end
-    end
-    @json[:organizations].delete_if { |h| h[:classification] == 'chamber' }
   end
 
   #---------------------------------------------------------------------
@@ -180,8 +172,7 @@ namespace :transform do
 
   task write: :ensure_behalf_of
   task ensure_behalf_of: :ensure_legislature do
-    leg_ids = @json[:organizations].select { |o| %w[legislature chamber].include? o[:classification] }.map { |o| o[:id] }
-    @json[:memberships].select { |m| m[:role] == 'member' && leg_ids.include?(m[:organization_id]) }.each do |m|
+    @json[:memberships].select { |m| m[:role] == 'member' }.each do |m|
       m[:on_behalf_of_id] = unknown_party[:id] if m[:on_behalf_of_id].to_s.empty?
     end
   end


### PR DESCRIPTION
Update to csv-to-popolo 0.31, which removes the handing of 'chamber'/'house' columns, which then lets us simplify some of our post-processing.